### PR TITLE
perf(compiler): elide local-only block scope allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler: elide block lexical-environment allocations when every binding is stored in an IL local, while retaining runtime scope instances for captured bindings and block-level functions.
 
 ## v0.11.34 - 2026-07-21
 

--- a/src/Compiler/IR/HIR/HIRBuilder.cs
+++ b/src/Compiler/IR/HIR/HIRBuilder.cs
@@ -1260,10 +1260,9 @@ class HIRMethodBuilder
 
     private static string? GetMaterializedBlockScopeName(Scope? scope)
     {
-        // Only blocks with lexical bindings have a runtime-observable environment.
-        // Empty block scopes remain in the symbol tree for structural analysis but
-        // must not cause a per-execution scope instance allocation.
-        return scope is { Kind: ScopeKind.Block } && scope.Bindings.Count > 0
+        // Uncaptured block bindings lower to IL locals, so only blocks with runtime
+        // field storage need a lexical-environment instance.
+        return scope?.RequiresRuntimeBlockScopeInstance == true
             ? ScopeNaming.GetRegistryScopeName(scope)
             : null;
     }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementFor.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementFor.cs
@@ -46,7 +46,7 @@ public sealed partial class HIRToLIRLowerer
             if (declaringScope != null
                 && declaringScope.Kind == ScopeKind.Block
                 && loopHeadLexicalBindings.All(b => b.DeclaringScope == declaringScope)
-                && (perIterationBindings.Count > 0 || declaringScope.HasDescendantCallableReferencingParentScopeVariables))
+                && declaringScope.RequiresRuntimeBlockScopeInstance)
             {
                 useTempPerIterationScope = true;
                 loopScopeName = ScopeNaming.GetRegistryScopeName(declaringScope);

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementForIn.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementForIn.cs
@@ -44,7 +44,7 @@ public sealed partial class HIRToLIRLowerer
             if (declaringScope != null
                 && declaringScope.Kind == ScopeKind.Block
                 && loopHeadLexicalBindings.All(b => b.DeclaringScope == declaringScope)
-                && (perIterationBindings.Count > 0 || declaringScope.HasDescendantCallableReferencingParentScopeVariables))
+                && declaringScope.RequiresRuntimeBlockScopeInstance)
             {
                 useTempPerIterationScope = true;
                 loopScopeName = ScopeNaming.GetRegistryScopeName(declaringScope);

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementForOf.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementForOf.cs
@@ -66,7 +66,7 @@ public sealed partial class HIRToLIRLowerer
                 if (declaringScope != null
                     && declaringScope.Kind == ScopeKind.Block
                     && loopHeadLexicalBindings.All(b => b.DeclaringScope == declaringScope)
-                    && (perIterationBindings.Count > 0 || declaringScope.HasDescendantCallableReferencingParentScopeVariables))
+                    && declaringScope.RequiresRuntimeBlockScopeInstance)
                 {
                     useTempPerIterationScope = true;
                     loopScopeName = ScopeNaming.GetRegistryScopeName(declaringScope);
@@ -440,7 +440,7 @@ public sealed partial class HIRToLIRLowerer
                 if (declaringScope != null
                     && declaringScope.Kind == ScopeKind.Block
                     && loopHeadLexicalBindings.All(b => b.DeclaringScope == declaringScope)
-                    && (perIterationBindings.Count > 0 || declaringScope.HasDescendantCallableReferencingParentScopeVariables))
+                    && declaringScope.RequiresRuntimeBlockScopeInstance)
                 {
                     useTempPerIterationScope = true;
                     loopScopeName = ScopeNaming.GetRegistryScopeName(declaringScope);

--- a/src/Compiler/Services/ScopesAbi/EnvironmentLayoutBuilder.cs
+++ b/src/Compiler/Services/ScopesAbi/EnvironmentLayoutBuilder.cs
@@ -109,9 +109,9 @@ public class EnvironmentLayoutBuilder
             : scope.Parent;
         while (current != null)
         {
-            // Only include ancestor scopes that can contribute bindings to the environment chain.
-            // Empty block scopes are elided since they have no runtime-observable bindings and
-            // the IR pipeline does not materialize instances for them.
+            // Only include ancestor scopes that can contribute runtime-stored bindings to the
+            // environment chain. Uncaptured block bindings lower to IL locals, so their blocks
+            // do not have runtime instances.
             // Most class scopes don't have runtime scope instances — they're compiled as CLR types.
             // Named class expressions are the exception because their internal class-name binding
             // is stored in the class lexical environment.
@@ -120,7 +120,7 @@ public class EnvironmentLayoutBuilder
                 current = current.Parent;
                 continue;
             }
-            if (current.Kind != ScopeKind.Block || current.Bindings.Count > 0)
+            if (current.Kind != ScopeKind.Block || current.RequiresRuntimeBlockScopeInstance)
             {
                 ancestorScopes.Add(current);
             }

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -175,6 +175,15 @@ public class Scope
     public bool IsVarHoistingScope { get; set; }
 
     /// <summary>
+    /// True when this block scope has bindings that require runtime field storage.
+    /// Uncaptured lexical bindings use IL locals and do not require a scope instance.
+    /// </summary>
+    public bool RequiresRuntimeBlockScopeInstance
+        => Kind == ScopeKind.Block
+           && Bindings.Values.Any(binding =>
+               binding.IsCaptured || binding.Kind == BindingKind.Function);
+
+    /// <summary>
     /// True when source code in this module referenced the ECMAScript globalThis binding.
     /// Used to gate global-var mirroring onto the global object so we only emit the extra
     /// global-object write when user code actually observes the global object.

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x507d
+				// Method begins at RVA 0x502d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5098
+						// Method begins at RVA 0x5048
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x50a1
+						// Method begins at RVA 0x5051
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x50aa
+						// Method begins at RVA 0x505a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x50b3
+						// Method begins at RVA 0x5063
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x50bc
+						// Method begins at RVA 0x506c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x50c5
+						// Method begins at RVA 0x5075
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x508f
+					// Method begins at RVA 0x503f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5086
+				// Method begins at RVA 0x5036
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -209,25 +209,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x275c
+			// Method begins at RVA 0x2754
 			// Header size: 12
-			// Code size: 715 (0x2cb)
+			// Code size: 699 (0x2bb)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[1] float64,
-				[2] class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/Scope_For_L18C7/Block_L18C40,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] bool,
+				[2] object,
+				[3] float64,
+				[4] object,
+				[5] bool,
+				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
 				[11] object,
-				[12] object,
-				[13] object
+				[12] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -262,243 +261,241 @@
 			IL_0061: stloc.1
 			// loop start (head: IL_0062)
 				IL_0062: ldloc.1
-				IL_0063: stloc.s 4
-				IL_0065: ldloc.s 4
-				IL_0067: ldarg.2
-				IL_0068: ldstr "length"
-				IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0072: clt
-				IL_0074: brfalse IL_02c9
+				IL_0063: stloc.3
+				IL_0064: ldloc.3
+				IL_0065: ldarg.2
+				IL_0066: ldstr "length"
+				IL_006b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0070: clt
+				IL_0072: brfalse IL_02b9
 
-				IL_0079: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/parseArgs/Scope_For_L18C7/Block_L18C40::.ctor()
+				IL_0077: ldarg.2
+				IL_0078: ldloc.1
+				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_007e: stloc.2
-				IL_007f: ldarg.2
-				IL_0080: ldloc.1
-				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0086: stloc.3
-				IL_0087: ldloc.3
-				IL_0088: stloc.s 5
-				IL_008a: ldloc.s 5
-				IL_008c: ldstr "--pin"
-				IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0096: stloc.s 6
-				IL_0098: ldloc.s 6
-				IL_009a: box [System.Runtime]System.Boolean
-				IL_009f: stloc.s 7
-				IL_00a1: ldloc.s 7
-				IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00a8: stloc.s 6
-				IL_00aa: ldloc.s 6
-				IL_00ac: brfalse IL_00d5
+				IL_007f: ldloc.2
+				IL_0080: stloc.s 4
+				IL_0082: ldloc.s 4
+				IL_0084: ldstr "--pin"
+				IL_0089: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_008e: stloc.s 5
+				IL_0090: ldloc.s 5
+				IL_0092: box [System.Runtime]System.Boolean
+				IL_0097: stloc.s 6
+				IL_0099: ldloc.s 6
+				IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00a0: stloc.s 5
+				IL_00a2: ldloc.s 5
+				IL_00a4: brfalse IL_00c9
 
-				IL_00b1: ldloc.1
-				IL_00b2: stloc.s 4
-				IL_00b4: ldloc.s 4
-				IL_00b6: ldc.r8 1
-				IL_00bf: add
-				IL_00c0: stloc.s 4
-				IL_00c2: ldarg.2
-				IL_00c3: ldloc.s 4
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00ca: stloc.s 5
-				IL_00cc: ldloc.s 5
-				IL_00ce: stloc.s 9
-				IL_00d0: br IL_00d9
+				IL_00a9: ldloc.1
+				IL_00aa: stloc.3
+				IL_00ab: ldloc.3
+				IL_00ac: ldc.r8 1
+				IL_00b5: add
+				IL_00b6: stloc.3
+				IL_00b7: ldarg.2
+				IL_00b8: ldloc.3
+				IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00be: stloc.s 4
+				IL_00c0: ldloc.s 4
+				IL_00c2: stloc.s 8
+				IL_00c4: br IL_00cd
 
-				IL_00d5: ldloc.s 7
-				IL_00d7: stloc.s 9
+				IL_00c9: ldloc.s 6
+				IL_00cb: stloc.s 8
 
-				IL_00d9: ldloc.s 9
-				IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00e0: stloc.s 6
-				IL_00e2: ldloc.s 6
-				IL_00e4: brfalse IL_011b
+				IL_00cd: ldloc.s 8
+				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00d4: stloc.s 5
+				IL_00d6: ldloc.s 5
+				IL_00d8: brfalse IL_010f
 
+				IL_00dd: ldloc.1
+				IL_00de: ldc.r8 1
+				IL_00e7: add
+				IL_00e8: stloc.1
 				IL_00e9: ldloc.1
-				IL_00ea: ldc.r8 1
-				IL_00f3: add
-				IL_00f4: stloc.1
-				IL_00f5: ldloc.1
-				IL_00f6: box [System.Runtime]System.Double
-				IL_00fb: stloc.s 10
-				IL_00fd: ldarg.2
-				IL_00fe: ldloc.s 10
-				IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0105: stloc.s 5
-				IL_0107: ldloc.0
-				IL_0108: ldstr "pin"
-				IL_010d: ldloc.s 5
-				IL_010f: ldc.i4.1
-				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0115: pop
-				IL_0116: br IL_02b8
+				IL_00ea: box [System.Runtime]System.Double
+				IL_00ef: stloc.s 9
+				IL_00f1: ldarg.2
+				IL_00f2: ldloc.s 9
+				IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00f9: stloc.s 4
+				IL_00fb: ldloc.0
+				IL_00fc: ldstr "pin"
+				IL_0101: ldloc.s 4
+				IL_0103: ldc.i4.1
+				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0109: pop
+				IL_010a: br IL_02a8
 
-				IL_011b: ldloc.3
-				IL_011c: stloc.s 5
-				IL_011e: ldloc.s 5
-				IL_0120: ldstr "--root"
-				IL_0125: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_012a: stloc.s 6
-				IL_012c: ldloc.s 6
-				IL_012e: box [System.Runtime]System.Boolean
-				IL_0133: stloc.s 7
-				IL_0135: ldloc.s 7
-				IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013c: stloc.s 6
-				IL_013e: ldloc.s 6
-				IL_0140: brfalse IL_0169
+				IL_010f: ldloc.2
+				IL_0110: stloc.s 4
+				IL_0112: ldloc.s 4
+				IL_0114: ldstr "--root"
+				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_011e: stloc.s 5
+				IL_0120: ldloc.s 5
+				IL_0122: box [System.Runtime]System.Boolean
+				IL_0127: stloc.s 6
+				IL_0129: ldloc.s 6
+				IL_012b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0130: stloc.s 5
+				IL_0132: ldloc.s 5
+				IL_0134: brfalse IL_0159
 
-				IL_0145: ldloc.1
-				IL_0146: stloc.s 4
-				IL_0148: ldloc.s 4
-				IL_014a: ldc.r8 1
-				IL_0153: add
-				IL_0154: stloc.s 4
-				IL_0156: ldarg.2
-				IL_0157: ldloc.s 4
-				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_015e: stloc.s 5
-				IL_0160: ldloc.s 5
-				IL_0162: stloc.s 11
-				IL_0164: br IL_016d
+				IL_0139: ldloc.1
+				IL_013a: stloc.3
+				IL_013b: ldloc.3
+				IL_013c: ldc.r8 1
+				IL_0145: add
+				IL_0146: stloc.3
+				IL_0147: ldarg.2
+				IL_0148: ldloc.3
+				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_014e: stloc.s 4
+				IL_0150: ldloc.s 4
+				IL_0152: stloc.s 10
+				IL_0154: br IL_015d
 
-				IL_0169: ldloc.s 7
-				IL_016b: stloc.s 11
+				IL_0159: ldloc.s 6
+				IL_015b: stloc.s 10
 
-				IL_016d: ldloc.s 11
-				IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0174: stloc.s 6
-				IL_0176: ldloc.s 6
-				IL_0178: brfalse IL_01af
+				IL_015d: ldloc.s 10
+				IL_015f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0164: stloc.s 5
+				IL_0166: ldloc.s 5
+				IL_0168: brfalse IL_019f
 
-				IL_017d: ldloc.1
-				IL_017e: ldc.r8 1
-				IL_0187: add
-				IL_0188: stloc.1
-				IL_0189: ldloc.1
-				IL_018a: box [System.Runtime]System.Double
-				IL_018f: stloc.s 10
-				IL_0191: ldarg.2
-				IL_0192: ldloc.s 10
-				IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0199: stloc.s 5
-				IL_019b: ldloc.0
-				IL_019c: ldstr "root"
-				IL_01a1: ldloc.s 5
-				IL_01a3: ldc.i4.1
-				IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_01a9: pop
-				IL_01aa: br IL_02b8
+				IL_016d: ldloc.1
+				IL_016e: ldc.r8 1
+				IL_0177: add
+				IL_0178: stloc.1
+				IL_0179: ldloc.1
+				IL_017a: box [System.Runtime]System.Double
+				IL_017f: stloc.s 9
+				IL_0181: ldarg.2
+				IL_0182: ldloc.s 9
+				IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0189: stloc.s 4
+				IL_018b: ldloc.0
+				IL_018c: ldstr "root"
+				IL_0191: ldloc.s 4
+				IL_0193: ldc.i4.1
+				IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0199: pop
+				IL_019a: br IL_02a8
 
-				IL_01af: ldloc.3
-				IL_01b0: stloc.s 5
-				IL_01b2: ldloc.s 5
-				IL_01b4: ldstr "--describe"
-				IL_01b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01be: stloc.s 6
-				IL_01c0: ldloc.s 6
-				IL_01c2: brfalse IL_01df
+				IL_019f: ldloc.2
+				IL_01a0: stloc.s 4
+				IL_01a2: ldloc.s 4
+				IL_01a4: ldstr "--describe"
+				IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01ae: stloc.s 5
+				IL_01b0: ldloc.s 5
+				IL_01b2: brfalse IL_01cf
 
-				IL_01c7: ldloc.0
-				IL_01c8: ldstr "describe"
-				IL_01cd: ldc.i4.1
-				IL_01ce: box [System.Runtime]System.Boolean
-				IL_01d3: ldc.i4.1
-				IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_01d9: pop
-				IL_01da: br IL_02b8
+				IL_01b7: ldloc.0
+				IL_01b8: ldstr "describe"
+				IL_01bd: ldc.i4.1
+				IL_01be: box [System.Runtime]System.Boolean
+				IL_01c3: ldc.i4.1
+				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_01c9: pop
+				IL_01ca: br IL_02a8
 
-				IL_01df: ldloc.3
-				IL_01e0: stloc.s 5
-				IL_01e2: ldloc.s 5
-				IL_01e4: ldstr "--force"
-				IL_01e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01ee: stloc.s 6
-				IL_01f0: ldloc.s 6
-				IL_01f2: brfalse IL_020f
+				IL_01cf: ldloc.2
+				IL_01d0: stloc.s 4
+				IL_01d2: ldloc.s 4
+				IL_01d4: ldstr "--force"
+				IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01de: stloc.s 5
+				IL_01e0: ldloc.s 5
+				IL_01e2: brfalse IL_01ff
 
-				IL_01f7: ldloc.0
-				IL_01f8: ldstr "force"
-				IL_01fd: ldc.i4.1
-				IL_01fe: box [System.Runtime]System.Boolean
-				IL_0203: ldc.i4.1
-				IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0209: pop
-				IL_020a: br IL_02b8
+				IL_01e7: ldloc.0
+				IL_01e8: ldstr "force"
+				IL_01ed: ldc.i4.1
+				IL_01ee: box [System.Runtime]System.Boolean
+				IL_01f3: ldc.i4.1
+				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_01f9: pop
+				IL_01fa: br IL_02a8
 
-				IL_020f: ldloc.3
-				IL_0210: stloc.s 5
-				IL_0212: ldloc.s 5
-				IL_0214: ldstr "--print-root"
-				IL_0219: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_021e: stloc.s 6
-				IL_0220: ldloc.s 6
-				IL_0222: brfalse IL_023f
+				IL_01ff: ldloc.2
+				IL_0200: stloc.s 4
+				IL_0202: ldloc.s 4
+				IL_0204: ldstr "--print-root"
+				IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_020e: stloc.s 5
+				IL_0210: ldloc.s 5
+				IL_0212: brfalse IL_022f
 
-				IL_0227: ldloc.0
-				IL_0228: ldstr "printRoot"
-				IL_022d: ldc.i4.1
-				IL_022e: box [System.Runtime]System.Boolean
-				IL_0233: ldc.i4.1
-				IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0239: pop
-				IL_023a: br IL_02b8
+				IL_0217: ldloc.0
+				IL_0218: ldstr "printRoot"
+				IL_021d: ldc.i4.1
+				IL_021e: box [System.Runtime]System.Boolean
+				IL_0223: ldc.i4.1
+				IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0229: pop
+				IL_022a: br IL_02a8
 
-				IL_023f: ldloc.3
-				IL_0240: stloc.s 5
-				IL_0242: ldloc.s 5
-				IL_0244: ldstr "--help"
-				IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_024e: stloc.s 6
-				IL_0250: ldloc.s 6
-				IL_0252: box [System.Runtime]System.Boolean
-				IL_0257: stloc.s 7
-				IL_0259: ldloc.s 7
-				IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0260: stloc.s 6
-				IL_0262: ldloc.s 6
-				IL_0264: brtrue IL_028c
+				IL_022f: ldloc.2
+				IL_0230: stloc.s 4
+				IL_0232: ldloc.s 4
+				IL_0234: ldstr "--help"
+				IL_0239: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_023e: stloc.s 5
+				IL_0240: ldloc.s 5
+				IL_0242: box [System.Runtime]System.Boolean
+				IL_0247: stloc.s 6
+				IL_0249: ldloc.s 6
+				IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0250: stloc.s 5
+				IL_0252: ldloc.s 5
+				IL_0254: brtrue IL_027c
 
-				IL_0269: ldloc.3
-				IL_026a: stloc.s 5
-				IL_026c: ldloc.s 5
-				IL_026e: ldstr "-h"
-				IL_0273: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0278: stloc.s 6
-				IL_027a: ldloc.s 6
-				IL_027c: box [System.Runtime]System.Boolean
-				IL_0281: stloc.s 12
-				IL_0283: ldloc.s 12
-				IL_0285: stloc.s 13
-				IL_0287: br IL_0290
+				IL_0259: ldloc.2
+				IL_025a: stloc.s 4
+				IL_025c: ldloc.s 4
+				IL_025e: ldstr "-h"
+				IL_0263: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0268: stloc.s 5
+				IL_026a: ldloc.s 5
+				IL_026c: box [System.Runtime]System.Boolean
+				IL_0271: stloc.s 11
+				IL_0273: ldloc.s 11
+				IL_0275: stloc.s 12
+				IL_0277: br IL_0280
 
-				IL_028c: ldloc.s 7
-				IL_028e: stloc.s 13
+				IL_027c: ldloc.s 6
+				IL_027e: stloc.s 12
 
-				IL_0290: ldloc.s 13
-				IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0297: stloc.s 6
-				IL_0299: ldloc.s 6
-				IL_029b: brfalse IL_02b8
+				IL_0280: ldloc.s 12
+				IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0287: stloc.s 5
+				IL_0289: ldloc.s 5
+				IL_028b: brfalse IL_02a8
 
-				IL_02a0: ldloc.0
-				IL_02a1: ldstr "help"
-				IL_02a6: ldc.i4.1
-				IL_02a7: box [System.Runtime]System.Boolean
-				IL_02ac: ldc.i4.1
-				IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_02b2: pop
-				IL_02b3: br IL_02b8
+				IL_0290: ldloc.0
+				IL_0291: ldstr "help"
+				IL_0296: ldc.i4.1
+				IL_0297: box [System.Runtime]System.Boolean
+				IL_029c: ldc.i4.1
+				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_02a2: pop
+				IL_02a3: br IL_02a8
 
-				IL_02b8: ldloc.1
-				IL_02b9: ldc.r8 1
-				IL_02c2: add
-				IL_02c3: stloc.1
-				IL_02c4: br IL_0062
+				IL_02a8: ldloc.1
+				IL_02a9: ldc.r8 1
+				IL_02b2: add
+				IL_02b3: stloc.1
+				IL_02b4: br IL_0062
 			// end loop
 
-			IL_02c9: ldloc.0
-			IL_02ca: ret
+			IL_02b9: ldloc.0
+			IL_02ba: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
@@ -514,7 +511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ce
+				// Method begins at RVA 0x507e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -537,7 +534,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a34
+			// Method begins at RVA 0x2a1c
 			// Header size: 12
 			// Code size: 203 (0xcb)
 			.maxstack 8
@@ -623,7 +620,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d7
+				// Method begins at RVA 0x5087
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -649,7 +646,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2b0c
+			// Method begins at RVA 0x2af4
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -713,7 +710,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50e9
+					// Method begins at RVA 0x5099
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -731,7 +728,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50e0
+				// Method begins at RVA 0x5090
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -758,7 +755,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2b6c
+			// Method begins at RVA 0x2b54
 			// Header size: 12
 			// Code size: 120 (0x78)
 			.maxstack 8
@@ -834,7 +831,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50f2
+				// Method begins at RVA 0x50a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -858,7 +855,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bf0
+			// Method begins at RVA 0x2bd8
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -897,7 +894,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50fb
+				// Method begins at RVA 0x50ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -924,7 +921,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2c28
+			// Method begins at RVA 0x2c10
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -994,7 +991,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x510d
+					// Method begins at RVA 0x50bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1012,7 +1009,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5104
+				// Method begins at RVA 0x50b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1037,7 +1034,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ca4
+			// Method begins at RVA 0x2c8c
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -1143,7 +1140,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x511f
+					// Method begins at RVA 0x50cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1161,7 +1158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5116
+				// Method begins at RVA 0x50c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1189,7 +1186,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x513a
+						// Method begins at RVA 0x50ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1207,7 +1204,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5131
+					// Method begins at RVA 0x50e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1225,7 +1222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5128
+				// Method begins at RVA 0x50d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1250,7 +1247,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d60
+			// Method begins at RVA 0x2d48
 			// Header size: 12
 			// Code size: 478 (0x1de)
 			.maxstack 8
@@ -1478,7 +1475,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5143
+				// Method begins at RVA 0x50f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1506,7 +1503,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x515e
+						// Method begins at RVA 0x510e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1524,7 +1521,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5155
+					// Method begins at RVA 0x5105
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1542,7 +1539,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x514c
+				// Method begins at RVA 0x50fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1569,7 +1566,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2f68
+			// Method begins at RVA 0x2f50
 			// Header size: 12
 			// Code size: 212 (0xd4)
 			.maxstack 8
@@ -1701,7 +1698,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5170
+					// Method begins at RVA 0x5120
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1721,7 +1718,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5179
+					// Method begins at RVA 0x5129
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1741,7 +1738,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5182
+					// Method begins at RVA 0x5132
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1759,7 +1756,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5167
+				// Method begins at RVA 0x5117
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1786,7 +1783,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3058
+			// Method begins at RVA 0x3040
 			// Header size: 12
 			// Code size: 1232 (0x4d0)
 			.maxstack 8
@@ -2302,7 +2299,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x518b
+				// Method begins at RVA 0x513b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2329,7 +2326,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3534
+			// Method begins at RVA 0x351c
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -2384,7 +2381,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5194
+				// Method begins at RVA 0x5144
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2412,7 +2409,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3584
+			// Method begins at RVA 0x356c
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -2469,7 +2466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x519d
+				// Method begins at RVA 0x514d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2496,7 +2493,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x35e8
+			// Method begins at RVA 0x35d0
 			// Header size: 12
 			// Code size: 116 (0x74)
 			.maxstack 8
@@ -2573,7 +2570,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51af
+					// Method begins at RVA 0x515f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2591,7 +2588,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51a6
+				// Method begins at RVA 0x5156
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2619,7 +2616,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3668
+			// Method begins at RVA 0x3650
 			// Header size: 12
 			// Code size: 238 (0xee)
 			.maxstack 8
@@ -2748,7 +2745,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51c1
+					// Method begins at RVA 0x5171
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2766,7 +2763,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51b8
+				// Method begins at RVA 0x5168
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2794,7 +2791,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3764
+			// Method begins at RVA 0x374c
 			// Header size: 12
 			// Code size: 1099 (0x44b)
 			.maxstack 8
@@ -3193,7 +3190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51ca
+				// Method begins at RVA 0x517a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3220,7 +3217,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3bbc
+			// Method begins at RVA 0x3ba4
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -3263,7 +3260,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51dc
+					// Method begins at RVA 0x518c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3281,7 +3278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51d3
+				// Method begins at RVA 0x5183
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3308,7 +3305,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3bf4
+			// Method begins at RVA 0x3bdc
 			// Header size: 12
 			// Code size: 99 (0x63)
 			.maxstack 8
@@ -3376,7 +3373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51ee
+					// Method begins at RVA 0x519e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3396,7 +3393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51f7
+					// Method begins at RVA 0x51a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3414,7 +3411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51e5
+				// Method begins at RVA 0x5195
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3442,43 +3439,42 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3c64
+			// Method begins at RVA 0x3c4c
 			// Header size: 12
-			// Code size: 679 (0x2a7)
+			// Code size: 671 (0x29f)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] class Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L234C27,
+				[2] object,
 				[3] object,
-				[4] object,
-				[5] string,
+				[4] string,
+				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] float64,
-				[10] bool,
+				[8] float64,
+				[9] bool,
+				[10] object,
 				[11] object,
-				[12] object,
-				[13] string,
-				[14] object,
-				[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[16] string
+				[12] string,
+				[13] object,
+				[14] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[15] string
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: stloc.s 8
+			IL_000b: stloc.s 7
 			IL_000d: ldc.r8 4
 			IL_0016: ldc.r8 1024
 			IL_001f: mul
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 9
+			IL_0020: stloc.s 8
+			IL_0022: ldloc.s 8
 			IL_0024: ldc.r8 1024
 			IL_002d: mul
-			IL_002e: stloc.s 9
-			IL_0030: ldloc.s 8
+			IL_002e: stloc.s 8
+			IL_0030: ldloc.s 7
 			IL_0032: ldstr "spawnSync"
 			IL_0037: ldstr "git"
 			IL_003c: ldarg.2
@@ -3493,22 +3489,22 @@
 			IL_0059: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_005e: dup
 			IL_005f: ldstr "maxBuffer"
-			IL_0064: ldloc.s 9
+			IL_0064: ldloc.s 8
 			IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 			IL_006b: dup
 			IL_006c: ldstr "shell"
 			IL_0071: ldc.i4.0
 			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_007c: stloc.s 8
-			IL_007e: ldloc.s 8
+			IL_007c: stloc.s 7
+			IL_007e: ldloc.s 7
 			IL_0080: stloc.0
 			IL_0081: ldloc.0
 			IL_0082: ldstr "error"
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0091: stloc.s 10
-			IL_0093: ldloc.s 10
+			IL_0091: stloc.s 9
+			IL_0093: ldloc.s 9
 			IL_0095: brfalse IL_00bb
 
 			IL_009a: ldloc.0
@@ -3530,180 +3526,178 @@
 			IL_00bb: ldloc.0
 			IL_00bc: ldstr "status"
 			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c6: stloc.s 8
-			IL_00c8: ldloc.s 8
+			IL_00c6: stloc.s 7
+			IL_00c8: ldloc.s 7
 			IL_00ca: ldc.r8 0.0
 			IL_00d3: box [System.Runtime]System.Double
 			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00dd: stloc.s 10
-			IL_00df: ldloc.s 10
-			IL_00e1: brfalse IL_0281
+			IL_00dd: stloc.s 9
+			IL_00df: ldloc.s 9
+			IL_00e1: brfalse IL_0279
 
-			IL_00e6: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/Scope/Block_L234C27::.ctor()
-			IL_00eb: stloc.2
-			IL_00ec: ldloc.0
-			IL_00ed: ldstr "stderr"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.s 8
-			IL_00f9: ldloc.s 8
-			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0100: stloc.s 10
-			IL_0102: ldloc.s 10
-			IL_0104: brtrue IL_0115
+			IL_00e6: ldloc.0
+			IL_00e7: ldstr "stderr"
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f1: stloc.s 7
+			IL_00f3: ldloc.s 7
+			IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00fa: stloc.s 9
+			IL_00fc: ldloc.s 9
+			IL_00fe: brtrue IL_010f
 
-			IL_0109: ldstr ""
-			IL_010e: stloc.s 12
-			IL_0110: br IL_0119
+			IL_0103: ldstr ""
+			IL_0108: stloc.s 11
+			IL_010a: br IL_0113
 
-			IL_0115: ldloc.s 8
-			IL_0117: stloc.s 12
+			IL_010f: ldloc.s 7
+			IL_0111: stloc.s 11
 
-			IL_0119: ldloc.s 12
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0120: stloc.s 8
-			IL_0122: ldloc.s 8
-			IL_0124: castclass [System.Runtime]System.String
-			IL_0129: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_012e: stloc.s 13
-			IL_0130: ldloc.s 13
-			IL_0132: stloc.3
-			IL_0133: ldloc.0
-			IL_0134: ldstr "stdout"
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013e: stloc.s 8
-			IL_0140: ldloc.s 8
-			IL_0142: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0147: stloc.s 10
-			IL_0149: ldloc.s 10
-			IL_014b: brtrue IL_015c
+			IL_0113: ldloc.s 11
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011a: stloc.s 7
+			IL_011c: ldloc.s 7
+			IL_011e: castclass [System.Runtime]System.String
+			IL_0123: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0128: stloc.s 12
+			IL_012a: ldloc.s 12
+			IL_012c: stloc.2
+			IL_012d: ldloc.0
+			IL_012e: ldstr "stdout"
+			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0138: stloc.s 7
+			IL_013a: ldloc.s 7
+			IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0141: stloc.s 9
+			IL_0143: ldloc.s 9
+			IL_0145: brtrue IL_0156
 
-			IL_0150: ldstr ""
-			IL_0155: stloc.s 14
-			IL_0157: br IL_0160
+			IL_014a: ldstr ""
+			IL_014f: stloc.s 13
+			IL_0151: br IL_015a
 
-			IL_015c: ldloc.s 8
-			IL_015e: stloc.s 14
+			IL_0156: ldloc.s 7
+			IL_0158: stloc.s 13
 
-			IL_0160: ldloc.s 14
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
-			IL_016b: castclass [System.Runtime]System.String
-			IL_0170: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0175: stloc.s 13
-			IL_0177: ldloc.s 13
-			IL_0179: stloc.s 4
-			IL_017b: ldc.i4.2
-			IL_017c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_015a: ldloc.s 13
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0161: stloc.s 7
+			IL_0163: ldloc.s 7
+			IL_0165: castclass [System.Runtime]System.String
+			IL_016a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_016f: stloc.s 12
+			IL_0171: ldloc.s 12
+			IL_0173: stloc.3
+			IL_0174: ldc.i4.2
+			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_017a: dup
+			IL_017b: ldloc.2
+			IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0181: dup
 			IL_0182: ldloc.3
 			IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0188: dup
-			IL_0189: ldloc.s 4
-			IL_018b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0190: stloc.s 15
-			IL_0192: ldstr "Boolean"
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019c: stloc.s 8
-			IL_019e: ldloc.s 15
-			IL_01a0: ldc.i4.1
-			IL_01a1: newarr [System.Runtime]System.Object
-			IL_01a6: dup
-			IL_01a7: ldc.i4.0
-			IL_01a8: ldloc.s 8
-			IL_01aa: stelem.ref
-			IL_01ab: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
-			IL_01b0: stloc.s 15
-			IL_01b2: ldloc.s 15
-			IL_01b4: ldc.i4.1
-			IL_01b5: newarr [System.Runtime]System.Object
-			IL_01ba: dup
-			IL_01bb: ldc.i4.0
-			IL_01bc: ldstr "\n"
-			IL_01c1: stelem.ref
-			IL_01c2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01c7: stloc.s 13
-			IL_01c9: ldloc.s 13
-			IL_01cb: stloc.s 5
-			IL_01cd: ldarg.2
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d3: stloc.s 8
-			IL_01d5: ldloc.s 8
-			IL_01d7: ldstr "join"
-			IL_01dc: ldstr " "
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01e6: stloc.s 8
-			IL_01e8: ldloc.s 8
-			IL_01ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ef: stloc.s 13
-			IL_01f1: ldstr "git "
-			IL_01f6: ldloc.s 13
-			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fd: stloc.s 13
-			IL_01ff: ldloc.s 13
-			IL_0201: ldstr " failed"
-			IL_0206: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020b: stloc.s 13
-			IL_020d: ldloc.s 5
-			IL_020f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0214: stloc.s 10
-			IL_0216: ldloc.s 10
-			IL_0218: brfalse IL_023d
+			IL_0188: stloc.s 14
+			IL_018a: ldstr "Boolean"
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0194: stloc.s 7
+			IL_0196: ldloc.s 14
+			IL_0198: ldc.i4.1
+			IL_0199: newarr [System.Runtime]System.Object
+			IL_019e: dup
+			IL_019f: ldc.i4.0
+			IL_01a0: ldloc.s 7
+			IL_01a2: stelem.ref
+			IL_01a3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
+			IL_01a8: stloc.s 14
+			IL_01aa: ldloc.s 14
+			IL_01ac: ldc.i4.1
+			IL_01ad: newarr [System.Runtime]System.Object
+			IL_01b2: dup
+			IL_01b3: ldc.i4.0
+			IL_01b4: ldstr "\n"
+			IL_01b9: stelem.ref
+			IL_01ba: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01bf: stloc.s 12
+			IL_01c1: ldloc.s 12
+			IL_01c3: stloc.s 4
+			IL_01c5: ldarg.2
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cb: stloc.s 7
+			IL_01cd: ldloc.s 7
+			IL_01cf: ldstr "join"
+			IL_01d4: ldstr " "
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01de: stloc.s 7
+			IL_01e0: ldloc.s 7
+			IL_01e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e7: stloc.s 12
+			IL_01e9: ldstr "git "
+			IL_01ee: ldloc.s 12
+			IL_01f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f5: stloc.s 12
+			IL_01f7: ldloc.s 12
+			IL_01f9: ldstr " failed"
+			IL_01fe: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0203: stloc.s 12
+			IL_0205: ldloc.s 4
+			IL_0207: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_020c: stloc.s 9
+			IL_020e: ldloc.s 9
+			IL_0210: brfalse IL_0235
 
-			IL_021d: ldloc.s 5
-			IL_021f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0224: stloc.s 16
-			IL_0226: ldstr ":\n"
-			IL_022b: ldloc.s 16
-			IL_022d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0232: stloc.s 16
-			IL_0234: ldloc.s 16
-			IL_0236: stloc.s 6
-			IL_0238: br IL_0244
+			IL_0215: ldloc.s 4
+			IL_0217: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_021c: stloc.s 15
+			IL_021e: ldstr ":\n"
+			IL_0223: ldloc.s 15
+			IL_0225: call string [System.Runtime]System.String::Concat(string, string)
+			IL_022a: stloc.s 15
+			IL_022c: ldloc.s 15
+			IL_022e: stloc.s 5
+			IL_0230: br IL_023c
 
-			IL_023d: ldstr "."
-			IL_0242: stloc.s 6
+			IL_0235: ldstr "."
+			IL_023a: stloc.s 5
 
-			IL_0244: ldloc.s 6
-			IL_0246: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_024b: stloc.s 16
-			IL_024d: ldloc.s 13
-			IL_024f: ldloc.s 16
-			IL_0251: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0256: stloc.s 16
-			IL_0258: ldloc.s 16
-			IL_025a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0264: stloc.s 8
-			IL_0266: ldloc.s 8
-			IL_0268: stloc.s 7
-			IL_026a: ldloc.s 7
-			IL_026c: isinst [System.Runtime]System.Exception
-			IL_0271: dup
-			IL_0272: brtrue IL_0280
+			IL_023c: ldloc.s 5
+			IL_023e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0243: stloc.s 15
+			IL_0245: ldloc.s 12
+			IL_0247: ldloc.s 15
+			IL_0249: call string [System.Runtime]System.String::Concat(string, string)
+			IL_024e: stloc.s 15
+			IL_0250: ldloc.s 15
+			IL_0252: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0257: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_025c: stloc.s 7
+			IL_025e: ldloc.s 7
+			IL_0260: stloc.s 6
+			IL_0262: ldloc.s 6
+			IL_0264: isinst [System.Runtime]System.Exception
+			IL_0269: dup
+			IL_026a: brtrue IL_0278
 
-			IL_0277: pop
-			IL_0278: ldloc.s 7
-			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_027f: throw
+			IL_026f: pop
+			IL_0270: ldloc.s 6
+			IL_0272: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0277: throw
 
-			IL_0280: throw
+			IL_0278: throw
 
-			IL_0281: ldloc.0
-			IL_0282: ldstr "stdout"
-			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028c: stloc.s 8
-			IL_028e: ldloc.s 8
-			IL_0290: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0295: stloc.s 10
-			IL_0297: ldloc.s 10
-			IL_0299: brtrue IL_02a4
+			IL_0279: ldloc.0
+			IL_027a: ldstr "stdout"
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0284: stloc.s 7
+			IL_0286: ldloc.s 7
+			IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_028d: stloc.s 9
+			IL_028f: ldloc.s 9
+			IL_0291: brtrue IL_029c
 
-			IL_029e: ldstr ""
-			IL_02a3: ret
+			IL_0296: ldstr ""
+			IL_029b: ret
 
-			IL_02a4: ldloc.s 8
-			IL_02a6: ret
+			IL_029c: ldloc.s 7
+			IL_029e: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -3719,7 +3713,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5200
+				// Method begins at RVA 0x51b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3743,7 +3737,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5212
+					// Method begins at RVA 0x51c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3755,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5209
+				// Method begins at RVA 0x51b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3785,7 +3779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5224
+					// Method begins at RVA 0x51d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3803,7 +3797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x521b
+				// Method begins at RVA 0x51cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3830,9 +3824,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3f18
+			// Method begins at RVA 0x3ef8
 			// Header size: 12
-			// Code size: 408 (0x198)
+			// Code size: 401 (0x191)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3844,11 +3838,10 @@
 				[6] bool,
 				[7] bool,
 				[8] object,
-				[9] class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54,
+				[9] object,
 				[10] object,
-				[11] object,
-				[12] bool,
-				[13] string
+				[11] bool,
+				[12] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -3868,17 +3861,17 @@
 				// loop start (head: IL_001c)
 					IL_001c: ldloc.1
 					IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_0022: stloc.s 11
-					IL_0024: ldloc.s 11
+					IL_0022: stloc.s 10
+					IL_0024: ldloc.s 10
 					IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_002b: stloc.s 12
-					IL_002d: ldloc.s 12
+					IL_002b: stloc.s 11
+					IL_002d: ldloc.s 11
 					IL_002f: brtrue IL_008c
 
-					IL_0034: ldloc.s 11
+					IL_0034: ldloc.s 10
 					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_003b: stloc.s 11
-					IL_003d: ldloc.s 11
+					IL_003b: stloc.s 10
+					IL_003d: ldloc.s 10
 					IL_003f: stloc.s 4
 					IL_0041: ldarg.0
 					IL_0042: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
@@ -3890,16 +3883,16 @@
 					IL_0050: stelem.ref
 					IL_0051: ldloc.s 4
 					IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0058: stloc.s 11
-					IL_005a: ldloc.s 11
+					IL_0058: stloc.s 10
+					IL_005a: ldloc.s 10
 					IL_005c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0061: stloc.s 13
+					IL_0061: stloc.s 12
 					IL_0063: ldstr "/"
-					IL_0068: ldloc.s 13
+					IL_0068: ldloc.s 12
 					IL_006a: call string [System.Runtime]System.String::Concat(string, string)
-					IL_006f: stloc.s 13
+					IL_006f: stloc.s 12
 					IL_0071: ldloc.0
-					IL_0072: ldloc.s 13
+					IL_0072: ldloc.s 12
 					IL_0074: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_0079: pop
 					IL_007a: br IL_001c
@@ -3942,91 +3935,89 @@
 				// loop start (head: IL_00be)
 					IL_00be: ldloc.s 5
 					IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_00c5: stloc.s 11
-					IL_00c7: ldloc.s 11
+					IL_00c5: stloc.s 10
+					IL_00c7: ldloc.s 10
 					IL_00c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_00ce: stloc.s 12
-					IL_00d0: ldloc.s 12
-					IL_00d2: brtrue IL_0178
+					IL_00ce: stloc.s 11
+					IL_00d0: ldloc.s 11
+					IL_00d2: brtrue IL_0171
 
-					IL_00d7: ldloc.s 11
+					IL_00d7: ldloc.s 10
 					IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_00de: stloc.s 11
-					IL_00e0: ldloc.s 11
+					IL_00de: stloc.s 10
+					IL_00e0: ldloc.s 10
 					IL_00e2: stloc.s 8
-					IL_00e4: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
-					IL_00e9: stloc.s 9
-					IL_00eb: ldarg.0
-					IL_00ec: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_00f1: ldc.i4.1
-					IL_00f2: newarr [System.Runtime]System.Object
-					IL_00f7: dup
-					IL_00f8: ldc.i4.0
-					IL_00f9: ldarg.0
-					IL_00fa: stelem.ref
-					IL_00fb: ldloc.s 8
-					IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0102: stloc.s 11
-					IL_0104: ldloc.s 11
-					IL_0106: stloc.s 10
-					IL_0108: ldloc.s 10
-					IL_010a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_010f: stloc.s 13
-					IL_0111: ldstr "/"
-					IL_0116: ldloc.s 13
-					IL_0118: call string [System.Runtime]System.String::Concat(string, string)
-					IL_011d: stloc.s 13
-					IL_011f: ldloc.s 13
-					IL_0121: ldstr "/"
-					IL_0126: call string [System.Runtime]System.String::Concat(string, string)
-					IL_012b: stloc.s 13
-					IL_012d: ldloc.0
-					IL_012e: ldloc.s 13
-					IL_0130: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0135: pop
-					IL_0136: ldloc.s 10
-					IL_0138: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_013d: stloc.s 13
-					IL_013f: ldstr "/"
-					IL_0144: ldloc.s 13
-					IL_0146: call string [System.Runtime]System.String::Concat(string, string)
-					IL_014b: stloc.s 13
-					IL_014d: ldloc.s 13
-					IL_014f: ldstr "/**"
-					IL_0154: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0159: stloc.s 13
-					IL_015b: ldloc.0
-					IL_015c: ldloc.s 13
-					IL_015e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0163: pop
-					IL_0164: br IL_00be
+					IL_00e4: ldarg.0
+					IL_00e5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_00ea: ldc.i4.1
+					IL_00eb: newarr [System.Runtime]System.Object
+					IL_00f0: dup
+					IL_00f1: ldc.i4.0
+					IL_00f2: ldarg.0
+					IL_00f3: stelem.ref
+					IL_00f4: ldloc.s 8
+					IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_00fb: stloc.s 10
+					IL_00fd: ldloc.s 10
+					IL_00ff: stloc.s 9
+					IL_0101: ldloc.s 9
+					IL_0103: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0108: stloc.s 12
+					IL_010a: ldstr "/"
+					IL_010f: ldloc.s 12
+					IL_0111: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0116: stloc.s 12
+					IL_0118: ldloc.s 12
+					IL_011a: ldstr "/"
+					IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0124: stloc.s 12
+					IL_0126: ldloc.0
+					IL_0127: ldloc.s 12
+					IL_0129: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_012e: pop
+					IL_012f: ldloc.s 9
+					IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0136: stloc.s 12
+					IL_0138: ldstr "/"
+					IL_013d: ldloc.s 12
+					IL_013f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0144: stloc.s 12
+					IL_0146: ldloc.s 12
+					IL_0148: ldstr "/**"
+					IL_014d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0152: stloc.s 12
+					IL_0154: ldloc.0
+					IL_0155: ldloc.s 12
+					IL_0157: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_015c: pop
+					IL_015d: br IL_00be
 				// end loop
-				IL_0169: ldloc.s 5
-				IL_016b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0170: ldc.i4.1
-				IL_0171: stloc.s 7
-				IL_0173: leave IL_0196
+				IL_0162: ldloc.s 5
+				IL_0164: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0169: ldc.i4.1
+				IL_016a: stloc.s 7
+				IL_016c: leave IL_018f
 
-				IL_0178: ldc.i4.1
-				IL_0179: stloc.s 6
-				IL_017b: leave IL_0196
+				IL_0171: ldc.i4.1
+				IL_0172: stloc.s 6
+				IL_0174: leave IL_018f
 			} // end .try
 			finally
 			{
-				IL_0180: ldloc.s 6
-				IL_0182: brtrue IL_0195
+				IL_0179: ldloc.s 6
+				IL_017b: brtrue IL_018e
 
-				IL_0187: ldloc.s 7
-				IL_0189: brtrue IL_0195
+				IL_0180: ldloc.s 7
+				IL_0182: brtrue IL_018e
 
-				IL_018e: ldloc.s 5
-				IL_0190: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0187: ldloc.s 5
+				IL_0189: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0195: endfinally
+				IL_018e: endfinally
 			} // end handler
 
-			IL_0196: ldloc.0
-			IL_0197: ret
+			IL_018f: ldloc.0
+			IL_0190: ret
 		} // end of method buildSparsePatterns::__js_call__
 
 	} // end of class buildSparsePatterns
@@ -4050,7 +4041,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5275
+						// Method begins at RVA 0x5225
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4070,7 +4061,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x527e
+						// Method begins at RVA 0x522e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4088,7 +4079,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x526c
+					// Method begins at RVA 0x521c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4108,7 +4099,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5287
+					// Method begins at RVA 0x5237
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4126,7 +4117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x522d
+				// Method begins at RVA 0x51dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4154,7 +4145,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5248
+						// Method begins at RVA 0x51f8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4172,7 +4163,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x523f
+					// Method begins at RVA 0x51ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4190,7 +4181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5236
+				// Method begins at RVA 0x51e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4218,7 +4209,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5263
+						// Method begins at RVA 0x5213
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4236,7 +4227,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x525a
+					// Method begins at RVA 0x520a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4254,7 +4245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5251
+				// Method begins at RVA 0x5201
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4282,9 +4273,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x40d8
+			// Method begins at RVA 0x40b4
 			// Header size: 12
-			// Code size: 1582 (0x62e)
+			// Code size: 1561 (0x619)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4293,35 +4284,32 @@
 				[3] bool,
 				[4] bool,
 				[5] object,
-				[6] class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44,
-				[7] object,
-				[8] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[6] object,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[8] bool,
 				[9] bool,
-				[10] bool,
+				[10] object,
 				[11] object,
-				[12] class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55,
+				[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[13] object,
-				[14] class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64,
-				[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[14] object,
+				[15] object,
 				[16] object,
-				[17] object,
-				[18] object,
+				[17] bool,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[19] object,
-				[20] bool,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[20] object[],
+				[21] object,
 				[22] object,
-				[23] object[],
+				[23] object,
 				[24] object,
 				[25] object,
 				[26] object,
-				[27] object,
-				[28] object,
+				[27] string,
+				[28] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[29] object,
-				[30] string,
-				[31] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[32] object,
-				[33] object,
-				[34] string
+				[30] object,
+				[31] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -4344,568 +4332,562 @@
 				// loop start (head: IL_0024)
 					IL_0024: ldloc.2
 					IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_002a: stloc.s 19
-					IL_002c: ldloc.s 19
+					IL_002a: stloc.s 16
+					IL_002c: ldloc.s 16
 					IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0033: stloc.s 20
-					IL_0035: ldloc.s 20
-					IL_0037: brtrue IL_018b
+					IL_0033: stloc.s 17
+					IL_0035: ldloc.s 17
+					IL_0037: brtrue IL_0184
 
-					IL_003c: ldloc.s 19
+					IL_003c: ldloc.s 16
 					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0043: stloc.s 19
-					IL_0045: ldloc.s 19
+					IL_0043: stloc.s 16
+					IL_0045: ldloc.s 16
 					IL_0047: stloc.s 5
-					IL_0049: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44::.ctor()
-					IL_004e: stloc.s 6
-					IL_0050: ldarg.0
-					IL_0051: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_005b: stloc.s 19
-					IL_005d: ldc.i4.1
-					IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0063: dup
-					IL_0064: ldarg.2
-					IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_006a: stloc.s 21
-					IL_006c: ldarg.0
-					IL_006d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_0072: ldc.i4.1
-					IL_0073: newarr [System.Runtime]System.Object
-					IL_0078: dup
-					IL_0079: ldc.i4.0
-					IL_007a: ldarg.0
-					IL_007b: stelem.ref
-					IL_007c: ldloc.s 5
-					IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0083: stloc.s 22
-					IL_0085: ldloc.s 22
-					IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_008c: stloc.s 22
-					IL_008e: ldloc.s 22
-					IL_0090: ldstr "split"
-					IL_0095: ldstr "/"
-					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_009f: stloc.s 22
-					IL_00a1: ldloc.s 21
-					IL_00a3: ldloc.s 22
-					IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00aa: ldloc.s 21
-					IL_00ac: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00b1: stloc.s 23
-					IL_00b3: ldloc.s 19
-					IL_00b5: ldstr "join"
-					IL_00ba: ldloc.s 23
-					IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_00c1: stloc.s 19
-					IL_00c3: ldloc.s 19
-					IL_00c5: stloc.s 7
-					IL_00c7: ldarg.0
-					IL_00c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00d2: stloc.s 19
-					IL_00d4: ldloc.s 19
-					IL_00d6: ldstr "existsSync"
-					IL_00db: ldloc.s 7
-					IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00e2: stloc.s 19
-					IL_00e4: ldloc.s 19
-					IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_00eb: ldc.i4.0
-					IL_00ec: ceq
-					IL_00ee: stloc.s 20
-					IL_00f0: ldloc.s 20
-					IL_00f2: box [System.Runtime]System.Boolean
-					IL_00f7: stloc.s 24
-					IL_00f9: ldloc.s 24
-					IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0100: stloc.s 20
-					IL_0102: ldloc.s 20
-					IL_0104: brtrue IL_015b
+					IL_0049: ldarg.0
+					IL_004a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0054: stloc.s 16
+					IL_0056: ldc.i4.1
+					IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_005c: dup
+					IL_005d: ldarg.2
+					IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_0063: stloc.s 18
+					IL_0065: ldarg.0
+					IL_0066: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_006b: ldc.i4.1
+					IL_006c: newarr [System.Runtime]System.Object
+					IL_0071: dup
+					IL_0072: ldc.i4.0
+					IL_0073: ldarg.0
+					IL_0074: stelem.ref
+					IL_0075: ldloc.s 5
+					IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_007c: stloc.s 19
+					IL_007e: ldloc.s 19
+					IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0085: stloc.s 19
+					IL_0087: ldloc.s 19
+					IL_0089: ldstr "split"
+					IL_008e: ldstr "/"
+					IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0098: stloc.s 19
+					IL_009a: ldloc.s 18
+					IL_009c: ldloc.s 19
+					IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00a3: ldloc.s 18
+					IL_00a5: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00aa: stloc.s 20
+					IL_00ac: ldloc.s 16
+					IL_00ae: ldstr "join"
+					IL_00b3: ldloc.s 20
+					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_00ba: stloc.s 16
+					IL_00bc: ldloc.s 16
+					IL_00be: stloc.s 6
+					IL_00c0: ldarg.0
+					IL_00c1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00cb: stloc.s 16
+					IL_00cd: ldloc.s 16
+					IL_00cf: ldstr "existsSync"
+					IL_00d4: ldloc.s 6
+					IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00db: stloc.s 16
+					IL_00dd: ldloc.s 16
+					IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_00e4: ldc.i4.0
+					IL_00e5: ceq
+					IL_00e7: stloc.s 17
+					IL_00e9: ldloc.s 17
+					IL_00eb: box [System.Runtime]System.Boolean
+					IL_00f0: stloc.s 21
+					IL_00f2: ldloc.s 21
+					IL_00f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00f9: stloc.s 17
+					IL_00fb: ldloc.s 17
+					IL_00fd: brtrue IL_0154
 
-					IL_0109: ldarg.0
-					IL_010a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0114: stloc.s 19
-					IL_0116: ldloc.s 19
-					IL_0118: ldstr "statSync"
-					IL_011d: ldloc.s 7
-					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0124: stloc.s 19
-					IL_0126: ldloc.s 19
-					IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_012d: stloc.s 19
-					IL_012f: ldloc.s 19
-					IL_0131: ldstr "isFile"
-					IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_013b: stloc.s 19
-					IL_013d: ldloc.s 19
-					IL_013f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0144: ldc.i4.0
-					IL_0145: ceq
-					IL_0147: stloc.s 20
-					IL_0149: ldloc.s 20
-					IL_014b: box [System.Runtime]System.Boolean
-					IL_0150: stloc.s 25
-					IL_0152: ldloc.s 25
-					IL_0154: stloc.s 27
-					IL_0156: br IL_015f
+					IL_0102: ldarg.0
+					IL_0103: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_010d: stloc.s 16
+					IL_010f: ldloc.s 16
+					IL_0111: ldstr "statSync"
+					IL_0116: ldloc.s 6
+					IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_011d: stloc.s 16
+					IL_011f: ldloc.s 16
+					IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0126: stloc.s 16
+					IL_0128: ldloc.s 16
+					IL_012a: ldstr "isFile"
+					IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0134: stloc.s 16
+					IL_0136: ldloc.s 16
+					IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_013d: ldc.i4.0
+					IL_013e: ceq
+					IL_0140: stloc.s 17
+					IL_0142: ldloc.s 17
+					IL_0144: box [System.Runtime]System.Boolean
+					IL_0149: stloc.s 22
+					IL_014b: ldloc.s 22
+					IL_014d: stloc.s 24
+					IL_014f: br IL_0158
 
-					IL_015b: ldloc.s 24
-					IL_015d: stloc.s 27
+					IL_0154: ldloc.s 21
+					IL_0156: stloc.s 24
 
-					IL_015f: ldloc.s 27
-					IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0166: stloc.s 20
-					IL_0168: ldloc.s 20
-					IL_016a: brfalse IL_0178
+					IL_0158: ldloc.s 24
+					IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_015f: stloc.s 17
+					IL_0161: ldloc.s 17
+					IL_0163: brfalse IL_0171
 
-					IL_016f: ldloc.0
-					IL_0170: ldloc.s 5
-					IL_0172: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0177: pop
+					IL_0168: ldloc.0
+					IL_0169: ldloc.s 5
+					IL_016b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0170: pop
 
-					IL_0178: br IL_0024
+					IL_0171: br IL_0024
 				// end loop
-				IL_017d: ldloc.2
-				IL_017e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0183: ldc.i4.1
-				IL_0184: stloc.s 4
-				IL_0186: leave IL_01a6
+				IL_0176: ldloc.2
+				IL_0177: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_017c: ldc.i4.1
+				IL_017d: stloc.s 4
+				IL_017f: leave IL_019f
 
-				IL_018b: ldc.i4.1
-				IL_018c: stloc.3
-				IL_018d: leave IL_01a6
+				IL_0184: ldc.i4.1
+				IL_0185: stloc.3
+				IL_0186: leave IL_019f
 			} // end .try
 			finally
 			{
-				IL_0192: ldloc.3
-				IL_0193: brtrue IL_01a5
+				IL_018b: ldloc.3
+				IL_018c: brtrue IL_019e
 
-				IL_0198: ldloc.s 4
-				IL_019a: brtrue IL_01a5
+				IL_0191: ldloc.s 4
+				IL_0193: brtrue IL_019e
 
-				IL_019f: ldloc.2
-				IL_01a0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0198: ldloc.2
+				IL_0199: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_01a5: endfinally
+				IL_019e: endfinally
 			} // end handler
 
-			IL_01a6: ldarg.3
-			IL_01a7: ldstr "requiredDirectories"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_01b6: stloc.s 8
-			IL_01b8: ldc.i4.0
-			IL_01b9: stloc.s 9
-			IL_01bb: ldc.i4.0
-			IL_01bc: stloc.s 10
+			IL_019f: ldarg.3
+			IL_01a0: ldstr "requiredDirectories"
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01aa: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_01af: stloc.s 7
+			IL_01b1: ldc.i4.0
+			IL_01b2: stloc.s 8
+			IL_01b4: ldc.i4.0
+			IL_01b5: stloc.s 9
 			.try
 			{
-				// loop start (head: IL_01be)
-					IL_01be: ldloc.s 8
-					IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_01c5: stloc.s 19
-					IL_01c7: ldloc.s 19
-					IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_01ce: stloc.s 20
-					IL_01d0: ldloc.s 20
-					IL_01d2: brtrue IL_0327
+				// loop start (head: IL_01b7)
+					IL_01b7: ldloc.s 7
+					IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_01be: stloc.s 16
+					IL_01c0: ldloc.s 16
+					IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_01c7: stloc.s 17
+					IL_01c9: ldloc.s 17
+					IL_01cb: brtrue IL_0319
 
-					IL_01d7: ldloc.s 19
-					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_01de: stloc.s 19
-					IL_01e0: ldloc.s 19
-					IL_01e2: stloc.s 11
-					IL_01e4: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
-					IL_01e9: stloc.s 12
-					IL_01eb: ldarg.0
-					IL_01ec: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01f6: stloc.s 19
-					IL_01f8: ldc.i4.1
-					IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_01fe: dup
-					IL_01ff: ldarg.2
-					IL_0200: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0205: stloc.s 21
+					IL_01d0: ldloc.s 16
+					IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_01d7: stloc.s 16
+					IL_01d9: ldloc.s 16
+					IL_01db: stloc.s 10
+					IL_01dd: ldarg.0
+					IL_01de: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01e8: stloc.s 16
+					IL_01ea: ldc.i4.1
+					IL_01eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01f0: dup
+					IL_01f1: ldarg.2
+					IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_01f7: stloc.s 18
+					IL_01f9: ldarg.0
+					IL_01fa: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_01ff: ldc.i4.1
+					IL_0200: newarr [System.Runtime]System.Object
+					IL_0205: dup
+					IL_0206: ldc.i4.0
 					IL_0207: ldarg.0
-					IL_0208: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_020d: ldc.i4.1
-					IL_020e: newarr [System.Runtime]System.Object
-					IL_0213: dup
-					IL_0214: ldc.i4.0
-					IL_0215: ldarg.0
-					IL_0216: stelem.ref
-					IL_0217: ldloc.s 11
-					IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_021e: stloc.s 22
-					IL_0220: ldloc.s 22
-					IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0227: stloc.s 22
-					IL_0229: ldloc.s 22
-					IL_022b: ldstr "split"
-					IL_0230: ldstr "/"
-					IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_023a: stloc.s 22
-					IL_023c: ldloc.s 21
-					IL_023e: ldloc.s 22
-					IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_0245: ldloc.s 21
-					IL_0247: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_024c: stloc.s 23
-					IL_024e: ldloc.s 19
-					IL_0250: ldstr "join"
-					IL_0255: ldloc.s 23
-					IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_025c: stloc.s 19
-					IL_025e: ldloc.s 19
-					IL_0260: stloc.s 13
-					IL_0262: ldarg.0
-					IL_0263: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_026d: stloc.s 19
-					IL_026f: ldloc.s 19
-					IL_0271: ldstr "existsSync"
-					IL_0276: ldloc.s 13
-					IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_027d: stloc.s 19
-					IL_027f: ldloc.s 19
-					IL_0281: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0286: ldc.i4.0
-					IL_0287: ceq
-					IL_0289: stloc.s 20
-					IL_028b: ldloc.s 20
-					IL_028d: box [System.Runtime]System.Boolean
-					IL_0292: stloc.s 24
-					IL_0294: ldloc.s 24
-					IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_029b: stloc.s 20
-					IL_029d: ldloc.s 20
-					IL_029f: brtrue IL_02f6
+					IL_0208: stelem.ref
+					IL_0209: ldloc.s 10
+					IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0210: stloc.s 19
+					IL_0212: ldloc.s 19
+					IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0219: stloc.s 19
+					IL_021b: ldloc.s 19
+					IL_021d: ldstr "split"
+					IL_0222: ldstr "/"
+					IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_022c: stloc.s 19
+					IL_022e: ldloc.s 18
+					IL_0230: ldloc.s 19
+					IL_0232: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_0237: ldloc.s 18
+					IL_0239: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_023e: stloc.s 20
+					IL_0240: ldloc.s 16
+					IL_0242: ldstr "join"
+					IL_0247: ldloc.s 20
+					IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_024e: stloc.s 16
+					IL_0250: ldloc.s 16
+					IL_0252: stloc.s 11
+					IL_0254: ldarg.0
+					IL_0255: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_025f: stloc.s 16
+					IL_0261: ldloc.s 16
+					IL_0263: ldstr "existsSync"
+					IL_0268: ldloc.s 11
+					IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_026f: stloc.s 16
+					IL_0271: ldloc.s 16
+					IL_0273: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0278: ldc.i4.0
+					IL_0279: ceq
+					IL_027b: stloc.s 17
+					IL_027d: ldloc.s 17
+					IL_027f: box [System.Runtime]System.Boolean
+					IL_0284: stloc.s 21
+					IL_0286: ldloc.s 21
+					IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_028d: stloc.s 17
+					IL_028f: ldloc.s 17
+					IL_0291: brtrue IL_02e8
 
-					IL_02a4: ldarg.0
-					IL_02a5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02af: stloc.s 19
-					IL_02b1: ldloc.s 19
-					IL_02b3: ldstr "statSync"
-					IL_02b8: ldloc.s 13
-					IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_02bf: stloc.s 19
-					IL_02c1: ldloc.s 19
-					IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02c8: stloc.s 19
-					IL_02ca: ldloc.s 19
-					IL_02cc: ldstr "isDirectory"
-					IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02d6: stloc.s 19
-					IL_02d8: ldloc.s 19
-					IL_02da: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02df: ldc.i4.0
-					IL_02e0: ceq
-					IL_02e2: stloc.s 20
-					IL_02e4: ldloc.s 20
-					IL_02e6: box [System.Runtime]System.Boolean
-					IL_02eb: stloc.s 25
-					IL_02ed: ldloc.s 25
-					IL_02ef: stloc.s 28
-					IL_02f1: br IL_02fa
+					IL_0296: ldarg.0
+					IL_0297: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02a1: stloc.s 16
+					IL_02a3: ldloc.s 16
+					IL_02a5: ldstr "statSync"
+					IL_02aa: ldloc.s 11
+					IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_02b1: stloc.s 16
+					IL_02b3: ldloc.s 16
+					IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02ba: stloc.s 16
+					IL_02bc: ldloc.s 16
+					IL_02be: ldstr "isDirectory"
+					IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02c8: stloc.s 16
+					IL_02ca: ldloc.s 16
+					IL_02cc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02d1: ldc.i4.0
+					IL_02d2: ceq
+					IL_02d4: stloc.s 17
+					IL_02d6: ldloc.s 17
+					IL_02d8: box [System.Runtime]System.Boolean
+					IL_02dd: stloc.s 22
+					IL_02df: ldloc.s 22
+					IL_02e1: stloc.s 25
+					IL_02e3: br IL_02ec
 
-					IL_02f6: ldloc.s 24
-					IL_02f8: stloc.s 28
+					IL_02e8: ldloc.s 21
+					IL_02ea: stloc.s 25
 
-					IL_02fa: ldloc.s 28
-					IL_02fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0301: stloc.s 20
-					IL_0303: ldloc.s 20
-					IL_0305: brfalse IL_0313
+					IL_02ec: ldloc.s 25
+					IL_02ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02f3: stloc.s 17
+					IL_02f5: ldloc.s 17
+					IL_02f7: brfalse IL_0305
 
-					IL_030a: ldloc.1
-					IL_030b: ldloc.s 11
-					IL_030d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0312: pop
+					IL_02fc: ldloc.1
+					IL_02fd: ldloc.s 10
+					IL_02ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0304: pop
 
-					IL_0313: br IL_01be
+					IL_0305: br IL_01b7
 				// end loop
-				IL_0318: ldloc.s 8
-				IL_031a: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_031f: ldc.i4.1
-				IL_0320: stloc.s 10
-				IL_0322: leave IL_0345
+				IL_030a: ldloc.s 7
+				IL_030c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0311: ldc.i4.1
+				IL_0312: stloc.s 9
+				IL_0314: leave IL_0337
 
-				IL_0327: ldc.i4.1
-				IL_0328: stloc.s 9
-				IL_032a: leave IL_0345
+				IL_0319: ldc.i4.1
+				IL_031a: stloc.s 8
+				IL_031c: leave IL_0337
 			} // end .try
 			finally
 			{
-				IL_032f: ldloc.s 9
-				IL_0331: brtrue IL_0344
+				IL_0321: ldloc.s 8
+				IL_0323: brtrue IL_0336
 
-				IL_0336: ldloc.s 10
-				IL_0338: brtrue IL_0344
+				IL_0328: ldloc.s 9
+				IL_032a: brtrue IL_0336
 
-				IL_033d: ldloc.s 8
-				IL_033f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_032f: ldloc.s 7
+				IL_0331: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0344: endfinally
+				IL_0336: endfinally
 			} // end handler
 
-			IL_0345: ldloc.0
-			IL_0346: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_034b: ldc.r8 0.0
-			IL_0354: cgt
-			IL_0356: box [System.Runtime]System.Boolean
-			IL_035b: stloc.s 24
-			IL_035d: ldloc.s 24
-			IL_035f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0364: stloc.s 20
-			IL_0366: ldloc.s 20
-			IL_0368: brtrue IL_038a
+			IL_0337: ldloc.0
+			IL_0338: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_033d: ldc.r8 0.0
+			IL_0346: cgt
+			IL_0348: box [System.Runtime]System.Boolean
+			IL_034d: stloc.s 21
+			IL_034f: ldloc.s 21
+			IL_0351: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0356: stloc.s 17
+			IL_0358: ldloc.s 17
+			IL_035a: brtrue IL_037c
 
-			IL_036d: ldloc.1
-			IL_036e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0373: ldc.r8 0.0
-			IL_037c: cgt
-			IL_037e: box [System.Runtime]System.Boolean
-			IL_0383: stloc.s 29
-			IL_0385: br IL_038e
+			IL_035f: ldloc.1
+			IL_0360: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0365: ldc.r8 0.0
+			IL_036e: cgt
+			IL_0370: box [System.Runtime]System.Boolean
+			IL_0375: stloc.s 26
+			IL_0377: br IL_0380
 
-			IL_038a: ldloc.s 24
-			IL_038c: stloc.s 29
+			IL_037c: ldloc.s 21
+			IL_037e: stloc.s 26
 
-			IL_038e: ldloc.s 29
-			IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0395: stloc.s 20
-			IL_0397: ldloc.s 20
-			IL_0399: brfalse IL_0481
+			IL_0380: ldloc.s 26
+			IL_0382: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0387: stloc.s 17
+			IL_0389: ldloc.s 17
+			IL_038b: brfalse IL_046c
 
-			IL_039e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
-			IL_03a3: stloc.s 14
-			IL_03a5: ldc.i4.0
-			IL_03a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03ab: stloc.s 15
-			IL_03ad: ldloc.0
-			IL_03ae: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_03b3: ldc.r8 0.0
-			IL_03bc: cgt
-			IL_03be: brfalse IL_03fa
+			IL_0390: ldc.i4.0
+			IL_0391: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0396: stloc.s 12
+			IL_0398: ldloc.0
+			IL_0399: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_039e: ldc.r8 0.0
+			IL_03a7: cgt
+			IL_03a9: brfalse IL_03e5
 
-			IL_03c3: ldloc.0
-			IL_03c4: ldc.i4.1
-			IL_03c5: newarr [System.Runtime]System.Object
-			IL_03ca: dup
-			IL_03cb: ldc.i4.0
-			IL_03cc: ldstr ", "
-			IL_03d1: stelem.ref
-			IL_03d2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_03d7: stloc.s 30
-			IL_03d9: ldloc.s 30
-			IL_03db: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03e0: stloc.s 30
-			IL_03e2: ldstr "missing files: "
-			IL_03e7: ldloc.s 30
-			IL_03e9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03ee: stloc.s 30
-			IL_03f0: ldloc.s 15
-			IL_03f2: ldloc.s 30
-			IL_03f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03f9: pop
+			IL_03ae: ldloc.0
+			IL_03af: ldc.i4.1
+			IL_03b0: newarr [System.Runtime]System.Object
+			IL_03b5: dup
+			IL_03b6: ldc.i4.0
+			IL_03b7: ldstr ", "
+			IL_03bc: stelem.ref
+			IL_03bd: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03c2: stloc.s 27
+			IL_03c4: ldloc.s 27
+			IL_03c6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03cb: stloc.s 27
+			IL_03cd: ldstr "missing files: "
+			IL_03d2: ldloc.s 27
+			IL_03d4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03d9: stloc.s 27
+			IL_03db: ldloc.s 12
+			IL_03dd: ldloc.s 27
+			IL_03df: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03e4: pop
 
-			IL_03fa: ldloc.1
-			IL_03fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0400: ldc.r8 0.0
-			IL_0409: cgt
-			IL_040b: brfalse IL_0447
+			IL_03e5: ldloc.1
+			IL_03e6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_03eb: ldc.r8 0.0
+			IL_03f4: cgt
+			IL_03f6: brfalse IL_0432
 
-			IL_0410: ldloc.1
-			IL_0411: ldc.i4.1
-			IL_0412: newarr [System.Runtime]System.Object
-			IL_0417: dup
-			IL_0418: ldc.i4.0
-			IL_0419: ldstr ", "
-			IL_041e: stelem.ref
-			IL_041f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0424: stloc.s 30
-			IL_0426: ldloc.s 30
-			IL_0428: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_042d: stloc.s 30
-			IL_042f: ldstr "missing directories: "
-			IL_0434: ldloc.s 30
-			IL_0436: call string [System.Runtime]System.String::Concat(string, string)
-			IL_043b: stloc.s 30
-			IL_043d: ldloc.s 15
-			IL_043f: ldloc.s 30
-			IL_0441: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0446: pop
+			IL_03fb: ldloc.1
+			IL_03fc: ldc.i4.1
+			IL_03fd: newarr [System.Runtime]System.Object
+			IL_0402: dup
+			IL_0403: ldc.i4.0
+			IL_0404: ldstr ", "
+			IL_0409: stelem.ref
+			IL_040a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_040f: stloc.s 27
+			IL_0411: ldloc.s 27
+			IL_0413: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0418: stloc.s 27
+			IL_041a: ldstr "missing directories: "
+			IL_041f: ldloc.s 27
+			IL_0421: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0426: stloc.s 27
+			IL_0428: ldloc.s 12
+			IL_042a: ldloc.s 27
+			IL_042c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0431: pop
 
-			IL_0447: ldloc.s 15
-			IL_0449: ldc.i4.1
-			IL_044a: newarr [System.Runtime]System.Object
-			IL_044f: dup
-			IL_0450: ldc.i4.0
-			IL_0451: ldstr "; "
-			IL_0456: stelem.ref
-			IL_0457: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_045c: stloc.s 30
-			IL_045e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0463: dup
-			IL_0464: ldstr "ok"
-			IL_0469: ldc.i4.0
-			IL_046a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_046f: dup
-			IL_0470: ldstr "message"
-			IL_0475: ldloc.s 30
-			IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_047c: stloc.s 31
-			IL_047e: ldloc.s 31
-			IL_0480: ret
+			IL_0432: ldloc.s 12
+			IL_0434: ldc.i4.1
+			IL_0435: newarr [System.Runtime]System.Object
+			IL_043a: dup
+			IL_043b: ldc.i4.0
+			IL_043c: ldstr "; "
+			IL_0441: stelem.ref
+			IL_0442: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0447: stloc.s 27
+			IL_0449: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_044e: dup
+			IL_044f: ldstr "ok"
+			IL_0454: ldc.i4.0
+			IL_0455: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_045a: dup
+			IL_045b: ldstr "message"
+			IL_0460: ldloc.s 27
+			IL_0462: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0467: stloc.s 28
+			IL_0469: ldloc.s 28
+			IL_046b: ret
 
-			IL_0481: ldarg.0
-			IL_0482: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_048c: stloc.s 19
-			IL_048e: ldloc.s 19
-			IL_0490: ldstr "join"
-			IL_0495: ldarg.2
-			IL_0496: ldstr "package.json"
-			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04a0: stloc.s 19
-			IL_04a2: ldloc.s 19
-			IL_04a4: stloc.s 16
-			IL_04a6: ldarg.0
-			IL_04a7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04b1: stloc.s 19
-			IL_04b3: ldloc.s 19
-			IL_04b5: ldstr "readFileSync"
-			IL_04ba: ldloc.s 16
-			IL_04bc: ldstr "utf8"
-			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04c6: stloc.s 19
-			IL_04c8: ldloc.s 19
-			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_04cf: stloc.s 19
-			IL_04d1: ldloc.s 19
-			IL_04d3: stloc.s 17
-			IL_04d5: ldloc.s 17
-			IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04dc: ldc.i4.0
-			IL_04dd: ceq
-			IL_04df: stloc.s 20
-			IL_04e1: ldloc.s 20
-			IL_04e3: box [System.Runtime]System.Boolean
-			IL_04e8: stloc.s 24
-			IL_04ea: ldloc.s 24
-			IL_04ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04f1: stloc.s 20
-			IL_04f3: ldloc.s 20
-			IL_04f5: brtrue IL_0538
+			IL_046c: ldarg.0
+			IL_046d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0477: stloc.s 16
+			IL_0479: ldloc.s 16
+			IL_047b: ldstr "join"
+			IL_0480: ldarg.2
+			IL_0481: ldstr "package.json"
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_048b: stloc.s 16
+			IL_048d: ldloc.s 16
+			IL_048f: stloc.s 13
+			IL_0491: ldarg.0
+			IL_0492: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_049c: stloc.s 16
+			IL_049e: ldloc.s 16
+			IL_04a0: ldstr "readFileSync"
+			IL_04a5: ldloc.s 13
+			IL_04a7: ldstr "utf8"
+			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04b1: stloc.s 16
+			IL_04b3: ldloc.s 16
+			IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_04ba: stloc.s 16
+			IL_04bc: ldloc.s 16
+			IL_04be: stloc.s 14
+			IL_04c0: ldloc.s 14
+			IL_04c2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04c7: ldc.i4.0
+			IL_04c8: ceq
+			IL_04ca: stloc.s 17
+			IL_04cc: ldloc.s 17
+			IL_04ce: box [System.Runtime]System.Boolean
+			IL_04d3: stloc.s 21
+			IL_04d5: ldloc.s 21
+			IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04dc: stloc.s 17
+			IL_04de: ldloc.s 17
+			IL_04e0: brtrue IL_0523
 
-			IL_04fa: ldloc.s 17
-			IL_04fc: ldstr "version"
-			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0506: stloc.s 19
-			IL_0508: ldloc.s 19
-			IL_050a: ldarg.3
-			IL_050b: ldstr "upstream"
-			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0515: ldstr "packageVersion"
-			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_051f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0524: stloc.s 20
-			IL_0526: ldloc.s 20
-			IL_0528: box [System.Runtime]System.Boolean
-			IL_052d: stloc.s 25
-			IL_052f: ldloc.s 25
-			IL_0531: stloc.s 32
-			IL_0533: br IL_053c
+			IL_04e5: ldloc.s 14
+			IL_04e7: ldstr "version"
+			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f1: stloc.s 16
+			IL_04f3: ldloc.s 16
+			IL_04f5: ldarg.3
+			IL_04f6: ldstr "upstream"
+			IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0500: ldstr "packageVersion"
+			IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_050a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_050f: stloc.s 17
+			IL_0511: ldloc.s 17
+			IL_0513: box [System.Runtime]System.Boolean
+			IL_0518: stloc.s 22
+			IL_051a: ldloc.s 22
+			IL_051c: stloc.s 29
+			IL_051e: br IL_0527
 
-			IL_0538: ldloc.s 24
-			IL_053a: stloc.s 32
+			IL_0523: ldloc.s 21
+			IL_0525: stloc.s 29
 
-			IL_053c: ldloc.s 32
-			IL_053e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0543: stloc.s 20
-			IL_0545: ldloc.s 20
-			IL_0547: brfalse IL_060c
+			IL_0527: ldloc.s 29
+			IL_0529: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_052e: stloc.s 17
+			IL_0530: ldloc.s 17
+			IL_0532: brfalse IL_05f7
 
-			IL_054c: ldarg.3
-			IL_054d: ldstr "upstream"
-			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0557: ldstr "packageVersion"
-			IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0561: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0566: stloc.s 30
-			IL_0568: ldstr "package.json version mismatch: expected "
-			IL_056d: ldloc.s 30
-			IL_056f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0574: stloc.s 30
-			IL_0576: ldloc.s 30
-			IL_0578: ldstr ", got "
-			IL_057d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0582: stloc.s 30
-			IL_0584: ldloc.s 17
-			IL_0586: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_058b: stloc.s 20
-			IL_058d: ldloc.s 20
-			IL_058f: brfalse IL_05a7
+			IL_0537: ldarg.3
+			IL_0538: ldstr "upstream"
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0542: ldstr "packageVersion"
+			IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_054c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0551: stloc.s 27
+			IL_0553: ldstr "package.json version mismatch: expected "
+			IL_0558: ldloc.s 27
+			IL_055a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_055f: stloc.s 27
+			IL_0561: ldloc.s 27
+			IL_0563: ldstr ", got "
+			IL_0568: call string [System.Runtime]System.String::Concat(string, string)
+			IL_056d: stloc.s 27
+			IL_056f: ldloc.s 14
+			IL_0571: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0576: stloc.s 17
+			IL_0578: ldloc.s 17
+			IL_057a: brfalse IL_0592
 
-			IL_0594: ldloc.s 17
-			IL_0596: ldstr "version"
-			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a0: stloc.s 33
-			IL_05a2: br IL_05ab
+			IL_057f: ldloc.s 14
+			IL_0581: ldstr "version"
+			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_058b: stloc.s 30
+			IL_058d: br IL_0596
 
-			IL_05a7: ldloc.s 17
-			IL_05a9: stloc.s 33
+			IL_0592: ldloc.s 14
+			IL_0594: stloc.s 30
 
-			IL_05ab: ldloc.s 33
-			IL_05ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05b2: stloc.s 20
-			IL_05b4: ldloc.s 20
-			IL_05b6: brfalse IL_05ce
+			IL_0596: ldloc.s 30
+			IL_0598: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_059d: stloc.s 17
+			IL_059f: ldloc.s 17
+			IL_05a1: brfalse IL_05b9
 
-			IL_05bb: ldloc.s 17
-			IL_05bd: ldstr "version"
-			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05c7: stloc.s 18
-			IL_05c9: br IL_05d5
+			IL_05a6: ldloc.s 14
+			IL_05a8: ldstr "version"
+			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b2: stloc.s 15
+			IL_05b4: br IL_05c0
 
-			IL_05ce: ldstr "<missing>"
-			IL_05d3: stloc.s 18
+			IL_05b9: ldstr "<missing>"
+			IL_05be: stloc.s 15
 
-			IL_05d5: ldloc.s 18
-			IL_05d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05dc: stloc.s 34
-			IL_05de: ldloc.s 30
-			IL_05e0: ldloc.s 34
-			IL_05e2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05e7: stloc.s 34
-			IL_05e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05ee: dup
-			IL_05ef: ldstr "ok"
-			IL_05f4: ldc.i4.0
-			IL_05f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05fa: dup
-			IL_05fb: ldstr "message"
-			IL_0600: ldloc.s 34
-			IL_0602: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0607: stloc.s 31
-			IL_0609: ldloc.s 31
-			IL_060b: ret
+			IL_05c0: ldloc.s 15
+			IL_05c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05c7: stloc.s 31
+			IL_05c9: ldloc.s 27
+			IL_05cb: ldloc.s 31
+			IL_05cd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05d2: stloc.s 31
+			IL_05d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05d9: dup
+			IL_05da: ldstr "ok"
+			IL_05df: ldc.i4.0
+			IL_05e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05e5: dup
+			IL_05e6: ldstr "message"
+			IL_05eb: ldloc.s 31
+			IL_05ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05f2: stloc.s 28
+			IL_05f4: ldloc.s 28
+			IL_05f6: ret
 
-			IL_060c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0611: dup
-			IL_0612: ldstr "ok"
-			IL_0617: ldc.i4.1
-			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_061d: dup
-			IL_061e: ldstr "message"
-			IL_0623: ldstr ""
-			IL_0628: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_062d: ret
+			IL_05f7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05fc: dup
+			IL_05fd: ldstr "ok"
+			IL_0602: ldc.i4.1
+			IL_0603: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0608: dup
+			IL_0609: ldstr "message"
+			IL_060e: ldstr ""
+			IL_0613: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0618: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -4929,7 +4911,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52a2
+						// Method begins at RVA 0x5252
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4947,7 +4929,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5299
+					// Method begins at RVA 0x5249
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4967,7 +4949,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52ab
+					// Method begins at RVA 0x525b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4985,7 +4967,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5290
+				// Method begins at RVA 0x5240
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5014,423 +4996,420 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4748
+			// Method begins at RVA 0x4710
 			// Header size: 12
-			// Code size: 1041 (0x411)
+			// Code size: 1029 (0x405)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14,
+				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] bool,
-				[5] object[],
-				[6] object,
-				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[8] object[],
-				[9] object,
-				[10] string
+				[3] bool,
+				[4] object[],
+				[5] object,
+				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[7] object[],
+				[8] object,
+				[9] string
 			)
 
 			IL_0000: ldarg.s force
 			IL_0002: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_0007: ldc.i4.0
 			IL_0008: ceq
-			IL_000a: stloc.s 4
-			IL_000c: ldloc.s 4
-			IL_000e: brfalse IL_0080
+			IL_000a: stloc.3
+			IL_000b: ldloc.3
+			IL_000c: brfalse IL_0076
 
-			IL_0013: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14::.ctor()
-			IL_0018: stloc.0
-			IL_0019: ldc.i4.1
-			IL_001a: newarr [System.Runtime]System.Object
-			IL_001f: dup
-			IL_0020: ldc.i4.0
-			IL_0021: ldarg.0
-			IL_0022: stelem.ref
-			IL_0023: stloc.s 5
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_002b: ldloc.s 5
-			IL_002d: ldarg.2
-			IL_002e: ldarg.3
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0034: stloc.s 6
-			IL_0036: ldloc.s 6
-			IL_0038: stloc.1
-			IL_0039: ldloc.1
-			IL_003a: ldstr "ok"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0049: stloc.s 4
-			IL_004b: ldloc.s 4
-			IL_004d: brfalse IL_0080
+			IL_0011: ldc.i4.1
+			IL_0012: newarr [System.Runtime]System.Object
+			IL_0017: dup
+			IL_0018: ldc.i4.0
+			IL_0019: ldarg.0
+			IL_001a: stelem.ref
+			IL_001b: stloc.s 4
+			IL_001d: ldarg.0
+			IL_001e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_0023: ldloc.s 4
+			IL_0025: ldarg.2
+			IL_0026: ldarg.3
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_002c: stloc.s 5
+			IL_002e: ldloc.s 5
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: ldstr "ok"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0041: stloc.3
+			IL_0042: ldloc.3
+			IL_0043: brfalse IL_0076
 
-			IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0057: dup
-			IL_0058: ldstr "source"
-			IL_005d: ldstr "managed-cache"
-			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0067: dup
-			IL_0068: ldstr "rootPath"
-			IL_006d: ldarg.2
-			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0073: dup
-			IL_0074: ldstr "reused"
-			IL_0079: ldc.i4.1
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007f: ret
+			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004d: dup
+			IL_004e: ldstr "source"
+			IL_0053: ldstr "managed-cache"
+			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005d: dup
+			IL_005e: ldstr "rootPath"
+			IL_0063: ldarg.2
+			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0069: dup
+			IL_006a: ldstr "reused"
+			IL_006f: ldc.i4.1
+			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0075: ret
 
-			IL_0080: ldc.i4.1
-			IL_0081: newarr [System.Runtime]System.Object
-			IL_0086: dup
-			IL_0087: ldc.i4.0
-			IL_0088: ldarg.0
-			IL_0089: stelem.ref
-			IL_008a: stloc.s 5
-			IL_008c: ldarg.0
-			IL_008d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
-			IL_0092: ldloc.s 5
-			IL_0094: ldarg.2
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_009a: pop
-			IL_009b: ldc.i4.1
-			IL_009c: newarr [System.Runtime]System.Object
-			IL_00a1: dup
-			IL_00a2: ldc.i4.0
-			IL_00a3: ldarg.0
-			IL_00a4: stelem.ref
-			IL_00a5: stloc.s 5
-			IL_00a7: ldarg.0
-			IL_00a8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
-			IL_00ad: ldloc.s 5
-			IL_00af: ldarg.2
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00b5: pop
-			IL_00b6: ldarg.0
-			IL_00b7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_00bc: stloc.s 6
-			IL_00be: ldc.i4.1
-			IL_00bf: newarr [System.Runtime]System.Object
-			IL_00c4: dup
-			IL_00c5: ldc.i4.0
-			IL_00c6: ldarg.0
-			IL_00c7: stelem.ref
-			IL_00c8: stloc.s 5
-			IL_00ca: ldc.i4.1
-			IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00d0: dup
-			IL_00d1: ldstr "init"
-			IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00db: stloc.s 7
-			IL_00dd: ldloc.s 6
-			IL_00df: ldloc.s 5
-			IL_00e1: ldloc.s 7
-			IL_00e3: ldarg.2
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_00e9: pop
-			IL_00ea: ldarg.0
-			IL_00eb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_00f0: stloc.s 6
-			IL_00f2: ldc.i4.1
-			IL_00f3: newarr [System.Runtime]System.Object
-			IL_00f8: dup
-			IL_00f9: ldc.i4.0
-			IL_00fa: ldarg.0
-			IL_00fb: stelem.ref
-			IL_00fc: stloc.s 5
-			IL_00fe: ldc.i4.3
-			IL_00ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0104: dup
-			IL_0105: ldstr "config"
-			IL_010a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_010f: dup
-			IL_0110: ldstr "core.autocrlf"
-			IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011a: dup
-			IL_011b: ldstr "false"
-			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0125: stloc.s 7
-			IL_0127: ldloc.s 6
-			IL_0129: ldloc.s 5
-			IL_012b: ldloc.s 7
-			IL_012d: ldarg.2
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0133: pop
-			IL_0134: ldarg.0
-			IL_0135: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_013a: stloc.s 6
-			IL_013c: ldc.i4.1
-			IL_013d: newarr [System.Runtime]System.Object
-			IL_0142: dup
-			IL_0143: ldc.i4.0
-			IL_0144: ldarg.0
-			IL_0145: stelem.ref
-			IL_0146: stloc.s 5
-			IL_0148: ldc.i4.3
-			IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_014e: dup
-			IL_014f: ldstr "config"
-			IL_0154: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0159: dup
-			IL_015a: ldstr "core.eol"
-			IL_015f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0164: dup
-			IL_0165: ldstr "lf"
-			IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_016f: stloc.s 7
-			IL_0171: ldloc.s 6
-			IL_0173: ldloc.s 5
-			IL_0175: ldloc.s 7
-			IL_0177: ldarg.2
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_017d: pop
-			IL_017e: ldarg.0
-			IL_017f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_0184: stloc.s 6
-			IL_0186: ldc.i4.1
-			IL_0187: newarr [System.Runtime]System.Object
-			IL_018c: dup
-			IL_018d: ldc.i4.0
-			IL_018e: ldarg.0
-			IL_018f: stelem.ref
-			IL_0190: stloc.s 5
-			IL_0192: ldc.i4.4
-			IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0198: dup
-			IL_0199: ldstr "remote"
-			IL_019e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a3: dup
-			IL_01a4: ldstr "add"
-			IL_01a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ae: dup
-			IL_01af: ldstr "origin"
-			IL_01b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01b9: dup
-			IL_01ba: ldarg.3
-			IL_01bb: ldstr "upstream"
+			IL_0076: ldc.i4.1
+			IL_0077: newarr [System.Runtime]System.Object
+			IL_007c: dup
+			IL_007d: ldc.i4.0
+			IL_007e: ldarg.0
+			IL_007f: stelem.ref
+			IL_0080: stloc.s 4
+			IL_0082: ldarg.0
+			IL_0083: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
+			IL_0088: ldloc.s 4
+			IL_008a: ldarg.2
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0090: pop
+			IL_0091: ldc.i4.1
+			IL_0092: newarr [System.Runtime]System.Object
+			IL_0097: dup
+			IL_0098: ldc.i4.0
+			IL_0099: ldarg.0
+			IL_009a: stelem.ref
+			IL_009b: stloc.s 4
+			IL_009d: ldarg.0
+			IL_009e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
+			IL_00a3: ldloc.s 4
+			IL_00a5: ldarg.2
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00ab: pop
+			IL_00ac: ldarg.0
+			IL_00ad: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_00b2: stloc.s 5
+			IL_00b4: ldc.i4.1
+			IL_00b5: newarr [System.Runtime]System.Object
+			IL_00ba: dup
+			IL_00bb: ldc.i4.0
+			IL_00bc: ldarg.0
+			IL_00bd: stelem.ref
+			IL_00be: stloc.s 4
+			IL_00c0: ldc.i4.1
+			IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00c6: dup
+			IL_00c7: ldstr "init"
+			IL_00cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00d1: stloc.s 6
+			IL_00d3: ldloc.s 5
+			IL_00d5: ldloc.s 4
+			IL_00d7: ldloc.s 6
+			IL_00d9: ldarg.2
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00df: pop
+			IL_00e0: ldarg.0
+			IL_00e1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_00e6: stloc.s 5
+			IL_00e8: ldc.i4.1
+			IL_00e9: newarr [System.Runtime]System.Object
+			IL_00ee: dup
+			IL_00ef: ldc.i4.0
+			IL_00f0: ldarg.0
+			IL_00f1: stelem.ref
+			IL_00f2: stloc.s 4
+			IL_00f4: ldc.i4.3
+			IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fa: dup
+			IL_00fb: ldstr "config"
+			IL_0100: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0105: dup
+			IL_0106: ldstr "core.autocrlf"
+			IL_010b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0110: dup
+			IL_0111: ldstr "false"
+			IL_0116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011b: stloc.s 6
+			IL_011d: ldloc.s 5
+			IL_011f: ldloc.s 4
+			IL_0121: ldloc.s 6
+			IL_0123: ldarg.2
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0129: pop
+			IL_012a: ldarg.0
+			IL_012b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0130: stloc.s 5
+			IL_0132: ldc.i4.1
+			IL_0133: newarr [System.Runtime]System.Object
+			IL_0138: dup
+			IL_0139: ldc.i4.0
+			IL_013a: ldarg.0
+			IL_013b: stelem.ref
+			IL_013c: stloc.s 4
+			IL_013e: ldc.i4.3
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0144: dup
+			IL_0145: ldstr "config"
+			IL_014a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_014f: dup
+			IL_0150: ldstr "core.eol"
+			IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015a: dup
+			IL_015b: ldstr "lf"
+			IL_0160: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0165: stloc.s 6
+			IL_0167: ldloc.s 5
+			IL_0169: ldloc.s 4
+			IL_016b: ldloc.s 6
+			IL_016d: ldarg.2
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0173: pop
+			IL_0174: ldarg.0
+			IL_0175: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_017a: stloc.s 5
+			IL_017c: ldc.i4.1
+			IL_017d: newarr [System.Runtime]System.Object
+			IL_0182: dup
+			IL_0183: ldc.i4.0
+			IL_0184: ldarg.0
+			IL_0185: stelem.ref
+			IL_0186: stloc.s 4
+			IL_0188: ldc.i4.4
+			IL_0189: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_018e: dup
+			IL_018f: ldstr "remote"
+			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0199: dup
+			IL_019a: ldstr "add"
+			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a4: dup
+			IL_01a5: ldstr "origin"
+			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01af: dup
+			IL_01b0: ldarg.3
+			IL_01b1: ldstr "upstream"
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bb: ldstr "cloneUrl"
 			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c5: ldstr "cloneUrl"
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01d4: stloc.s 7
-			IL_01d6: ldloc.s 6
-			IL_01d8: ldloc.s 5
-			IL_01da: ldloc.s 7
-			IL_01dc: ldarg.2
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01e2: pop
-			IL_01e3: ldarg.0
-			IL_01e4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_01e9: stloc.s 6
-			IL_01eb: ldc.i4.1
-			IL_01ec: newarr [System.Runtime]System.Object
-			IL_01f1: dup
-			IL_01f2: ldc.i4.0
-			IL_01f3: ldarg.0
-			IL_01f4: stelem.ref
-			IL_01f5: stloc.s 5
-			IL_01f7: ldc.i4.3
-			IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01fd: dup
-			IL_01fe: ldstr "sparse-checkout"
-			IL_0203: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0208: dup
-			IL_0209: ldstr "init"
-			IL_020e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0213: dup
-			IL_0214: ldstr "--no-cone"
-			IL_0219: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_021e: stloc.s 7
-			IL_0220: ldloc.s 6
-			IL_0222: ldloc.s 5
-			IL_0224: ldloc.s 7
-			IL_0226: ldarg.2
-			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_022c: pop
-			IL_022d: ldarg.0
-			IL_022e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_0233: stloc.s 6
-			IL_0235: ldc.i4.1
-			IL_0236: newarr [System.Runtime]System.Object
-			IL_023b: dup
-			IL_023c: ldc.i4.0
-			IL_023d: ldarg.0
-			IL_023e: stelem.ref
-			IL_023f: stloc.s 5
-			IL_0241: ldc.i4.3
-			IL_0242: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0247: dup
-			IL_0248: ldstr "sparse-checkout"
-			IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0252: dup
-			IL_0253: ldstr "set"
-			IL_0258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_025d: dup
-			IL_025e: ldstr "--no-cone"
-			IL_0263: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0268: stloc.s 7
-			IL_026a: ldc.i4.1
-			IL_026b: newarr [System.Runtime]System.Object
-			IL_0270: dup
-			IL_0271: ldc.i4.0
-			IL_0272: ldarg.0
-			IL_0273: stelem.ref
-			IL_0274: stloc.s 8
-			IL_0276: ldarg.0
-			IL_0277: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
-			IL_027c: ldloc.s 8
-			IL_027e: ldarg.3
-			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0284: stloc.s 9
-			IL_0286: ldloc.s 7
-			IL_0288: ldc.i4.1
-			IL_0289: newarr [System.Runtime]System.Object
-			IL_028e: dup
-			IL_028f: ldc.i4.0
-			IL_0290: ldloc.s 9
-			IL_0292: stelem.ref
-			IL_0293: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-			IL_0298: stloc.s 7
-			IL_029a: ldloc.s 6
-			IL_029c: ldloc.s 5
-			IL_029e: ldloc.s 7
-			IL_02a0: ldarg.2
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02a6: pop
-			IL_02a7: ldarg.0
-			IL_02a8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_02ad: stloc.s 6
-			IL_02af: ldc.i4.1
-			IL_02b0: newarr [System.Runtime]System.Object
-			IL_02b5: dup
-			IL_02b6: ldc.i4.0
-			IL_02b7: ldarg.0
-			IL_02b8: stelem.ref
-			IL_02b9: stloc.s 5
-			IL_02bb: ldc.i4.5
-			IL_02bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02c1: dup
-			IL_02c2: ldstr "fetch"
-			IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02cc: dup
-			IL_02cd: ldstr "--depth"
-			IL_02d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02d7: dup
-			IL_02d8: ldstr "1"
-			IL_02dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e2: dup
-			IL_02e3: ldstr "origin"
-			IL_02e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02ed: dup
-			IL_02ee: ldarg.3
-			IL_02ef: ldstr "upstream"
+			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ca: stloc.s 6
+			IL_01cc: ldloc.s 5
+			IL_01ce: ldloc.s 4
+			IL_01d0: ldloc.s 6
+			IL_01d2: ldarg.2
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01d8: pop
+			IL_01d9: ldarg.0
+			IL_01da: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_01df: stloc.s 5
+			IL_01e1: ldc.i4.1
+			IL_01e2: newarr [System.Runtime]System.Object
+			IL_01e7: dup
+			IL_01e8: ldc.i4.0
+			IL_01e9: ldarg.0
+			IL_01ea: stelem.ref
+			IL_01eb: stloc.s 4
+			IL_01ed: ldc.i4.3
+			IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01f3: dup
+			IL_01f4: ldstr "sparse-checkout"
+			IL_01f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01fe: dup
+			IL_01ff: ldstr "init"
+			IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0209: dup
+			IL_020a: ldstr "--no-cone"
+			IL_020f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0214: stloc.s 6
+			IL_0216: ldloc.s 5
+			IL_0218: ldloc.s 4
+			IL_021a: ldloc.s 6
+			IL_021c: ldarg.2
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0222: pop
+			IL_0223: ldarg.0
+			IL_0224: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0229: stloc.s 5
+			IL_022b: ldc.i4.1
+			IL_022c: newarr [System.Runtime]System.Object
+			IL_0231: dup
+			IL_0232: ldc.i4.0
+			IL_0233: ldarg.0
+			IL_0234: stelem.ref
+			IL_0235: stloc.s 4
+			IL_0237: ldc.i4.3
+			IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_023d: dup
+			IL_023e: ldstr "sparse-checkout"
+			IL_0243: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0248: dup
+			IL_0249: ldstr "set"
+			IL_024e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0253: dup
+			IL_0254: ldstr "--no-cone"
+			IL_0259: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_025e: stloc.s 6
+			IL_0260: ldc.i4.1
+			IL_0261: newarr [System.Runtime]System.Object
+			IL_0266: dup
+			IL_0267: ldc.i4.0
+			IL_0268: ldarg.0
+			IL_0269: stelem.ref
+			IL_026a: stloc.s 7
+			IL_026c: ldarg.0
+			IL_026d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+			IL_0272: ldloc.s 7
+			IL_0274: ldarg.3
+			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_027a: stloc.s 8
+			IL_027c: ldloc.s 6
+			IL_027e: ldc.i4.1
+			IL_027f: newarr [System.Runtime]System.Object
+			IL_0284: dup
+			IL_0285: ldc.i4.0
+			IL_0286: ldloc.s 8
+			IL_0288: stelem.ref
+			IL_0289: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+			IL_028e: stloc.s 6
+			IL_0290: ldloc.s 5
+			IL_0292: ldloc.s 4
+			IL_0294: ldloc.s 6
+			IL_0296: ldarg.2
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_029c: pop
+			IL_029d: ldarg.0
+			IL_029e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_02a3: stloc.s 5
+			IL_02a5: ldc.i4.1
+			IL_02a6: newarr [System.Runtime]System.Object
+			IL_02ab: dup
+			IL_02ac: ldc.i4.0
+			IL_02ad: ldarg.0
+			IL_02ae: stelem.ref
+			IL_02af: stloc.s 4
+			IL_02b1: ldc.i4.5
+			IL_02b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02b7: dup
+			IL_02b8: ldstr "fetch"
+			IL_02bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02c2: dup
+			IL_02c3: ldstr "--depth"
+			IL_02c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02cd: dup
+			IL_02ce: ldstr "1"
+			IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02d8: dup
+			IL_02d9: ldstr "origin"
+			IL_02de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e3: dup
+			IL_02e4: ldarg.3
+			IL_02e5: ldstr "upstream"
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ef: ldstr "commit"
 			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f9: ldstr "commit"
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0303: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0308: stloc.s 7
-			IL_030a: ldloc.s 6
-			IL_030c: ldloc.s 5
-			IL_030e: ldloc.s 7
-			IL_0310: ldarg.2
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0316: pop
-			IL_0317: ldarg.0
-			IL_0318: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_031d: stloc.s 6
-			IL_031f: ldc.i4.1
-			IL_0320: newarr [System.Runtime]System.Object
-			IL_0325: dup
-			IL_0326: ldc.i4.0
-			IL_0327: ldarg.0
-			IL_0328: stelem.ref
-			IL_0329: stloc.s 5
-			IL_032b: ldc.i4.3
-			IL_032c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0331: dup
-			IL_0332: ldstr "checkout"
-			IL_0337: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_033c: dup
-			IL_033d: ldstr "--detach"
-			IL_0342: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0347: dup
-			IL_0348: ldstr "FETCH_HEAD"
-			IL_034d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0352: stloc.s 7
-			IL_0354: ldloc.s 6
-			IL_0356: ldloc.s 5
-			IL_0358: ldloc.s 7
-			IL_035a: ldarg.2
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0360: pop
-			IL_0361: ldc.i4.1
-			IL_0362: newarr [System.Runtime]System.Object
-			IL_0367: dup
-			IL_0368: ldc.i4.0
-			IL_0369: ldarg.0
-			IL_036a: stelem.ref
-			IL_036b: stloc.s 5
-			IL_036d: ldarg.0
-			IL_036e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_0373: ldloc.s 5
-			IL_0375: ldarg.2
-			IL_0376: ldarg.3
-			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_037c: stloc.s 6
-			IL_037e: ldloc.s 6
-			IL_0380: stloc.2
-			IL_0381: ldloc.2
-			IL_0382: ldstr "ok"
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0391: ldc.i4.0
-			IL_0392: ceq
-			IL_0394: stloc.s 4
-			IL_0396: ldloc.s 4
-			IL_0398: brfalse IL_03e3
+			IL_02f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02fe: stloc.s 6
+			IL_0300: ldloc.s 5
+			IL_0302: ldloc.s 4
+			IL_0304: ldloc.s 6
+			IL_0306: ldarg.2
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_030c: pop
+			IL_030d: ldarg.0
+			IL_030e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0313: stloc.s 5
+			IL_0315: ldc.i4.1
+			IL_0316: newarr [System.Runtime]System.Object
+			IL_031b: dup
+			IL_031c: ldc.i4.0
+			IL_031d: ldarg.0
+			IL_031e: stelem.ref
+			IL_031f: stloc.s 4
+			IL_0321: ldc.i4.3
+			IL_0322: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0327: dup
+			IL_0328: ldstr "checkout"
+			IL_032d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0332: dup
+			IL_0333: ldstr "--detach"
+			IL_0338: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_033d: dup
+			IL_033e: ldstr "FETCH_HEAD"
+			IL_0343: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0348: stloc.s 6
+			IL_034a: ldloc.s 5
+			IL_034c: ldloc.s 4
+			IL_034e: ldloc.s 6
+			IL_0350: ldarg.2
+			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0356: pop
+			IL_0357: ldc.i4.1
+			IL_0358: newarr [System.Runtime]System.Object
+			IL_035d: dup
+			IL_035e: ldc.i4.0
+			IL_035f: ldarg.0
+			IL_0360: stelem.ref
+			IL_0361: stloc.s 4
+			IL_0363: ldarg.0
+			IL_0364: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_0369: ldloc.s 4
+			IL_036b: ldarg.2
+			IL_036c: ldarg.3
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0372: stloc.s 5
+			IL_0374: ldloc.s 5
+			IL_0376: stloc.1
+			IL_0377: ldloc.1
+			IL_0378: ldstr "ok"
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0382: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0387: ldc.i4.0
+			IL_0388: ceq
+			IL_038a: stloc.3
+			IL_038b: ldloc.3
+			IL_038c: brfalse IL_03d7
 
-			IL_039d: ldloc.2
-			IL_039e: ldstr "message"
-			IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03ad: stloc.s 10
-			IL_03af: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
-			IL_03b4: ldloc.s 10
-			IL_03b6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03bb: stloc.s 10
-			IL_03bd: ldloc.s 10
-			IL_03bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03c9: stloc.s 6
-			IL_03cb: ldloc.s 6
-			IL_03cd: stloc.3
-			IL_03ce: ldloc.3
-			IL_03cf: isinst [System.Runtime]System.Exception
-			IL_03d4: dup
-			IL_03d5: brtrue IL_03e2
+			IL_0391: ldloc.1
+			IL_0392: ldstr "message"
+			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_039c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a1: stloc.s 9
+			IL_03a3: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
+			IL_03a8: ldloc.s 9
+			IL_03aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03af: stloc.s 9
+			IL_03b1: ldloc.s 9
+			IL_03b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03bd: stloc.s 5
+			IL_03bf: ldloc.s 5
+			IL_03c1: stloc.2
+			IL_03c2: ldloc.2
+			IL_03c3: isinst [System.Runtime]System.Exception
+			IL_03c8: dup
+			IL_03c9: brtrue IL_03d6
 
-			IL_03da: pop
-			IL_03db: ldloc.3
-			IL_03dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03e1: throw
+			IL_03ce: pop
+			IL_03cf: ldloc.2
+			IL_03d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03d5: throw
 
-			IL_03e2: throw
+			IL_03d6: throw
 
-			IL_03e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03e8: dup
-			IL_03e9: ldstr "source"
-			IL_03ee: ldstr "managed-cache"
+			IL_03d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03dc: dup
+			IL_03dd: ldstr "source"
+			IL_03e2: ldstr "managed-cache"
+			IL_03e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ec: dup
+			IL_03ed: ldstr "rootPath"
+			IL_03f2: ldarg.2
 			IL_03f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_03f8: dup
-			IL_03f9: ldstr "rootPath"
-			IL_03fe: ldarg.2
-			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0404: dup
-			IL_0405: ldstr "reused"
-			IL_040a: ldc.i4.0
-			IL_040b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0410: ret
+			IL_03f9: ldstr "reused"
+			IL_03fe: ldc.i4.0
+			IL_03ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0404: ret
 		} // end of method ensureManagedCheckout::__js_call__
 
 	} // end of class ensureManagedCheckout
@@ -5454,7 +5433,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52c6
+						// Method begins at RVA 0x5276
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5472,7 +5451,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52bd
+					// Method begins at RVA 0x526d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5490,7 +5469,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52b4
+				// Method begins at RVA 0x5264
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5519,21 +5498,20 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4b68
+			// Method begins at RVA 0x4b24
 			// Header size: 12
-			// Code size: 380 (0x17c)
+			// Code size: 368 (0x170)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16,
+				[1] object,
 				[2] object,
-				[3] object,
-				[4] object[],
-				[5] object,
-				[6] bool,
-				[7] object,
-				[8] string,
-				[9] string
+				[3] object[],
+				[4] object,
+				[5] bool,
+				[6] object,
+				[7] string,
+				[8] string
 			)
 
 			IL_0000: ldc.i4.1
@@ -5542,149 +5520,147 @@
 			IL_0007: ldc.i4.0
 			IL_0008: ldarg.0
 			IL_0009: stelem.ref
-			IL_000a: stloc.s 4
-			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_0012: ldloc.s 4
-			IL_0014: ldarg.s args
-			IL_0016: ldarg.3
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_001c: stloc.s 5
-			IL_001e: ldloc.s 5
-			IL_0020: stloc.0
-			IL_0021: ldloc.0
-			IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0027: stloc.s 6
-			IL_0029: ldloc.s 6
-			IL_002b: brfalse IL_013b
+			IL_000a: stloc.3
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0011: ldloc.3
+			IL_0012: ldarg.s args
+			IL_0014: ldarg.3
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001a: stloc.s 4
+			IL_001c: ldloc.s 4
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0025: stloc.s 5
+			IL_0027: ldloc.s 5
+			IL_0029: brfalse IL_0131
 
-			IL_0030: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
-			IL_0035: stloc.1
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_003c: stloc.s 5
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 4
-			IL_004a: ldloc.0
-			IL_004b: ldstr "rootPath"
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0055: stloc.s 7
-			IL_0057: ldloc.s 5
-			IL_0059: ldloc.s 4
-			IL_005b: ldloc.s 7
-			IL_005d: ldarg.3
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0063: stloc.s 7
-			IL_0065: ldloc.s 7
-			IL_0067: stloc.2
-			IL_0068: ldloc.2
-			IL_0069: ldstr "ok"
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0078: ldc.i4.0
-			IL_0079: ceq
-			IL_007b: stloc.s 6
-			IL_007d: ldloc.s 6
-			IL_007f: brfalse IL_00f5
+			IL_002e: ldarg.0
+			IL_002f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_0034: stloc.s 4
+			IL_0036: ldc.i4.1
+			IL_0037: newarr [System.Runtime]System.Object
+			IL_003c: dup
+			IL_003d: ldc.i4.0
+			IL_003e: ldarg.0
+			IL_003f: stelem.ref
+			IL_0040: stloc.3
+			IL_0041: ldloc.0
+			IL_0042: ldstr "rootPath"
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004c: stloc.s 6
+			IL_004e: ldloc.s 4
+			IL_0050: ldloc.3
+			IL_0051: ldloc.s 6
+			IL_0053: ldarg.3
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0059: stloc.s 6
+			IL_005b: ldloc.s 6
+			IL_005d: stloc.1
+			IL_005e: ldloc.1
+			IL_005f: ldstr "ok"
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_006e: ldc.i4.0
+			IL_006f: ceq
+			IL_0071: stloc.s 5
+			IL_0073: ldloc.s 5
+			IL_0075: brfalse IL_00eb
 
-			IL_0084: ldloc.0
-			IL_0085: ldstr "rootPath"
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0094: stloc.s 8
-			IL_0096: ldstr "Override test262 root '"
-			IL_009b: ldloc.s 8
-			IL_009d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00a2: stloc.s 8
-			IL_00a4: ldloc.s 8
-			IL_00a6: ldstr "' is invalid: "
-			IL_00ab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b0: stloc.s 8
-			IL_00b2: ldloc.2
-			IL_00b3: ldstr "message"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c2: stloc.s 9
-			IL_00c4: ldloc.s 8
-			IL_00c6: ldloc.s 9
-			IL_00c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00cd: stloc.s 9
-			IL_00cf: ldloc.s 9
-			IL_00d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00db: stloc.s 7
-			IL_00dd: ldloc.s 7
-			IL_00df: stloc.3
-			IL_00e0: ldloc.3
-			IL_00e1: isinst [System.Runtime]System.Exception
-			IL_00e6: dup
-			IL_00e7: brtrue IL_00f4
+			IL_007a: ldloc.0
+			IL_007b: ldstr "rootPath"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0085: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_008a: stloc.s 7
+			IL_008c: ldstr "Override test262 root '"
+			IL_0091: ldloc.s 7
+			IL_0093: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0098: stloc.s 7
+			IL_009a: ldloc.s 7
+			IL_009c: ldstr "' is invalid: "
+			IL_00a1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00a6: stloc.s 7
+			IL_00a8: ldloc.1
+			IL_00a9: ldstr "message"
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b8: stloc.s 8
+			IL_00ba: ldloc.s 7
+			IL_00bc: ldloc.s 8
+			IL_00be: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c3: stloc.s 8
+			IL_00c5: ldloc.s 8
+			IL_00c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00d1: stloc.s 6
+			IL_00d3: ldloc.s 6
+			IL_00d5: stloc.2
+			IL_00d6: ldloc.2
+			IL_00d7: isinst [System.Runtime]System.Exception
+			IL_00dc: dup
+			IL_00dd: brtrue IL_00ea
 
-			IL_00ec: pop
-			IL_00ed: ldloc.3
-			IL_00ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00f3: throw
+			IL_00e2: pop
+			IL_00e3: ldloc.2
+			IL_00e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00e9: throw
 
-			IL_00f4: throw
+			IL_00ea: throw
 
-			IL_00f5: ldloc.0
-			IL_00f6: ldstr "source"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0100: stloc.s 7
-			IL_0102: ldloc.0
-			IL_0103: ldstr "rootPath"
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010d: stloc.s 5
-			IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0114: dup
-			IL_0115: ldstr "source"
-			IL_011a: ldloc.s 7
-			IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0121: dup
-			IL_0122: ldstr "rootPath"
-			IL_0127: ldloc.s 5
-			IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_012e: dup
-			IL_012f: ldstr "reused"
-			IL_0134: ldc.i4.1
-			IL_0135: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_013a: ret
+			IL_00eb: ldloc.0
+			IL_00ec: ldstr "source"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: stloc.s 6
+			IL_00f8: ldloc.0
+			IL_00f9: ldstr "rootPath"
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0103: stloc.s 4
+			IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_010a: dup
+			IL_010b: ldstr "source"
+			IL_0110: ldloc.s 6
+			IL_0112: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0117: dup
+			IL_0118: ldstr "rootPath"
+			IL_011d: ldloc.s 4
+			IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0124: dup
+			IL_0125: ldstr "reused"
+			IL_012a: ldc.i4.1
+			IL_012b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0130: ret
 
-			IL_013b: ldc.i4.1
-			IL_013c: newarr [System.Runtime]System.Object
-			IL_0141: dup
-			IL_0142: ldc.i4.0
-			IL_0143: ldarg.0
-			IL_0144: stelem.ref
-			IL_0145: stloc.s 4
-			IL_0147: ldarg.0
-			IL_0148: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
-			IL_014d: ldloc.s 4
-			IL_014f: ldarg.2
-			IL_0150: ldarg.3
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0156: stloc.s 5
-			IL_0158: ldarg.s args
-			IL_015a: ldstr "force"
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0164: stloc.s 7
-			IL_0166: ldarg.0
-			IL_0167: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_016c: ldnull
-			IL_016d: ldloc.s 5
-			IL_016f: ldarg.3
-			IL_0170: ldloc.s 7
-			IL_0172: tail.
-			IL_0174: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_0179: ret
+			IL_0131: ldc.i4.1
+			IL_0132: newarr [System.Runtime]System.Object
+			IL_0137: dup
+			IL_0138: ldc.i4.0
+			IL_0139: ldarg.0
+			IL_013a: stelem.ref
+			IL_013b: stloc.3
+			IL_013c: ldarg.0
+			IL_013d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+			IL_0142: ldloc.3
+			IL_0143: ldarg.2
+			IL_0144: ldarg.3
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_014a: stloc.s 4
+			IL_014c: ldarg.s args
+			IL_014e: ldstr "force"
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0158: stloc.s 6
+			IL_015a: ldarg.0
+			IL_015b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0160: ldnull
+			IL_0161: ldloc.s 4
+			IL_0163: ldarg.3
+			IL_0164: ldloc.s 6
+			IL_0166: tail.
+			IL_0168: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_016d: ret
 
-			IL_017a: ldnull
-			IL_017b: ret
+			IL_016e: ldnull
+			IL_016f: ret
 		} // end of method resolveBootstrapRoot::__js_call__
 
 	} // end of class resolveBootstrapRoot
@@ -5704,7 +5680,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52d8
+					// Method begins at RVA 0x5288
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5722,7 +5698,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52cf
+				// Method begins at RVA 0x527f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5751,7 +5727,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4cf0
+			// Method begins at RVA 0x4ca0
 			// Header size: 12
 			// Code size: 407 (0x197)
 			.maxstack 8
@@ -5930,7 +5906,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52ea
+					// Method begins at RVA 0x529a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5950,7 +5926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52f3
+					// Method begins at RVA 0x52a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5968,7 +5944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52e1
+				// Method begins at RVA 0x5291
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5994,7 +5970,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4e94
+			// Method begins at RVA 0x4e44
 			// Header size: 12
 			// Code size: 468 (0x1d4)
 			.maxstack 8
@@ -6243,7 +6219,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5305
+					// Method begins at RVA 0x52b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6263,7 +6239,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x530e
+					// Method begins at RVA 0x52be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6281,7 +6257,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52fc
+				// Method begins at RVA 0x52ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6329,7 +6305,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5074
+			// Method begins at RVA 0x5024
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6355,7 +6331,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1775 (0x6ef)
+		// Code size: 1768 (0x6e8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
@@ -6363,7 +6339,7 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L397C18,
+			[5] object,
 			[6] object,
 			[7] object,
 			[8] object,
@@ -6374,12 +6350,11 @@
 			[13] object,
 			[14] object,
 			[15] object,
-			[16] object,
-			[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[18] bool,
+			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[17] bool,
+			[18] object,
 			[19] object,
-			[20] object,
-			[21] string
+			[20] string
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope::.ctor()
@@ -6404,9 +6379,9 @@
 		IL_0031: ldc.i4.0
 		IL_0032: ldc.i4.1
 		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0038: stloc.s 9
+		IL_0038: stloc.s 8
 		IL_003a: ldloc.0
-		IL_003b: ldloc.s 9
+		IL_003b: ldloc.s 8
 		IL_003d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
 		IL_0042: ldnull
 		IL_0043: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
@@ -6417,9 +6392,9 @@
 		IL_0055: ldc.i4.0
 		IL_0056: ldc.i4.1
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_005c: stloc.s 9
+		IL_005c: stloc.s 8
 		IL_005e: ldloc.0
-		IL_005f: ldloc.s 9
+		IL_005f: ldloc.s 8
 		IL_0061: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -6438,9 +6413,9 @@
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.1
 		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0090: stloc.s 9
+		IL_0090: stloc.s 8
 		IL_0092: ldloc.0
-		IL_0093: ldloc.s 9
+		IL_0093: ldloc.s 8
 		IL_0095: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
 		IL_009a: ldc.i4.1
 		IL_009b: newarr [System.Runtime]System.Object
@@ -6459,9 +6434,9 @@
 		IL_00bd: ldc.i4.0
 		IL_00be: ldc.i4.1
 		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00c4: stloc.s 9
+		IL_00c4: stloc.s 8
 		IL_00c6: ldloc.0
-		IL_00c7: ldloc.s 9
+		IL_00c7: ldloc.s 8
 		IL_00c9: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
 		IL_00ce: ldnull
 		IL_00cf: ldftn object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
@@ -6472,9 +6447,9 @@
 		IL_00e1: ldc.i4.0
 		IL_00e2: ldc.i4.1
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00e8: stloc.s 9
+		IL_00e8: stloc.s 8
 		IL_00ea: ldloc.0
-		IL_00eb: ldloc.s 9
+		IL_00eb: ldloc.s 8
 		IL_00ed: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
 		IL_00f2: ldc.i4.1
 		IL_00f3: newarr [System.Runtime]System.Object
@@ -6493,9 +6468,9 @@
 		IL_0115: ldc.i4.0
 		IL_0116: ldc.i4.1
 		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_011c: stloc.s 9
+		IL_011c: stloc.s 8
 		IL_011e: ldloc.0
-		IL_011f: ldloc.s 9
+		IL_011f: ldloc.s 8
 		IL_0121: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
 		IL_0126: ldnull
 		IL_0127: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
@@ -6506,9 +6481,9 @@
 		IL_0139: ldc.i4.0
 		IL_013a: ldc.i4.1
 		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0140: stloc.s 9
+		IL_0140: stloc.s 8
 		IL_0142: ldloc.0
-		IL_0143: ldloc.s 9
+		IL_0143: ldloc.s 8
 		IL_0145: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
 		IL_014a: ldnull
 		IL_014b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
@@ -6519,9 +6494,9 @@
 		IL_015d: ldc.i4.0
 		IL_015e: ldc.i4.1
 		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0164: stloc.s 9
+		IL_0164: stloc.s 8
 		IL_0166: ldloc.0
-		IL_0167: ldloc.s 9
+		IL_0167: ldloc.s 8
 		IL_0169: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
 		IL_016e: ldc.i4.1
 		IL_016f: newarr [System.Runtime]System.Object
@@ -6540,9 +6515,9 @@
 		IL_0191: ldc.i4.0
 		IL_0192: ldc.i4.1
 		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0198: stloc.s 9
+		IL_0198: stloc.s 8
 		IL_019a: ldloc.0
-		IL_019b: ldloc.s 9
+		IL_019b: ldloc.s 8
 		IL_019d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
 		IL_01a2: ldc.i4.1
 		IL_01a3: newarr [System.Runtime]System.Object
@@ -6561,9 +6536,9 @@
 		IL_01c5: ldc.i4.0
 		IL_01c6: ldc.i4.1
 		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01cc: stloc.s 9
+		IL_01cc: stloc.s 8
 		IL_01ce: ldloc.0
-		IL_01cf: ldloc.s 9
+		IL_01cf: ldloc.s 8
 		IL_01d1: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
 		IL_01d6: ldc.i4.1
 		IL_01d7: newarr [System.Runtime]System.Object
@@ -6582,9 +6557,9 @@
 		IL_01f9: ldc.i4.0
 		IL_01fa: ldc.i4.1
 		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0200: stloc.s 9
+		IL_0200: stloc.s 8
 		IL_0202: ldloc.0
-		IL_0203: ldloc.s 9
+		IL_0203: ldloc.s 8
 		IL_0205: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
 		IL_020a: ldc.i4.1
 		IL_020b: newarr [System.Runtime]System.Object
@@ -6603,9 +6578,9 @@
 		IL_022d: ldc.i4.0
 		IL_022e: ldc.i4.1
 		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0234: stloc.s 9
+		IL_0234: stloc.s 8
 		IL_0236: ldloc.0
-		IL_0237: ldloc.s 9
+		IL_0237: ldloc.s 8
 		IL_0239: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
 		IL_023e: ldc.i4.1
 		IL_023f: newarr [System.Runtime]System.Object
@@ -6624,9 +6599,9 @@
 		IL_0261: ldc.i4.0
 		IL_0262: ldc.i4.1
 		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0268: stloc.s 9
+		IL_0268: stloc.s 8
 		IL_026a: ldloc.0
-		IL_026b: ldloc.s 9
+		IL_026b: ldloc.s 8
 		IL_026d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
 		IL_0272: ldc.i4.1
 		IL_0273: newarr [System.Runtime]System.Object
@@ -6645,9 +6620,9 @@
 		IL_0295: ldc.i4.0
 		IL_0296: ldc.i4.1
 		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_029c: stloc.s 9
+		IL_029c: stloc.s 8
 		IL_029e: ldloc.0
-		IL_029f: ldloc.s 9
+		IL_029f: ldloc.s 8
 		IL_02a1: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
 		IL_02a6: ldc.i4.1
 		IL_02a7: newarr [System.Runtime]System.Object
@@ -6666,9 +6641,9 @@
 		IL_02c9: ldc.i4.0
 		IL_02ca: ldc.i4.1
 		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02d0: stloc.s 9
+		IL_02d0: stloc.s 8
 		IL_02d2: ldloc.0
-		IL_02d3: ldloc.s 9
+		IL_02d3: ldloc.s 8
 		IL_02d5: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
 		IL_02da: ldc.i4.1
 		IL_02db: newarr [System.Runtime]System.Object
@@ -6687,9 +6662,9 @@
 		IL_02fd: ldc.i4.0
 		IL_02fe: ldc.i4.1
 		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0304: stloc.s 9
+		IL_0304: stloc.s 8
 		IL_0306: ldloc.0
-		IL_0307: ldloc.s 9
+		IL_0307: ldloc.s 8
 		IL_0309: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
 		IL_030e: ldc.i4.1
 		IL_030f: newarr [System.Runtime]System.Object
@@ -6708,9 +6683,9 @@
 		IL_0331: ldc.i4.0
 		IL_0332: ldc.i4.1
 		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0338: stloc.s 9
+		IL_0338: stloc.s 8
 		IL_033a: ldloc.0
-		IL_033b: ldloc.s 9
+		IL_033b: ldloc.s 8
 		IL_033d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
 		IL_0342: ldc.i4.1
 		IL_0343: newarr [System.Runtime]System.Object
@@ -6729,9 +6704,9 @@
 		IL_0365: ldc.i4.0
 		IL_0366: ldc.i4.1
 		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_036c: stloc.s 9
+		IL_036c: stloc.s 8
 		IL_036e: ldloc.0
-		IL_036f: ldloc.s 9
+		IL_036f: ldloc.s 8
 		IL_0371: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
 		IL_0376: ldc.i4.1
 		IL_0377: newarr [System.Runtime]System.Object
@@ -6750,9 +6725,9 @@
 		IL_0399: ldc.i4.0
 		IL_039a: ldc.i4.1
 		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03a0: stloc.s 9
+		IL_03a0: stloc.s 8
 		IL_03a2: ldloc.0
-		IL_03a3: ldloc.s 9
+		IL_03a3: ldloc.s 8
 		IL_03a5: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
 		IL_03aa: ldc.i4.1
 		IL_03ab: newarr [System.Runtime]System.Object
@@ -6771,9 +6746,9 @@
 		IL_03cd: ldc.i4.0
 		IL_03ce: ldc.i4.1
 		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03d4: stloc.s 9
+		IL_03d4: stloc.s 8
 		IL_03d6: ldloc.0
-		IL_03d7: ldloc.s 9
+		IL_03d7: ldloc.s 8
 		IL_03d9: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
 		IL_03de: ldc.i4.1
 		IL_03df: newarr [System.Runtime]System.Object
@@ -6792,9 +6767,9 @@
 		IL_0401: ldc.i4.0
 		IL_0402: ldc.i4.1
 		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0408: stloc.s 9
+		IL_0408: stloc.s 8
 		IL_040a: ldloc.0
-		IL_040b: ldloc.s 9
+		IL_040b: ldloc.s 8
 		IL_040d: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
 		IL_0412: ldc.i4.1
 		IL_0413: newarr [System.Runtime]System.Object
@@ -6813,9 +6788,9 @@
 		IL_0435: ldc.i4.0
 		IL_0436: ldc.i4.1
 		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_043c: stloc.s 9
+		IL_043c: stloc.s 8
 		IL_043e: ldloc.0
-		IL_043f: ldloc.s 9
+		IL_043f: ldloc.s 8
 		IL_0441: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
 		IL_0446: ldc.i4.1
 		IL_0447: newarr [System.Runtime]System.Object
@@ -6834,9 +6809,9 @@
 		IL_0469: ldc.i4.0
 		IL_046a: ldc.i4.1
 		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0470: stloc.s 9
+		IL_0470: stloc.s 8
 		IL_0472: ldloc.0
-		IL_0473: ldloc.s 9
+		IL_0473: ldloc.s 8
 		IL_0475: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
 		IL_047a: ldc.i4.1
 		IL_047b: newarr [System.Runtime]System.Object
@@ -6855,30 +6830,30 @@
 		IL_049d: ldc.i4.0
 		IL_049e: ldc.i4.1
 		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04a4: stloc.s 9
-		IL_04a6: ldloc.s 9
+		IL_04a4: stloc.s 8
+		IL_04a6: ldloc.s 8
 		IL_04a8: stloc.1
 		IL_04a9: nop
 		IL_04aa: ldarg.1
 		IL_04ab: ldstr "node:child_process"
 		IL_04b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_04b5: stloc.s 9
+		IL_04b5: stloc.s 8
 		IL_04b7: ldloc.0
-		IL_04b8: ldloc.s 9
+		IL_04b8: ldloc.s 8
 		IL_04ba: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
 		IL_04bf: ldarg.1
 		IL_04c0: ldstr "node:fs"
 		IL_04c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_04ca: stloc.s 9
+		IL_04ca: stloc.s 8
 		IL_04cc: ldloc.0
-		IL_04cd: ldloc.s 9
+		IL_04cd: ldloc.s 8
 		IL_04cf: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
 		IL_04d4: ldarg.1
 		IL_04d5: ldstr "node:path"
 		IL_04da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_04df: stloc.s 9
+		IL_04df: stloc.s 8
 		IL_04e1: ldloc.0
-		IL_04e2: ldloc.s 9
+		IL_04e2: ldloc.s 8
 		IL_04e4: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
 		IL_04e9: nop
 		IL_04ea: nop
@@ -6906,28 +6881,28 @@
 		IL_0500: nop
 		IL_0501: ldloc.0
 		IL_0502: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
-		IL_0507: stloc.s 9
+		IL_0507: stloc.s 8
 		IL_0509: ldloc.0
 		IL_050a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
-		IL_050f: stloc.s 10
+		IL_050f: stloc.s 9
 		IL_0511: ldloc.0
 		IL_0512: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureManagedCheckout
-		IL_0517: stloc.s 11
+		IL_0517: stloc.s 10
 		IL_0519: ldloc.0
 		IL_051a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
-		IL_051f: stloc.s 12
+		IL_051f: stloc.s 11
 		IL_0521: ldloc.0
 		IL_0522: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
-		IL_0527: stloc.s 13
+		IL_0527: stloc.s 12
 		IL_0529: ldloc.0
 		IL_052a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
-		IL_052f: stloc.s 14
+		IL_052f: stloc.s 13
 		IL_0531: ldloc.0
 		IL_0532: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
-		IL_0537: stloc.s 15
+		IL_0537: stloc.s 14
 		IL_0539: ldloc.0
 		IL_053a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
-		IL_053f: stloc.s 16
+		IL_053f: stloc.s 15
 		IL_0541: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0546: dup
 		IL_0547: ldstr "buildSparsePatterns"
@@ -6936,45 +6911,45 @@
 		IL_0552: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0557: dup
 		IL_0558: ldstr "defaultPinPath"
-		IL_055d: ldloc.s 9
+		IL_055d: ldloc.s 8
 		IL_055f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0564: dup
 		IL_0565: ldstr "describePlan"
-		IL_056a: ldloc.s 10
+		IL_056a: ldloc.s 9
 		IL_056c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0571: dup
 		IL_0572: ldstr "ensureManagedCheckout"
-		IL_0577: ldloc.s 11
+		IL_0577: ldloc.s 10
 		IL_0579: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_057e: dup
 		IL_057f: ldstr "loadPin"
-		IL_0584: ldloc.s 12
+		IL_0584: ldloc.s 11
 		IL_0586: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_058b: dup
 		IL_058c: ldstr "parseArgs"
-		IL_0591: ldloc.s 13
+		IL_0591: ldloc.s 12
 		IL_0593: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0598: dup
 		IL_0599: ldstr "resolveBootstrapRoot"
-		IL_059e: ldloc.s 14
+		IL_059e: ldloc.s 13
 		IL_05a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_05a5: dup
 		IL_05a6: ldstr "resolveManagedCheckoutLabel"
-		IL_05ab: ldloc.s 15
+		IL_05ab: ldloc.s 14
 		IL_05ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_05b2: dup
 		IL_05b3: ldstr "resolveManagedCheckoutRoot"
-		IL_05b8: ldloc.s 16
+		IL_05b8: ldloc.s 15
 		IL_05ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_05bf: dup
 		IL_05c0: ldstr "validateResolvedRoot"
 		IL_05c5: ldloc.0
 		IL_05c6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
 		IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05d0: stloc.s 17
+		IL_05d0: stloc.s 16
 		IL_05d2: ldarg.2
 		IL_05d3: ldstr "exports"
-		IL_05d8: ldloc.s 17
+		IL_05d8: ldloc.s 16
 		IL_05da: ldc.i4.1
 		IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_05e0: pop
@@ -6983,9 +6958,9 @@
 		IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_05ec: ldarg.2
 		IL_05ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05f2: stloc.s 18
-		IL_05f4: ldloc.s 18
-		IL_05f6: brfalse IL_06eb
+		IL_05f2: stloc.s 17
+		IL_05f4: ldloc.s 17
+		IL_05f6: brfalse IL_06e4
 		.try
 		{
 			IL_05fb: nop
@@ -6993,7 +6968,7 @@
 			IL_05fd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_0607: pop
-			IL_0608: leave IL_06eb
+			IL_0608: leave IL_06e4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -7019,72 +6994,70 @@
 			IL_0635: stloc.3
 
 			IL_0636: ldloc.3
-			IL_0637: stloc.s 16
-			IL_0639: ldloc.s 16
+			IL_0637: stloc.s 15
+			IL_0639: ldloc.s 15
 			IL_063b: stloc.s 4
-			IL_063d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L397C18::.ctor()
-			IL_0642: stloc.s 5
-			IL_0644: ldloc.s 4
-			IL_0646: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_064b: stloc.s 18
-			IL_064d: ldloc.s 18
-			IL_064f: brfalse IL_0667
+			IL_063d: ldloc.s 4
+			IL_063f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0644: stloc.s 17
+			IL_0646: ldloc.s 17
+			IL_0648: brfalse IL_0660
 
-			IL_0654: ldloc.s 4
-			IL_0656: ldstr "message"
-			IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0660: stloc.s 20
-			IL_0662: br IL_066b
+			IL_064d: ldloc.s 4
+			IL_064f: ldstr "message"
+			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0659: stloc.s 19
+			IL_065b: br IL_0664
 
-			IL_0667: ldloc.s 4
-			IL_0669: stloc.s 20
+			IL_0660: ldloc.s 4
+			IL_0662: stloc.s 19
 
-			IL_066b: ldloc.s 20
-			IL_066d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0672: stloc.s 18
-			IL_0674: ldloc.s 18
-			IL_0676: brfalse IL_068e
+			IL_0664: ldloc.s 19
+			IL_0666: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_066b: stloc.s 17
+			IL_066d: ldloc.s 17
+			IL_066f: brfalse IL_0687
 
-			IL_067b: ldloc.s 4
-			IL_067d: ldstr "message"
-			IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0687: stloc.s 6
-			IL_0689: br IL_069b
+			IL_0674: ldloc.s 4
+			IL_0676: ldstr "message"
+			IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0680: stloc.s 5
+			IL_0682: br IL_0694
 
-			IL_068e: ldloc.s 4
-			IL_0690: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0695: stloc.s 21
-			IL_0697: ldloc.s 21
-			IL_0699: stloc.s 6
+			IL_0687: ldloc.s 4
+			IL_0689: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_068e: stloc.s 20
+			IL_0690: ldloc.s 20
+			IL_0692: stloc.s 5
 
-			IL_069b: ldloc.s 6
-			IL_069d: stloc.s 7
-			IL_069f: ldstr "console"
-			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06a9: stloc.s 16
-			IL_06ab: ldloc.s 16
-			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b2: stloc.s 16
-			IL_06b4: ldloc.s 16
-			IL_06b6: ldstr "error"
-			IL_06bb: ldloc.s 7
-			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06c2: pop
-			IL_06c3: ldstr "process"
-			IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06cd: stloc.s 16
-			IL_06cf: ldloc.s 16
-			IL_06d1: ldstr "exitCode"
-			IL_06d6: ldc.r8 1
-			IL_06df: ldc.i4.1
-			IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_06e5: pop
-			IL_06e6: leave IL_06eb
+			IL_0694: ldloc.s 5
+			IL_0696: stloc.s 6
+			IL_0698: ldstr "console"
+			IL_069d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06a2: stloc.s 15
+			IL_06a4: ldloc.s 15
+			IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06ab: stloc.s 15
+			IL_06ad: ldloc.s 15
+			IL_06af: ldstr "error"
+			IL_06b4: ldloc.s 6
+			IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06bb: pop
+			IL_06bc: ldstr "process"
+			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06c6: stloc.s 15
+			IL_06c8: ldloc.s 15
+			IL_06ca: ldstr "exitCode"
+			IL_06cf: ldc.r8 1
+			IL_06d8: ldc.i4.1
+			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_06de: pop
+			IL_06df: leave IL_06e4
 		} // end handler
 
-		IL_06eb: ldnull
-		IL_06ec: stloc.s 8
-		IL_06ee: ret
+		IL_06e4: ldnull
+		IL_06e5: stloc.s 7
+		IL_06e7: ret
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap
@@ -7096,7 +7069,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5317
+		// Method begins at RVA 0x52c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67a2
+				// Method begins at RVA 0x6722
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67b4
+					// Method begins at RVA 0x6734
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67bd
+					// Method begins at RVA 0x673d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67c6
+					// Method begins at RVA 0x6746
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67ab
+				// Method begins at RVA 0x672b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -294,7 +294,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67d8
+					// Method begins at RVA 0x6758
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67cf
+				// Method begins at RVA 0x674f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -432,7 +432,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67ea
+					// Method begins at RVA 0x676a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -450,7 +450,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67e1
+				// Method begins at RVA 0x6761
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -591,7 +591,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67f3
+				// Method begins at RVA 0x6773
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2459,7 +2459,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x6799
+			// Method begins at RVA 0x6719
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2798,7 +2798,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6805
+				// Method begins at RVA 0x6785
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2886,7 +2886,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6820
+						// Method begins at RVA 0x67a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2904,7 +2904,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6817
+					// Method begins at RVA 0x6797
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2922,7 +2922,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x680e
+				// Method begins at RVA 0x678e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2951,91 +2951,88 @@
 			)
 			// Method begins at RVA 0x3f50
 			// Header size: 12
-			// Code size: 175 (0xaf)
+			// Code size: 165 (0xa5)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] class Modules.test262_metadataParser/countIndent/Scope/Block_L40C33,
-				[2] object,
-				[3] float64,
-				[4] object,
-				[5] bool,
+				[1] object,
+				[2] float64,
+				[3] object,
+				[4] bool,
+				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
-				[9] object,
-				[10] object
+				[9] object
 			)
 
 			IL_0000: ldc.r8 0.0
 			IL_0009: stloc.0
 			// loop start (head: IL_000a)
 				IL_000a: ldloc.0
-				IL_000b: stloc.3
-				IL_000c: ldloc.3
+				IL_000b: stloc.2
+				IL_000c: ldloc.2
 				IL_000d: ldarg.2
 				IL_000e: ldstr "length"
 				IL_0013: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_0018: clt
-				IL_001a: brfalse IL_00a4
+				IL_001a: brfalse IL_009a
 
-				IL_001f: newobj instance void Modules.test262_metadataParser/countIndent/Scope/Block_L40C33::.ctor()
-				IL_0024: stloc.1
-				IL_0025: ldarg.2
-				IL_0026: ldloc.0
-				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_002c: stloc.2
-				IL_002d: ldloc.2
-				IL_002e: stloc.s 4
-				IL_0030: ldloc.s 4
-				IL_0032: ldstr " "
-				IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_003c: stloc.s 5
-				IL_003e: ldloc.s 5
-				IL_0040: box [System.Runtime]System.Boolean
-				IL_0045: stloc.s 6
-				IL_0047: ldloc.s 6
-				IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_004e: stloc.s 5
-				IL_0050: ldloc.s 5
-				IL_0052: brfalse IL_007a
+				IL_001f: ldarg.2
+				IL_0020: ldloc.0
+				IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0026: stloc.1
+				IL_0027: ldloc.1
+				IL_0028: stloc.3
+				IL_0029: ldloc.3
+				IL_002a: ldstr " "
+				IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0034: stloc.s 4
+				IL_0036: ldloc.s 4
+				IL_0038: box [System.Runtime]System.Boolean
+				IL_003d: stloc.s 5
+				IL_003f: ldloc.s 5
+				IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0046: stloc.s 4
+				IL_0048: ldloc.s 4
+				IL_004a: brfalse IL_0070
 
-				IL_0057: ldloc.2
-				IL_0058: stloc.s 4
-				IL_005a: ldloc.s 4
-				IL_005c: ldstr "\t"
-				IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0066: stloc.s 5
-				IL_0068: ldloc.s 5
-				IL_006a: box [System.Runtime]System.Boolean
-				IL_006f: stloc.s 7
-				IL_0071: ldloc.s 7
-				IL_0073: stloc.s 9
-				IL_0075: br IL_007e
+				IL_004f: ldloc.1
+				IL_0050: stloc.3
+				IL_0051: ldloc.3
+				IL_0052: ldstr "\t"
+				IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_005c: stloc.s 4
+				IL_005e: ldloc.s 4
+				IL_0060: box [System.Runtime]System.Boolean
+				IL_0065: stloc.s 6
+				IL_0067: ldloc.s 6
+				IL_0069: stloc.s 8
+				IL_006b: br IL_0074
 
-				IL_007a: ldloc.s 6
-				IL_007c: stloc.s 9
+				IL_0070: ldloc.s 5
+				IL_0072: stloc.s 8
 
-				IL_007e: ldloc.s 9
-				IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0085: stloc.s 5
-				IL_0087: ldloc.s 5
-				IL_0089: brfalse IL_0093
+				IL_0074: ldloc.s 8
+				IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_007b: stloc.s 4
+				IL_007d: ldloc.s 4
+				IL_007f: brfalse IL_0089
 
-				IL_008e: br IL_00a4
+				IL_0084: br IL_009a
 
-				IL_0093: ldloc.0
-				IL_0094: ldc.r8 1
-				IL_009d: add
-				IL_009e: stloc.0
-				IL_009f: br IL_000a
+				IL_0089: ldloc.0
+				IL_008a: ldc.r8 1
+				IL_0093: add
+				IL_0094: stloc.0
+				IL_0095: br IL_000a
 			// end loop
 
-			IL_00a4: ldloc.0
-			IL_00a5: box [System.Runtime]System.Double
-			IL_00aa: stloc.s 10
-			IL_00ac: ldloc.s 10
-			IL_00ae: ret
+			IL_009a: ldloc.0
+			IL_009b: box [System.Runtime]System.Double
+			IL_00a0: stloc.s 9
+			IL_00a2: ldloc.s 9
+			IL_00a4: ret
 		} // end of method countIndent::__js_call__
 
 	} // end of class countIndent
@@ -3059,7 +3056,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x683b
+						// Method begins at RVA 0x67bb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3077,7 +3074,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6832
+					// Method begins at RVA 0x67b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3095,7 +3092,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6829
+				// Method begins at RVA 0x67a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3122,22 +3119,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x400c
+			// Method begins at RVA 0x4004
 			// Header size: 12
-			// Code size: 353 (0x161)
+			// Code size: 331 (0x14b)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.test262_metadataParser/unquote/Scope/Block_L51C25,
+				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] bool,
+				[3] bool,
+				[4] object,
 				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
-				[9] object,
-				[10] object
+				[9] object
 			)
 
 			IL_0000: ldarg.2
@@ -3148,122 +3144,120 @@
 			IL_0019: clt
 			IL_001b: ldc.i4.0
 			IL_001c: ceq
-			IL_001e: brfalse IL_015f
+			IL_001e: brfalse IL_0149
 
-			IL_0023: newobj instance void Modules.test262_metadataParser/unquote/Scope/Block_L51C25::.ctor()
-			IL_0028: stloc.0
-			IL_0029: ldarg.2
-			IL_002a: ldc.r8 0.0
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0038: stloc.1
-			IL_0039: ldarg.2
-			IL_003a: ldarg.2
-			IL_003b: ldstr "length"
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0045: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_004a: ldc.r8 1
-			IL_0053: sub
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0059: stloc.2
-			IL_005a: ldloc.1
-			IL_005b: stloc.3
-			IL_005c: ldloc.3
-			IL_005d: ldstr "\""
-			IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0067: stloc.s 4
-			IL_0069: ldloc.s 4
-			IL_006b: box [System.Runtime]System.Boolean
-			IL_0070: stloc.s 5
-			IL_0072: ldloc.s 5
-			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0079: stloc.s 4
-			IL_007b: ldloc.s 4
-			IL_007d: brfalse IL_00a3
+			IL_0023: ldarg.2
+			IL_0024: ldc.r8 0.0
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0032: stloc.0
+			IL_0033: ldarg.2
+			IL_0034: ldarg.2
+			IL_0035: ldstr "length"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0044: ldc.r8 1
+			IL_004d: sub
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0053: stloc.1
+			IL_0054: ldloc.0
+			IL_0055: stloc.2
+			IL_0056: ldloc.2
+			IL_0057: ldstr "\""
+			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0061: stloc.3
+			IL_0062: ldloc.3
+			IL_0063: box [System.Runtime]System.Boolean
+			IL_0068: stloc.s 4
+			IL_006a: ldloc.s 4
+			IL_006c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0071: stloc.3
+			IL_0072: ldloc.3
+			IL_0073: brfalse IL_0097
 
-			IL_0082: ldloc.2
-			IL_0083: stloc.3
-			IL_0084: ldloc.3
-			IL_0085: ldstr "\""
-			IL_008a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_008f: stloc.s 4
-			IL_0091: ldloc.s 4
-			IL_0093: box [System.Runtime]System.Boolean
-			IL_0098: stloc.s 6
-			IL_009a: ldloc.s 6
-			IL_009c: stloc.s 8
-			IL_009e: br IL_00a7
+			IL_0078: ldloc.1
+			IL_0079: stloc.2
+			IL_007a: ldloc.2
+			IL_007b: ldstr "\""
+			IL_0080: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0085: stloc.3
+			IL_0086: ldloc.3
+			IL_0087: box [System.Runtime]System.Boolean
+			IL_008c: stloc.s 5
+			IL_008e: ldloc.s 5
+			IL_0090: stloc.s 7
+			IL_0092: br IL_009b
 
-			IL_00a3: ldloc.s 5
-			IL_00a5: stloc.s 8
+			IL_0097: ldloc.s 4
+			IL_0099: stloc.s 7
 
-			IL_00a7: ldloc.s 8
-			IL_00a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.s 4
-			IL_00b2: brtrue IL_010d
+			IL_009b: ldloc.s 7
+			IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a2: stloc.3
+			IL_00a3: ldloc.3
+			IL_00a4: brtrue IL_00f9
 
-			IL_00b7: ldloc.1
-			IL_00b8: stloc.3
-			IL_00b9: ldloc.3
-			IL_00ba: ldstr "'"
-			IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00c4: stloc.s 4
-			IL_00c6: ldloc.s 4
-			IL_00c8: box [System.Runtime]System.Boolean
-			IL_00cd: stloc.s 5
-			IL_00cf: ldloc.s 5
-			IL_00d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00d6: stloc.s 4
-			IL_00d8: ldloc.s 4
-			IL_00da: brfalse IL_0100
+			IL_00a9: ldloc.0
+			IL_00aa: stloc.2
+			IL_00ab: ldloc.2
+			IL_00ac: ldstr "'"
+			IL_00b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00b6: stloc.3
+			IL_00b7: ldloc.3
+			IL_00b8: box [System.Runtime]System.Boolean
+			IL_00bd: stloc.s 4
+			IL_00bf: ldloc.s 4
+			IL_00c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00c6: stloc.3
+			IL_00c7: ldloc.3
+			IL_00c8: brfalse IL_00ec
 
-			IL_00df: ldloc.2
-			IL_00e0: stloc.3
-			IL_00e1: ldloc.3
-			IL_00e2: ldstr "'"
-			IL_00e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00ec: stloc.s 4
-			IL_00ee: ldloc.s 4
-			IL_00f0: box [System.Runtime]System.Boolean
-			IL_00f5: stloc.s 6
-			IL_00f7: ldloc.s 6
-			IL_00f9: stloc.s 10
-			IL_00fb: br IL_0104
+			IL_00cd: ldloc.1
+			IL_00ce: stloc.2
+			IL_00cf: ldloc.2
+			IL_00d0: ldstr "'"
+			IL_00d5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00da: stloc.3
+			IL_00db: ldloc.3
+			IL_00dc: box [System.Runtime]System.Boolean
+			IL_00e1: stloc.s 5
+			IL_00e3: ldloc.s 5
+			IL_00e5: stloc.s 9
+			IL_00e7: br IL_00f0
 
-			IL_0100: ldloc.s 5
-			IL_0102: stloc.s 10
+			IL_00ec: ldloc.s 4
+			IL_00ee: stloc.s 9
 
-			IL_0104: ldloc.s 10
-			IL_0106: stloc.s 8
-			IL_0108: br IL_010d
+			IL_00f0: ldloc.s 9
+			IL_00f2: stloc.s 7
+			IL_00f4: br IL_00f9
 
-			IL_010d: ldloc.s 8
-			IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0114: stloc.s 4
-			IL_0116: ldloc.s 4
-			IL_0118: brfalse IL_015f
+			IL_00f9: ldloc.s 7
+			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0100: stloc.3
+			IL_0101: ldloc.3
+			IL_0102: brfalse IL_0149
 
-			IL_011d: ldarg.2
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0123: stloc.3
-			IL_0124: ldloc.3
-			IL_0125: ldstr "substring"
-			IL_012a: ldc.r8 1
-			IL_0133: box [System.Runtime]System.Double
-			IL_0138: ldarg.2
-			IL_0139: ldstr "length"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0143: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0148: ldc.r8 1
-			IL_0151: sub
-			IL_0152: box [System.Runtime]System.Double
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_015c: stloc.3
-			IL_015d: ldloc.3
-			IL_015e: ret
+			IL_0107: ldarg.2
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010d: stloc.2
+			IL_010e: ldloc.2
+			IL_010f: ldstr "substring"
+			IL_0114: ldc.r8 1
+			IL_011d: box [System.Runtime]System.Double
+			IL_0122: ldarg.2
+			IL_0123: ldstr "length"
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0132: ldc.r8 1
+			IL_013b: sub
+			IL_013c: box [System.Runtime]System.Double
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0146: stloc.2
+			IL_0147: ldloc.2
+			IL_0148: ret
 
-			IL_015f: ldarg.2
-			IL_0160: ret
+			IL_0149: ldarg.2
+			IL_014a: ret
 		} // end of method unquote::__js_call__
 
 	} // end of class unquote
@@ -3283,7 +3277,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x684d
+					// Method begins at RVA 0x67cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3301,7 +3295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6844
+				// Method begins at RVA 0x67c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3329,7 +3323,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6868
+						// Method begins at RVA 0x67e8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3347,7 +3341,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x685f
+					// Method begins at RVA 0x67df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3365,7 +3359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6856
+				// Method begins at RVA 0x67d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3392,26 +3386,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x417c
+			// Method begins at RVA 0x415c
 			// Header size: 12
-			// Code size: 311 (0x137)
+			// Code size: 304 (0x130)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[3] float64,
-				[4] class Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41,
+				[4] object,
 				[5] object,
-				[6] object,
-				[7] bool,
-				[8] float64
+				[6] bool,
+				[7] float64
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: stloc.s 6
-			IL_0008: ldloc.s 6
+			IL_0006: stloc.s 5
+			IL_0008: ldloc.s 5
 			IL_000a: ldstr "substring"
 			IL_000f: ldc.r8 1
 			IL_0018: box [System.Runtime]System.Double
@@ -3423,23 +3416,23 @@
 			IL_0036: sub
 			IL_0037: box [System.Runtime]System.Double
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0041: stloc.s 6
-			IL_0043: ldloc.s 6
+			IL_0041: stloc.s 5
+			IL_0043: ldloc.s 5
 			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004a: stloc.s 6
-			IL_004c: ldloc.s 6
+			IL_004a: stloc.s 5
+			IL_004c: ldloc.s 5
 			IL_004e: ldstr "trim"
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0058: stloc.s 6
-			IL_005a: ldloc.s 6
+			IL_0058: stloc.s 5
+			IL_005a: ldloc.s 5
 			IL_005c: stloc.0
 			IL_005d: ldloc.0
-			IL_005e: stloc.s 6
-			IL_0060: ldloc.s 6
+			IL_005e: stloc.s 5
+			IL_0060: ldloc.s 5
 			IL_0062: ldstr ""
 			IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_006c: stloc.s 7
-			IL_006e: ldloc.s 7
+			IL_006c: stloc.s 6
+			IL_006e: ldloc.s 6
 			IL_0070: brfalse IL_007c
 
 			IL_0075: ldc.i4.0
@@ -3448,13 +3441,13 @@
 
 			IL_007c: ldloc.0
 			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0082: stloc.s 6
-			IL_0084: ldloc.s 6
+			IL_0082: stloc.s 5
+			IL_0084: ldloc.s 5
 			IL_0086: ldstr "split"
 			IL_008b: ldstr ","
 			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0095: stloc.s 6
-			IL_0097: ldloc.s 6
+			IL_0095: stloc.s 5
+			IL_0097: ldloc.s 5
 			IL_0099: stloc.1
 			IL_009a: ldc.i4.0
 			IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -3463,61 +3456,59 @@
 			IL_00aa: stloc.3
 			// loop start (head: IL_00ab)
 				IL_00ab: ldloc.3
-				IL_00ac: stloc.s 8
-				IL_00ae: ldloc.s 8
+				IL_00ac: stloc.s 7
+				IL_00ae: ldloc.s 7
 				IL_00b0: ldloc.1
 				IL_00b1: ldstr "length"
 				IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_00bb: clt
-				IL_00bd: brfalse IL_0135
+				IL_00bd: brfalse IL_012e
 
-				IL_00c2: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41::.ctor()
-				IL_00c7: stloc.s 4
-				IL_00c9: ldloc.1
-				IL_00ca: ldloc.3
-				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d5: stloc.s 6
-				IL_00d7: ldloc.s 6
-				IL_00d9: ldstr "trim"
-				IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00e3: stloc.s 6
-				IL_00e5: ldloc.s 6
-				IL_00e7: stloc.s 5
-				IL_00e9: ldloc.s 5
-				IL_00eb: stloc.s 6
-				IL_00ed: ldloc.s 6
-				IL_00ef: ldstr ""
-				IL_00f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_00f9: stloc.s 7
-				IL_00fb: ldloc.s 7
-				IL_00fd: brfalse IL_0124
+				IL_00c2: ldloc.1
+				IL_00c3: ldloc.3
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ce: stloc.s 5
+				IL_00d0: ldloc.s 5
+				IL_00d2: ldstr "trim"
+				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00dc: stloc.s 5
+				IL_00de: ldloc.s 5
+				IL_00e0: stloc.s 4
+				IL_00e2: ldloc.s 4
+				IL_00e4: stloc.s 5
+				IL_00e6: ldloc.s 5
+				IL_00e8: ldstr ""
+				IL_00ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_00f2: stloc.s 6
+				IL_00f4: ldloc.s 6
+				IL_00f6: brfalse IL_011d
 
-				IL_0102: ldarg.0
-				IL_0103: ldfld object Modules.test262_metadataParser/Scope::unquote
-				IL_0108: ldc.i4.1
-				IL_0109: newarr [System.Runtime]System.Object
-				IL_010e: dup
-				IL_010f: ldc.i4.0
-				IL_0110: ldarg.0
-				IL_0111: stelem.ref
-				IL_0112: ldloc.s 5
-				IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0119: stloc.s 6
-				IL_011b: ldloc.2
-				IL_011c: ldloc.s 6
-				IL_011e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0123: pop
+				IL_00fb: ldarg.0
+				IL_00fc: ldfld object Modules.test262_metadataParser/Scope::unquote
+				IL_0101: ldc.i4.1
+				IL_0102: newarr [System.Runtime]System.Object
+				IL_0107: dup
+				IL_0108: ldc.i4.0
+				IL_0109: ldarg.0
+				IL_010a: stelem.ref
+				IL_010b: ldloc.s 4
+				IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0112: stloc.s 5
+				IL_0114: ldloc.2
+				IL_0115: ldloc.s 5
+				IL_0117: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_011c: pop
 
-				IL_0124: ldloc.3
-				IL_0125: ldc.r8 1
-				IL_012e: add
-				IL_012f: stloc.3
-				IL_0130: br IL_00ab
+				IL_011d: ldloc.3
+				IL_011e: ldc.r8 1
+				IL_0127: add
+				IL_0128: stloc.3
+				IL_0129: br IL_00ab
 			// end loop
 
-			IL_0135: ldloc.2
-			IL_0136: ret
+			IL_012e: ldloc.2
+			IL_012f: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -3537,7 +3528,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x687a
+					// Method begins at RVA 0x67fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3555,7 +3546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6871
+				// Method begins at RVA 0x67f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3582,7 +3573,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x42c0
+			// Method begins at RVA 0x4298
 			// Header size: 12
 			// Code size: 141 (0x8d)
 			.maxstack 8
@@ -3672,7 +3663,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6883
+				// Method begins at RVA 0x6803
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3700,7 +3691,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x689e
+						// Method begins at RVA 0x681e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3720,7 +3711,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68a7
+						// Method begins at RVA 0x6827
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3740,7 +3731,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68b0
+						// Method begins at RVA 0x6830
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3760,7 +3751,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68b9
+						// Method begins at RVA 0x6839
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3778,7 +3769,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6895
+					// Method begins at RVA 0x6815
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3796,7 +3787,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x688c
+				// Method begins at RVA 0x680c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3823,22 +3814,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x435c
+			// Method begins at RVA 0x4334
 			// Header size: 12
-			// Code size: 317 (0x13d)
+			// Code size: 306 (0x132)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] float64,
-				[3] class Modules.test262_metadataParser/foldBlockLines/Scope_For_L92C7/Block_L92C41,
-				[4] object,
-				[5] float64,
-				[6] object,
-				[7] bool,
+				[3] object,
+				[4] float64,
+				[5] object,
+				[6] bool,
+				[7] object,
 				[8] object,
-				[9] object,
-				[10] string
+				[9] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -3850,112 +3840,110 @@
 			IL_001a: stloc.2
 			// loop start (head: IL_001b)
 				IL_001b: ldloc.2
-				IL_001c: stloc.s 5
-				IL_001e: ldloc.s 5
+				IL_001c: stloc.s 4
+				IL_001e: ldloc.s 4
 				IL_0020: ldarg.2
 				IL_0021: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
 				IL_0026: clt
-				IL_0028: brfalse IL_0124
+				IL_0028: brfalse IL_0119
 
-				IL_002d: newobj instance void Modules.test262_metadataParser/foldBlockLines/Scope_For_L92C7/Block_L92C41::.ctor()
-				IL_0032: stloc.3
-				IL_0033: ldarg.2
-				IL_0034: ldloc.2
-				IL_0035: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_003a: stloc.s 4
-				IL_003c: ldloc.s 4
-				IL_003e: stloc.s 6
-				IL_0040: ldloc.s 6
-				IL_0042: ldstr ""
-				IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_004c: stloc.s 7
-				IL_004e: ldloc.s 7
-				IL_0050: brfalse IL_0066
+				IL_002d: ldarg.2
+				IL_002e: ldloc.2
+				IL_002f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0034: stloc.3
+				IL_0035: ldloc.3
+				IL_0036: stloc.s 5
+				IL_0038: ldloc.s 5
+				IL_003a: ldstr ""
+				IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0044: stloc.s 6
+				IL_0046: ldloc.s 6
+				IL_0048: brfalse IL_005e
 
-				IL_0055: ldloc.1
-				IL_0056: ldc.r8 1
-				IL_005f: add
-				IL_0060: stloc.1
-				IL_0061: br IL_0113
+				IL_004d: ldloc.1
+				IL_004e: ldc.r8 1
+				IL_0057: add
+				IL_0058: stloc.1
+				IL_0059: br IL_0108
 
-				IL_0066: ldloc.0
-				IL_0067: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_006c: ldc.r8 0.0
-				IL_0075: ceq
-				IL_0077: brfalse IL_008a
+				IL_005e: ldloc.0
+				IL_005f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0064: ldc.r8 0.0
+				IL_006d: ceq
+				IL_006f: brfalse IL_0081
 
-				IL_007c: ldloc.0
-				IL_007d: ldloc.s 4
-				IL_007f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0084: pop
-				IL_0085: br IL_0105
+				IL_0074: ldloc.0
+				IL_0075: ldloc.3
+				IL_0076: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_007b: pop
+				IL_007c: br IL_00fa
 
-				IL_008a: ldloc.1
-				IL_008b: stloc.s 5
-				IL_008d: ldloc.s 5
-				IL_008f: ldc.r8 0.0
-				IL_0098: cgt
-				IL_009a: brfalse IL_00ee
+				IL_0081: ldloc.1
+				IL_0082: stloc.s 4
+				IL_0084: ldloc.s 4
+				IL_0086: ldc.r8 0.0
+				IL_008f: cgt
+				IL_0091: brfalse IL_00e4
 
-				IL_009f: ldstr "\n"
-				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a9: stloc.s 6
-				IL_00ab: ldloc.1
-				IL_00ac: stloc.s 5
-				IL_00ae: ldloc.s 5
-				IL_00b0: ldc.r8 1
-				IL_00b9: add
-				IL_00ba: stloc.s 5
+				IL_0096: ldstr "\n"
+				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a0: stloc.s 5
+				IL_00a2: ldloc.1
+				IL_00a3: stloc.s 4
+				IL_00a5: ldloc.s 4
+				IL_00a7: ldc.r8 1
+				IL_00b0: add
+				IL_00b1: stloc.s 4
+				IL_00b3: ldloc.s 4
+				IL_00b5: box [System.Runtime]System.Double
+				IL_00ba: stloc.s 7
 				IL_00bc: ldloc.s 5
-				IL_00be: box [System.Runtime]System.Double
-				IL_00c3: stloc.s 8
-				IL_00c5: ldloc.s 6
-				IL_00c7: ldstr "repeat"
-				IL_00cc: ldloc.s 8
-				IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00d3: stloc.s 6
-				IL_00d5: ldloc.s 6
-				IL_00d7: ldloc.s 4
-				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00de: stloc.s 9
-				IL_00e0: ldloc.0
-				IL_00e1: ldloc.s 9
-				IL_00e3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00e8: pop
-				IL_00e9: br IL_0105
+				IL_00be: ldstr "repeat"
+				IL_00c3: ldloc.s 7
+				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00ca: stloc.s 5
+				IL_00cc: ldloc.s 5
+				IL_00ce: ldloc.3
+				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00d4: stloc.s 8
+				IL_00d6: ldloc.0
+				IL_00d7: ldloc.s 8
+				IL_00d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00de: pop
+				IL_00df: br IL_00fa
 
-				IL_00ee: ldstr " "
-				IL_00f3: ldloc.s 4
-				IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00fa: stloc.s 9
-				IL_00fc: ldloc.0
-				IL_00fd: ldloc.s 9
-				IL_00ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0104: pop
+				IL_00e4: ldstr " "
+				IL_00e9: ldloc.3
+				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00ef: stloc.s 8
+				IL_00f1: ldloc.0
+				IL_00f2: ldloc.s 8
+				IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00f9: pop
 
-				IL_0105: ldc.r8 0.0
-				IL_010e: stloc.s 5
-				IL_0110: ldloc.s 5
-				IL_0112: stloc.1
+				IL_00fa: ldc.r8 0.0
+				IL_0103: stloc.s 4
+				IL_0105: ldloc.s 4
+				IL_0107: stloc.1
 
-				IL_0113: ldloc.2
-				IL_0114: ldc.r8 1
-				IL_011d: add
-				IL_011e: stloc.2
-				IL_011f: br IL_001b
+				IL_0108: ldloc.2
+				IL_0109: ldc.r8 1
+				IL_0112: add
+				IL_0113: stloc.2
+				IL_0114: br IL_001b
 			// end loop
 
-			IL_0124: ldloc.0
-			IL_0125: ldc.i4.1
-			IL_0126: newarr [System.Runtime]System.Object
-			IL_012b: dup
-			IL_012c: ldc.i4.0
-			IL_012d: ldstr ""
-			IL_0132: stelem.ref
-			IL_0133: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0138: stloc.s 10
-			IL_013a: ldloc.s 10
-			IL_013c: ret
+			IL_0119: ldloc.0
+			IL_011a: ldc.i4.1
+			IL_011b: newarr [System.Runtime]System.Object
+			IL_0120: dup
+			IL_0121: ldc.i4.0
+			IL_0122: ldstr ""
+			IL_0127: stelem.ref
+			IL_0128: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_012d: stloc.s 9
+			IL_012f: ldloc.s 9
+			IL_0131: ret
 		} // end of method foldBlockLines::__js_call__
 
 	} // end of class foldBlockLines
@@ -3979,7 +3967,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68d4
+						// Method begins at RVA 0x6854
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3999,7 +3987,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68dd
+						// Method begins at RVA 0x685d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4019,7 +4007,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68e6
+						// Method begins at RVA 0x6866
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4037,7 +4025,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68cb
+					// Method begins at RVA 0x684b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4055,7 +4043,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68c2
+				// Method begins at RVA 0x6842
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4085,22 +4073,21 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x44a8
+			// Method begins at RVA 0x4474
 			// Header size: 12
-			// Code size: 432 (0x1b0)
+			// Code size: 423 (0x1a7)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
-				[2] class Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37,
-				[3] object,
-				[4] float64,
+				[2] object,
+				[3] float64,
+				[4] object,
 				[5] object,
-				[6] object,
-				[7] float64,
-				[8] bool,
-				[9] object,
-				[10] string
+				[6] float64,
+				[7] bool,
+				[8] object,
+				[9] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -4114,153 +4101,151 @@
 				IL_0017: ldarg.3
 				IL_0018: ldstr "index"
 				IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0022: stloc.s 5
+				IL_0022: stloc.s 4
 				IL_0024: ldarg.2
 				IL_0025: ldstr "length"
 				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_002f: stloc.s 6
-				IL_0031: ldloc.s 5
+				IL_002f: stloc.s 5
+				IL_0031: ldloc.s 4
 				IL_0033: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0038: stloc.s 7
-				IL_003a: ldloc.s 7
-				IL_003c: ldloc.s 6
+				IL_0038: stloc.s 6
+				IL_003a: ldloc.s 6
+				IL_003c: ldloc.s 5
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_016d
+				IL_0045: brfalse IL_0164
 
-				IL_004a: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37::.ctor()
-				IL_004f: stloc.2
-				IL_0050: ldarg.2
-				IL_0051: ldarg.3
-				IL_0052: ldstr "index"
-				IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0061: stloc.3
-				IL_0062: ldloc.3
-				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0068: stloc.s 6
-				IL_006a: ldloc.s 6
-				IL_006c: ldstr "trim"
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0076: stloc.s 6
-				IL_0078: ldloc.s 6
-				IL_007a: ldstr ""
-				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0084: stloc.s 8
-				IL_0086: ldloc.s 8
-				IL_0088: brfalse IL_00c0
+				IL_004a: ldarg.2
+				IL_004b: ldarg.3
+				IL_004c: ldstr "index"
+				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_005b: stloc.2
+				IL_005c: ldloc.2
+				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0062: stloc.s 5
+				IL_0064: ldloc.s 5
+				IL_0066: ldstr "trim"
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0070: stloc.s 5
+				IL_0072: ldloc.s 5
+				IL_0074: ldstr ""
+				IL_0079: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_007e: stloc.s 7
+				IL_0080: ldloc.s 7
+				IL_0082: brfalse IL_00ba
 
-				IL_008d: ldloc.0
-				IL_008e: ldstr ""
-				IL_0093: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0098: pop
+				IL_0087: ldloc.0
+				IL_0088: ldstr ""
+				IL_008d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0092: pop
+				IL_0093: ldarg.3
+				IL_0094: ldstr "index"
 				IL_0099: ldarg.3
 				IL_009a: ldstr "index"
-				IL_009f: ldarg.3
-				IL_00a0: ldstr "index"
-				IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00aa: ldc.r8 1
-				IL_00b3: add
-				IL_00b4: ldc.i4.1
-				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00ba: pop
-				IL_00bb: br IL_0017
+				IL_009f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00a4: ldc.r8 1
+				IL_00ad: add
+				IL_00ae: ldc.i4.1
+				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00b4: pop
+				IL_00b5: br IL_0017
 
-				IL_00c0: ldarg.0
-				IL_00c1: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00c6: ldc.i4.1
-				IL_00c7: newarr [System.Runtime]System.Object
-				IL_00cc: dup
-				IL_00cd: ldc.i4.0
-				IL_00ce: ldarg.0
-				IL_00cf: stelem.ref
-				IL_00d0: ldloc.3
-				IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00d6: stloc.s 6
-				IL_00d8: ldloc.s 6
-				IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00df: stloc.s 7
-				IL_00e1: ldloc.s 7
-				IL_00e3: stloc.s 4
-				IL_00e5: ldloc.s 4
-				IL_00e7: stloc.s 7
-				IL_00e9: ldloc.s 7
-				IL_00eb: ldarg.s parentIndent
-				IL_00ed: cgt
-				IL_00ef: ldc.i4.0
-				IL_00f0: ceq
-				IL_00f2: brfalse IL_00fc
+				IL_00ba: ldarg.0
+				IL_00bb: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00c0: ldc.i4.1
+				IL_00c1: newarr [System.Runtime]System.Object
+				IL_00c6: dup
+				IL_00c7: ldc.i4.0
+				IL_00c8: ldarg.0
+				IL_00c9: stelem.ref
+				IL_00ca: ldloc.2
+				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00d0: stloc.s 5
+				IL_00d2: ldloc.s 5
+				IL_00d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d9: stloc.s 6
+				IL_00db: ldloc.s 6
+				IL_00dd: stloc.3
+				IL_00de: ldloc.3
+				IL_00df: stloc.s 6
+				IL_00e1: ldloc.s 6
+				IL_00e3: ldarg.s parentIndent
+				IL_00e5: cgt
+				IL_00e7: ldc.i4.0
+				IL_00e8: ceq
+				IL_00ea: brfalse IL_00f4
 
-				IL_00f7: br IL_016d
+				IL_00ef: br IL_0164
 
-				IL_00fc: ldloc.1
-				IL_00fd: stloc.s 9
-				IL_00ff: ldloc.s 9
-				IL_0101: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0106: stloc.s 7
-				IL_0108: ldloc.s 7
-				IL_010a: ldc.r8 0.0
-				IL_0113: clt
-				IL_0115: brfalse IL_0126
+				IL_00f4: ldloc.1
+				IL_00f5: stloc.s 8
+				IL_00f7: ldloc.s 8
+				IL_00f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00fe: stloc.s 6
+				IL_0100: ldloc.s 6
+				IL_0102: ldc.r8 0.0
+				IL_010b: clt
+				IL_010d: brfalse IL_011d
 
-				IL_011a: ldloc.s 4
-				IL_011c: box [System.Runtime]System.Double
-				IL_0121: stloc.s 9
-				IL_0123: ldloc.s 9
-				IL_0125: stloc.1
+				IL_0112: ldloc.3
+				IL_0113: box [System.Runtime]System.Double
+				IL_0118: stloc.s 8
+				IL_011a: ldloc.s 8
+				IL_011c: stloc.1
 
-				IL_0126: ldloc.3
-				IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_012c: stloc.s 6
-				IL_012e: ldloc.s 6
-				IL_0130: ldstr "substring"
-				IL_0135: ldloc.1
-				IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_013b: stloc.s 6
-				IL_013d: ldloc.0
-				IL_013e: ldloc.s 6
-				IL_0140: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0145: pop
-				IL_0146: ldarg.3
-				IL_0147: ldstr "index"
-				IL_014c: ldarg.3
-				IL_014d: ldstr "index"
-				IL_0152: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0157: ldc.r8 1
-				IL_0160: add
-				IL_0161: ldc.i4.1
-				IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0167: pop
-				IL_0168: br IL_0017
+				IL_011d: ldloc.2
+				IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0123: stloc.s 5
+				IL_0125: ldloc.s 5
+				IL_0127: ldstr "substring"
+				IL_012c: ldloc.1
+				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0132: stloc.s 5
+				IL_0134: ldloc.0
+				IL_0135: ldloc.s 5
+				IL_0137: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_013c: pop
+				IL_013d: ldarg.3
+				IL_013e: ldstr "index"
+				IL_0143: ldarg.3
+				IL_0144: ldstr "index"
+				IL_0149: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_014e: ldc.r8 1
+				IL_0157: add
+				IL_0158: ldc.i4.1
+				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_015e: pop
+				IL_015f: br IL_0017
 			// end loop
 
-			IL_016d: ldarg.s style
-			IL_016f: ldstr ">"
-			IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0179: stloc.s 8
-			IL_017b: ldloc.s 8
-			IL_017d: brfalse IL_0197
+			IL_0164: ldarg.s style
+			IL_0166: ldstr ">"
+			IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0170: stloc.s 7
+			IL_0172: ldloc.s 7
+			IL_0174: brfalse IL_018e
 
-			IL_0182: ldarg.0
-			IL_0183: castclass Modules.test262_metadataParser/Scope
-			IL_0188: ldnull
-			IL_0189: ldloc.0
-			IL_018a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_018f: tail.
-			IL_0191: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_0196: ret
+			IL_0179: ldarg.0
+			IL_017a: castclass Modules.test262_metadataParser/Scope
+			IL_017f: ldnull
+			IL_0180: ldloc.0
+			IL_0181: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0186: tail.
+			IL_0188: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_018d: ret
 
-			IL_0197: ldloc.0
-			IL_0198: ldc.i4.1
-			IL_0199: newarr [System.Runtime]System.Object
-			IL_019e: dup
-			IL_019f: ldc.i4.0
-			IL_01a0: ldstr "\n"
-			IL_01a5: stelem.ref
-			IL_01a6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01ab: stloc.s 10
-			IL_01ad: ldloc.s 10
-			IL_01af: ret
+			IL_018e: ldloc.0
+			IL_018f: ldc.i4.1
+			IL_0190: newarr [System.Runtime]System.Object
+			IL_0195: dup
+			IL_0196: ldc.i4.0
+			IL_0197: ldstr "\n"
+			IL_019c: stelem.ref
+			IL_019d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01a2: stloc.s 9
+			IL_01a4: ldloc.s 9
+			IL_01a6: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -4280,7 +4265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68f8
+					// Method begins at RVA 0x6878
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4300,7 +4285,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6901
+					// Method begins at RVA 0x6881
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4320,7 +4305,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x690a
+					// Method begins at RVA 0x688a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4338,7 +4323,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68ef
+				// Method begins at RVA 0x686f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4367,7 +4352,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4664
+			// Method begins at RVA 0x4628
 			// Header size: 12
 			// Code size: 373 (0x175)
 			.maxstack 8
@@ -4568,7 +4553,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6925
+						// Method begins at RVA 0x68a5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4588,7 +4573,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x692e
+						// Method begins at RVA 0x68ae
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4608,7 +4593,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6937
+						// Method begins at RVA 0x68b7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4628,7 +4613,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6940
+						// Method begins at RVA 0x68c0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4648,7 +4633,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6949
+						// Method begins at RVA 0x68c9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4668,7 +4653,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6952
+						// Method begins at RVA 0x68d2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4688,7 +4673,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x695b
+						// Method begins at RVA 0x68db
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4706,7 +4691,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x691c
+					// Method begins at RVA 0x689c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4724,7 +4709,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6913
+				// Method begins at RVA 0x6893
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4753,15 +4738,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x47e8
+			// Method begins at RVA 0x47ac
 			// Header size: 12
-			// Code size: 953 (0x3b9)
+			// Code size: 944 (0x3b0)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] class Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37,
-				[2] object,
-				[3] float64,
+				[1] object,
+				[2] float64,
+				[3] object,
 				[4] object,
 				[5] object,
 				[6] object,
@@ -4770,19 +4755,18 @@
 				[9] object,
 				[10] object,
 				[11] object,
-				[12] object,
-				[13] float64,
-				[14] bool,
-				[15] object,
-				[16] string,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[19] string,
+				[12] float64,
+				[13] bool,
+				[14] object,
+				[15] string,
+				[16] object,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[18] string,
+				[19] object,
 				[20] object,
 				[21] object,
-				[22] object,
-				[23] object[],
-				[24] object[]
+				[22] object[],
+				[23] object[]
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -4791,357 +4775,355 @@
 				IL_0006: ldarg.3
 				IL_0007: ldstr "index"
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0011: stloc.s 11
+				IL_0011: stloc.s 10
 				IL_0013: ldarg.2
 				IL_0014: ldstr "length"
 				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_001e: stloc.s 12
-				IL_0020: ldloc.s 11
+				IL_001e: stloc.s 11
+				IL_0020: ldloc.s 10
 				IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0027: stloc.s 13
-				IL_0029: ldloc.s 13
-				IL_002b: ldloc.s 12
+				IL_0027: stloc.s 12
+				IL_0029: ldloc.s 12
+				IL_002b: ldloc.s 11
 				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0032: clt
-				IL_0034: brfalse IL_03b7
+				IL_0034: brfalse IL_03ae
 
-				IL_0039: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37::.ctor()
-				IL_003e: stloc.1
-				IL_003f: ldarg.2
-				IL_0040: ldarg.3
-				IL_0041: ldstr "index"
-				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0050: stloc.2
-				IL_0051: ldloc.2
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0057: stloc.s 12
-				IL_0059: ldloc.s 12
-				IL_005b: ldstr "trim"
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0065: stloc.s 12
-				IL_0067: ldloc.s 12
-				IL_0069: ldstr ""
-				IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0073: stloc.s 14
-				IL_0075: ldloc.s 14
-				IL_0077: brfalse IL_00a3
+				IL_0039: ldarg.2
+				IL_003a: ldarg.3
+				IL_003b: ldstr "index"
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_004a: stloc.1
+				IL_004b: ldloc.1
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0051: stloc.s 11
+				IL_0053: ldloc.s 11
+				IL_0055: ldstr "trim"
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_005f: stloc.s 11
+				IL_0061: ldloc.s 11
+				IL_0063: ldstr ""
+				IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_006d: stloc.s 13
+				IL_006f: ldloc.s 13
+				IL_0071: brfalse IL_009d
 
+				IL_0076: ldarg.3
+				IL_0077: ldstr "index"
 				IL_007c: ldarg.3
 				IL_007d: ldstr "index"
-				IL_0082: ldarg.3
-				IL_0083: ldstr "index"
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_008d: ldc.r8 1
-				IL_0096: add
-				IL_0097: ldc.i4.1
-				IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_009d: pop
-				IL_009e: br IL_0006
+				IL_0082: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0087: ldc.r8 1
+				IL_0090: add
+				IL_0091: ldc.i4.1
+				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0097: pop
+				IL_0098: br IL_0006
 
-				IL_00a3: ldarg.0
-				IL_00a4: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00a9: ldc.i4.1
-				IL_00aa: newarr [System.Runtime]System.Object
-				IL_00af: dup
-				IL_00b0: ldc.i4.0
-				IL_00b1: ldarg.0
-				IL_00b2: stelem.ref
-				IL_00b3: ldloc.2
-				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00b9: stloc.s 12
-				IL_00bb: ldloc.s 12
-				IL_00bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00c2: stloc.s 13
-				IL_00c4: ldloc.s 13
-				IL_00c6: stloc.3
-				IL_00c7: ldloc.3
-				IL_00c8: stloc.s 13
-				IL_00ca: ldloc.s 13
-				IL_00cc: ldarg.s baseIndent
-				IL_00ce: clt
-				IL_00d0: brfalse IL_00da
+				IL_009d: ldarg.0
+				IL_009e: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00a3: ldc.i4.1
+				IL_00a4: newarr [System.Runtime]System.Object
+				IL_00a9: dup
+				IL_00aa: ldc.i4.0
+				IL_00ab: ldarg.0
+				IL_00ac: stelem.ref
+				IL_00ad: ldloc.1
+				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00b3: stloc.s 11
+				IL_00b5: ldloc.s 11
+				IL_00b7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00bc: stloc.s 12
+				IL_00be: ldloc.s 12
+				IL_00c0: stloc.2
+				IL_00c1: ldloc.2
+				IL_00c2: stloc.s 12
+				IL_00c4: ldloc.s 12
+				IL_00c6: ldarg.s baseIndent
+				IL_00c8: clt
+				IL_00ca: brfalse IL_00d4
 
-				IL_00d5: br IL_03b7
+				IL_00cf: br IL_03ae
 
-				IL_00da: ldloc.3
-				IL_00db: stloc.s 13
-				IL_00dd: ldloc.s 13
-				IL_00df: ldarg.s baseIndent
-				IL_00e1: cgt
-				IL_00e3: brfalse IL_0151
+				IL_00d4: ldloc.2
+				IL_00d5: stloc.s 12
+				IL_00d7: ldloc.s 12
+				IL_00d9: ldarg.s baseIndent
+				IL_00db: cgt
+				IL_00dd: brfalse IL_0148
 
-				IL_00e8: ldarg.3
-				IL_00e9: ldstr "index"
-				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00f3: ldc.r8 1
-				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0101: stloc.s 15
-				IL_0103: ldloc.s 15
-				IL_0105: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_010a: stloc.s 16
-				IL_010c: ldstr "Unexpected indentation at frontmatter line "
-				IL_0111: ldloc.s 16
-				IL_0113: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0118: stloc.s 16
-				IL_011a: ldloc.s 16
-				IL_011c: ldstr "."
-				IL_0121: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0126: stloc.s 16
-				IL_0128: ldloc.s 16
-				IL_012a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0134: stloc.s 12
-				IL_0136: ldloc.s 12
-				IL_0138: stloc.s 4
-				IL_013a: ldloc.s 4
-				IL_013c: isinst [System.Runtime]System.Exception
-				IL_0141: dup
-				IL_0142: brtrue IL_0150
+				IL_00e2: ldarg.3
+				IL_00e3: ldstr "index"
+				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00ed: ldc.r8 1
+				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_00fb: stloc.s 14
+				IL_00fd: ldloc.s 14
+				IL_00ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0104: stloc.s 15
+				IL_0106: ldstr "Unexpected indentation at frontmatter line "
+				IL_010b: ldloc.s 15
+				IL_010d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0112: stloc.s 15
+				IL_0114: ldloc.s 15
+				IL_0116: ldstr "."
+				IL_011b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0120: stloc.s 15
+				IL_0122: ldloc.s 15
+				IL_0124: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_012e: stloc.s 11
+				IL_0130: ldloc.s 11
+				IL_0132: stloc.3
+				IL_0133: ldloc.3
+				IL_0134: isinst [System.Runtime]System.Exception
+				IL_0139: dup
+				IL_013a: brtrue IL_0147
 
-				IL_0147: pop
-				IL_0148: ldloc.s 4
-				IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_014f: throw
+				IL_013f: pop
+				IL_0140: ldloc.3
+				IL_0141: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0146: throw
 
-				IL_0150: throw
+				IL_0147: throw
 
-				IL_0151: ldloc.2
-				IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0157: stloc.s 12
-				IL_0159: ldloc.3
-				IL_015a: box [System.Runtime]System.Double
-				IL_015f: stloc.s 17
-				IL_0161: ldloc.s 12
-				IL_0163: ldstr "substring"
-				IL_0168: ldloc.s 17
-				IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_016f: stloc.s 12
-				IL_0171: ldloc.s 12
-				IL_0173: stloc.s 5
-				IL_0175: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_017a: ldstr ""
-				IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0184: stloc.s 18
-				IL_0186: ldloc.s 18
-				IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_018d: stloc.s 12
-				IL_018f: ldloc.s 12
-				IL_0191: ldstr "exec"
-				IL_0196: ldloc.s 5
-				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_019d: stloc.s 12
-				IL_019f: ldloc.s 12
-				IL_01a1: stloc.s 6
-				IL_01a3: ldloc.s 6
-				IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01aa: ldc.i4.0
-				IL_01ab: ceq
-				IL_01ad: stloc.s 14
-				IL_01af: ldloc.s 14
-				IL_01b1: brfalse IL_0233
+				IL_0148: ldloc.1
+				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_014e: stloc.s 11
+				IL_0150: ldloc.2
+				IL_0151: box [System.Runtime]System.Double
+				IL_0156: stloc.s 16
+				IL_0158: ldloc.s 11
+				IL_015a: ldstr "substring"
+				IL_015f: ldloc.s 16
+				IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0166: stloc.s 11
+				IL_0168: ldloc.s 11
+				IL_016a: stloc.s 4
+				IL_016c: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_0171: ldstr ""
+				IL_0176: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_017b: stloc.s 17
+				IL_017d: ldloc.s 17
+				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0184: stloc.s 11
+				IL_0186: ldloc.s 11
+				IL_0188: ldstr "exec"
+				IL_018d: ldloc.s 4
+				IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0194: stloc.s 11
+				IL_0196: ldloc.s 11
+				IL_0198: stloc.s 5
+				IL_019a: ldloc.s 5
+				IL_019c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01a1: ldc.i4.0
+				IL_01a2: ceq
+				IL_01a4: stloc.s 13
+				IL_01a6: ldloc.s 13
+				IL_01a8: brfalse IL_022a
 
-				IL_01b6: ldarg.3
-				IL_01b7: ldstr "index"
-				IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01c1: ldc.r8 1
-				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01ad: ldarg.3
+				IL_01ae: ldstr "index"
+				IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01b8: ldc.r8 1
+				IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01c6: stloc.s 14
+				IL_01c8: ldloc.s 14
+				IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_01cf: stloc.s 15
-				IL_01d1: ldloc.s 15
-				IL_01d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01d8: stloc.s 16
-				IL_01da: ldstr "Invalid frontmatter line "
-				IL_01df: ldloc.s 16
-				IL_01e1: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01e6: stloc.s 16
-				IL_01e8: ldloc.s 16
-				IL_01ea: ldstr ": "
-				IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01f4: stloc.s 16
-				IL_01f6: ldloc.s 5
-				IL_01f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01fd: stloc.s 19
-				IL_01ff: ldloc.s 16
-				IL_0201: ldloc.s 19
-				IL_0203: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0208: stloc.s 19
-				IL_020a: ldloc.s 19
-				IL_020c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0211: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0216: stloc.s 12
-				IL_0218: ldloc.s 12
-				IL_021a: stloc.s 7
-				IL_021c: ldloc.s 7
-				IL_021e: isinst [System.Runtime]System.Exception
-				IL_0223: dup
-				IL_0224: brtrue IL_0232
+				IL_01d1: ldstr "Invalid frontmatter line "
+				IL_01d6: ldloc.s 15
+				IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01dd: stloc.s 15
+				IL_01df: ldloc.s 15
+				IL_01e1: ldstr ": "
+				IL_01e6: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01eb: stloc.s 15
+				IL_01ed: ldloc.s 4
+				IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f4: stloc.s 18
+				IL_01f6: ldloc.s 15
+				IL_01f8: ldloc.s 18
+				IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ff: stloc.s 18
+				IL_0201: ldloc.s 18
+				IL_0203: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0208: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_020d: stloc.s 11
+				IL_020f: ldloc.s 11
+				IL_0211: stloc.s 6
+				IL_0213: ldloc.s 6
+				IL_0215: isinst [System.Runtime]System.Exception
+				IL_021a: dup
+				IL_021b: brtrue IL_0229
 
-				IL_0229: pop
-				IL_022a: ldloc.s 7
-				IL_022c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0231: throw
+				IL_0220: pop
+				IL_0221: ldloc.s 6
+				IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0228: throw
 
-				IL_0232: throw
+				IL_0229: throw
 
-				IL_0233: ldloc.s 6
-				IL_0235: ldc.r8 1
-				IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0243: stloc.s 8
-				IL_0245: ldloc.s 6
-				IL_0247: ldc.r8 2
-				IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_025a: stloc.s 12
-				IL_025c: ldloc.s 12
-				IL_025e: ldstr "trim"
-				IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0268: stloc.s 12
-				IL_026a: ldloc.s 12
-				IL_026c: stloc.s 9
-				IL_026e: ldarg.3
-				IL_026f: ldstr "index"
-				IL_0274: ldarg.3
-				IL_0275: ldstr "index"
-				IL_027a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_027f: ldc.r8 1
-				IL_0288: add
-				IL_0289: ldc.i4.1
-				IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_028f: pop
-				IL_0290: ldnull
-				IL_0291: stloc.s 10
-				IL_0293: ldloc.s 9
-				IL_0295: stloc.s 12
-				IL_0297: ldloc.s 12
-				IL_0299: ldstr "|"
-				IL_029e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02a3: stloc.s 14
-				IL_02a5: ldloc.s 14
-				IL_02a7: box [System.Runtime]System.Boolean
-				IL_02ac: stloc.s 20
-				IL_02ae: ldloc.s 20
-				IL_02b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02b5: stloc.s 14
-				IL_02b7: ldloc.s 14
-				IL_02b9: brtrue IL_02e2
+				IL_022a: ldloc.s 5
+				IL_022c: ldc.r8 1
+				IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_023a: stloc.s 7
+				IL_023c: ldloc.s 5
+				IL_023e: ldc.r8 2
+				IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0251: stloc.s 11
+				IL_0253: ldloc.s 11
+				IL_0255: ldstr "trim"
+				IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_025f: stloc.s 11
+				IL_0261: ldloc.s 11
+				IL_0263: stloc.s 8
+				IL_0265: ldarg.3
+				IL_0266: ldstr "index"
+				IL_026b: ldarg.3
+				IL_026c: ldstr "index"
+				IL_0271: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0276: ldc.r8 1
+				IL_027f: add
+				IL_0280: ldc.i4.1
+				IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0286: pop
+				IL_0287: ldnull
+				IL_0288: stloc.s 9
+				IL_028a: ldloc.s 8
+				IL_028c: stloc.s 11
+				IL_028e: ldloc.s 11
+				IL_0290: ldstr "|"
+				IL_0295: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_029a: stloc.s 13
+				IL_029c: ldloc.s 13
+				IL_029e: box [System.Runtime]System.Boolean
+				IL_02a3: stloc.s 19
+				IL_02a5: ldloc.s 19
+				IL_02a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02ac: stloc.s 13
+				IL_02ae: ldloc.s 13
+				IL_02b0: brtrue IL_02d9
 
-				IL_02be: ldloc.s 9
-				IL_02c0: stloc.s 12
-				IL_02c2: ldloc.s 12
-				IL_02c4: ldstr ">"
-				IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02ce: stloc.s 14
-				IL_02d0: ldloc.s 14
-				IL_02d2: box [System.Runtime]System.Boolean
-				IL_02d7: stloc.s 21
-				IL_02d9: ldloc.s 21
-				IL_02db: stloc.s 22
-				IL_02dd: br IL_02e6
+				IL_02b5: ldloc.s 8
+				IL_02b7: stloc.s 11
+				IL_02b9: ldloc.s 11
+				IL_02bb: ldstr ">"
+				IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02c5: stloc.s 13
+				IL_02c7: ldloc.s 13
+				IL_02c9: box [System.Runtime]System.Boolean
+				IL_02ce: stloc.s 20
+				IL_02d0: ldloc.s 20
+				IL_02d2: stloc.s 21
+				IL_02d4: br IL_02dd
 
-				IL_02e2: ldloc.s 20
-				IL_02e4: stloc.s 22
+				IL_02d9: ldloc.s 19
+				IL_02db: stloc.s 21
 
-				IL_02e6: ldloc.s 22
-				IL_02e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ed: stloc.s 14
-				IL_02ef: ldloc.s 14
-				IL_02f1: brfalse IL_033f
+				IL_02dd: ldloc.s 21
+				IL_02df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02e4: stloc.s 13
+				IL_02e6: ldloc.s 13
+				IL_02e8: brfalse IL_0336
 
-				IL_02f6: ldarg.0
-				IL_02f7: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_02fc: stloc.s 12
-				IL_02fe: ldc.i4.1
-				IL_02ff: newarr [System.Runtime]System.Object
-				IL_0304: dup
-				IL_0305: ldc.i4.0
-				IL_0306: ldarg.0
-				IL_0307: stelem.ref
-				IL_0308: stloc.s 23
-				IL_030a: ldc.i4.4
-				IL_030b: newarr [System.Runtime]System.Object
-				IL_0310: dup
-				IL_0311: ldc.i4.0
-				IL_0312: ldarg.2
-				IL_0313: stelem.ref
-				IL_0314: dup
-				IL_0315: ldc.i4.1
-				IL_0316: ldarg.3
-				IL_0317: stelem.ref
-				IL_0318: dup
-				IL_0319: ldc.i4.2
-				IL_031a: ldarg.s baseIndent
-				IL_031c: box [System.Runtime]System.Double
-				IL_0321: stelem.ref
-				IL_0322: dup
-				IL_0323: ldc.i4.3
-				IL_0324: ldloc.s 9
-				IL_0326: stelem.ref
-				IL_0327: stloc.s 24
-				IL_0329: ldloc.s 12
-				IL_032b: ldloc.s 23
-				IL_032d: ldloc.s 24
-				IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_0334: stloc.s 12
-				IL_0336: ldloc.s 12
-				IL_0338: stloc.s 10
-				IL_033a: br IL_03a6
+				IL_02ed: ldarg.0
+				IL_02ee: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_02f3: stloc.s 11
+				IL_02f5: ldc.i4.1
+				IL_02f6: newarr [System.Runtime]System.Object
+				IL_02fb: dup
+				IL_02fc: ldc.i4.0
+				IL_02fd: ldarg.0
+				IL_02fe: stelem.ref
+				IL_02ff: stloc.s 22
+				IL_0301: ldc.i4.4
+				IL_0302: newarr [System.Runtime]System.Object
+				IL_0307: dup
+				IL_0308: ldc.i4.0
+				IL_0309: ldarg.2
+				IL_030a: stelem.ref
+				IL_030b: dup
+				IL_030c: ldc.i4.1
+				IL_030d: ldarg.3
+				IL_030e: stelem.ref
+				IL_030f: dup
+				IL_0310: ldc.i4.2
+				IL_0311: ldarg.s baseIndent
+				IL_0313: box [System.Runtime]System.Double
+				IL_0318: stelem.ref
+				IL_0319: dup
+				IL_031a: ldc.i4.3
+				IL_031b: ldloc.s 8
+				IL_031d: stelem.ref
+				IL_031e: stloc.s 23
+				IL_0320: ldloc.s 11
+				IL_0322: ldloc.s 22
+				IL_0324: ldloc.s 23
+				IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_032b: stloc.s 11
+				IL_032d: ldloc.s 11
+				IL_032f: stloc.s 9
+				IL_0331: br IL_039d
 
-				IL_033f: ldloc.s 9
-				IL_0341: stloc.s 12
-				IL_0343: ldloc.s 12
-				IL_0345: ldstr ""
-				IL_034a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034f: stloc.s 14
-				IL_0351: ldloc.s 14
-				IL_0353: brfalse IL_0389
+				IL_0336: ldloc.s 8
+				IL_0338: stloc.s 11
+				IL_033a: ldloc.s 11
+				IL_033c: ldstr ""
+				IL_0341: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0346: stloc.s 13
+				IL_0348: ldloc.s 13
+				IL_034a: brfalse IL_0380
 
-				IL_0358: ldarg.0
-				IL_0359: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_035e: stloc.s 12
-				IL_0360: ldc.i4.1
-				IL_0361: newarr [System.Runtime]System.Object
-				IL_0366: dup
-				IL_0367: ldc.i4.0
-				IL_0368: ldarg.0
-				IL_0369: stelem.ref
-				IL_036a: stloc.s 24
-				IL_036c: ldloc.s 12
-				IL_036e: ldloc.s 24
-				IL_0370: ldarg.2
-				IL_0371: ldarg.3
-				IL_0372: ldarg.s baseIndent
-				IL_0374: box [System.Runtime]System.Double
-				IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_037e: stloc.s 12
-				IL_0380: ldloc.s 12
-				IL_0382: stloc.s 10
-				IL_0384: br IL_03a6
+				IL_034f: ldarg.0
+				IL_0350: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_0355: stloc.s 11
+				IL_0357: ldc.i4.1
+				IL_0358: newarr [System.Runtime]System.Object
+				IL_035d: dup
+				IL_035e: ldc.i4.0
+				IL_035f: ldarg.0
+				IL_0360: stelem.ref
+				IL_0361: stloc.s 23
+				IL_0363: ldloc.s 11
+				IL_0365: ldloc.s 23
+				IL_0367: ldarg.2
+				IL_0368: ldarg.3
+				IL_0369: ldarg.s baseIndent
+				IL_036b: box [System.Runtime]System.Double
+				IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0375: stloc.s 11
+				IL_0377: ldloc.s 11
+				IL_0379: stloc.s 9
+				IL_037b: br IL_039d
 
-				IL_0389: ldarg.0
-				IL_038a: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_038f: ldc.i4.1
-				IL_0390: newarr [System.Runtime]System.Object
-				IL_0395: dup
-				IL_0396: ldc.i4.0
-				IL_0397: ldarg.0
-				IL_0398: stelem.ref
-				IL_0399: ldloc.s 9
-				IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_03a0: stloc.s 12
-				IL_03a2: ldloc.s 12
-				IL_03a4: stloc.s 10
+				IL_0380: ldarg.0
+				IL_0381: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_0386: ldc.i4.1
+				IL_0387: newarr [System.Runtime]System.Object
+				IL_038c: dup
+				IL_038d: ldc.i4.0
+				IL_038e: ldarg.0
+				IL_038f: stelem.ref
+				IL_0390: ldloc.s 8
+				IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0397: stloc.s 11
+				IL_0399: ldloc.s 11
+				IL_039b: stloc.s 9
 
-				IL_03a6: ldloc.0
-				IL_03a7: ldloc.s 8
-				IL_03a9: ldloc.s 10
-				IL_03ab: ldc.i4.1
-				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_03b1: pop
-				IL_03b2: br IL_0006
+				IL_039d: ldloc.0
+				IL_039e: ldloc.s 7
+				IL_03a0: ldloc.s 9
+				IL_03a2: ldc.i4.1
+				IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_03a8: pop
+				IL_03a9: br IL_0006
 			// end loop
 
-			IL_03b7: ldloc.0
-			IL_03b8: ret
+			IL_03ae: ldloc.0
+			IL_03af: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -5157,7 +5139,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6964
+				// Method begins at RVA 0x68e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5184,7 +5166,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4bb0
+			// Method begins at RVA 0x4b68
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5255,7 +5237,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6976
+					// Method begins at RVA 0x68f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5275,7 +5257,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x697f
+					// Method begins at RVA 0x68ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5295,7 +5277,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6988
+					// Method begins at RVA 0x6908
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5313,7 +5295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x696d
+				// Method begins at RVA 0x68ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5340,7 +5322,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4c28
+			// Method begins at RVA 0x4be0
 			// Header size: 12
 			// Code size: 360 (0x168)
 			.maxstack 8
@@ -5502,7 +5484,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6991
+				// Method begins at RVA 0x6911
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5526,7 +5508,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d9c
+			// Method begins at RVA 0x4d54
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5585,7 +5567,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69a3
+					// Method begins at RVA 0x6923
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5603,7 +5585,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x699a
+				// Method begins at RVA 0x691a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5627,7 +5609,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4df0
+			// Method begins at RVA 0x4da8
 			// Header size: 12
 			// Code size: 123 (0x7b)
 			.maxstack 8
@@ -5707,7 +5689,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69ac
+				// Method begins at RVA 0x692c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5732,7 +5714,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4e78
+			// Method begins at RVA 0x4e30
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5780,7 +5762,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69b5
+				// Method begins at RVA 0x6935
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5807,7 +5789,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4eb8
+			// Method begins at RVA 0x4e70
 			// Header size: 1
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -5849,7 +5831,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69c7
+					// Method begins at RVA 0x6947
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5869,7 +5851,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69d0
+					// Method begins at RVA 0x6950
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5887,7 +5869,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69be
+				// Method begins at RVA 0x693e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5915,7 +5897,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x69eb
+						// Method begins at RVA 0x696b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5933,7 +5915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69e2
+					// Method begins at RVA 0x6962
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5951,7 +5933,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69d9
+				// Method begins at RVA 0x6959
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5980,232 +5962,229 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4eec
+			// Method begins at RVA 0x4ea4
 			// Header size: 12
-			// Code size: 476 (0x1dc)
+			// Code size: 452 (0x1c4)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
-				[2] class Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41,
-				[3] object,
-				[4] bool,
+				[2] object,
+				[3] bool,
+				[4] object,
 				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] object,
-				[11] object[],
-				[12] string,
-				[13] object[],
-				[14] float64
+				[10] object[],
+				[11] string,
+				[12] object[],
+				[13] float64
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: ldnull
 			IL_0002: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0007: stloc.s 4
-			IL_0009: ldloc.s 4
-			IL_000b: box [System.Runtime]System.Boolean
-			IL_0010: stloc.s 5
-			IL_0012: ldloc.s 5
-			IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: brtrue IL_0042
+			IL_0007: stloc.3
+			IL_0008: ldloc.3
+			IL_0009: box [System.Runtime]System.Boolean
+			IL_000e: stloc.s 4
+			IL_0010: ldloc.s 4
+			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0017: stloc.3
+			IL_0018: ldloc.3
+			IL_0019: brtrue IL_003c
 
-			IL_0022: ldarg.2
-			IL_0023: ldc.i4.0
-			IL_0024: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.s 4
-			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.s 6
-			IL_0039: ldloc.s 6
-			IL_003b: stloc.s 8
-			IL_003d: br IL_0046
+			IL_001e: ldarg.2
+			IL_001f: ldc.i4.0
+			IL_0020: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0025: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_002a: stloc.3
+			IL_002b: ldloc.3
+			IL_002c: box [System.Runtime]System.Boolean
+			IL_0031: stloc.s 5
+			IL_0033: ldloc.s 5
+			IL_0035: stloc.s 7
+			IL_0037: br IL_0040
 
-			IL_0042: ldloc.s 5
-			IL_0044: stloc.s 8
+			IL_003c: ldloc.s 4
+			IL_003e: stloc.s 7
 
-			IL_0046: ldloc.s 8
-			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.s 4
-			IL_0051: brtrue IL_0075
+			IL_0040: ldloc.s 7
+			IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0047: stloc.3
+			IL_0048: ldloc.3
+			IL_0049: brtrue IL_006b
 
-			IL_0056: ldarg.2
-			IL_0057: ldstr ""
-			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0061: stloc.s 4
-			IL_0063: ldloc.s 4
-			IL_0065: box [System.Runtime]System.Boolean
-			IL_006a: stloc.s 5
-			IL_006c: ldloc.s 5
-			IL_006e: stloc.s 8
-			IL_0070: br IL_0075
+			IL_004e: ldarg.2
+			IL_004f: ldstr ""
+			IL_0054: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0059: stloc.3
+			IL_005a: ldloc.3
+			IL_005b: box [System.Runtime]System.Boolean
+			IL_0060: stloc.s 4
+			IL_0062: ldloc.s 4
+			IL_0064: stloc.s 7
+			IL_0066: br IL_006b
 
-			IL_0075: ldloc.s 8
-			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007c: stloc.s 4
-			IL_007e: ldloc.s 4
-			IL_0080: brfalse IL_008c
+			IL_006b: ldloc.s 7
+			IL_006d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0072: stloc.3
+			IL_0073: ldloc.3
+			IL_0074: brfalse IL_0080
 
-			IL_0085: ldc.i4.0
-			IL_0086: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_008b: ret
+			IL_0079: ldc.i4.0
+			IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_007f: ret
 
-			IL_008c: ldarg.2
-			IL_008d: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
-			IL_0092: stloc.s 4
-			IL_0094: ldloc.s 4
-			IL_0096: ldc.i4.0
-			IL_0097: ceq
-			IL_0099: stloc.s 4
-			IL_009b: ldloc.s 4
-			IL_009d: brfalse IL_010b
+			IL_0080: ldarg.2
+			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
+			IL_0086: stloc.3
+			IL_0087: ldloc.3
+			IL_0088: ldc.i4.0
+			IL_0089: ceq
+			IL_008b: stloc.3
+			IL_008c: ldloc.3
+			IL_008d: brfalse IL_00fb
 
+			IL_0092: ldarg.0
+			IL_0093: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0098: stloc.s 9
+			IL_009a: ldc.i4.1
+			IL_009b: newarr [System.Runtime]System.Object
+			IL_00a0: dup
+			IL_00a1: ldc.i4.0
 			IL_00a2: ldarg.0
-			IL_00a3: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_00a8: stloc.s 10
-			IL_00aa: ldc.i4.1
-			IL_00ab: newarr [System.Runtime]System.Object
-			IL_00b0: dup
-			IL_00b1: ldc.i4.0
-			IL_00b2: ldarg.0
-			IL_00b3: stelem.ref
-			IL_00b4: stloc.s 11
-			IL_00b6: ldarg.3
-			IL_00b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00bc: stloc.s 12
-			IL_00be: ldstr "Expected an array for '"
-			IL_00c3: ldloc.s 12
-			IL_00c5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ca: stloc.s 12
-			IL_00cc: ldloc.s 12
-			IL_00ce: ldstr "'."
-			IL_00d3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d8: stloc.s 12
-			IL_00da: ldc.i4.4
-			IL_00db: newarr [System.Runtime]System.Object
-			IL_00e0: dup
-			IL_00e1: ldc.i4.0
-			IL_00e2: ldarg.s issues
-			IL_00e4: stelem.ref
-			IL_00e5: dup
-			IL_00e6: ldc.i4.1
-			IL_00e7: ldstr "invalid-array"
-			IL_00ec: stelem.ref
-			IL_00ed: dup
-			IL_00ee: ldc.i4.2
-			IL_00ef: ldarg.3
-			IL_00f0: stelem.ref
-			IL_00f1: dup
-			IL_00f2: ldc.i4.3
-			IL_00f3: ldloc.s 12
-			IL_00f5: stelem.ref
-			IL_00f6: stloc.s 13
-			IL_00f8: ldloc.s 10
-			IL_00fa: ldloc.s 11
-			IL_00fc: ldloc.s 13
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0103: pop
-			IL_0104: ldc.i4.0
-			IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_010a: ret
+			IL_00a3: stelem.ref
+			IL_00a4: stloc.s 10
+			IL_00a6: ldarg.3
+			IL_00a7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ac: stloc.s 11
+			IL_00ae: ldstr "Expected an array for '"
+			IL_00b3: ldloc.s 11
+			IL_00b5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ba: stloc.s 11
+			IL_00bc: ldloc.s 11
+			IL_00be: ldstr "'."
+			IL_00c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c8: stloc.s 11
+			IL_00ca: ldc.i4.4
+			IL_00cb: newarr [System.Runtime]System.Object
+			IL_00d0: dup
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldarg.s issues
+			IL_00d4: stelem.ref
+			IL_00d5: dup
+			IL_00d6: ldc.i4.1
+			IL_00d7: ldstr "invalid-array"
+			IL_00dc: stelem.ref
+			IL_00dd: dup
+			IL_00de: ldc.i4.2
+			IL_00df: ldarg.3
+			IL_00e0: stelem.ref
+			IL_00e1: dup
+			IL_00e2: ldc.i4.3
+			IL_00e3: ldloc.s 11
+			IL_00e5: stelem.ref
+			IL_00e6: stloc.s 12
+			IL_00e8: ldloc.s 9
+			IL_00ea: ldloc.s 10
+			IL_00ec: ldloc.s 12
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_00f3: pop
+			IL_00f4: ldc.i4.0
+			IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fa: ret
 
-			IL_010b: ldc.i4.0
-			IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0111: stloc.0
-			IL_0112: ldc.r8 0.0
-			IL_011b: stloc.1
-			// loop start (head: IL_011c)
-				IL_011c: ldloc.1
-				IL_011d: stloc.s 14
-				IL_011f: ldloc.s 14
-				IL_0121: ldarg.2
-				IL_0122: ldstr "length"
-				IL_0127: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_012c: clt
-				IL_012e: brfalse IL_01da
+			IL_00fb: ldc.i4.0
+			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0101: stloc.0
+			IL_0102: ldc.r8 0.0
+			IL_010b: stloc.1
+			// loop start (head: IL_010c)
+				IL_010c: ldloc.1
+				IL_010d: stloc.s 13
+				IL_010f: ldloc.s 13
+				IL_0111: ldarg.2
+				IL_0112: ldstr "length"
+				IL_0117: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_011c: clt
+				IL_011e: brfalse IL_01c2
 
-				IL_0133: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41::.ctor()
-				IL_0138: stloc.2
-				IL_0139: ldarg.2
-				IL_013a: ldloc.1
-				IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0140: stloc.3
-				IL_0141: ldloc.3
-				IL_0142: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-				IL_0147: ldstr "string"
-				IL_014c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0151: stloc.s 4
-				IL_0153: ldloc.s 4
-				IL_0155: brfalse IL_01c1
+				IL_0123: ldarg.2
+				IL_0124: ldloc.1
+				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_012a: stloc.2
+				IL_012b: ldloc.2
+				IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+				IL_0131: ldstr "string"
+				IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_013b: stloc.3
+				IL_013c: ldloc.3
+				IL_013d: brfalse IL_01a9
 
-				IL_015a: ldarg.0
-				IL_015b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0160: stloc.s 10
-				IL_0162: ldc.i4.1
-				IL_0163: newarr [System.Runtime]System.Object
-				IL_0168: dup
-				IL_0169: ldc.i4.0
-				IL_016a: ldarg.0
-				IL_016b: stelem.ref
-				IL_016c: stloc.s 13
-				IL_016e: ldarg.3
-				IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0174: stloc.s 12
-				IL_0176: ldstr "Expected string entries for '"
-				IL_017b: ldloc.s 12
-				IL_017d: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0182: stloc.s 12
-				IL_0184: ldloc.s 12
-				IL_0186: ldstr "'."
-				IL_018b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0190: stloc.s 12
-				IL_0192: ldc.i4.4
-				IL_0193: newarr [System.Runtime]System.Object
-				IL_0198: dup
-				IL_0199: ldc.i4.0
-				IL_019a: ldarg.s issues
-				IL_019c: stelem.ref
-				IL_019d: dup
-				IL_019e: ldc.i4.1
-				IL_019f: ldstr "invalid-array-entry"
-				IL_01a4: stelem.ref
-				IL_01a5: dup
-				IL_01a6: ldc.i4.2
-				IL_01a7: ldarg.3
-				IL_01a8: stelem.ref
-				IL_01a9: dup
-				IL_01aa: ldc.i4.3
-				IL_01ab: ldloc.s 12
-				IL_01ad: stelem.ref
-				IL_01ae: stloc.s 11
-				IL_01b0: ldloc.s 10
-				IL_01b2: ldloc.s 13
-				IL_01b4: ldloc.s 11
-				IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_01bb: pop
-				IL_01bc: br IL_01c9
+				IL_0142: ldarg.0
+				IL_0143: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0148: stloc.s 9
+				IL_014a: ldc.i4.1
+				IL_014b: newarr [System.Runtime]System.Object
+				IL_0150: dup
+				IL_0151: ldc.i4.0
+				IL_0152: ldarg.0
+				IL_0153: stelem.ref
+				IL_0154: stloc.s 12
+				IL_0156: ldarg.3
+				IL_0157: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_015c: stloc.s 11
+				IL_015e: ldstr "Expected string entries for '"
+				IL_0163: ldloc.s 11
+				IL_0165: call string [System.Runtime]System.String::Concat(string, string)
+				IL_016a: stloc.s 11
+				IL_016c: ldloc.s 11
+				IL_016e: ldstr "'."
+				IL_0173: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0178: stloc.s 11
+				IL_017a: ldc.i4.4
+				IL_017b: newarr [System.Runtime]System.Object
+				IL_0180: dup
+				IL_0181: ldc.i4.0
+				IL_0182: ldarg.s issues
+				IL_0184: stelem.ref
+				IL_0185: dup
+				IL_0186: ldc.i4.1
+				IL_0187: ldstr "invalid-array-entry"
+				IL_018c: stelem.ref
+				IL_018d: dup
+				IL_018e: ldc.i4.2
+				IL_018f: ldarg.3
+				IL_0190: stelem.ref
+				IL_0191: dup
+				IL_0192: ldc.i4.3
+				IL_0193: ldloc.s 11
+				IL_0195: stelem.ref
+				IL_0196: stloc.s 10
+				IL_0198: ldloc.s 9
+				IL_019a: ldloc.s 12
+				IL_019c: ldloc.s 10
+				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_01a3: pop
+				IL_01a4: br IL_01b1
 
-				IL_01c1: ldloc.0
-				IL_01c2: ldloc.3
-				IL_01c3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01c8: pop
+				IL_01a9: ldloc.0
+				IL_01aa: ldloc.2
+				IL_01ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01b0: pop
 
-				IL_01c9: ldloc.1
-				IL_01ca: ldc.r8 1
-				IL_01d3: add
-				IL_01d4: stloc.1
-				IL_01d5: br IL_011c
+				IL_01b1: ldloc.1
+				IL_01b2: ldc.r8 1
+				IL_01bb: add
+				IL_01bc: stloc.1
+				IL_01bd: br IL_010c
 			// end loop
 
-			IL_01da: ldloc.0
-			IL_01db: ret
+			IL_01c2: ldloc.0
+			IL_01c3: ret
 		} // end of method toStringArray::__js_call__
 
 	} // end of class toStringArray
@@ -6225,7 +6204,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x69fd
+					// Method begins at RVA 0x697d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6245,7 +6224,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a06
+					// Method begins at RVA 0x6986
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6263,7 +6242,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x69f4
+				// Method begins at RVA 0x6974
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6292,7 +6271,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x50d4
+			// Method begins at RVA 0x5074
 			// Header size: 12
 			// Code size: 251 (0xfb)
 			.maxstack 8
@@ -6442,7 +6421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a18
+					// Method begins at RVA 0x6998
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6462,7 +6441,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a21
+					// Method begins at RVA 0x69a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6482,7 +6461,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a2a
+					// Method begins at RVA 0x69aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6502,7 +6481,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a4e
+					// Method begins at RVA 0x69ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6520,7 +6499,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a0f
+				// Method begins at RVA 0x698f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6548,7 +6527,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a45
+						// Method begins at RVA 0x69c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6566,7 +6545,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a3c
+					// Method begins at RVA 0x69bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6584,7 +6563,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a33
+				// Method begins at RVA 0x69b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6612,9 +6591,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x51dc
+			// Method begins at RVA 0x517c
 			// Header size: 12
-			// Code size: 1110 (0x456)
+			// Code size: 1103 (0x44f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6622,9 +6601,9 @@
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[3] object,
 				[4] float64,
-				[5] class Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40,
-				[6] object,
-				[7] bool,
+				[5] object,
+				[6] bool,
+				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
@@ -6632,68 +6611,67 @@
 				[12] object,
 				[13] object,
 				[14] object,
-				[15] object,
-				[16] object[],
-				[17] object,
-				[18] float64,
-				[19] object,
-				[20] string,
-				[21] object[],
-				[22] object,
-				[23] string,
-				[24] object,
-				[25] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[15] object[],
+				[16] object,
+				[17] float64,
+				[18] object,
+				[19] string,
+				[20] object[],
+				[21] object,
+				[22] string,
+				[23] object,
+				[24] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: ldnull
 			IL_0002: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0007: stloc.s 7
-			IL_0009: ldloc.s 7
+			IL_0007: stloc.s 6
+			IL_0009: ldloc.s 6
 			IL_000b: box [System.Runtime]System.Boolean
-			IL_0010: stloc.s 8
-			IL_0012: ldloc.s 8
+			IL_0010: stloc.s 7
+			IL_0012: ldloc.s 7
 			IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0019: stloc.s 7
-			IL_001b: ldloc.s 7
+			IL_0019: stloc.s 6
+			IL_001b: ldloc.s 6
 			IL_001d: brtrue IL_0042
 
 			IL_0022: ldarg.2
 			IL_0023: ldc.i4.0
 			IL_0024: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_002e: stloc.s 7
-			IL_0030: ldloc.s 7
+			IL_002e: stloc.s 6
+			IL_0030: ldloc.s 6
 			IL_0032: box [System.Runtime]System.Boolean
-			IL_0037: stloc.s 9
-			IL_0039: ldloc.s 9
-			IL_003b: stloc.s 11
+			IL_0037: stloc.s 8
+			IL_0039: ldloc.s 8
+			IL_003b: stloc.s 10
 			IL_003d: br IL_0046
 
-			IL_0042: ldloc.s 8
-			IL_0044: stloc.s 11
+			IL_0042: ldloc.s 7
+			IL_0044: stloc.s 10
 
-			IL_0046: ldloc.s 11
+			IL_0046: ldloc.s 10
 			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 7
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 6
 			IL_0051: brtrue IL_0075
 
 			IL_0056: ldarg.2
 			IL_0057: ldstr ""
 			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0061: stloc.s 7
-			IL_0063: ldloc.s 7
+			IL_0061: stloc.s 6
+			IL_0063: ldloc.s 6
 			IL_0065: box [System.Runtime]System.Boolean
-			IL_006a: stloc.s 8
-			IL_006c: ldloc.s 8
-			IL_006e: stloc.s 11
+			IL_006a: stloc.s 7
+			IL_006c: ldloc.s 7
+			IL_006e: stloc.s 10
 			IL_0070: br IL_0075
 
-			IL_0075: ldloc.s 11
+			IL_0075: ldloc.s 10
 			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007c: stloc.s 7
-			IL_007e: ldloc.s 7
+			IL_007c: stloc.s 6
+			IL_007e: ldloc.s 6
 			IL_0080: brfalse IL_008c
 
 			IL_0085: ldc.i4.0
@@ -6704,65 +6682,65 @@
 			IL_008d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_0092: ldc.i4.0
 			IL_0093: ceq
-			IL_0095: stloc.s 7
-			IL_0097: ldloc.s 7
+			IL_0095: stloc.s 6
+			IL_0097: ldloc.s 6
 			IL_0099: box [System.Runtime]System.Boolean
-			IL_009e: stloc.s 8
-			IL_00a0: ldloc.s 8
+			IL_009e: stloc.s 7
+			IL_00a0: ldloc.s 7
 			IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a7: stloc.s 7
-			IL_00a9: ldloc.s 7
+			IL_00a7: stloc.s 6
+			IL_00a9: ldloc.s 6
 			IL_00ab: brtrue IL_00d4
 
 			IL_00b0: ldarg.2
 			IL_00b1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00b6: ldstr "object"
 			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00c0: stloc.s 7
-			IL_00c2: ldloc.s 7
+			IL_00c0: stloc.s 6
+			IL_00c2: ldloc.s 6
 			IL_00c4: box [System.Runtime]System.Boolean
-			IL_00c9: stloc.s 9
-			IL_00cb: ldloc.s 9
-			IL_00cd: stloc.s 13
+			IL_00c9: stloc.s 8
+			IL_00cb: ldloc.s 8
+			IL_00cd: stloc.s 12
 			IL_00cf: br IL_00d8
 
-			IL_00d4: ldloc.s 8
-			IL_00d6: stloc.s 13
+			IL_00d4: ldloc.s 7
+			IL_00d6: stloc.s 12
 
-			IL_00d8: ldloc.s 13
+			IL_00d8: ldloc.s 12
 			IL_00da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00df: stloc.s 7
-			IL_00e1: ldloc.s 7
+			IL_00df: stloc.s 6
+			IL_00e1: ldloc.s 6
 			IL_00e3: brtrue IL_0102
 
 			IL_00e8: ldarg.2
 			IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
-			IL_00ee: stloc.s 7
-			IL_00f0: ldloc.s 7
+			IL_00ee: stloc.s 6
+			IL_00f0: ldloc.s 6
 			IL_00f2: box [System.Runtime]System.Boolean
-			IL_00f7: stloc.s 8
-			IL_00f9: ldloc.s 8
-			IL_00fb: stloc.s 13
+			IL_00f7: stloc.s 7
+			IL_00f9: ldloc.s 7
+			IL_00fb: stloc.s 12
 			IL_00fd: br IL_0102
 
-			IL_0102: ldloc.s 13
+			IL_0102: ldloc.s 12
 			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0109: stloc.s 7
-			IL_010b: ldloc.s 7
+			IL_0109: stloc.s 6
+			IL_010b: ldloc.s 6
 			IL_010d: brfalse IL_0159
 
 			IL_0112: ldarg.0
 			IL_0113: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0118: stloc.s 15
+			IL_0118: stloc.s 14
 			IL_011a: ldc.i4.1
 			IL_011b: newarr [System.Runtime]System.Object
 			IL_0120: dup
 			IL_0121: ldc.i4.0
 			IL_0122: ldarg.0
 			IL_0123: stelem.ref
-			IL_0124: stloc.s 16
-			IL_0126: ldloc.s 15
-			IL_0128: ldloc.s 16
+			IL_0124: stloc.s 15
+			IL_0126: ldloc.s 14
+			IL_0128: ldloc.s 15
 			IL_012a: ldc.i4.4
 			IL_012b: newarr [System.Runtime]System.Object
 			IL_0130: dup
@@ -6789,49 +6767,49 @@
 
 			IL_0159: ldarg.0
 			IL_015a: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_015f: stloc.s 15
+			IL_015f: stloc.s 14
 			IL_0161: ldc.i4.1
 			IL_0162: newarr [System.Runtime]System.Object
 			IL_0167: dup
 			IL_0168: ldc.i4.0
 			IL_0169: ldarg.0
 			IL_016a: stelem.ref
-			IL_016b: stloc.s 16
+			IL_016b: stloc.s 15
 			IL_016d: ldarg.2
 			IL_016e: ldstr "phase"
 			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0178: stloc.s 17
-			IL_017a: ldloc.s 15
-			IL_017c: ldloc.s 16
-			IL_017e: ldloc.s 17
+			IL_0178: stloc.s 16
+			IL_017a: ldloc.s 14
+			IL_017c: ldloc.s 15
+			IL_017e: ldloc.s 16
 			IL_0180: ldstr "negative.phase"
 			IL_0185: ldarg.3
 			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_018b: stloc.s 17
-			IL_018d: ldloc.s 17
+			IL_018b: stloc.s 16
+			IL_018d: ldloc.s 16
 			IL_018f: stloc.0
 			IL_0190: ldarg.0
 			IL_0191: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_0196: stloc.s 17
+			IL_0196: stloc.s 16
 			IL_0198: ldc.i4.1
 			IL_0199: newarr [System.Runtime]System.Object
 			IL_019e: dup
 			IL_019f: ldc.i4.0
 			IL_01a0: ldarg.0
 			IL_01a1: stelem.ref
-			IL_01a2: stloc.s 16
+			IL_01a2: stloc.s 15
 			IL_01a4: ldarg.2
 			IL_01a5: ldstr "type"
 			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01af: stloc.s 15
-			IL_01b1: ldloc.s 17
-			IL_01b3: ldloc.s 16
-			IL_01b5: ldloc.s 15
+			IL_01af: stloc.s 14
+			IL_01b1: ldloc.s 16
+			IL_01b3: ldloc.s 15
+			IL_01b5: ldloc.s 14
 			IL_01b7: ldstr "negative.type"
 			IL_01bc: ldarg.3
 			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01c2: stloc.s 15
-			IL_01c4: ldloc.s 15
+			IL_01c2: stloc.s 14
+			IL_01c4: ldloc.s 14
 			IL_01c6: stloc.1
 			IL_01c7: ldc.i4.3
 			IL_01c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -6847,8 +6825,8 @@
 			IL_01ee: stloc.2
 			IL_01ef: ldloc.0
 			IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01f5: stloc.s 7
-			IL_01f7: ldloc.s 7
+			IL_01f5: stloc.s 6
+			IL_01f7: ldloc.s 6
 			IL_01f9: brfalse IL_0231
 
 			IL_01fe: ldloc.2
@@ -6859,48 +6837,48 @@
 			IL_0207: ldloc.0
 			IL_0208: stelem.ref
 			IL_0209: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-			IL_020e: stloc.s 18
-			IL_0210: ldloc.s 18
+			IL_020e: stloc.s 17
+			IL_0210: ldloc.s 17
 			IL_0212: ldc.r8 0.0
 			IL_021b: clt
-			IL_021d: stloc.s 7
-			IL_021f: ldloc.s 7
+			IL_021d: stloc.s 6
+			IL_021f: ldloc.s 6
 			IL_0221: box [System.Runtime]System.Boolean
-			IL_0226: stloc.s 8
-			IL_0228: ldloc.s 8
-			IL_022a: stloc.s 19
+			IL_0226: stloc.s 7
+			IL_0228: ldloc.s 7
+			IL_022a: stloc.s 18
 			IL_022c: br IL_0234
 
 			IL_0231: ldloc.0
-			IL_0232: stloc.s 19
+			IL_0232: stloc.s 18
 
-			IL_0234: ldloc.s 19
+			IL_0234: ldloc.s 18
 			IL_0236: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_023b: stloc.s 7
-			IL_023d: ldloc.s 7
+			IL_023b: stloc.s 6
+			IL_023d: ldloc.s 6
 			IL_023f: brfalse IL_02a9
 
 			IL_0244: ldarg.0
 			IL_0245: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_024a: stloc.s 15
+			IL_024a: stloc.s 14
 			IL_024c: ldc.i4.1
 			IL_024d: newarr [System.Runtime]System.Object
 			IL_0252: dup
 			IL_0253: ldc.i4.0
 			IL_0254: ldarg.0
 			IL_0255: stelem.ref
-			IL_0256: stloc.s 16
+			IL_0256: stloc.s 15
 			IL_0258: ldloc.0
 			IL_0259: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025e: stloc.s 20
+			IL_025e: stloc.s 19
 			IL_0260: ldstr "Unsupported negative phase '"
-			IL_0265: ldloc.s 20
+			IL_0265: ldloc.s 19
 			IL_0267: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026c: stloc.s 20
-			IL_026e: ldloc.s 20
+			IL_026c: stloc.s 19
+			IL_026e: ldloc.s 19
 			IL_0270: ldstr "'."
 			IL_0275: call string [System.Runtime]System.String::Concat(string, string)
-			IL_027a: stloc.s 20
+			IL_027a: stloc.s 19
 			IL_027c: ldc.i4.4
 			IL_027d: newarr [System.Runtime]System.Object
 			IL_0282: dup
@@ -6917,186 +6895,184 @@
 			IL_0295: stelem.ref
 			IL_0296: dup
 			IL_0297: ldc.i4.3
-			IL_0298: ldloc.s 20
+			IL_0298: ldloc.s 19
 			IL_029a: stelem.ref
-			IL_029b: stloc.s 21
-			IL_029d: ldloc.s 15
-			IL_029f: ldloc.s 16
-			IL_02a1: ldloc.s 21
+			IL_029b: stloc.s 20
+			IL_029d: ldloc.s 14
+			IL_029f: ldloc.s 15
+			IL_02a1: ldloc.s 20
 			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 			IL_02a8: pop
 
 			IL_02a9: ldarg.2
 			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_02af: stloc.s 15
-			IL_02b1: ldloc.s 15
+			IL_02af: stloc.s 14
+			IL_02b1: ldloc.s 14
 			IL_02b3: stloc.3
 			IL_02b4: ldc.r8 0.0
 			IL_02bd: stloc.s 4
 			// loop start (head: IL_02bf)
 				IL_02bf: ldloc.s 4
-				IL_02c1: stloc.s 18
-				IL_02c3: ldloc.s 18
+				IL_02c1: stloc.s 17
+				IL_02c3: ldloc.s 17
 				IL_02c5: ldloc.3
 				IL_02c6: ldstr "length"
 				IL_02cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_02d0: clt
-				IL_02d2: brfalse IL_03d8
+				IL_02d2: brfalse IL_03d1
 
-				IL_02d7: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
-				IL_02dc: stloc.s 5
-				IL_02de: ldloc.3
-				IL_02df: ldloc.s 4
-				IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02e6: stloc.s 6
-				IL_02e8: ldloc.s 6
-				IL_02ea: stloc.s 15
-				IL_02ec: ldloc.s 15
-				IL_02ee: ldstr "phase"
-				IL_02f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_02f8: stloc.s 7
-				IL_02fa: ldloc.s 7
-				IL_02fc: box [System.Runtime]System.Boolean
-				IL_0301: stloc.s 8
-				IL_0303: ldloc.s 8
-				IL_0305: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_030a: stloc.s 7
-				IL_030c: ldloc.s 7
-				IL_030e: brfalse IL_0337
+				IL_02d7: ldloc.3
+				IL_02d8: ldloc.s 4
+				IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02df: stloc.s 5
+				IL_02e1: ldloc.s 5
+				IL_02e3: stloc.s 14
+				IL_02e5: ldloc.s 14
+				IL_02e7: ldstr "phase"
+				IL_02ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_02f1: stloc.s 6
+				IL_02f3: ldloc.s 6
+				IL_02f5: box [System.Runtime]System.Boolean
+				IL_02fa: stloc.s 7
+				IL_02fc: ldloc.s 7
+				IL_02fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0303: stloc.s 6
+				IL_0305: ldloc.s 6
+				IL_0307: brfalse IL_0330
 
-				IL_0313: ldloc.s 6
-				IL_0315: stloc.s 15
-				IL_0317: ldloc.s 15
-				IL_0319: ldstr "type"
-				IL_031e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0323: stloc.s 7
-				IL_0325: ldloc.s 7
-				IL_0327: box [System.Runtime]System.Boolean
-				IL_032c: stloc.s 9
-				IL_032e: ldloc.s 9
-				IL_0330: stloc.s 22
-				IL_0332: br IL_033b
+				IL_030c: ldloc.s 5
+				IL_030e: stloc.s 14
+				IL_0310: ldloc.s 14
+				IL_0312: ldstr "type"
+				IL_0317: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_031c: stloc.s 6
+				IL_031e: ldloc.s 6
+				IL_0320: box [System.Runtime]System.Boolean
+				IL_0325: stloc.s 8
+				IL_0327: ldloc.s 8
+				IL_0329: stloc.s 21
+				IL_032b: br IL_0334
 
-				IL_0337: ldloc.s 8
-				IL_0339: stloc.s 22
+				IL_0330: ldloc.s 7
+				IL_0332: stloc.s 21
 
-				IL_033b: ldloc.s 22
-				IL_033d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0342: stloc.s 7
-				IL_0344: ldloc.s 7
-				IL_0346: brfalse IL_03c5
+				IL_0334: ldloc.s 21
+				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_033b: stloc.s 6
+				IL_033d: ldloc.s 6
+				IL_033f: brfalse IL_03be
 
-				IL_034b: ldarg.0
-				IL_034c: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0351: stloc.s 15
-				IL_0353: ldc.i4.1
-				IL_0354: newarr [System.Runtime]System.Object
-				IL_0359: dup
-				IL_035a: ldc.i4.0
-				IL_035b: ldarg.0
-				IL_035c: stelem.ref
-				IL_035d: stloc.s 21
-				IL_035f: ldloc.s 6
-				IL_0361: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0366: stloc.s 20
-				IL_0368: ldstr "negative."
-				IL_036d: ldloc.s 20
-				IL_036f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0374: stloc.s 20
-				IL_0376: ldloc.s 6
-				IL_0378: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_037d: stloc.s 23
-				IL_037f: ldstr "Unsupported negative metadata key '"
-				IL_0384: ldloc.s 23
-				IL_0386: call string [System.Runtime]System.String::Concat(string, string)
-				IL_038b: stloc.s 23
-				IL_038d: ldloc.s 23
-				IL_038f: ldstr "'."
-				IL_0394: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0399: stloc.s 23
-				IL_039b: ldc.i4.4
-				IL_039c: newarr [System.Runtime]System.Object
-				IL_03a1: dup
-				IL_03a2: ldc.i4.0
-				IL_03a3: ldarg.3
-				IL_03a4: stelem.ref
-				IL_03a5: dup
-				IL_03a6: ldc.i4.1
-				IL_03a7: ldstr "unknown-negative-key"
-				IL_03ac: stelem.ref
-				IL_03ad: dup
-				IL_03ae: ldc.i4.2
-				IL_03af: ldloc.s 20
-				IL_03b1: stelem.ref
-				IL_03b2: dup
-				IL_03b3: ldc.i4.3
-				IL_03b4: ldloc.s 23
-				IL_03b6: stelem.ref
-				IL_03b7: stloc.s 16
-				IL_03b9: ldloc.s 15
-				IL_03bb: ldloc.s 21
-				IL_03bd: ldloc.s 16
-				IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_03c4: pop
+				IL_0344: ldarg.0
+				IL_0345: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_034a: stloc.s 14
+				IL_034c: ldc.i4.1
+				IL_034d: newarr [System.Runtime]System.Object
+				IL_0352: dup
+				IL_0353: ldc.i4.0
+				IL_0354: ldarg.0
+				IL_0355: stelem.ref
+				IL_0356: stloc.s 20
+				IL_0358: ldloc.s 5
+				IL_035a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_035f: stloc.s 19
+				IL_0361: ldstr "negative."
+				IL_0366: ldloc.s 19
+				IL_0368: call string [System.Runtime]System.String::Concat(string, string)
+				IL_036d: stloc.s 19
+				IL_036f: ldloc.s 5
+				IL_0371: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0376: stloc.s 22
+				IL_0378: ldstr "Unsupported negative metadata key '"
+				IL_037d: ldloc.s 22
+				IL_037f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0384: stloc.s 22
+				IL_0386: ldloc.s 22
+				IL_0388: ldstr "'."
+				IL_038d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0392: stloc.s 22
+				IL_0394: ldc.i4.4
+				IL_0395: newarr [System.Runtime]System.Object
+				IL_039a: dup
+				IL_039b: ldc.i4.0
+				IL_039c: ldarg.3
+				IL_039d: stelem.ref
+				IL_039e: dup
+				IL_039f: ldc.i4.1
+				IL_03a0: ldstr "unknown-negative-key"
+				IL_03a5: stelem.ref
+				IL_03a6: dup
+				IL_03a7: ldc.i4.2
+				IL_03a8: ldloc.s 19
+				IL_03aa: stelem.ref
+				IL_03ab: dup
+				IL_03ac: ldc.i4.3
+				IL_03ad: ldloc.s 22
+				IL_03af: stelem.ref
+				IL_03b0: stloc.s 15
+				IL_03b2: ldloc.s 14
+				IL_03b4: ldloc.s 20
+				IL_03b6: ldloc.s 15
+				IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_03bd: pop
 
-				IL_03c5: ldloc.s 4
-				IL_03c7: ldc.r8 1
-				IL_03d0: add
-				IL_03d1: stloc.s 4
-				IL_03d3: br IL_02bf
+				IL_03be: ldloc.s 4
+				IL_03c0: ldc.r8 1
+				IL_03c9: add
+				IL_03ca: stloc.s 4
+				IL_03cc: br IL_02bf
 			// end loop
 
-			IL_03d8: ldloc.0
-			IL_03d9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03de: ldc.i4.0
-			IL_03df: ceq
-			IL_03e1: stloc.s 7
-			IL_03e3: ldloc.s 7
-			IL_03e5: box [System.Runtime]System.Boolean
-			IL_03ea: stloc.s 8
-			IL_03ec: ldloc.s 8
-			IL_03ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03f3: stloc.s 7
-			IL_03f5: ldloc.s 7
-			IL_03f7: brtrue IL_0419
+			IL_03d1: ldloc.0
+			IL_03d2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03d7: ldc.i4.0
+			IL_03d8: ceq
+			IL_03da: stloc.s 6
+			IL_03dc: ldloc.s 6
+			IL_03de: box [System.Runtime]System.Boolean
+			IL_03e3: stloc.s 7
+			IL_03e5: ldloc.s 7
+			IL_03e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03ec: stloc.s 6
+			IL_03ee: ldloc.s 6
+			IL_03f0: brtrue IL_0412
 
-			IL_03fc: ldloc.1
-			IL_03fd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0402: ldc.i4.0
-			IL_0403: ceq
-			IL_0405: stloc.s 7
-			IL_0407: ldloc.s 7
-			IL_0409: box [System.Runtime]System.Boolean
-			IL_040e: stloc.s 9
-			IL_0410: ldloc.s 9
-			IL_0412: stloc.s 24
-			IL_0414: br IL_041d
+			IL_03f5: ldloc.1
+			IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03fb: ldc.i4.0
+			IL_03fc: ceq
+			IL_03fe: stloc.s 6
+			IL_0400: ldloc.s 6
+			IL_0402: box [System.Runtime]System.Boolean
+			IL_0407: stloc.s 8
+			IL_0409: ldloc.s 8
+			IL_040b: stloc.s 23
+			IL_040d: br IL_0416
 
-			IL_0419: ldloc.s 8
-			IL_041b: stloc.s 24
+			IL_0412: ldloc.s 7
+			IL_0414: stloc.s 23
 
-			IL_041d: ldloc.s 24
-			IL_041f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0424: stloc.s 7
-			IL_0426: ldloc.s 7
-			IL_0428: brfalse IL_0434
+			IL_0416: ldloc.s 23
+			IL_0418: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_041d: stloc.s 6
+			IL_041f: ldloc.s 6
+			IL_0421: brfalse IL_042d
 
-			IL_042d: ldc.i4.0
-			IL_042e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0433: ret
+			IL_0426: ldc.i4.0
+			IL_0427: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_042c: ret
 
-			IL_0434: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0439: dup
-			IL_043a: ldstr "phase"
-			IL_043f: ldloc.0
-			IL_0440: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0445: dup
-			IL_0446: ldstr "type"
-			IL_044b: ldloc.1
-			IL_044c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0451: stloc.s 25
-			IL_0453: ldloc.s 25
-			IL_0455: ret
+			IL_042d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0432: dup
+			IL_0433: ldstr "phase"
+			IL_0438: ldloc.0
+			IL_0439: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_043e: dup
+			IL_043f: ldstr "type"
+			IL_0444: ldloc.1
+			IL_0445: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_044a: stloc.s 24
+			IL_044c: ldloc.s 24
+			IL_044e: ret
 		} // end of method normalizeNegative::__js_call__
 
 	} // end of class normalizeNegative
@@ -7120,7 +7096,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a84
+						// Method begins at RVA 0x6a04
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7140,7 +7116,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a8d
+						// Method begins at RVA 0x6a0d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7160,7 +7136,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a96
+						// Method begins at RVA 0x6a16
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7178,7 +7154,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a7b
+					// Method begins at RVA 0x69fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7198,7 +7174,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a9f
+					// Method begins at RVA 0x6a1f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7218,7 +7194,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6aa8
+					// Method begins at RVA 0x6a28
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7236,7 +7212,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a57
+				// Method begins at RVA 0x69d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7264,7 +7240,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6a72
+						// Method begins at RVA 0x69f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7282,7 +7258,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6a69
+					// Method begins at RVA 0x69e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7300,7 +7276,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6a60
+				// Method begins at RVA 0x69e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7328,7 +7304,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6ac3
+						// Method begins at RVA 0x6a43
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7346,7 +7322,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6aba
+					// Method begins at RVA 0x6a3a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7364,7 +7340,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6ab1
+				// Method begins at RVA 0x6a31
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7393,9 +7369,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5640
+			// Method begins at RVA 0x55d8
 			// Header size: 12
-			// Code size: 1645 (0x66d)
+			// Code size: 1631 (0x65f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7407,37 +7383,35 @@
 				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[8] float64,
-				[9] class Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51,
+				[9] string,
 				[10] string,
-				[11] string,
-				[12] class Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36,
+				[11] object,
+				[12] object,
 				[13] object,
 				[14] object,
-				[15] object,
+				[15] float64,
 				[16] object,
-				[17] float64,
+				[17] object,
 				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
+				[21] object[],
 				[22] object,
-				[23] object[],
-				[24] object,
-				[25] float64,
-				[26] bool,
-				[27] string,
+				[23] float64,
+				[24] bool,
+				[25] string,
+				[26] object,
+				[27] object,
 				[28] object,
 				[29] object,
-				[30] object,
+				[30] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[31] object,
-				[32] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[33] object,
+				[32] object,
+				[33] bool,
 				[34] object,
-				[35] bool,
+				[35] object,
 				[36] object,
-				[37] object,
-				[38] object,
-				[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[37] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldc.i4.1
@@ -7446,15 +7420,15 @@
 			IL_0007: ldc.i4.0
 			IL_0008: ldarg.0
 			IL_0009: stelem.ref
-			IL_000a: stloc.s 23
+			IL_000a: stloc.s 21
 			IL_000c: ldarg.0
 			IL_000d: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0012: ldloc.s 23
+			IL_0012: ldloc.s 21
 			IL_0014: ldarg.2
 			IL_0015: ldstr "module"
 			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_001f: stloc.s 24
-			IL_0021: ldloc.s 24
+			IL_001f: stloc.s 22
+			IL_0021: ldloc.s 22
 			IL_0023: stloc.0
 			IL_0024: ldc.i4.1
 			IL_0025: newarr [System.Runtime]System.Object
@@ -7462,15 +7436,15 @@
 			IL_002b: ldc.i4.0
 			IL_002c: ldarg.0
 			IL_002d: stelem.ref
-			IL_002e: stloc.s 23
+			IL_002e: stloc.s 21
 			IL_0030: ldarg.0
 			IL_0031: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0036: ldloc.s 23
+			IL_0036: ldloc.s 21
 			IL_0038: ldarg.2
 			IL_0039: ldstr "raw"
 			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0043: stloc.s 24
-			IL_0045: ldloc.s 24
+			IL_0043: stloc.s 22
+			IL_0045: ldloc.s 22
 			IL_0047: stloc.1
 			IL_0048: ldc.i4.1
 			IL_0049: newarr [System.Runtime]System.Object
@@ -7478,15 +7452,15 @@
 			IL_004f: ldc.i4.0
 			IL_0050: ldarg.0
 			IL_0051: stelem.ref
-			IL_0052: stloc.s 23
+			IL_0052: stloc.s 21
 			IL_0054: ldarg.0
 			IL_0055: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_005a: ldloc.s 23
+			IL_005a: ldloc.s 21
 			IL_005c: ldarg.2
 			IL_005d: ldstr "async"
 			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0067: stloc.s 24
-			IL_0069: ldloc.s 24
+			IL_0067: stloc.s 22
+			IL_0069: ldloc.s 22
 			IL_006b: stloc.2
 			IL_006c: ldc.i4.1
 			IL_006d: newarr [System.Runtime]System.Object
@@ -7494,15 +7468,15 @@
 			IL_0073: ldc.i4.0
 			IL_0074: ldarg.0
 			IL_0075: stelem.ref
-			IL_0076: stloc.s 23
+			IL_0076: stloc.s 21
 			IL_0078: ldarg.0
 			IL_0079: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_007e: ldloc.s 23
+			IL_007e: ldloc.s 21
 			IL_0080: ldarg.2
 			IL_0081: ldstr "generated"
 			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_008b: stloc.s 24
-			IL_008d: ldloc.s 24
+			IL_008b: stloc.s 22
+			IL_008d: ldloc.s 22
 			IL_008f: stloc.3
 			IL_0090: ldc.i4.1
 			IL_0091: newarr [System.Runtime]System.Object
@@ -7510,34 +7484,34 @@
 			IL_0097: ldc.i4.0
 			IL_0098: ldarg.0
 			IL_0099: stelem.ref
-			IL_009a: stloc.s 23
+			IL_009a: stloc.s 21
 			IL_009c: ldarg.0
 			IL_009d: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_00a2: ldloc.s 23
+			IL_00a2: ldloc.s 21
 			IL_00a4: ldarg.2
 			IL_00a5: ldstr "non-deterministic"
 			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_00af: stloc.s 24
-			IL_00b1: ldloc.s 24
+			IL_00af: stloc.s 22
+			IL_00b1: ldloc.s 22
 			IL_00b3: stloc.s 4
 			IL_00b5: ldarg.s fileName
 			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bc: stloc.s 24
-			IL_00be: ldloc.s 24
+			IL_00bc: stloc.s 22
+			IL_00be: ldloc.s 22
 			IL_00c0: ldstr "indexOf"
 			IL_00c5: ldstr "_FIXTURE"
 			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cf: stloc.s 24
-			IL_00d1: ldloc.s 24
+			IL_00cf: stloc.s 22
+			IL_00d1: ldloc.s 22
 			IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00d8: stloc.s 25
-			IL_00da: ldloc.s 25
+			IL_00d8: stloc.s 23
+			IL_00da: ldloc.s 23
 			IL_00dc: ldc.r8 0.0
 			IL_00e5: clt
 			IL_00e7: ldc.i4.0
 			IL_00e8: ceq
-			IL_00ea: stloc.s 26
-			IL_00ec: ldloc.s 26
+			IL_00ea: stloc.s 24
+			IL_00ec: ldloc.s 24
 			IL_00ee: stloc.s 5
 			IL_00f0: ldc.i4.0
 			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -7561,507 +7535,503 @@
 			IL_0135: stloc.s 8
 			// loop start (head: IL_0137)
 				IL_0137: ldloc.s 8
-				IL_0139: stloc.s 25
-				IL_013b: ldloc.s 25
+				IL_0139: stloc.s 23
+				IL_013b: ldloc.s 23
 				IL_013d: ldloc.s 7
 				IL_013f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
 				IL_0144: clt
-				IL_0146: brfalse IL_01ad
+				IL_0146: brfalse IL_01a6
 
-				IL_014b: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51::.ctor()
-				IL_0150: stloc.s 9
-				IL_0152: ldloc.s 7
-				IL_0154: ldloc.s 8
-				IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_015b: castclass [System.Runtime]System.String
-				IL_0160: stloc.s 10
-				IL_0162: ldc.i4.1
-				IL_0163: newarr [System.Runtime]System.Object
-				IL_0168: dup
-				IL_0169: ldc.i4.0
-				IL_016a: ldarg.0
-				IL_016b: stelem.ref
-				IL_016c: stloc.s 23
-				IL_016e: ldarg.0
-				IL_016f: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_0174: ldloc.s 23
-				IL_0176: ldarg.2
-				IL_0177: ldloc.s 10
-				IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_017e: stloc.s 24
-				IL_0180: ldloc.s 24
-				IL_0182: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0187: stloc.s 26
-				IL_0189: ldloc.s 26
-				IL_018b: brfalse IL_019a
+				IL_014b: ldloc.s 7
+				IL_014d: ldloc.s 8
+				IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0154: castclass [System.Runtime]System.String
+				IL_0159: stloc.s 9
+				IL_015b: ldc.i4.1
+				IL_015c: newarr [System.Runtime]System.Object
+				IL_0161: dup
+				IL_0162: ldc.i4.0
+				IL_0163: ldarg.0
+				IL_0164: stelem.ref
+				IL_0165: stloc.s 21
+				IL_0167: ldarg.0
+				IL_0168: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_016d: ldloc.s 21
+				IL_016f: ldarg.2
+				IL_0170: ldloc.s 9
+				IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0177: stloc.s 22
+				IL_0179: ldloc.s 22
+				IL_017b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0180: stloc.s 24
+				IL_0182: ldloc.s 24
+				IL_0184: brfalse IL_0193
 
-				IL_0190: ldloc.s 6
-				IL_0192: ldloc.s 10
-				IL_0194: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0199: pop
+				IL_0189: ldloc.s 6
+				IL_018b: ldloc.s 9
+				IL_018d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0192: pop
 
-				IL_019a: ldloc.s 8
-				IL_019c: ldc.r8 1
-				IL_01a5: add
-				IL_01a6: stloc.s 8
-				IL_01a8: br IL_0137
+				IL_0193: ldloc.s 8
+				IL_0195: ldc.r8 1
+				IL_019e: add
+				IL_019f: stloc.s 8
+				IL_01a1: br IL_0137
 			// end loop
 
-			IL_01ad: ldstr "strict-and-non-strict"
-			IL_01b2: stloc.s 11
-			IL_01b4: ldloc.s 6
-			IL_01b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_01bb: ldc.r8 1
-			IL_01c4: ceq
-			IL_01c6: brfalse IL_02a9
+			IL_01a6: ldstr "strict-and-non-strict"
+			IL_01ab: stloc.s 10
+			IL_01ad: ldloc.s 6
+			IL_01af: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_01b4: ldc.r8 1
+			IL_01bd: ceq
+			IL_01bf: brfalse IL_029b
 
-			IL_01cb: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36::.ctor()
-			IL_01d0: stloc.s 12
-			IL_01d2: ldloc.s 6
-			IL_01d4: ldc.r8 0.0
-			IL_01dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01e2: stloc.s 13
-			IL_01e4: ldloc.s 13
+			IL_01c4: ldloc.s 6
+			IL_01c6: ldc.r8 0.0
+			IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01d4: stloc.s 11
+			IL_01d6: ldloc.s 11
+			IL_01d8: stloc.s 22
+			IL_01da: ldloc.s 22
+			IL_01dc: ldstr "onlyStrict"
+			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_01e6: stloc.s 24
 			IL_01e8: ldloc.s 24
-			IL_01ea: ldstr "onlyStrict"
-			IL_01ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01f4: stloc.s 26
-			IL_01f6: ldloc.s 26
-			IL_01f8: brfalse IL_020d
+			IL_01ea: brfalse IL_01ff
 
-			IL_01fd: ldstr "strict-only"
-			IL_0202: stloc.s 27
-			IL_0204: ldloc.s 27
-			IL_0206: stloc.s 11
-			IL_0208: br IL_02a4
+			IL_01ef: ldstr "strict-only"
+			IL_01f4: stloc.s 25
+			IL_01f6: ldloc.s 25
+			IL_01f8: stloc.s 10
+			IL_01fa: br IL_0296
 
-			IL_020d: ldloc.s 13
+			IL_01ff: ldloc.s 11
+			IL_0201: stloc.s 22
+			IL_0203: ldloc.s 22
+			IL_0205: ldstr "noStrict"
+			IL_020a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_020f: stloc.s 24
 			IL_0211: ldloc.s 24
-			IL_0213: ldstr "noStrict"
-			IL_0218: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_021d: stloc.s 26
-			IL_021f: ldloc.s 26
-			IL_0221: box [System.Runtime]System.Boolean
-			IL_0226: stloc.s 28
-			IL_0228: ldloc.s 28
-			IL_022a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022f: stloc.s 26
-			IL_0231: ldloc.s 26
-			IL_0233: brtrue IL_025c
+			IL_0213: box [System.Runtime]System.Boolean
+			IL_0218: stloc.s 26
+			IL_021a: ldloc.s 26
+			IL_021c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0221: stloc.s 24
+			IL_0223: ldloc.s 24
+			IL_0225: brtrue IL_024e
 
-			IL_0238: ldloc.s 13
+			IL_022a: ldloc.s 11
+			IL_022c: stloc.s 22
+			IL_022e: ldloc.s 22
+			IL_0230: ldstr "raw"
+			IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_023a: stloc.s 24
 			IL_023c: ldloc.s 24
-			IL_023e: ldstr "raw"
-			IL_0243: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0248: stloc.s 26
-			IL_024a: ldloc.s 26
-			IL_024c: box [System.Runtime]System.Boolean
-			IL_0251: stloc.s 29
-			IL_0253: ldloc.s 29
-			IL_0255: stloc.s 31
-			IL_0257: br IL_0260
+			IL_023e: box [System.Runtime]System.Boolean
+			IL_0243: stloc.s 27
+			IL_0245: ldloc.s 27
+			IL_0247: stloc.s 29
+			IL_0249: br IL_0252
 
-			IL_025c: ldloc.s 28
-			IL_025e: stloc.s 31
+			IL_024e: ldloc.s 26
+			IL_0250: stloc.s 29
 
-			IL_0260: ldloc.s 31
-			IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0267: stloc.s 26
-			IL_0269: ldloc.s 26
-			IL_026b: brfalse IL_0280
+			IL_0252: ldloc.s 29
+			IL_0254: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0259: stloc.s 24
+			IL_025b: ldloc.s 24
+			IL_025d: brfalse IL_0272
 
-			IL_0270: ldstr "non-strict-only"
-			IL_0275: stloc.s 27
-			IL_0277: ldloc.s 27
-			IL_0279: stloc.s 11
-			IL_027b: br IL_02a4
+			IL_0262: ldstr "non-strict-only"
+			IL_0267: stloc.s 25
+			IL_0269: ldloc.s 25
+			IL_026b: stloc.s 10
+			IL_026d: br IL_0296
 
-			IL_0280: ldloc.s 13
+			IL_0272: ldloc.s 11
+			IL_0274: stloc.s 22
+			IL_0276: ldloc.s 22
+			IL_0278: ldstr "module"
+			IL_027d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0282: stloc.s 24
 			IL_0284: ldloc.s 24
-			IL_0286: ldstr "module"
-			IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0290: stloc.s 26
-			IL_0292: ldloc.s 26
-			IL_0294: brfalse IL_02a4
+			IL_0286: brfalse IL_0296
 
-			IL_0299: ldstr "module"
-			IL_029e: stloc.s 27
-			IL_02a0: ldloc.s 27
-			IL_02a2: stloc.s 11
+			IL_028b: ldstr "module"
+			IL_0290: stloc.s 25
+			IL_0292: ldloc.s 25
+			IL_0294: stloc.s 10
 
-			IL_02a4: br IL_02cb
+			IL_0296: br IL_02bd
 
-			IL_02a9: ldloc.s 6
-			IL_02ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_02b0: ldc.r8 1
-			IL_02b9: cgt
-			IL_02bb: brfalse IL_02cb
+			IL_029b: ldloc.s 6
+			IL_029d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_02a2: ldc.r8 1
+			IL_02ab: cgt
+			IL_02ad: brfalse IL_02bd
 
-			IL_02c0: ldstr "conflicting-flags"
-			IL_02c5: stloc.s 27
-			IL_02c7: ldloc.s 27
-			IL_02c9: stloc.s 11
+			IL_02b2: ldstr "conflicting-flags"
+			IL_02b7: stloc.s 25
+			IL_02b9: ldloc.s 25
+			IL_02bb: stloc.s 10
 
-			IL_02cb: ldloc.1
-			IL_02cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02d1: stloc.s 26
-			IL_02d3: ldloc.s 26
-			IL_02d5: brfalse IL_02e7
+			IL_02bd: ldloc.1
+			IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c3: stloc.s 24
+			IL_02c5: ldloc.s 24
+			IL_02c7: brfalse IL_02d9
 
-			IL_02da: ldc.i4.0
-			IL_02db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02e0: stloc.s 14
-			IL_02e2: br IL_02f8
+			IL_02cc: ldc.i4.0
+			IL_02cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02d2: stloc.s 12
+			IL_02d4: br IL_02ea
 
-			IL_02e7: ldarg.0
-			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_02ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_02f2: stloc.s 32
-			IL_02f4: ldloc.s 32
-			IL_02f6: stloc.s 14
+			IL_02d9: ldarg.0
+			IL_02da: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_02df: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_02e4: stloc.s 30
+			IL_02e6: ldloc.s 30
+			IL_02e8: stloc.s 12
 
-			IL_02f8: ldloc.s 14
-			IL_02fa: stloc.s 15
-			IL_02fc: ldloc.s 15
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0303: stloc.s 24
-			IL_0305: ldloc.s 24
-			IL_0307: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_030c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_0311: stloc.s 32
-			IL_0313: ldloc.s 32
-			IL_0315: stloc.s 16
-			IL_0317: ldloc.2
-			IL_0318: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_031d: stloc.s 26
-			IL_031f: ldloc.s 26
-			IL_0321: brfalse IL_0343
+			IL_02ea: ldloc.s 12
+			IL_02ec: stloc.s 13
+			IL_02ee: ldloc.s 13
+			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f5: stloc.s 22
+			IL_02f7: ldloc.s 22
+			IL_02f9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_0303: stloc.s 30
+			IL_0305: ldloc.s 30
+			IL_0307: stloc.s 14
+			IL_0309: ldloc.2
+			IL_030a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_030f: stloc.s 24
+			IL_0311: ldloc.s 24
+			IL_0313: brfalse IL_0335
 
-			IL_0326: ldloc.1
-			IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_032c: ldc.i4.0
-			IL_032d: ceq
-			IL_032f: stloc.s 26
-			IL_0331: ldloc.s 26
-			IL_0333: box [System.Runtime]System.Boolean
-			IL_0338: stloc.s 28
-			IL_033a: ldloc.s 28
-			IL_033c: stloc.s 33
-			IL_033e: br IL_0346
+			IL_0318: ldloc.1
+			IL_0319: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_031e: ldc.i4.0
+			IL_031f: ceq
+			IL_0321: stloc.s 24
+			IL_0323: ldloc.s 24
+			IL_0325: box [System.Runtime]System.Boolean
+			IL_032a: stloc.s 26
+			IL_032c: ldloc.s 26
+			IL_032e: stloc.s 31
+			IL_0330: br IL_0338
 
-			IL_0343: ldloc.2
-			IL_0344: stloc.s 33
+			IL_0335: ldloc.2
+			IL_0336: stloc.s 31
 
-			IL_0346: ldloc.s 33
-			IL_0348: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_034d: stloc.s 26
-			IL_034f: ldloc.s 26
-			IL_0351: brfalse IL_0397
+			IL_0338: ldloc.s 31
+			IL_033a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_033f: stloc.s 24
+			IL_0341: ldloc.s 24
+			IL_0343: brfalse IL_0389
 
-			IL_0356: ldc.i4.1
-			IL_0357: newarr [System.Runtime]System.Object
-			IL_035c: dup
-			IL_035d: ldc.i4.0
+			IL_0348: ldc.i4.1
+			IL_0349: newarr [System.Runtime]System.Object
+			IL_034e: dup
+			IL_034f: ldc.i4.0
+			IL_0350: ldarg.0
+			IL_0351: stelem.ref
+			IL_0352: stloc.s 21
+			IL_0354: ldarg.0
+			IL_0355: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_035a: ldloc.s 21
+			IL_035c: ldloc.s 14
 			IL_035e: ldarg.0
-			IL_035f: stelem.ref
-			IL_0360: stloc.s 23
-			IL_0362: ldarg.0
-			IL_0363: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0368: ldloc.s 23
-			IL_036a: ldloc.s 16
-			IL_036c: ldarg.0
-			IL_036d: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0377: stloc.s 24
-			IL_0379: ldloc.s 24
-			IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0380: ldc.i4.0
-			IL_0381: ceq
-			IL_0383: stloc.s 26
-			IL_0385: ldloc.s 26
-			IL_0387: box [System.Runtime]System.Boolean
-			IL_038c: stloc.s 28
-			IL_038e: ldloc.s 28
-			IL_0390: stloc.s 33
-			IL_0392: br IL_0397
+			IL_035f: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0369: stloc.s 22
+			IL_036b: ldloc.s 22
+			IL_036d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0372: ldc.i4.0
+			IL_0373: ceq
+			IL_0375: stloc.s 24
+			IL_0377: ldloc.s 24
+			IL_0379: box [System.Runtime]System.Boolean
+			IL_037e: stloc.s 26
+			IL_0380: ldloc.s 26
+			IL_0382: stloc.s 31
+			IL_0384: br IL_0389
 
-			IL_0397: ldloc.s 33
-			IL_0399: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_039e: stloc.s 26
-			IL_03a0: ldloc.s 26
-			IL_03a2: brfalse IL_03c3
+			IL_0389: ldloc.s 31
+			IL_038b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0390: stloc.s 24
+			IL_0392: ldloc.s 24
+			IL_0394: brfalse IL_03b5
 
-			IL_03a7: ldloc.s 16
-			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ae: stloc.s 24
-			IL_03b0: ldloc.s 24
-			IL_03b2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_03b7: ldarg.0
-			IL_03b8: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_03bd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03c2: pop
+			IL_0399: ldloc.s 14
+			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a0: stloc.s 22
+			IL_03a2: ldloc.s 22
+			IL_03a4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03a9: ldarg.0
+			IL_03aa: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_03af: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03b4: pop
 
-			IL_03c3: ldc.r8 0.0
-			IL_03cc: stloc.s 17
-			// loop start (head: IL_03ce)
-				IL_03ce: ldloc.s 17
-				IL_03d0: stloc.s 25
-				IL_03d2: ldloc.s 25
-				IL_03d4: ldarg.3
-				IL_03d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_03da: clt
-				IL_03dc: brfalse IL_044e
+			IL_03b5: ldc.r8 0.0
+			IL_03be: stloc.s 15
+			// loop start (head: IL_03c0)
+				IL_03c0: ldloc.s 15
+				IL_03c2: stloc.s 23
+				IL_03c4: ldloc.s 23
+				IL_03c6: ldarg.3
+				IL_03c7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_03cc: clt
+				IL_03ce: brfalse IL_0440
 
-				IL_03e1: ldarg.0
-				IL_03e2: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_03e7: stloc.s 24
-				IL_03e9: ldc.i4.1
-				IL_03ea: newarr [System.Runtime]System.Object
-				IL_03ef: dup
-				IL_03f0: ldc.i4.0
-				IL_03f1: ldarg.0
-				IL_03f2: stelem.ref
-				IL_03f3: stloc.s 23
-				IL_03f5: ldloc.s 24
-				IL_03f7: ldloc.s 23
-				IL_03f9: ldloc.s 16
-				IL_03fb: ldarg.3
-				IL_03fc: ldloc.s 17
-				IL_03fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0408: stloc.s 24
-				IL_040a: ldloc.s 24
-				IL_040c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0411: ldc.i4.0
-				IL_0412: ceq
-				IL_0414: stloc.s 26
-				IL_0416: ldloc.s 26
-				IL_0418: brfalse IL_043b
+				IL_03d3: ldarg.0
+				IL_03d4: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_03d9: stloc.s 22
+				IL_03db: ldc.i4.1
+				IL_03dc: newarr [System.Runtime]System.Object
+				IL_03e1: dup
+				IL_03e2: ldc.i4.0
+				IL_03e3: ldarg.0
+				IL_03e4: stelem.ref
+				IL_03e5: stloc.s 21
+				IL_03e7: ldloc.s 22
+				IL_03e9: ldloc.s 21
+				IL_03eb: ldloc.s 14
+				IL_03ed: ldarg.3
+				IL_03ee: ldloc.s 15
+				IL_03f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_03fa: stloc.s 22
+				IL_03fc: ldloc.s 22
+				IL_03fe: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0403: ldc.i4.0
+				IL_0404: ceq
+				IL_0406: stloc.s 24
+				IL_0408: ldloc.s 24
+				IL_040a: brfalse IL_042d
 
-				IL_041d: ldloc.s 16
-				IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0424: stloc.s 24
-				IL_0426: ldloc.s 24
-				IL_0428: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_042d: ldarg.3
-				IL_042e: ldloc.s 17
-				IL_0430: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0435: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_043a: pop
+				IL_040f: ldloc.s 14
+				IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0416: stloc.s 22
+				IL_0418: ldloc.s 22
+				IL_041a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_041f: ldarg.3
+				IL_0420: ldloc.s 15
+				IL_0422: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0427: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_042c: pop
 
-				IL_043b: ldloc.s 17
-				IL_043d: ldc.r8 1
-				IL_0446: add
-				IL_0447: stloc.s 17
-				IL_0449: br IL_03ce
+				IL_042d: ldloc.s 15
+				IL_042f: ldc.r8 1
+				IL_0438: add
+				IL_0439: stloc.s 15
+				IL_043b: br IL_03c0
 			// end loop
 
-			IL_044e: ldc.i4.1
-			IL_044f: newarr [System.Runtime]System.Object
-			IL_0454: dup
-			IL_0455: ldc.i4.0
-			IL_0456: ldarg.0
-			IL_0457: stelem.ref
-			IL_0458: stloc.s 23
-			IL_045a: ldarg.0
-			IL_045b: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0460: ldloc.s 23
-			IL_0462: ldarg.3
-			IL_0463: ldstr "agent.js"
-			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_046d: stloc.s 24
-			IL_046f: ldloc.s 24
-			IL_0471: stloc.s 18
-			IL_0473: ldc.i4.1
-			IL_0474: newarr [System.Runtime]System.Object
-			IL_0479: dup
-			IL_047a: ldc.i4.0
-			IL_047b: ldarg.0
-			IL_047c: stelem.ref
-			IL_047d: stloc.s 23
-			IL_047f: ldarg.0
-			IL_0480: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0485: ldloc.s 23
-			IL_0487: ldarg.2
-			IL_0488: ldstr "CanBlockIsFalse"
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0492: stloc.s 24
-			IL_0494: ldloc.s 24
-			IL_0496: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_049b: stloc.s 26
-			IL_049d: ldloc.s 26
-			IL_049f: brfalse IL_04b0
+			IL_0440: ldc.i4.1
+			IL_0441: newarr [System.Runtime]System.Object
+			IL_0446: dup
+			IL_0447: ldc.i4.0
+			IL_0448: ldarg.0
+			IL_0449: stelem.ref
+			IL_044a: stloc.s 21
+			IL_044c: ldarg.0
+			IL_044d: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0452: ldloc.s 21
+			IL_0454: ldarg.3
+			IL_0455: ldstr "agent.js"
+			IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_045f: stloc.s 22
+			IL_0461: ldloc.s 22
+			IL_0463: stloc.s 16
+			IL_0465: ldc.i4.1
+			IL_0466: newarr [System.Runtime]System.Object
+			IL_046b: dup
+			IL_046c: ldc.i4.0
+			IL_046d: ldarg.0
+			IL_046e: stelem.ref
+			IL_046f: stloc.s 21
+			IL_0471: ldarg.0
+			IL_0472: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0477: ldloc.s 21
+			IL_0479: ldarg.2
+			IL_047a: ldstr "CanBlockIsFalse"
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0484: stloc.s 22
+			IL_0486: ldloc.s 22
+			IL_0488: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_048d: stloc.s 24
+			IL_048f: ldloc.s 24
+			IL_0491: brfalse IL_04a2
 
-			IL_04a4: ldstr "false"
-			IL_04a9: stloc.s 19
-			IL_04ab: br IL_04f8
+			IL_0496: ldstr "false"
+			IL_049b: stloc.s 17
+			IL_049d: br IL_04ea
 
-			IL_04b0: ldc.i4.1
-			IL_04b1: newarr [System.Runtime]System.Object
-			IL_04b6: dup
-			IL_04b7: ldc.i4.0
-			IL_04b8: ldarg.0
-			IL_04b9: stelem.ref
-			IL_04ba: stloc.s 23
-			IL_04bc: ldarg.0
-			IL_04bd: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_04c2: ldloc.s 23
-			IL_04c4: ldarg.2
-			IL_04c5: ldstr "CanBlockIsTrue"
-			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04cf: stloc.s 24
-			IL_04d1: ldloc.s 24
-			IL_04d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04d8: stloc.s 26
-			IL_04da: ldloc.s 26
-			IL_04dc: brfalse IL_04ed
+			IL_04a2: ldc.i4.1
+			IL_04a3: newarr [System.Runtime]System.Object
+			IL_04a8: dup
+			IL_04a9: ldc.i4.0
+			IL_04aa: ldarg.0
+			IL_04ab: stelem.ref
+			IL_04ac: stloc.s 21
+			IL_04ae: ldarg.0
+			IL_04af: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04b4: ldloc.s 21
+			IL_04b6: ldarg.2
+			IL_04b7: ldstr "CanBlockIsTrue"
+			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04c1: stloc.s 22
+			IL_04c3: ldloc.s 22
+			IL_04c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04ca: stloc.s 24
+			IL_04cc: ldloc.s 24
+			IL_04ce: brfalse IL_04df
 
-			IL_04e1: ldstr "true"
-			IL_04e6: stloc.s 20
-			IL_04e8: br IL_04f4
+			IL_04d3: ldstr "true"
+			IL_04d8: stloc.s 18
+			IL_04da: br IL_04e6
 
-			IL_04ed: ldstr "unspecified"
-			IL_04f2: stloc.s 20
+			IL_04df: ldstr "unspecified"
+			IL_04e4: stloc.s 18
 
-			IL_04f4: ldloc.s 20
-			IL_04f6: stloc.s 19
+			IL_04e6: ldloc.s 18
+			IL_04e8: stloc.s 17
 
-			IL_04f8: ldloc.s 19
-			IL_04fa: stloc.s 21
-			IL_04fc: ldloc.0
-			IL_04fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0502: stloc.s 26
-			IL_0504: ldloc.s 26
-			IL_0506: brfalse IL_0517
+			IL_04ea: ldloc.s 17
+			IL_04ec: stloc.s 19
+			IL_04ee: ldloc.0
+			IL_04ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04f4: stloc.s 24
+			IL_04f6: ldloc.s 24
+			IL_04f8: brfalse IL_0509
 
-			IL_050b: ldstr "module"
-			IL_0510: stloc.s 22
-			IL_0512: br IL_051e
+			IL_04fd: ldstr "module"
+			IL_0502: stloc.s 20
+			IL_0504: br IL_0510
 
-			IL_0517: ldstr "script"
-			IL_051c: stloc.s 22
+			IL_0509: ldstr "script"
+			IL_050e: stloc.s 20
 
-			IL_051e: ldloc.s 15
-			IL_0520: ldstr "length"
-			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_052a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_052f: ldc.r8 0.0
-			IL_0538: cgt
-			IL_053a: stloc.s 26
-			IL_053c: ldloc.2
-			IL_053d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0542: stloc.s 35
-			IL_0544: ldloc.s 35
-			IL_0546: brtrue IL_0576
+			IL_0510: ldloc.s 13
+			IL_0512: ldstr "length"
+			IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_051c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0521: ldc.r8 0.0
+			IL_052a: cgt
+			IL_052c: stloc.s 24
+			IL_052e: ldloc.2
+			IL_052f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0534: stloc.s 33
+			IL_0536: ldloc.s 33
+			IL_0538: brtrue IL_0568
 
-			IL_054b: ldc.i4.1
-			IL_054c: newarr [System.Runtime]System.Object
-			IL_0551: dup
-			IL_0552: ldc.i4.0
-			IL_0553: ldarg.0
-			IL_0554: stelem.ref
-			IL_0555: stloc.s 23
-			IL_0557: ldarg.0
-			IL_0558: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_055d: ldloc.s 23
-			IL_055f: ldarg.3
-			IL_0560: ldarg.0
-			IL_0561: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_056b: stloc.s 24
-			IL_056d: ldloc.s 24
-			IL_056f: stloc.s 36
-			IL_0571: br IL_0579
+			IL_053d: ldc.i4.1
+			IL_053e: newarr [System.Runtime]System.Object
+			IL_0543: dup
+			IL_0544: ldc.i4.0
+			IL_0545: ldarg.0
+			IL_0546: stelem.ref
+			IL_0547: stloc.s 21
+			IL_0549: ldarg.0
+			IL_054a: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_054f: ldloc.s 21
+			IL_0551: ldarg.3
+			IL_0552: ldarg.0
+			IL_0553: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_055d: stloc.s 22
+			IL_055f: ldloc.s 22
+			IL_0561: stloc.s 34
+			IL_0563: br IL_056b
 
-			IL_0576: ldloc.2
-			IL_0577: stloc.s 36
+			IL_0568: ldloc.2
+			IL_0569: stloc.s 34
 
-			IL_0579: ldloc.s 18
-			IL_057b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0580: stloc.s 35
-			IL_0582: ldloc.s 35
-			IL_0584: brtrue IL_05ad
+			IL_056b: ldloc.s 16
+			IL_056d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0572: stloc.s 33
+			IL_0574: ldloc.s 33
+			IL_0576: brtrue IL_059f
 
-			IL_0589: ldloc.s 21
-			IL_058b: stloc.s 37
-			IL_058d: ldloc.s 37
-			IL_058f: ldstr "unspecified"
-			IL_0594: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0599: stloc.s 35
-			IL_059b: ldloc.s 35
-			IL_059d: box [System.Runtime]System.Boolean
-			IL_05a2: stloc.s 28
-			IL_05a4: ldloc.s 28
-			IL_05a6: stloc.s 38
-			IL_05a8: br IL_05b1
+			IL_057b: ldloc.s 19
+			IL_057d: stloc.s 35
+			IL_057f: ldloc.s 35
+			IL_0581: ldstr "unspecified"
+			IL_0586: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_058b: stloc.s 33
+			IL_058d: ldloc.s 33
+			IL_058f: box [System.Runtime]System.Boolean
+			IL_0594: stloc.s 26
+			IL_0596: ldloc.s 26
+			IL_0598: stloc.s 36
+			IL_059a: br IL_05a3
 
-			IL_05ad: ldloc.s 18
-			IL_05af: stloc.s 38
+			IL_059f: ldloc.s 16
+			IL_05a1: stloc.s 36
 
-			IL_05b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05b6: dup
-			IL_05b7: ldstr "sourceType"
-			IL_05bc: ldloc.s 22
-			IL_05be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05c3: dup
-			IL_05c4: ldstr "strictMode"
-			IL_05c9: ldloc.s 11
-			IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05d0: dup
-			IL_05d1: ldstr "defaultHarnessIncludes"
-			IL_05d6: ldloc.s 15
-			IL_05d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05dd: dup
-			IL_05de: ldstr "harnessIncludes"
-			IL_05e3: ldloc.s 16
-			IL_05e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05ea: dup
-			IL_05eb: ldstr "requiresDefaultHarness"
-			IL_05f0: ldloc.s 26
-			IL_05f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05f7: dup
-			IL_05f8: ldstr "requiresAsyncHarness"
-			IL_05fd: ldloc.s 36
-			IL_05ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0604: dup
-			IL_0605: ldstr "requiresAgent"
-			IL_060a: ldloc.s 38
-			IL_060c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0611: dup
-			IL_0612: ldstr "canBlock"
-			IL_0617: ldloc.s 21
-			IL_0619: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_061e: dup
-			IL_061f: ldstr "isModule"
-			IL_0624: ldloc.0
-			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_062a: dup
-			IL_062b: ldstr "isRaw"
-			IL_0630: ldloc.1
-			IL_0631: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0636: dup
-			IL_0637: ldstr "isAsync"
-			IL_063c: ldloc.2
-			IL_063d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0642: dup
-			IL_0643: ldstr "isGenerated"
-			IL_0648: ldloc.3
-			IL_0649: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_064e: dup
-			IL_064f: ldstr "isNonDeterministic"
-			IL_0654: ldloc.s 4
-			IL_0656: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_065b: dup
-			IL_065c: ldstr "isFixture"
-			IL_0661: ldloc.s 5
-			IL_0663: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0668: stloc.s 39
-			IL_066a: ldloc.s 39
-			IL_066c: ret
+			IL_05a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05a8: dup
+			IL_05a9: ldstr "sourceType"
+			IL_05ae: ldloc.s 20
+			IL_05b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05b5: dup
+			IL_05b6: ldstr "strictMode"
+			IL_05bb: ldloc.s 10
+			IL_05bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05c2: dup
+			IL_05c3: ldstr "defaultHarnessIncludes"
+			IL_05c8: ldloc.s 13
+			IL_05ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05cf: dup
+			IL_05d0: ldstr "harnessIncludes"
+			IL_05d5: ldloc.s 14
+			IL_05d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05dc: dup
+			IL_05dd: ldstr "requiresDefaultHarness"
+			IL_05e2: ldloc.s 24
+			IL_05e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05e9: dup
+			IL_05ea: ldstr "requiresAsyncHarness"
+			IL_05ef: ldloc.s 34
+			IL_05f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05f6: dup
+			IL_05f7: ldstr "requiresAgent"
+			IL_05fc: ldloc.s 36
+			IL_05fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0603: dup
+			IL_0604: ldstr "canBlock"
+			IL_0609: ldloc.s 19
+			IL_060b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0610: dup
+			IL_0611: ldstr "isModule"
+			IL_0616: ldloc.0
+			IL_0617: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_061c: dup
+			IL_061d: ldstr "isRaw"
+			IL_0622: ldloc.1
+			IL_0623: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0628: dup
+			IL_0629: ldstr "isAsync"
+			IL_062e: ldloc.2
+			IL_062f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0634: dup
+			IL_0635: ldstr "isGenerated"
+			IL_063a: ldloc.3
+			IL_063b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0640: dup
+			IL_0641: ldstr "isNonDeterministic"
+			IL_0646: ldloc.s 4
+			IL_0648: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_064d: dup
+			IL_064e: ldstr "isFixture"
+			IL_0653: ldloc.s 5
+			IL_0655: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_065a: stloc.s 37
+			IL_065c: ldloc.s 37
+			IL_065e: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata
@@ -8081,7 +8051,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6ad5
+					// Method begins at RVA 0x6a55
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8101,7 +8071,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6ade
+					// Method begins at RVA 0x6a5e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8121,7 +8091,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6ae7
+					// Method begins at RVA 0x6a67
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8141,7 +8111,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6af0
+					// Method begins at RVA 0x6a70
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8161,7 +8131,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6af9
+					// Method begins at RVA 0x6a79
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8181,7 +8151,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b02
+					// Method begins at RVA 0x6a82
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8201,7 +8171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b0b
+					// Method begins at RVA 0x6a8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8219,7 +8189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6acc
+				// Method begins at RVA 0x6a4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8248,7 +8218,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5cbc
+			// Method begins at RVA 0x5c44
 			// Header size: 12
 			// Code size: 779 (0x30b)
 			.maxstack 8
@@ -8648,7 +8618,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b53
+					// Method begins at RVA 0x6ad3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8666,7 +8636,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b14
+				// Method begins at RVA 0x6a94
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8694,7 +8664,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b2f
+						// Method begins at RVA 0x6aaf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8712,7 +8682,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b26
+					// Method begins at RVA 0x6aa6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8730,7 +8700,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b1d
+				// Method begins at RVA 0x6a9d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8758,7 +8728,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6b4a
+						// Method begins at RVA 0x6aca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8776,7 +8746,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6b41
+					// Method begins at RVA 0x6ac1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8794,7 +8764,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b38
+				// Method begins at RVA 0x6ab8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8822,9 +8792,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5fd4
+			// Method begins at RVA 0x5f5c
 			// Header size: 12
-			// Code size: 1894 (0x766)
+			// Code size: 1887 (0x75f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8838,28 +8808,28 @@
 				[8] object,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[10] float64,
-				[11] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48,
+				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
 				[16] object,
 				[17] object,
-				[18] object,
-				[19] float64,
-				[20] object,
-				[21] bool,
+				[18] float64,
+				[19] object,
+				[20] bool,
+				[21] object,
 				[22] object,
 				[23] object,
-				[24] object,
-				[25] object[],
+				[24] object[],
+				[25] object,
 				[26] object,
-				[27] object,
-				[28] float64,
-				[29] string,
-				[30] object[],
-				[31] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[32] string,
+				[27] float64,
+				[28] string,
+				[29] object[],
+				[30] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[31] string,
+				[32] object,
 				[33] object,
 				[34] object,
 				[35] object,
@@ -8867,58 +8837,57 @@
 				[37] object,
 				[38] object,
 				[39] object,
-				[40] object,
-				[41] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[40] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0006: stloc.s 21
-			IL_0008: ldloc.s 21
+			IL_0006: stloc.s 20
+			IL_0008: ldloc.s 20
 			IL_000a: brtrue IL_001b
 
 			IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0014: stloc.s 23
+			IL_0014: stloc.s 22
 			IL_0016: br IL_001e
 
 			IL_001b: ldarg.3
-			IL_001c: stloc.s 23
+			IL_001c: stloc.s 22
 
-			IL_001e: ldloc.s 23
+			IL_001e: ldloc.s 22
 			IL_0020: stloc.0
 			IL_0021: ldarg.0
 			IL_0022: ldfld object Modules.test262_metadataParser/Scope::normalizePath
-			IL_0027: stloc.s 24
+			IL_0027: stloc.s 23
 			IL_0029: ldc.i4.1
 			IL_002a: newarr [System.Runtime]System.Object
 			IL_002f: dup
 			IL_0030: ldc.i4.0
 			IL_0031: ldarg.0
 			IL_0032: stelem.ref
-			IL_0033: stloc.s 25
+			IL_0033: stloc.s 24
 			IL_0035: ldloc.0
 			IL_0036: ldstr "filePath"
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0040: stloc.s 26
-			IL_0042: ldloc.s 26
+			IL_0040: stloc.s 25
+			IL_0042: ldloc.s 25
 			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0049: stloc.s 21
-			IL_004b: ldloc.s 21
+			IL_0049: stloc.s 20
+			IL_004b: ldloc.s 20
 			IL_004d: brtrue IL_005e
 
 			IL_0052: ldstr ""
-			IL_0057: stloc.s 27
+			IL_0057: stloc.s 26
 			IL_0059: br IL_0062
 
-			IL_005e: ldloc.s 26
-			IL_0060: stloc.s 27
+			IL_005e: ldloc.s 25
+			IL_0060: stloc.s 26
 
-			IL_0062: ldloc.s 24
-			IL_0064: ldloc.s 25
-			IL_0066: ldloc.s 27
+			IL_0062: ldloc.s 23
+			IL_0064: ldloc.s 24
+			IL_0066: ldloc.s 26
 			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_006d: stloc.s 24
-			IL_006f: ldloc.s 24
+			IL_006d: stloc.s 23
+			IL_006f: ldloc.s 23
 			IL_0071: stloc.1
 			IL_0072: ldarg.0
 			IL_0073: ldfld object Modules.test262_metadataParser/Scope::getFileName
@@ -8930,8 +8899,8 @@
 			IL_0081: stelem.ref
 			IL_0082: ldloc.1
 			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0088: stloc.s 24
-			IL_008a: ldloc.s 24
+			IL_0088: stloc.s 23
+			IL_008a: ldloc.s 23
 			IL_008c: stloc.2
 			IL_008d: ldc.i4.1
 			IL_008e: newarr [System.Runtime]System.Object
@@ -8939,26 +8908,26 @@
 			IL_0094: ldc.i4.0
 			IL_0095: ldarg.0
 			IL_0096: stelem.ref
-			IL_0097: stloc.s 25
+			IL_0097: stloc.s 24
 			IL_0099: ldarg.0
 			IL_009a: ldfld object Modules.test262_metadataParser/Scope::extractTest262Frontmatter
-			IL_009f: ldloc.s 25
+			IL_009f: ldloc.s 24
 			IL_00a1: ldarg.2
 			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00a7: stloc.s 24
-			IL_00a9: ldloc.s 24
+			IL_00a7: stloc.s 23
+			IL_00a9: ldloc.s 23
 			IL_00ab: stloc.3
 			IL_00ac: ldc.i4.0
 			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_00b2: stloc.s 4
 			IL_00b4: ldloc.3
-			IL_00b5: stloc.s 24
-			IL_00b7: ldloc.s 24
+			IL_00b5: stloc.s 23
+			IL_00b7: ldloc.s 23
 			IL_00b9: ldc.i4.0
 			IL_00ba: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00c4: stloc.s 21
-			IL_00c6: ldloc.s 21
+			IL_00c4: stloc.s 20
+			IL_00c6: ldloc.s 20
 			IL_00c8: stloc.s 5
 			IL_00ca: ldloc.s 5
 			IL_00cc: brfalse IL_00f2
@@ -8973,8 +8942,8 @@
 			IL_00e0: stelem.ref
 			IL_00e1: ldloc.3
 			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00e7: stloc.s 24
-			IL_00e9: ldloc.s 24
+			IL_00e7: stloc.s 23
+			IL_00e9: ldloc.s 23
 			IL_00eb: stloc.s 6
 			IL_00ed: br IL_00f9
 
@@ -8985,8 +8954,8 @@
 			IL_00fb: stloc.s 7
 			IL_00fd: ldloc.s 7
 			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0104: stloc.s 24
-			IL_0106: ldloc.s 24
+			IL_0104: stloc.s 23
+			IL_0106: ldloc.s 23
 			IL_0108: stloc.s 8
 			IL_010a: ldc.i4.0
 			IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -8995,631 +8964,629 @@
 			IL_011b: stloc.s 10
 			// loop start (head: IL_011d)
 				IL_011d: ldloc.s 10
-				IL_011f: stloc.s 28
-				IL_0121: ldloc.s 28
+				IL_011f: stloc.s 27
+				IL_0121: ldloc.s 27
 				IL_0123: ldloc.s 8
 				IL_0125: ldstr "length"
 				IL_012a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_012f: clt
-				IL_0131: brfalse IL_01f3
+				IL_0131: brfalse IL_01ec
 
-				IL_0136: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
-				IL_013b: stloc.s 11
-				IL_013d: ldloc.s 8
-				IL_013f: ldloc.s 10
-				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0146: stloc.s 12
-				IL_0148: ldarg.0
-				IL_0149: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-				IL_014e: ldc.i4.1
-				IL_014f: newarr [System.Runtime]System.Object
-				IL_0154: dup
-				IL_0155: ldc.i4.0
-				IL_0156: ldloc.s 12
-				IL_0158: stelem.ref
-				IL_0159: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_015e: stloc.s 28
-				IL_0160: ldloc.s 28
-				IL_0162: ldc.r8 0.0
-				IL_016b: clt
-				IL_016d: brfalse IL_01e0
+				IL_0136: ldloc.s 8
+				IL_0138: ldloc.s 10
+				IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_013f: stloc.s 11
+				IL_0141: ldarg.0
+				IL_0142: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+				IL_0147: ldc.i4.1
+				IL_0148: newarr [System.Runtime]System.Object
+				IL_014d: dup
+				IL_014e: ldc.i4.0
+				IL_014f: ldloc.s 11
+				IL_0151: stelem.ref
+				IL_0152: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_0157: stloc.s 27
+				IL_0159: ldloc.s 27
+				IL_015b: ldc.r8 0.0
+				IL_0164: clt
+				IL_0166: brfalse IL_01d9
 
-				IL_0172: ldloc.s 9
-				IL_0174: ldloc.s 12
-				IL_0176: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_017b: pop
-				IL_017c: ldarg.0
-				IL_017d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0182: stloc.s 24
-				IL_0184: ldc.i4.1
-				IL_0185: newarr [System.Runtime]System.Object
-				IL_018a: dup
-				IL_018b: ldc.i4.0
-				IL_018c: ldarg.0
-				IL_018d: stelem.ref
-				IL_018e: stloc.s 25
-				IL_0190: ldloc.s 12
-				IL_0192: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0197: stloc.s 29
-				IL_0199: ldstr "Unsupported frontmatter key '"
-				IL_019e: ldloc.s 29
-				IL_01a0: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01a5: stloc.s 29
-				IL_01a7: ldloc.s 29
-				IL_01a9: ldstr "'."
-				IL_01ae: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01b3: stloc.s 29
-				IL_01b5: ldc.i4.4
-				IL_01b6: newarr [System.Runtime]System.Object
-				IL_01bb: dup
-				IL_01bc: ldc.i4.0
-				IL_01bd: ldloc.s 4
-				IL_01bf: stelem.ref
-				IL_01c0: dup
-				IL_01c1: ldc.i4.1
-				IL_01c2: ldstr "unknown-frontmatter-key"
-				IL_01c7: stelem.ref
-				IL_01c8: dup
-				IL_01c9: ldc.i4.2
-				IL_01ca: ldloc.s 12
-				IL_01cc: stelem.ref
-				IL_01cd: dup
-				IL_01ce: ldc.i4.3
-				IL_01cf: ldloc.s 29
-				IL_01d1: stelem.ref
-				IL_01d2: stloc.s 30
-				IL_01d4: ldloc.s 24
-				IL_01d6: ldloc.s 25
-				IL_01d8: ldloc.s 30
-				IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_01df: pop
+				IL_016b: ldloc.s 9
+				IL_016d: ldloc.s 11
+				IL_016f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0174: pop
+				IL_0175: ldarg.0
+				IL_0176: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_017b: stloc.s 23
+				IL_017d: ldc.i4.1
+				IL_017e: newarr [System.Runtime]System.Object
+				IL_0183: dup
+				IL_0184: ldc.i4.0
+				IL_0185: ldarg.0
+				IL_0186: stelem.ref
+				IL_0187: stloc.s 24
+				IL_0189: ldloc.s 11
+				IL_018b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0190: stloc.s 28
+				IL_0192: ldstr "Unsupported frontmatter key '"
+				IL_0197: ldloc.s 28
+				IL_0199: call string [System.Runtime]System.String::Concat(string, string)
+				IL_019e: stloc.s 28
+				IL_01a0: ldloc.s 28
+				IL_01a2: ldstr "'."
+				IL_01a7: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ac: stloc.s 28
+				IL_01ae: ldc.i4.4
+				IL_01af: newarr [System.Runtime]System.Object
+				IL_01b4: dup
+				IL_01b5: ldc.i4.0
+				IL_01b6: ldloc.s 4
+				IL_01b8: stelem.ref
+				IL_01b9: dup
+				IL_01ba: ldc.i4.1
+				IL_01bb: ldstr "unknown-frontmatter-key"
+				IL_01c0: stelem.ref
+				IL_01c1: dup
+				IL_01c2: ldc.i4.2
+				IL_01c3: ldloc.s 11
+				IL_01c5: stelem.ref
+				IL_01c6: dup
+				IL_01c7: ldc.i4.3
+				IL_01c8: ldloc.s 28
+				IL_01ca: stelem.ref
+				IL_01cb: stloc.s 29
+				IL_01cd: ldloc.s 23
+				IL_01cf: ldloc.s 24
+				IL_01d1: ldloc.s 29
+				IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_01d8: pop
 
-				IL_01e0: ldloc.s 10
-				IL_01e2: ldc.r8 1
-				IL_01eb: add
-				IL_01ec: stloc.s 10
-				IL_01ee: br IL_011d
+				IL_01d9: ldloc.s 10
+				IL_01db: ldc.r8 1
+				IL_01e4: add
+				IL_01e5: stloc.s 10
+				IL_01e7: br IL_011d
 			// end loop
 
-			IL_01f3: ldarg.0
-			IL_01f4: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_01f9: stloc.s 24
-			IL_01fb: ldc.i4.1
-			IL_01fc: newarr [System.Runtime]System.Object
-			IL_0201: dup
-			IL_0202: ldc.i4.0
-			IL_0203: ldarg.0
-			IL_0204: stelem.ref
-			IL_0205: stloc.s 30
-			IL_0207: ldloc.s 7
-			IL_0209: ldstr "includes"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0213: stloc.s 26
-			IL_0215: ldloc.s 24
-			IL_0217: ldloc.s 30
-			IL_0219: ldloc.s 26
-			IL_021b: ldstr "includes"
-			IL_0220: ldloc.s 4
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0227: stloc.s 26
-			IL_0229: ldloc.s 26
-			IL_022b: stloc.s 13
-			IL_022d: ldarg.0
-			IL_022e: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0233: stloc.s 26
-			IL_0235: ldc.i4.1
-			IL_0236: newarr [System.Runtime]System.Object
-			IL_023b: dup
-			IL_023c: ldc.i4.0
-			IL_023d: ldarg.0
-			IL_023e: stelem.ref
-			IL_023f: stloc.s 30
-			IL_0241: ldloc.s 7
-			IL_0243: ldstr "flags"
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024d: stloc.s 24
-			IL_024f: ldloc.s 26
-			IL_0251: ldloc.s 30
-			IL_0253: ldloc.s 24
-			IL_0255: ldstr "flags"
-			IL_025a: ldloc.s 4
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0261: stloc.s 24
-			IL_0263: ldloc.s 24
-			IL_0265: stloc.s 14
-			IL_0267: ldarg.0
-			IL_0268: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_026d: stloc.s 24
-			IL_026f: ldc.i4.1
-			IL_0270: newarr [System.Runtime]System.Object
-			IL_0275: dup
-			IL_0276: ldc.i4.0
-			IL_0277: ldarg.0
-			IL_0278: stelem.ref
-			IL_0279: stloc.s 30
-			IL_027b: ldloc.s 7
-			IL_027d: ldstr "features"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0287: stloc.s 26
-			IL_0289: ldloc.s 24
-			IL_028b: ldloc.s 30
-			IL_028d: ldloc.s 26
-			IL_028f: ldstr "features"
-			IL_0294: ldloc.s 4
-			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_029b: stloc.s 26
-			IL_029d: ldloc.s 26
-			IL_029f: stloc.s 15
-			IL_02a1: ldarg.0
-			IL_02a2: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_02a7: stloc.s 26
-			IL_02a9: ldc.i4.1
-			IL_02aa: newarr [System.Runtime]System.Object
-			IL_02af: dup
-			IL_02b0: ldc.i4.0
-			IL_02b1: ldarg.0
-			IL_02b2: stelem.ref
-			IL_02b3: stloc.s 30
-			IL_02b5: ldloc.s 7
-			IL_02b7: ldstr "locale"
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c1: stloc.s 24
-			IL_02c3: ldloc.s 26
-			IL_02c5: ldloc.s 30
-			IL_02c7: ldloc.s 24
-			IL_02c9: ldstr "locale"
-			IL_02ce: ldloc.s 4
-			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_02d5: stloc.s 24
-			IL_02d7: ldloc.s 24
-			IL_02d9: stloc.s 16
-			IL_02db: ldarg.0
-			IL_02dc: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_02e1: stloc.s 24
-			IL_02e3: ldc.i4.1
-			IL_02e4: newarr [System.Runtime]System.Object
-			IL_02e9: dup
-			IL_02ea: ldc.i4.0
-			IL_02eb: ldarg.0
-			IL_02ec: stelem.ref
-			IL_02ed: stloc.s 30
-			IL_02ef: ldloc.s 7
-			IL_02f1: ldstr "defines"
-			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02fb: stloc.s 26
-			IL_02fd: ldloc.s 24
-			IL_02ff: ldloc.s 30
-			IL_0301: ldloc.s 26
-			IL_0303: ldstr "defines"
-			IL_0308: ldloc.s 4
-			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_030f: stloc.s 26
-			IL_0311: ldloc.s 26
-			IL_0313: stloc.s 17
-			IL_0315: ldarg.0
-			IL_0316: ldfld object Modules.test262_metadataParser/Scope::normalizeNegative
-			IL_031b: stloc.s 26
-			IL_031d: ldc.i4.1
-			IL_031e: newarr [System.Runtime]System.Object
-			IL_0323: dup
-			IL_0324: ldc.i4.0
-			IL_0325: ldarg.0
-			IL_0326: stelem.ref
-			IL_0327: stloc.s 30
-			IL_0329: ldloc.s 26
-			IL_032b: ldloc.s 30
-			IL_032d: ldloc.s 7
-			IL_032f: ldstr "negative"
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0339: ldloc.s 4
-			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0340: stloc.s 26
-			IL_0342: ldloc.s 26
-			IL_0344: stloc.s 18
-			IL_0346: ldc.r8 0.0
-			IL_034f: stloc.s 19
-			// loop start (head: IL_0351)
-				IL_0351: ldloc.s 19
-				IL_0353: stloc.s 28
-				IL_0355: ldloc.s 28
-				IL_0357: ldloc.s 14
-				IL_0359: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_035e: clt
-				IL_0360: brfalse IL_0436
+			IL_01ec: ldarg.0
+			IL_01ed: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_01f2: stloc.s 23
+			IL_01f4: ldc.i4.1
+			IL_01f5: newarr [System.Runtime]System.Object
+			IL_01fa: dup
+			IL_01fb: ldc.i4.0
+			IL_01fc: ldarg.0
+			IL_01fd: stelem.ref
+			IL_01fe: stloc.s 29
+			IL_0200: ldloc.s 7
+			IL_0202: ldstr "includes"
+			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020c: stloc.s 25
+			IL_020e: ldloc.s 23
+			IL_0210: ldloc.s 29
+			IL_0212: ldloc.s 25
+			IL_0214: ldstr "includes"
+			IL_0219: ldloc.s 4
+			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0220: stloc.s 25
+			IL_0222: ldloc.s 25
+			IL_0224: stloc.s 12
+			IL_0226: ldarg.0
+			IL_0227: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_022c: stloc.s 25
+			IL_022e: ldc.i4.1
+			IL_022f: newarr [System.Runtime]System.Object
+			IL_0234: dup
+			IL_0235: ldc.i4.0
+			IL_0236: ldarg.0
+			IL_0237: stelem.ref
+			IL_0238: stloc.s 29
+			IL_023a: ldloc.s 7
+			IL_023c: ldstr "flags"
+			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0246: stloc.s 23
+			IL_0248: ldloc.s 25
+			IL_024a: ldloc.s 29
+			IL_024c: ldloc.s 23
+			IL_024e: ldstr "flags"
+			IL_0253: ldloc.s 4
+			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_025a: stloc.s 23
+			IL_025c: ldloc.s 23
+			IL_025e: stloc.s 13
+			IL_0260: ldarg.0
+			IL_0261: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_0266: stloc.s 23
+			IL_0268: ldc.i4.1
+			IL_0269: newarr [System.Runtime]System.Object
+			IL_026e: dup
+			IL_026f: ldc.i4.0
+			IL_0270: ldarg.0
+			IL_0271: stelem.ref
+			IL_0272: stloc.s 29
+			IL_0274: ldloc.s 7
+			IL_0276: ldstr "features"
+			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0280: stloc.s 25
+			IL_0282: ldloc.s 23
+			IL_0284: ldloc.s 29
+			IL_0286: ldloc.s 25
+			IL_0288: ldstr "features"
+			IL_028d: ldloc.s 4
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0294: stloc.s 25
+			IL_0296: ldloc.s 25
+			IL_0298: stloc.s 14
+			IL_029a: ldarg.0
+			IL_029b: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_02a0: stloc.s 25
+			IL_02a2: ldc.i4.1
+			IL_02a3: newarr [System.Runtime]System.Object
+			IL_02a8: dup
+			IL_02a9: ldc.i4.0
+			IL_02aa: ldarg.0
+			IL_02ab: stelem.ref
+			IL_02ac: stloc.s 29
+			IL_02ae: ldloc.s 7
+			IL_02b0: ldstr "locale"
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ba: stloc.s 23
+			IL_02bc: ldloc.s 25
+			IL_02be: ldloc.s 29
+			IL_02c0: ldloc.s 23
+			IL_02c2: ldstr "locale"
+			IL_02c7: ldloc.s 4
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_02ce: stloc.s 23
+			IL_02d0: ldloc.s 23
+			IL_02d2: stloc.s 15
+			IL_02d4: ldarg.0
+			IL_02d5: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_02da: stloc.s 23
+			IL_02dc: ldc.i4.1
+			IL_02dd: newarr [System.Runtime]System.Object
+			IL_02e2: dup
+			IL_02e3: ldc.i4.0
+			IL_02e4: ldarg.0
+			IL_02e5: stelem.ref
+			IL_02e6: stloc.s 29
+			IL_02e8: ldloc.s 7
+			IL_02ea: ldstr "defines"
+			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f4: stloc.s 25
+			IL_02f6: ldloc.s 23
+			IL_02f8: ldloc.s 29
+			IL_02fa: ldloc.s 25
+			IL_02fc: ldstr "defines"
+			IL_0301: ldloc.s 4
+			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0308: stloc.s 25
+			IL_030a: ldloc.s 25
+			IL_030c: stloc.s 16
+			IL_030e: ldarg.0
+			IL_030f: ldfld object Modules.test262_metadataParser/Scope::normalizeNegative
+			IL_0314: stloc.s 25
+			IL_0316: ldc.i4.1
+			IL_0317: newarr [System.Runtime]System.Object
+			IL_031c: dup
+			IL_031d: ldc.i4.0
+			IL_031e: ldarg.0
+			IL_031f: stelem.ref
+			IL_0320: stloc.s 29
+			IL_0322: ldloc.s 25
+			IL_0324: ldloc.s 29
+			IL_0326: ldloc.s 7
+			IL_0328: ldstr "negative"
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0332: ldloc.s 4
+			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0339: stloc.s 25
+			IL_033b: ldloc.s 25
+			IL_033d: stloc.s 17
+			IL_033f: ldc.r8 0.0
+			IL_0348: stloc.s 18
+			// loop start (head: IL_034a)
+				IL_034a: ldloc.s 18
+				IL_034c: stloc.s 27
+				IL_034e: ldloc.s 27
+				IL_0350: ldloc.s 13
+				IL_0352: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_0357: clt
+				IL_0359: brfalse IL_042f
 
-				IL_0365: ldarg.0
-				IL_0366: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_036b: stloc.s 31
-				IL_036d: ldloc.s 31
-				IL_036f: ldc.i4.1
-				IL_0370: newarr [System.Runtime]System.Object
-				IL_0375: dup
-				IL_0376: ldc.i4.0
-				IL_0377: ldloc.s 14
-				IL_0379: ldloc.s 19
-				IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0380: stelem.ref
-				IL_0381: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_0386: stloc.s 28
-				IL_0388: ldloc.s 28
-				IL_038a: ldc.r8 0.0
-				IL_0393: clt
-				IL_0395: brfalse IL_0423
+				IL_035e: ldarg.0
+				IL_035f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_0364: stloc.s 30
+				IL_0366: ldloc.s 30
+				IL_0368: ldc.i4.1
+				IL_0369: newarr [System.Runtime]System.Object
+				IL_036e: dup
+				IL_036f: ldc.i4.0
+				IL_0370: ldloc.s 13
+				IL_0372: ldloc.s 18
+				IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0379: stelem.ref
+				IL_037a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_037f: stloc.s 27
+				IL_0381: ldloc.s 27
+				IL_0383: ldc.r8 0.0
+				IL_038c: clt
+				IL_038e: brfalse IL_041c
 
-				IL_039a: ldarg.0
-				IL_039b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_03a0: stloc.s 26
-				IL_03a2: ldc.i4.1
-				IL_03a3: newarr [System.Runtime]System.Object
-				IL_03a8: dup
-				IL_03a9: ldc.i4.0
-				IL_03aa: ldarg.0
-				IL_03ab: stelem.ref
-				IL_03ac: stloc.s 30
-				IL_03ae: ldloc.s 14
-				IL_03b0: ldloc.s 19
-				IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03bc: stloc.s 29
-				IL_03be: ldstr "flags:"
-				IL_03c3: ldloc.s 29
-				IL_03c5: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03ca: stloc.s 29
-				IL_03cc: ldloc.s 14
-				IL_03ce: ldloc.s 19
-				IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03d5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03da: stloc.s 32
-				IL_03dc: ldstr "Unsupported flag '"
-				IL_03e1: ldloc.s 32
-				IL_03e3: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03e8: stloc.s 32
-				IL_03ea: ldloc.s 32
-				IL_03ec: ldstr "'."
-				IL_03f1: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03f6: stloc.s 32
-				IL_03f8: ldc.i4.4
-				IL_03f9: newarr [System.Runtime]System.Object
-				IL_03fe: dup
-				IL_03ff: ldc.i4.0
-				IL_0400: ldloc.s 4
-				IL_0402: stelem.ref
-				IL_0403: dup
-				IL_0404: ldc.i4.1
-				IL_0405: ldstr "unknown-flag"
-				IL_040a: stelem.ref
-				IL_040b: dup
-				IL_040c: ldc.i4.2
-				IL_040d: ldloc.s 29
-				IL_040f: stelem.ref
-				IL_0410: dup
-				IL_0411: ldc.i4.3
-				IL_0412: ldloc.s 32
-				IL_0414: stelem.ref
-				IL_0415: stloc.s 25
-				IL_0417: ldloc.s 26
-				IL_0419: ldloc.s 30
-				IL_041b: ldloc.s 25
-				IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-				IL_0422: pop
+				IL_0393: ldarg.0
+				IL_0394: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0399: stloc.s 25
+				IL_039b: ldc.i4.1
+				IL_039c: newarr [System.Runtime]System.Object
+				IL_03a1: dup
+				IL_03a2: ldc.i4.0
+				IL_03a3: ldarg.0
+				IL_03a4: stelem.ref
+				IL_03a5: stloc.s 29
+				IL_03a7: ldloc.s 13
+				IL_03a9: ldloc.s 18
+				IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03b0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03b5: stloc.s 28
+				IL_03b7: ldstr "flags:"
+				IL_03bc: ldloc.s 28
+				IL_03be: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03c3: stloc.s 28
+				IL_03c5: ldloc.s 13
+				IL_03c7: ldloc.s 18
+				IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03ce: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03d3: stloc.s 31
+				IL_03d5: ldstr "Unsupported flag '"
+				IL_03da: ldloc.s 31
+				IL_03dc: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03e1: stloc.s 31
+				IL_03e3: ldloc.s 31
+				IL_03e5: ldstr "'."
+				IL_03ea: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03ef: stloc.s 31
+				IL_03f1: ldc.i4.4
+				IL_03f2: newarr [System.Runtime]System.Object
+				IL_03f7: dup
+				IL_03f8: ldc.i4.0
+				IL_03f9: ldloc.s 4
+				IL_03fb: stelem.ref
+				IL_03fc: dup
+				IL_03fd: ldc.i4.1
+				IL_03fe: ldstr "unknown-flag"
+				IL_0403: stelem.ref
+				IL_0404: dup
+				IL_0405: ldc.i4.2
+				IL_0406: ldloc.s 28
+				IL_0408: stelem.ref
+				IL_0409: dup
+				IL_040a: ldc.i4.3
+				IL_040b: ldloc.s 31
+				IL_040d: stelem.ref
+				IL_040e: stloc.s 24
+				IL_0410: ldloc.s 25
+				IL_0412: ldloc.s 29
+				IL_0414: ldloc.s 24
+				IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_041b: pop
 
-				IL_0423: ldloc.s 19
-				IL_0425: ldc.r8 1
-				IL_042e: add
-				IL_042f: stloc.s 19
-				IL_0431: br IL_0351
+				IL_041c: ldloc.s 18
+				IL_041e: ldc.r8 1
+				IL_0427: add
+				IL_0428: stloc.s 18
+				IL_042a: br IL_034a
 			// end loop
 
-			IL_0436: ldarg.0
-			IL_0437: ldfld object Modules.test262_metadataParser/Scope::buildExecutionMetadata
-			IL_043c: ldc.i4.1
-			IL_043d: newarr [System.Runtime]System.Object
-			IL_0442: dup
-			IL_0443: ldc.i4.0
-			IL_0444: ldarg.0
-			IL_0445: stelem.ref
-			IL_0446: ldloc.s 14
-			IL_0448: ldloc.s 13
-			IL_044a: ldloc.2
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0450: stloc.s 26
-			IL_0452: ldloc.s 26
-			IL_0454: stloc.s 20
-			IL_0456: ldloc.s 20
-			IL_0458: ldstr "strictMode"
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0462: ldstr "conflicting-flags"
-			IL_0467: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_046c: stloc.s 21
-			IL_046e: ldloc.s 21
-			IL_0470: brfalse IL_04ba
+			IL_042f: ldarg.0
+			IL_0430: ldfld object Modules.test262_metadataParser/Scope::buildExecutionMetadata
+			IL_0435: ldc.i4.1
+			IL_0436: newarr [System.Runtime]System.Object
+			IL_043b: dup
+			IL_043c: ldc.i4.0
+			IL_043d: ldarg.0
+			IL_043e: stelem.ref
+			IL_043f: ldloc.s 13
+			IL_0441: ldloc.s 12
+			IL_0443: ldloc.2
+			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0449: stloc.s 25
+			IL_044b: ldloc.s 25
+			IL_044d: stloc.s 19
+			IL_044f: ldloc.s 19
+			IL_0451: ldstr "strictMode"
+			IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_045b: ldstr "conflicting-flags"
+			IL_0460: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0465: stloc.s 20
+			IL_0467: ldloc.s 20
+			IL_0469: brfalse IL_04b3
 
-			IL_0475: ldarg.0
-			IL_0476: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_047b: stloc.s 26
-			IL_047d: ldc.i4.1
-			IL_047e: newarr [System.Runtime]System.Object
-			IL_0483: dup
-			IL_0484: ldc.i4.0
-			IL_0485: ldarg.0
-			IL_0486: stelem.ref
-			IL_0487: stloc.s 25
-			IL_0489: ldc.i4.4
-			IL_048a: newarr [System.Runtime]System.Object
-			IL_048f: dup
-			IL_0490: ldc.i4.0
-			IL_0491: ldloc.s 4
-			IL_0493: stelem.ref
-			IL_0494: dup
-			IL_0495: ldc.i4.1
-			IL_0496: ldstr "conflicting-strictness-flags"
-			IL_049b: stelem.ref
-			IL_049c: dup
-			IL_049d: ldc.i4.2
-			IL_049e: ldstr "flags"
-			IL_04a3: stelem.ref
-			IL_04a4: dup
-			IL_04a5: ldc.i4.3
-			IL_04a6: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_04ab: stelem.ref
-			IL_04ac: stloc.s 30
-			IL_04ae: ldloc.s 26
-			IL_04b0: ldloc.s 25
-			IL_04b2: ldloc.s 30
-			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_04b9: pop
+			IL_046e: ldarg.0
+			IL_046f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0474: stloc.s 25
+			IL_0476: ldc.i4.1
+			IL_0477: newarr [System.Runtime]System.Object
+			IL_047c: dup
+			IL_047d: ldc.i4.0
+			IL_047e: ldarg.0
+			IL_047f: stelem.ref
+			IL_0480: stloc.s 24
+			IL_0482: ldc.i4.4
+			IL_0483: newarr [System.Runtime]System.Object
+			IL_0488: dup
+			IL_0489: ldc.i4.0
+			IL_048a: ldloc.s 4
+			IL_048c: stelem.ref
+			IL_048d: dup
+			IL_048e: ldc.i4.1
+			IL_048f: ldstr "conflicting-strictness-flags"
+			IL_0494: stelem.ref
+			IL_0495: dup
+			IL_0496: ldc.i4.2
+			IL_0497: ldstr "flags"
+			IL_049c: stelem.ref
+			IL_049d: dup
+			IL_049e: ldc.i4.3
+			IL_049f: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_04a4: stelem.ref
+			IL_04a5: stloc.s 29
+			IL_04a7: ldloc.s 25
+			IL_04a9: ldloc.s 24
+			IL_04ab: ldloc.s 29
+			IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_04b2: pop
 
-			IL_04ba: ldloc.1
-			IL_04bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04c0: stloc.s 21
-			IL_04c2: ldloc.s 21
-			IL_04c4: brtrue IL_04d6
+			IL_04b3: ldloc.1
+			IL_04b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04b9: stloc.s 20
+			IL_04bb: ldloc.s 20
+			IL_04bd: brtrue IL_04cf
 
-			IL_04c9: ldc.i4.0
-			IL_04ca: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04cf: stloc.s 33
-			IL_04d1: br IL_04d9
+			IL_04c2: ldc.i4.0
+			IL_04c3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04c8: stloc.s 32
+			IL_04ca: br IL_04d2
 
-			IL_04d6: ldloc.1
-			IL_04d7: stloc.s 33
+			IL_04cf: ldloc.1
+			IL_04d0: stloc.s 32
 
-			IL_04d9: ldloc.2
-			IL_04da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04df: stloc.s 21
-			IL_04e1: ldloc.s 21
-			IL_04e3: brtrue IL_04f5
+			IL_04d2: ldloc.2
+			IL_04d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d8: stloc.s 20
+			IL_04da: ldloc.s 20
+			IL_04dc: brtrue IL_04ee
 
-			IL_04e8: ldc.i4.0
-			IL_04e9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04ee: stloc.s 35
-			IL_04f0: br IL_04f8
+			IL_04e1: ldc.i4.0
+			IL_04e2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04e7: stloc.s 34
+			IL_04e9: br IL_04f1
 
-			IL_04f5: ldloc.2
-			IL_04f6: stloc.s 35
+			IL_04ee: ldloc.2
+			IL_04ef: stloc.s 34
 
-			IL_04f8: ldarg.0
-			IL_04f9: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_04fe: stloc.s 26
-			IL_0500: ldc.i4.1
-			IL_0501: newarr [System.Runtime]System.Object
-			IL_0506: dup
-			IL_0507: ldc.i4.0
-			IL_0508: ldarg.0
-			IL_0509: stelem.ref
-			IL_050a: stloc.s 30
-			IL_050c: ldloc.s 7
-			IL_050e: ldstr "description"
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0518: stloc.s 24
-			IL_051a: ldloc.s 26
-			IL_051c: ldloc.s 30
-			IL_051e: ldloc.s 24
-			IL_0520: ldstr "description"
-			IL_0525: ldloc.s 4
-			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_052c: stloc.s 24
-			IL_052e: ldarg.0
-			IL_052f: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_0534: stloc.s 26
-			IL_0536: ldc.i4.1
-			IL_0537: newarr [System.Runtime]System.Object
-			IL_053c: dup
-			IL_053d: ldc.i4.0
-			IL_053e: ldarg.0
-			IL_053f: stelem.ref
-			IL_0540: stloc.s 30
-			IL_0542: ldloc.s 7
-			IL_0544: ldstr "info"
-			IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054e: stloc.s 36
-			IL_0550: ldloc.s 26
-			IL_0552: ldloc.s 30
-			IL_0554: ldloc.s 36
-			IL_0556: ldstr "info"
-			IL_055b: ldloc.s 4
-			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0562: stloc.s 36
-			IL_0564: ldarg.0
-			IL_0565: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_056a: stloc.s 26
-			IL_056c: ldc.i4.1
-			IL_056d: newarr [System.Runtime]System.Object
-			IL_0572: dup
-			IL_0573: ldc.i4.0
-			IL_0574: ldarg.0
-			IL_0575: stelem.ref
-			IL_0576: stloc.s 30
-			IL_0578: ldloc.s 7
-			IL_057a: ldstr "esid"
-			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0584: stloc.s 37
-			IL_0586: ldloc.s 26
-			IL_0588: ldloc.s 30
-			IL_058a: ldloc.s 37
-			IL_058c: ldstr "esid"
-			IL_0591: ldloc.s 4
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0598: stloc.s 37
-			IL_059a: ldarg.0
-			IL_059b: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_05a0: stloc.s 26
-			IL_05a2: ldc.i4.1
-			IL_05a3: newarr [System.Runtime]System.Object
-			IL_05a8: dup
-			IL_05a9: ldc.i4.0
-			IL_05aa: ldarg.0
-			IL_05ab: stelem.ref
-			IL_05ac: stloc.s 30
-			IL_05ae: ldloc.s 7
-			IL_05b0: ldstr "es5id"
-			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ba: stloc.s 38
-			IL_05bc: ldloc.s 26
-			IL_05be: ldloc.s 30
-			IL_05c0: ldloc.s 38
-			IL_05c2: ldstr "es5id"
-			IL_05c7: ldloc.s 4
-			IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_05ce: stloc.s 38
-			IL_05d0: ldarg.0
-			IL_05d1: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_05d6: stloc.s 26
-			IL_05d8: ldc.i4.1
-			IL_05d9: newarr [System.Runtime]System.Object
-			IL_05de: dup
-			IL_05df: ldc.i4.0
-			IL_05e0: ldarg.0
-			IL_05e1: stelem.ref
-			IL_05e2: stloc.s 30
-			IL_05e4: ldloc.s 7
-			IL_05e6: ldstr "es6id"
-			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f0: stloc.s 39
-			IL_05f2: ldloc.s 26
-			IL_05f4: ldloc.s 30
-			IL_05f6: ldloc.s 39
-			IL_05f8: ldstr "es6id"
-			IL_05fd: ldloc.s 4
-			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0604: stloc.s 39
-			IL_0606: ldarg.0
-			IL_0607: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_060c: stloc.s 26
-			IL_060e: ldc.i4.1
-			IL_060f: newarr [System.Runtime]System.Object
-			IL_0614: dup
-			IL_0615: ldc.i4.0
-			IL_0616: ldarg.0
-			IL_0617: stelem.ref
-			IL_0618: stloc.s 30
-			IL_061a: ldloc.s 7
-			IL_061c: ldstr "author"
-			IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0626: stloc.s 40
-			IL_0628: ldloc.s 26
-			IL_062a: ldloc.s 30
-			IL_062c: ldloc.s 40
-			IL_062e: ldstr "author"
-			IL_0633: ldloc.s 4
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_063a: stloc.s 40
-			IL_063c: ldarg.0
-			IL_063d: ldfld object Modules.test262_metadataParser/Scope::buildMvpBlockers
-			IL_0642: ldc.i4.1
-			IL_0643: newarr [System.Runtime]System.Object
-			IL_0648: dup
-			IL_0649: ldc.i4.0
-			IL_064a: ldarg.0
-			IL_064b: stelem.ref
-			IL_064c: ldloc.1
-			IL_064d: ldloc.s 18
-			IL_064f: ldloc.s 20
-			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0656: stloc.s 26
-			IL_0658: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_065d: dup
-			IL_065e: ldstr "filePath"
-			IL_0663: ldloc.s 33
-			IL_0665: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_066a: dup
-			IL_066b: ldstr "fileName"
-			IL_0670: ldloc.s 35
-			IL_0672: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0677: dup
-			IL_0678: ldstr "hasFrontmatter"
-			IL_067d: ldloc.s 5
-			IL_067f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0684: dup
-			IL_0685: ldstr "frontmatter"
-			IL_068a: ldloc.s 7
-			IL_068c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0691: dup
-			IL_0692: ldstr "unknownKeys"
-			IL_0697: ldloc.s 9
-			IL_0699: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_069e: dup
-			IL_069f: ldstr "description"
-			IL_06a4: ldloc.s 24
-			IL_06a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06ab: dup
-			IL_06ac: ldstr "info"
-			IL_06b1: ldloc.s 36
-			IL_06b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06b8: dup
-			IL_06b9: ldstr "esid"
-			IL_06be: ldloc.s 37
-			IL_06c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06c5: dup
-			IL_06c6: ldstr "es5id"
-			IL_06cb: ldloc.s 38
-			IL_06cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06d2: dup
-			IL_06d3: ldstr "es6id"
-			IL_06d8: ldloc.s 39
-			IL_06da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06df: dup
-			IL_06e0: ldstr "author"
-			IL_06e5: ldloc.s 40
-			IL_06e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06ec: dup
-			IL_06ed: ldstr "includes"
-			IL_06f2: ldloc.s 13
-			IL_06f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06f9: dup
-			IL_06fa: ldstr "flags"
-			IL_06ff: ldloc.s 14
-			IL_0701: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0706: dup
-			IL_0707: ldstr "features"
-			IL_070c: ldloc.s 15
-			IL_070e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0713: dup
-			IL_0714: ldstr "locale"
-			IL_0719: ldloc.s 16
-			IL_071b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0720: dup
-			IL_0721: ldstr "defines"
-			IL_0726: ldloc.s 17
-			IL_0728: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_072d: dup
-			IL_072e: ldstr "negative"
-			IL_0733: ldloc.s 18
-			IL_0735: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_073a: dup
-			IL_073b: ldstr "execution"
-			IL_0740: ldloc.s 20
-			IL_0742: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0747: dup
-			IL_0748: ldstr "mvpBlockers"
-			IL_074d: ldloc.s 26
-			IL_074f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0754: dup
-			IL_0755: ldstr "unsupported"
-			IL_075a: ldloc.s 4
-			IL_075c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0761: stloc.s 41
-			IL_0763: ldloc.s 41
-			IL_0765: ret
+			IL_04f1: ldarg.0
+			IL_04f2: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_04f7: stloc.s 25
+			IL_04f9: ldc.i4.1
+			IL_04fa: newarr [System.Runtime]System.Object
+			IL_04ff: dup
+			IL_0500: ldc.i4.0
+			IL_0501: ldarg.0
+			IL_0502: stelem.ref
+			IL_0503: stloc.s 29
+			IL_0505: ldloc.s 7
+			IL_0507: ldstr "description"
+			IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0511: stloc.s 23
+			IL_0513: ldloc.s 25
+			IL_0515: ldloc.s 29
+			IL_0517: ldloc.s 23
+			IL_0519: ldstr "description"
+			IL_051e: ldloc.s 4
+			IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0525: stloc.s 23
+			IL_0527: ldarg.0
+			IL_0528: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_052d: stloc.s 25
+			IL_052f: ldc.i4.1
+			IL_0530: newarr [System.Runtime]System.Object
+			IL_0535: dup
+			IL_0536: ldc.i4.0
+			IL_0537: ldarg.0
+			IL_0538: stelem.ref
+			IL_0539: stloc.s 29
+			IL_053b: ldloc.s 7
+			IL_053d: ldstr "info"
+			IL_0542: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0547: stloc.s 35
+			IL_0549: ldloc.s 25
+			IL_054b: ldloc.s 29
+			IL_054d: ldloc.s 35
+			IL_054f: ldstr "info"
+			IL_0554: ldloc.s 4
+			IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_055b: stloc.s 35
+			IL_055d: ldarg.0
+			IL_055e: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0563: stloc.s 25
+			IL_0565: ldc.i4.1
+			IL_0566: newarr [System.Runtime]System.Object
+			IL_056b: dup
+			IL_056c: ldc.i4.0
+			IL_056d: ldarg.0
+			IL_056e: stelem.ref
+			IL_056f: stloc.s 29
+			IL_0571: ldloc.s 7
+			IL_0573: ldstr "esid"
+			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057d: stloc.s 36
+			IL_057f: ldloc.s 25
+			IL_0581: ldloc.s 29
+			IL_0583: ldloc.s 36
+			IL_0585: ldstr "esid"
+			IL_058a: ldloc.s 4
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0591: stloc.s 36
+			IL_0593: ldarg.0
+			IL_0594: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0599: stloc.s 25
+			IL_059b: ldc.i4.1
+			IL_059c: newarr [System.Runtime]System.Object
+			IL_05a1: dup
+			IL_05a2: ldc.i4.0
+			IL_05a3: ldarg.0
+			IL_05a4: stelem.ref
+			IL_05a5: stloc.s 29
+			IL_05a7: ldloc.s 7
+			IL_05a9: ldstr "es5id"
+			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b3: stloc.s 37
+			IL_05b5: ldloc.s 25
+			IL_05b7: ldloc.s 29
+			IL_05b9: ldloc.s 37
+			IL_05bb: ldstr "es5id"
+			IL_05c0: ldloc.s 4
+			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_05c7: stloc.s 37
+			IL_05c9: ldarg.0
+			IL_05ca: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_05cf: stloc.s 25
+			IL_05d1: ldc.i4.1
+			IL_05d2: newarr [System.Runtime]System.Object
+			IL_05d7: dup
+			IL_05d8: ldc.i4.0
+			IL_05d9: ldarg.0
+			IL_05da: stelem.ref
+			IL_05db: stloc.s 29
+			IL_05dd: ldloc.s 7
+			IL_05df: ldstr "es6id"
+			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e9: stloc.s 38
+			IL_05eb: ldloc.s 25
+			IL_05ed: ldloc.s 29
+			IL_05ef: ldloc.s 38
+			IL_05f1: ldstr "es6id"
+			IL_05f6: ldloc.s 4
+			IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_05fd: stloc.s 38
+			IL_05ff: ldarg.0
+			IL_0600: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0605: stloc.s 25
+			IL_0607: ldc.i4.1
+			IL_0608: newarr [System.Runtime]System.Object
+			IL_060d: dup
+			IL_060e: ldc.i4.0
+			IL_060f: ldarg.0
+			IL_0610: stelem.ref
+			IL_0611: stloc.s 29
+			IL_0613: ldloc.s 7
+			IL_0615: ldstr "author"
+			IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_061f: stloc.s 39
+			IL_0621: ldloc.s 25
+			IL_0623: ldloc.s 29
+			IL_0625: ldloc.s 39
+			IL_0627: ldstr "author"
+			IL_062c: ldloc.s 4
+			IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0633: stloc.s 39
+			IL_0635: ldarg.0
+			IL_0636: ldfld object Modules.test262_metadataParser/Scope::buildMvpBlockers
+			IL_063b: ldc.i4.1
+			IL_063c: newarr [System.Runtime]System.Object
+			IL_0641: dup
+			IL_0642: ldc.i4.0
+			IL_0643: ldarg.0
+			IL_0644: stelem.ref
+			IL_0645: ldloc.1
+			IL_0646: ldloc.s 17
+			IL_0648: ldloc.s 19
+			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_064f: stloc.s 25
+			IL_0651: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0656: dup
+			IL_0657: ldstr "filePath"
+			IL_065c: ldloc.s 32
+			IL_065e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0663: dup
+			IL_0664: ldstr "fileName"
+			IL_0669: ldloc.s 34
+			IL_066b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0670: dup
+			IL_0671: ldstr "hasFrontmatter"
+			IL_0676: ldloc.s 5
+			IL_0678: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_067d: dup
+			IL_067e: ldstr "frontmatter"
+			IL_0683: ldloc.s 7
+			IL_0685: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_068a: dup
+			IL_068b: ldstr "unknownKeys"
+			IL_0690: ldloc.s 9
+			IL_0692: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0697: dup
+			IL_0698: ldstr "description"
+			IL_069d: ldloc.s 23
+			IL_069f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06a4: dup
+			IL_06a5: ldstr "info"
+			IL_06aa: ldloc.s 35
+			IL_06ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06b1: dup
+			IL_06b2: ldstr "esid"
+			IL_06b7: ldloc.s 36
+			IL_06b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06be: dup
+			IL_06bf: ldstr "es5id"
+			IL_06c4: ldloc.s 37
+			IL_06c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06cb: dup
+			IL_06cc: ldstr "es6id"
+			IL_06d1: ldloc.s 38
+			IL_06d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06d8: dup
+			IL_06d9: ldstr "author"
+			IL_06de: ldloc.s 39
+			IL_06e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06e5: dup
+			IL_06e6: ldstr "includes"
+			IL_06eb: ldloc.s 12
+			IL_06ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06f2: dup
+			IL_06f3: ldstr "flags"
+			IL_06f8: ldloc.s 13
+			IL_06fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06ff: dup
+			IL_0700: ldstr "features"
+			IL_0705: ldloc.s 14
+			IL_0707: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_070c: dup
+			IL_070d: ldstr "locale"
+			IL_0712: ldloc.s 15
+			IL_0714: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0719: dup
+			IL_071a: ldstr "defines"
+			IL_071f: ldloc.s 16
+			IL_0721: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0726: dup
+			IL_0727: ldstr "negative"
+			IL_072c: ldloc.s 17
+			IL_072e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0733: dup
+			IL_0734: ldstr "execution"
+			IL_0739: ldloc.s 19
+			IL_073b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0740: dup
+			IL_0741: ldstr "mvpBlockers"
+			IL_0746: ldloc.s 25
+			IL_0748: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_074d: dup
+			IL_074e: ldstr "unsupported"
+			IL_0753: ldloc.s 4
+			IL_0755: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_075a: stloc.s 40
+			IL_075c: ldloc.s 40
+			IL_075e: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata
@@ -9635,7 +9602,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6b5c
+				// Method begins at RVA 0x6adc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9662,7 +9629,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x6748
+			// Method begins at RVA 0x66c8
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -9762,7 +9729,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x67fc
+			// Method begins at RVA 0x677c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -10375,7 +10342,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6b65
+		// Method begins at RVA 0x6ae5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_DenseFastPath_Guards.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_DenseFastPath_Guards.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ae
+				// Method begins at RVA 0x25a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2550
+			// Method begins at RVA 0x2548
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -71,7 +71,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c9
+				// Method begins at RVA 0x25c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +97,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x256c
+			// Method begins at RVA 0x2564
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -125,7 +125,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d2
+				// Method begins at RVA 0x25ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -152,7 +152,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2591
+			// Method begins at RVA 0x2589
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -177,7 +177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25db
+				// Method begins at RVA 0x25d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x259b
+			// Method begins at RVA 0x2593
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -241,7 +241,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b7
+				// Method begins at RVA 0x25af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -261,7 +261,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c0
+				// Method begins at RVA 0x25b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -285,7 +285,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25a5
+			// Method begins at RVA 0x259d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -311,7 +311,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1251 (0x4e3)
+		// Code size: 1244 (0x4dc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_DenseFastPath_Guards/Scope,
@@ -319,23 +319,22 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Array_DenseFastPath_Guards/Scope/Block_L12C16,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[12] object,
 			[13] object,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[16] object,
-			[17] string,
-			[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[19] object,
-			[20] bool,
-			[21] object
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[15] object,
+			[16] string,
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[18] object,
+			[19] bool,
+			[20] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -369,14 +368,14 @@
 		IL_0059: ldc.i4.0
 		IL_005a: ldc.i4.1
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0060: stloc.s 14
+		IL_0060: stloc.s 13
 		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0067: dup
 		IL_0068: ldstr "valueOf"
-		IL_006d: ldloc.s 14
+		IL_006d: ldloc.s 13
 		IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0074: stloc.s 15
-		IL_0076: ldloc.s 15
+		IL_0074: stloc.s 14
+		IL_0076: ldloc.s 14
 		IL_0078: stloc.1
 		.try
 		{
@@ -386,7 +385,7 @@
 			IL_0080: ldloc.1
 			IL_0081: ldc.i4.1
 			IL_0082: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(object, bool)
-			IL_0087: leave IL_00f6
+			IL_0087: leave IL_00ef
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -412,335 +411,333 @@
 			IL_00b4: stloc.3
 
 			IL_00b5: ldloc.3
-			IL_00b6: stloc.s 14
-			IL_00b8: ldloc.s 14
+			IL_00b6: stloc.s 13
+			IL_00b8: ldloc.s 13
 			IL_00ba: stloc.s 4
-			IL_00bc: newobj instance void Modules.Array_DenseFastPath_Guards/Scope/Block_L12C16::.ctor()
-			IL_00c1: stloc.s 5
-			IL_00c3: ldstr "console"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00cd: stloc.s 14
-			IL_00cf: ldloc.s 14
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d6: stloc.s 14
-			IL_00d8: ldloc.s 14
-			IL_00da: ldstr "log"
-			IL_00df: ldloc.s 4
-			IL_00e1: ldstr "name"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f0: pop
-			IL_00f1: leave IL_00f6
+			IL_00bc: ldstr "console"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c6: stloc.s 13
+			IL_00c8: ldloc.s 13
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cf: stloc.s 13
+			IL_00d1: ldloc.s 13
+			IL_00d3: ldstr "log"
+			IL_00d8: ldloc.s 4
+			IL_00da: ldstr "name"
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e9: pop
+			IL_00ea: leave IL_00ef
 		} // end handler
 
-		IL_00f6: ldstr "console"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0100: stloc.s 14
-		IL_0102: ldloc.s 14
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0109: stloc.s 14
-		IL_010b: ldloc.0
-		IL_010c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::lengthCoercion
-		IL_0111: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0116: box [System.Runtime]System.Double
-		IL_011b: stloc.s 16
-		IL_011d: ldloc.0
-		IL_011e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::lengthCoercion
-		IL_0123: ldc.i4.1
-		IL_0124: newarr [System.Runtime]System.Object
-		IL_0129: dup
-		IL_012a: ldc.i4.0
-		IL_012b: ldstr ","
-		IL_0130: stelem.ref
-		IL_0131: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0136: stloc.s 17
-		IL_0138: ldloc.s 14
-		IL_013a: ldstr "log"
-		IL_013f: ldloc.s 16
-		IL_0141: ldloc.s 17
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0148: pop
-		IL_0149: ldloc.0
-		IL_014a: ldc.i4.3
-		IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0150: dup
-		IL_0151: ldc.r8 1
-		IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_015f: dup
-		IL_0160: ldc.r8 2
-		IL_0169: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_016e: dup
-		IL_016f: ldc.r8 3
-		IL_0178: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_017d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::spliceCoercion
-		IL_0182: ldc.i4.1
-		IL_0183: newarr [System.Runtime]System.Object
-		IL_0188: dup
-		IL_0189: ldc.i4.0
-		IL_018a: ldloc.0
-		IL_018b: stelem.ref
-		IL_018c: ldc.i4.0
-		IL_018d: ldelem.ref
-		IL_018e: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_0193: ldftn object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
-		IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ef: ldstr "console"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f9: stloc.s 13
+		IL_00fb: ldloc.s 13
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0102: stloc.s 13
+		IL_0104: ldloc.0
+		IL_0105: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::lengthCoercion
+		IL_010a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_010f: box [System.Runtime]System.Double
+		IL_0114: stloc.s 15
+		IL_0116: ldloc.0
+		IL_0117: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::lengthCoercion
+		IL_011c: ldc.i4.1
+		IL_011d: newarr [System.Runtime]System.Object
+		IL_0122: dup
+		IL_0123: ldc.i4.0
+		IL_0124: ldstr ","
+		IL_0129: stelem.ref
+		IL_012a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_012f: stloc.s 16
+		IL_0131: ldloc.s 13
+		IL_0133: ldstr "log"
+		IL_0138: ldloc.s 15
+		IL_013a: ldloc.s 16
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0141: pop
+		IL_0142: ldloc.0
+		IL_0143: ldc.i4.3
+		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0149: dup
+		IL_014a: ldc.r8 1
+		IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0158: dup
+		IL_0159: ldc.r8 2
+		IL_0162: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0167: dup
+		IL_0168: ldc.r8 3
+		IL_0171: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0176: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::spliceCoercion
+		IL_017b: ldc.i4.1
+		IL_017c: newarr [System.Runtime]System.Object
+		IL_0181: dup
+		IL_0182: ldc.i4.0
+		IL_0183: ldloc.0
+		IL_0184: stelem.ref
+		IL_0185: ldc.i4.0
+		IL_0186: ldelem.ref
+		IL_0187: castclass Modules.Array_DenseFastPath_Guards/Scope
+		IL_018c: ldftn object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
+		IL_0192: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0197: ldc.i4.0
+		IL_0198: conv.r8
+		IL_0199: ldstr ""
 		IL_019e: ldc.i4.0
-		IL_019f: conv.r8
-		IL_01a0: ldstr ""
-		IL_01a5: ldc.i4.0
-		IL_01a6: ldc.i4.1
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01ac: stloc.s 14
-		IL_01ae: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01b3: dup
-		IL_01b4: ldstr "valueOf"
-		IL_01b9: ldloc.s 14
-		IL_01bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01c0: stloc.s 15
-		IL_01c2: ldloc.s 15
-		IL_01c4: stloc.s 6
-		IL_01c6: ldloc.0
-		IL_01c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::spliceCoercion
-		IL_01cc: stloc.s 18
-		IL_01ce: ldloc.s 18
-		IL_01d0: ldloc.s 6
-		IL_01d2: ldc.r8 1
-		IL_01db: box [System.Runtime]System.Double
-		IL_01e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
-		IL_01e5: stloc.s 18
-		IL_01e7: ldloc.s 18
-		IL_01e9: stloc.s 7
-		IL_01eb: ldstr "console"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f5: stloc.s 14
-		IL_01f7: ldloc.s 14
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fe: stloc.s 14
-		IL_0200: ldloc.0
-		IL_0201: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::spliceCoercion
-		IL_0206: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_020b: box [System.Runtime]System.Double
-		IL_0210: stloc.s 16
-		IL_0212: ldloc.s 14
-		IL_0214: ldstr "log"
-		IL_0219: ldloc.s 16
-		IL_021b: ldloc.s 7
-		IL_021d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0222: box [System.Runtime]System.Double
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_022c: pop
-		IL_022d: ldc.i4.0
-		IL_022e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0233: stloc.s 8
-		IL_0235: ldloc.s 8
-		IL_0237: ldstr "warm"
-		IL_023c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_0241: pop
-		IL_0242: ldloc.0
-		IL_0243: ldc.r8 0.0
-		IL_024c: box [System.Runtime]System.Double
-		IL_0251: stfld object Modules.Array_DenseFastPath_Guards/Scope::inheritedPushValue
-		IL_0256: ldstr "Array"
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0260: stloc.s 14
-		IL_0262: ldloc.s 14
-		IL_0264: ldstr "prototype"
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026e: stloc.s 14
-		IL_0270: ldc.i4.1
-		IL_0271: newarr [System.Runtime]System.Object
-		IL_0276: dup
-		IL_0277: ldc.i4.0
-		IL_0278: ldloc.0
-		IL_0279: stelem.ref
-		IL_027a: ldc.i4.0
-		IL_027b: ldelem.ref
-		IL_027c: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_0281: ldftn object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
-		IL_0287: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_028c: ldc.i4.1
-		IL_028d: conv.r8
-		IL_028e: ldstr ""
-		IL_0293: ldc.i4.0
-		IL_0294: ldc.i4.1
-		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_029a: stloc.s 19
-		IL_029c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02a1: dup
-		IL_02a2: ldstr "set"
-		IL_02a7: ldloc.s 19
-		IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02ae: dup
-		IL_02af: ldstr "configurable"
-		IL_02b4: ldc.i4.1
-		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_02ba: stloc.s 15
+		IL_019f: ldc.i4.1
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01a5: stloc.s 13
+		IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01ac: dup
+		IL_01ad: ldstr "valueOf"
+		IL_01b2: ldloc.s 13
+		IL_01b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01b9: stloc.s 14
+		IL_01bb: ldloc.s 14
+		IL_01bd: stloc.s 5
+		IL_01bf: ldloc.0
+		IL_01c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::spliceCoercion
+		IL_01c5: stloc.s 17
+		IL_01c7: ldloc.s 17
+		IL_01c9: ldloc.s 5
+		IL_01cb: ldc.r8 1
+		IL_01d4: box [System.Runtime]System.Double
+		IL_01d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
+		IL_01de: stloc.s 17
+		IL_01e0: ldloc.s 17
+		IL_01e2: stloc.s 6
+		IL_01e4: ldstr "console"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ee: stloc.s 13
+		IL_01f0: ldloc.s 13
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f7: stloc.s 13
+		IL_01f9: ldloc.0
+		IL_01fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_DenseFastPath_Guards/Scope::spliceCoercion
+		IL_01ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0204: box [System.Runtime]System.Double
+		IL_0209: stloc.s 15
+		IL_020b: ldloc.s 13
+		IL_020d: ldstr "log"
+		IL_0212: ldloc.s 15
+		IL_0214: ldloc.s 6
+		IL_0216: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_021b: box [System.Runtime]System.Double
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0225: pop
+		IL_0226: ldc.i4.0
+		IL_0227: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_022c: stloc.s 7
+		IL_022e: ldloc.s 7
+		IL_0230: ldstr "warm"
+		IL_0235: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_023a: pop
+		IL_023b: ldloc.0
+		IL_023c: ldc.r8 0.0
+		IL_0245: box [System.Runtime]System.Double
+		IL_024a: stfld object Modules.Array_DenseFastPath_Guards/Scope::inheritedPushValue
+		IL_024f: ldstr "Array"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0259: stloc.s 13
+		IL_025b: ldloc.s 13
+		IL_025d: ldstr "prototype"
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0267: stloc.s 13
+		IL_0269: ldc.i4.1
+		IL_026a: newarr [System.Runtime]System.Object
+		IL_026f: dup
+		IL_0270: ldc.i4.0
+		IL_0271: ldloc.0
+		IL_0272: stelem.ref
+		IL_0273: ldc.i4.0
+		IL_0274: ldelem.ref
+		IL_0275: castclass Modules.Array_DenseFastPath_Guards/Scope
+		IL_027a: ldftn object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
+		IL_0280: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0285: ldc.i4.1
+		IL_0286: conv.r8
+		IL_0287: ldstr ""
+		IL_028c: ldc.i4.0
+		IL_028d: ldc.i4.1
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0293: stloc.s 18
+		IL_0295: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_029a: dup
+		IL_029b: ldstr "set"
+		IL_02a0: ldloc.s 18
+		IL_02a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02a7: dup
+		IL_02a8: ldstr "configurable"
+		IL_02ad: ldc.i4.1
+		IL_02ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_02b3: stloc.s 14
+		IL_02b5: ldloc.s 13
+		IL_02b7: ldstr "0"
 		IL_02bc: ldloc.s 14
-		IL_02be: ldstr "0"
-		IL_02c3: ldloc.s 15
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_02ca: pop
-		IL_02cb: ldc.i4.0
-		IL_02cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02d1: stloc.s 9
-		IL_02d3: ldloc.s 9
-		IL_02d5: ldc.r8 42
-		IL_02de: box [System.Runtime]System.Double
-		IL_02e3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_02e8: pop
-		IL_02e9: ldstr "console"
-		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f3: stloc.s 14
-		IL_02f5: ldloc.s 14
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fc: stloc.s 14
-		IL_02fe: ldloc.s 9
-		IL_0300: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0305: box [System.Runtime]System.Double
-		IL_030a: stloc.s 16
-		IL_030c: ldloc.s 9
-		IL_030e: ldstr "0"
-		IL_0313: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0318: stloc.s 20
-		IL_031a: ldloc.s 20
-		IL_031c: box [System.Runtime]System.Boolean
-		IL_0321: stloc.s 21
-		IL_0323: ldloc.s 14
-		IL_0325: ldstr "log"
-		IL_032a: ldloc.s 16
-		IL_032c: ldloc.s 21
-		IL_032e: ldloc.0
-		IL_032f: ldfld object Modules.Array_DenseFastPath_Guards/Scope::inheritedPushValue
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0339: pop
-		IL_033a: ldstr "Array"
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0344: stloc.s 14
-		IL_0346: ldloc.s 14
-		IL_0348: ldstr "prototype"
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0352: stloc.s 14
-		IL_0354: ldloc.s 14
-		IL_0356: ldc.r8 0.0
-		IL_035f: box [System.Runtime]System.Double
-		IL_0364: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
-		IL_0369: stloc.s 20
-		IL_036b: ldloc.0
-		IL_036c: ldc.r8 0.0
-		IL_0375: box [System.Runtime]System.Double
-		IL_037a: stfld object Modules.Array_DenseFastPath_Guards/Scope::customPushValue
-		IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0384: stloc.s 10
-		IL_0386: ldc.i4.1
-		IL_0387: newarr [System.Runtime]System.Object
-		IL_038c: dup
-		IL_038d: ldc.i4.0
-		IL_038e: ldloc.0
-		IL_038f: stelem.ref
-		IL_0390: ldc.i4.0
-		IL_0391: ldelem.ref
-		IL_0392: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_0397: ldftn object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
-		IL_039d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_03a2: ldc.i4.1
-		IL_03a3: conv.r8
-		IL_03a4: ldstr ""
-		IL_03a9: ldc.i4.0
-		IL_03aa: ldc.i4.1
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03b0: stloc.s 14
-		IL_03b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03b7: dup
-		IL_03b8: ldstr "set"
-		IL_03bd: ldloc.s 14
-		IL_03bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03c4: dup
-		IL_03c5: ldstr "configurable"
-		IL_03ca: ldc.i4.1
-		IL_03cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_03d0: stloc.s 15
-		IL_03d2: ldloc.s 10
-		IL_03d4: ldstr "0"
-		IL_03d9: ldloc.s 15
-		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_03e0: pop
-		IL_03e1: ldc.i4.0
-		IL_03e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_03e7: stloc.s 11
-		IL_03e9: ldloc.s 11
-		IL_03eb: ldloc.s 10
-		IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_03f2: pop
-		IL_03f3: ldloc.s 11
-		IL_03f5: ldc.r8 84
-		IL_03fe: box [System.Runtime]System.Double
-		IL_0403: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_0408: pop
-		IL_0409: ldstr "console"
-		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0413: stloc.s 14
-		IL_0415: ldloc.s 14
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041c: stloc.s 14
-		IL_041e: ldloc.s 11
-		IL_0420: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0425: box [System.Runtime]System.Double
-		IL_042a: stloc.s 16
-		IL_042c: ldloc.s 11
-		IL_042e: ldstr "0"
-		IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0438: stloc.s 20
-		IL_043a: ldloc.s 20
-		IL_043c: box [System.Runtime]System.Boolean
-		IL_0441: stloc.s 21
-		IL_0443: ldloc.s 14
-		IL_0445: ldstr "log"
-		IL_044a: ldloc.s 16
-		IL_044c: ldloc.s 21
-		IL_044e: ldloc.0
-		IL_044f: ldfld object Modules.Array_DenseFastPath_Guards/Scope::customPushValue
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0459: pop
-		IL_045a: ldc.i4.0
-		IL_045b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0460: stloc.s 12
-		IL_0462: ldloc.s 12
-		IL_0464: ldc.r8 2000
-		IL_046d: ldstr "before"
-		IL_0472: ldc.i4.1
-		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0478: pop
-		IL_0479: ldloc.s 12
-		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0480: pop
-		IL_0481: ldloc.s 12
-		IL_0483: ldc.r8 2000
-		IL_048c: ldstr "after"
-		IL_0491: ldc.i4.1
-		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0497: pop
-		IL_0498: ldstr "console"
-		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04a2: stloc.s 14
-		IL_04a4: ldloc.s 14
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04ab: stloc.s 14
-		IL_04ad: ldloc.s 12
-		IL_04af: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_04b4: box [System.Runtime]System.Double
-		IL_04b9: stloc.s 16
-		IL_04bb: ldloc.s 14
-		IL_04bd: ldstr "log"
-		IL_04c2: ldloc.s 16
-		IL_04c4: ldloc.s 12
-		IL_04c6: ldc.r8 2000
-		IL_04cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_04d4: castclass [System.Runtime]System.String
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_04de: pop
-		IL_04df: ldnull
-		IL_04e0: stloc.s 13
-		IL_04e2: ret
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_02c3: pop
+		IL_02c4: ldc.i4.0
+		IL_02c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02ca: stloc.s 8
+		IL_02cc: ldloc.s 8
+		IL_02ce: ldc.r8 42
+		IL_02d7: box [System.Runtime]System.Double
+		IL_02dc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_02e1: pop
+		IL_02e2: ldstr "console"
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ec: stloc.s 13
+		IL_02ee: ldloc.s 13
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f5: stloc.s 13
+		IL_02f7: ldloc.s 8
+		IL_02f9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_02fe: box [System.Runtime]System.Double
+		IL_0303: stloc.s 15
+		IL_0305: ldloc.s 8
+		IL_0307: ldstr "0"
+		IL_030c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0311: stloc.s 19
+		IL_0313: ldloc.s 19
+		IL_0315: box [System.Runtime]System.Boolean
+		IL_031a: stloc.s 20
+		IL_031c: ldloc.s 13
+		IL_031e: ldstr "log"
+		IL_0323: ldloc.s 15
+		IL_0325: ldloc.s 20
+		IL_0327: ldloc.0
+		IL_0328: ldfld object Modules.Array_DenseFastPath_Guards/Scope::inheritedPushValue
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0332: pop
+		IL_0333: ldstr "Array"
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_033d: stloc.s 13
+		IL_033f: ldloc.s 13
+		IL_0341: ldstr "prototype"
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_034b: stloc.s 13
+		IL_034d: ldloc.s 13
+		IL_034f: ldc.r8 0.0
+		IL_0358: box [System.Runtime]System.Double
+		IL_035d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+		IL_0362: stloc.s 19
+		IL_0364: ldloc.0
+		IL_0365: ldc.r8 0.0
+		IL_036e: box [System.Runtime]System.Double
+		IL_0373: stfld object Modules.Array_DenseFastPath_Guards/Scope::customPushValue
+		IL_0378: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_037d: stloc.s 9
+		IL_037f: ldc.i4.1
+		IL_0380: newarr [System.Runtime]System.Object
+		IL_0385: dup
+		IL_0386: ldc.i4.0
+		IL_0387: ldloc.0
+		IL_0388: stelem.ref
+		IL_0389: ldc.i4.0
+		IL_038a: ldelem.ref
+		IL_038b: castclass Modules.Array_DenseFastPath_Guards/Scope
+		IL_0390: ldftn object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
+		IL_0396: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_039b: ldc.i4.1
+		IL_039c: conv.r8
+		IL_039d: ldstr ""
+		IL_03a2: ldc.i4.0
+		IL_03a3: ldc.i4.1
+		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03a9: stloc.s 13
+		IL_03ab: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03b0: dup
+		IL_03b1: ldstr "set"
+		IL_03b6: ldloc.s 13
+		IL_03b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03bd: dup
+		IL_03be: ldstr "configurable"
+		IL_03c3: ldc.i4.1
+		IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_03c9: stloc.s 14
+		IL_03cb: ldloc.s 9
+		IL_03cd: ldstr "0"
+		IL_03d2: ldloc.s 14
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_03d9: pop
+		IL_03da: ldc.i4.0
+		IL_03db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_03e0: stloc.s 10
+		IL_03e2: ldloc.s 10
+		IL_03e4: ldloc.s 9
+		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_03eb: pop
+		IL_03ec: ldloc.s 10
+		IL_03ee: ldc.r8 84
+		IL_03f7: box [System.Runtime]System.Double
+		IL_03fc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_0401: pop
+		IL_0402: ldstr "console"
+		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_040c: stloc.s 13
+		IL_040e: ldloc.s 13
+		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0415: stloc.s 13
+		IL_0417: ldloc.s 10
+		IL_0419: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_041e: box [System.Runtime]System.Double
+		IL_0423: stloc.s 15
+		IL_0425: ldloc.s 10
+		IL_0427: ldstr "0"
+		IL_042c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0431: stloc.s 19
+		IL_0433: ldloc.s 19
+		IL_0435: box [System.Runtime]System.Boolean
+		IL_043a: stloc.s 20
+		IL_043c: ldloc.s 13
+		IL_043e: ldstr "log"
+		IL_0443: ldloc.s 15
+		IL_0445: ldloc.s 20
+		IL_0447: ldloc.0
+		IL_0448: ldfld object Modules.Array_DenseFastPath_Guards/Scope::customPushValue
+		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0452: pop
+		IL_0453: ldc.i4.0
+		IL_0454: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0459: stloc.s 11
+		IL_045b: ldloc.s 11
+		IL_045d: ldc.r8 2000
+		IL_0466: ldstr "before"
+		IL_046b: ldc.i4.1
+		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0471: pop
+		IL_0472: ldloc.s 11
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0479: pop
+		IL_047a: ldloc.s 11
+		IL_047c: ldc.r8 2000
+		IL_0485: ldstr "after"
+		IL_048a: ldc.i4.1
+		IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0490: pop
+		IL_0491: ldstr "console"
+		IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_049b: stloc.s 13
+		IL_049d: ldloc.s 13
+		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a4: stloc.s 13
+		IL_04a6: ldloc.s 11
+		IL_04a8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_04ad: box [System.Runtime]System.Double
+		IL_04b2: stloc.s 15
+		IL_04b4: ldloc.s 13
+		IL_04b6: ldstr "log"
+		IL_04bb: ldloc.s 15
+		IL_04bd: ldloc.s 11
+		IL_04bf: ldc.r8 2000
+		IL_04c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_04cd: castclass [System.Runtime]System.String
+		IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_04d7: pop
+		IL_04d8: ldnull
+		IL_04d9: stloc.s 12
+		IL_04db: ret
 	} // end of method Array_DenseFastPath_Guards::__js_module_init__
 
 } // end of class Modules.Array_DenseFastPath_Guards
@@ -752,7 +749,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25e4
+		// Method begins at RVA 0x25dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x367b
+				// Method begins at RVA 0x3623
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x3600
+			// Method begins at RVA 0x35a8
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3684
+				// Method begins at RVA 0x362c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -94,7 +94,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x3608
+			// Method begins at RVA 0x35b0
 			// Header size: 1
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -123,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3753
+				// Method begins at RVA 0x36fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3626
+			// Method begins at RVA 0x35ce
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -173,7 +173,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x375c
+				// Method begins at RVA 0x3704
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +199,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x3639
+			// Method begins at RVA 0x35e1
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -238,7 +238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3669
+				// Method begins at RVA 0x3611
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -258,7 +258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3672
+				// Method begins at RVA 0x361a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x368d
+				// Method begins at RVA 0x3635
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3696
+				// Method begins at RVA 0x363e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -318,7 +318,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x369f
+				// Method begins at RVA 0x3647
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -338,7 +338,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a8
+				// Method begins at RVA 0x3650
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b1
+				// Method begins at RVA 0x3659
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -378,7 +378,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36ba
+				// Method begins at RVA 0x3662
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -398,7 +398,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c3
+				// Method begins at RVA 0x366b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -418,7 +418,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36cc
+				// Method begins at RVA 0x3674
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -438,7 +438,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d5
+				// Method begins at RVA 0x367d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -458,7 +458,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36de
+				// Method begins at RVA 0x3686
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -478,7 +478,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e7
+				// Method begins at RVA 0x368f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -498,7 +498,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36f0
+				// Method begins at RVA 0x3698
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -518,7 +518,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36f9
+				// Method begins at RVA 0x36a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -538,7 +538,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3702
+				// Method begins at RVA 0x36aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -558,7 +558,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x370b
+				// Method begins at RVA 0x36b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -578,7 +578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3714
+				// Method begins at RVA 0x36bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -598,7 +598,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x371d
+				// Method begins at RVA 0x36c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -618,7 +618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3726
+				// Method begins at RVA 0x36ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -638,7 +638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x372f
+				// Method begins at RVA 0x36d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -658,7 +658,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3738
+				// Method begins at RVA 0x36e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -678,7 +678,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3741
+				// Method begins at RVA 0x36e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -698,7 +698,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x374a
+				// Method begins at RVA 0x36f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -718,7 +718,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3765
+				// Method begins at RVA 0x370d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -738,7 +738,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x376e
+				// Method begins at RVA 0x3716
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -761,7 +761,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3660
+			// Method begins at RVA 0x3608
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -787,7 +787,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 5380 (0x1504)
+		// Code size: 5289 (0x14a9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Exotic_Property_Descriptors/Scope,
@@ -797,92 +797,79 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L15C16,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[10] class [System.Runtime]System.Exception,
+			[9] class [System.Runtime]System.Exception,
+			[10] object,
 			[11] object,
 			[12] object,
-			[13] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L37C16,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[16] class [System.Runtime]System.Exception,
-			[17] object,
-			[18] object,
-			[19] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L47C16,
-			[20] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[21] class [System.Runtime]System.Exception,
-			[22] object,
-			[23] object,
-			[24] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L63C16,
-			[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[26] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[14] class [System.Runtime]System.Exception,
+			[15] object,
+			[16] object,
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[18] class [System.Runtime]System.Exception,
+			[19] object,
+			[20] object,
+			[21] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[22] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[23] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[24] class [System.Runtime]System.Exception,
+			[25] object,
+			[26] object,
 			[27] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[28] class [System.Runtime]System.Exception,
 			[29] object,
 			[30] object,
-			[31] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L87C16,
-			[32] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[33] class [System.Runtime]System.Exception,
+			[31] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[32] class [System.Runtime]System.Exception,
+			[33] object,
 			[34] object,
-			[35] object,
-			[36] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L97C16,
-			[37] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[38] class [System.Runtime]System.Exception,
-			[39] object,
+			[35] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[36] class [System.Runtime]System.Exception,
+			[37] object,
+			[38] object,
+			[39] class [System.Runtime]System.Exception,
 			[40] object,
-			[41] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L106C16,
-			[42] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[43] class [System.Runtime]System.Exception,
+			[41] object,
+			[42] class [System.Runtime]System.Exception,
+			[43] object,
 			[44] object,
-			[45] object,
-			[46] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L115C16,
-			[47] class [System.Runtime]System.Exception,
+			[45] class [System.Runtime]System.Exception,
+			[46] object,
+			[47] object,
 			[48] object,
-			[49] object,
-			[50] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L120C16,
-			[51] class [System.Runtime]System.Exception,
-			[52] object,
-			[53] object,
-			[54] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L125C16,
-			[55] class [System.Runtime]System.Exception,
-			[56] object,
-			[57] object,
-			[58] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L130C16,
-			[59] object,
-			[60] class [System.Runtime]System.Exception,
+			[49] class [System.Runtime]System.Exception,
+			[50] object,
+			[51] object,
+			[52] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[53] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[54] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
+			[55] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[56] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[57] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[58] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[59] class [System.Runtime]System.Exception,
+			[60] object,
 			[61] object,
-			[62] object,
-			[63] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L138C16,
-			[64] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[65] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[66] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[67] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[68] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[69] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[62] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[63] object,
+			[64] object,
+			[65] object,
+			[66] bool,
+			[67] object,
+			[68] object,
+			[69] object,
 			[70] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[71] class [System.Runtime]System.Exception,
+			[71] object,
 			[72] object,
-			[73] object,
-			[74] class Modules.Array_Exotic_Property_Descriptors/Scope/Block_L172C16,
-			[75] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[76] object,
-			[77] object,
-			[78] object,
-			[79] bool,
-			[80] object,
-			[81] object,
-			[82] object,
-			[83] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[84] object,
-			[85] object,
-			[86] object[],
-			[87] string,
-			[88] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[89] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[90] string,
-			[91] float64,
-			[92] object
+			[73] object[],
+			[74] string,
+			[75] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
+			[76] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[77] string,
+			[78] float64,
+			[79] object
 		)
 
 		IL_0000: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope::.ctor()
@@ -896,8 +883,8 @@
 		IL_0019: ldc.i4.0
 		IL_001a: ldc.i4.1
 		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0020: stloc.s 77
-		IL_0022: ldloc.s 77
+		IL_0020: stloc.s 64
+		IL_0022: ldloc.s 64
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldc.i4.3
@@ -936,78 +923,78 @@
 		IL_00a3: ldloc.2
 		IL_00a4: ldstr "1"
 		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00ae: stloc.s 77
-		IL_00b0: ldloc.s 77
+		IL_00ae: stloc.s 64
+		IL_00b0: ldloc.s 64
 		IL_00b2: stloc.3
 		IL_00b3: ldstr "console"
 		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bd: stloc.s 77
-		IL_00bf: ldloc.s 77
+		IL_00bd: stloc.s 64
+		IL_00bf: ldloc.s 64
 		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c6: stloc.s 77
+		IL_00c6: stloc.s 64
 		IL_00c8: ldloc.2
 		IL_00c9: ldc.r8 1
 		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00d7: stloc.s 78
+		IL_00d7: stloc.s 65
 		IL_00d9: ldc.r8 1
 		IL_00e2: box [System.Runtime]System.Double
 		IL_00e7: ldloc.2
 		IL_00e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_00ed: stloc.s 79
-		IL_00ef: ldloc.s 79
+		IL_00ed: stloc.s 66
+		IL_00ef: ldloc.s 66
 		IL_00f1: box [System.Runtime]System.Boolean
-		IL_00f6: stloc.s 80
+		IL_00f6: stloc.s 67
 		IL_00f8: ldloc.2
 		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_00fe: stloc.s 81
-		IL_0100: ldloc.s 81
+		IL_00fe: stloc.s 68
+		IL_0100: ldloc.s 68
 		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0107: stloc.s 81
-		IL_0109: ldloc.s 81
+		IL_0107: stloc.s 68
+		IL_0109: ldloc.s 68
 		IL_010b: ldstr "join"
 		IL_0110: ldstr ","
 		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011a: stloc.s 81
-		IL_011c: ldloc.s 77
+		IL_011a: stloc.s 68
+		IL_011c: ldloc.s 64
 		IL_011e: ldstr "log"
-		IL_0123: ldloc.s 78
-		IL_0125: ldloc.s 80
-		IL_0127: ldloc.s 81
+		IL_0123: ldloc.s 65
+		IL_0125: ldloc.s 67
+		IL_0127: ldloc.s 68
 		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 		IL_012e: pop
 		IL_012f: ldstr "console"
 		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0139: stloc.s 81
-		IL_013b: ldloc.s 81
+		IL_0139: stloc.s 68
+		IL_013b: ldloc.s 68
 		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0142: stloc.s 81
+		IL_0142: stloc.s 68
 		IL_0144: ldloc.3
 		IL_0145: ldstr "value"
 		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014f: stloc.s 78
+		IL_014f: stloc.s 65
 		IL_0151: ldloc.3
 		IL_0152: ldstr "writable"
 		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015c: stloc.s 77
+		IL_015c: stloc.s 64
 		IL_015e: ldloc.3
 		IL_015f: ldstr "enumerable"
 		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0169: stloc.s 82
-		IL_016b: ldloc.s 81
+		IL_0169: stloc.s 69
+		IL_016b: ldloc.s 68
 		IL_016d: ldstr "log"
 		IL_0172: ldc.i4.4
 		IL_0173: newarr [System.Runtime]System.Object
 		IL_0178: dup
 		IL_0179: ldc.i4.0
-		IL_017a: ldloc.s 78
+		IL_017a: ldloc.s 65
 		IL_017c: stelem.ref
 		IL_017d: dup
 		IL_017e: ldc.i4.1
-		IL_017f: ldloc.s 77
+		IL_017f: ldloc.s 64
 		IL_0181: stelem.ref
 		IL_0182: dup
 		IL_0183: ldc.i4.2
-		IL_0184: ldloc.s 82
+		IL_0184: ldloc.s 69
 		IL_0186: stelem.ref
 		IL_0187: dup
 		IL_0188: ldc.i4.3
@@ -1025,7 +1012,7 @@
 			IL_01a6: ldc.r8 99
 			IL_01af: ldc.i4.1
 			IL_01b0: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_01b5: leave IL_022a
+			IL_01b5: leave IL_0223
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -1051,1607 +1038,1581 @@
 			IL_01e6: stloc.s 5
 
 			IL_01e8: ldloc.s 5
-			IL_01ea: stloc.s 81
-			IL_01ec: ldloc.s 81
+			IL_01ea: stloc.s 68
+			IL_01ec: ldloc.s 68
 			IL_01ee: stloc.s 6
-			IL_01f0: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L15C16::.ctor()
-			IL_01f5: stloc.s 7
-			IL_01f7: ldstr "console"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0201: stloc.s 81
-			IL_0203: ldloc.s 81
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_020a: stloc.s 81
-			IL_020c: ldloc.s 81
-			IL_020e: ldstr "log"
-			IL_0213: ldloc.s 6
-			IL_0215: ldstr "name"
-			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0224: pop
-			IL_0225: leave IL_022a
+			IL_01f0: ldstr "console"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01fa: stloc.s 68
+			IL_01fc: ldloc.s 68
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0203: stloc.s 68
+			IL_0205: ldloc.s 68
+			IL_0207: ldstr "log"
+			IL_020c: ldloc.s 6
+			IL_020e: ldstr "name"
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_021d: pop
+			IL_021e: leave IL_0223
 		} // end handler
 
-		IL_022a: ldstr "console"
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0234: stloc.s 81
-		IL_0236: ldloc.s 81
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023d: stloc.s 81
-		IL_023f: ldloc.s 81
-		IL_0241: ldstr "log"
-		IL_0246: ldloc.2
-		IL_0247: ldc.r8 1
-		IL_0250: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_025a: pop
-		IL_025b: ldloc.0
-		IL_025c: ldc.r8 4
-		IL_0265: box [System.Runtime]System.Double
-		IL_026a: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
-		IL_026f: ldc.i4.0
-		IL_0270: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0275: stloc.s 8
-		IL_0277: ldc.i4.1
-		IL_0278: newarr [System.Runtime]System.Object
-		IL_027d: dup
-		IL_027e: ldc.i4.0
-		IL_027f: ldloc.0
-		IL_0280: stelem.ref
-		IL_0281: ldc.i4.0
-		IL_0282: ldelem.ref
-		IL_0283: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_0288: ldftn object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
-		IL_028e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0223: ldstr "console"
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022d: stloc.s 68
+		IL_022f: ldloc.s 68
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0236: stloc.s 68
+		IL_0238: ldloc.s 68
+		IL_023a: ldstr "log"
+		IL_023f: ldloc.2
+		IL_0240: ldc.r8 1
+		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0253: pop
+		IL_0254: ldloc.0
+		IL_0255: ldc.r8 4
+		IL_025e: box [System.Runtime]System.Double
+		IL_0263: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
+		IL_0268: ldc.i4.0
+		IL_0269: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_026e: stloc.s 7
+		IL_0270: ldc.i4.1
+		IL_0271: newarr [System.Runtime]System.Object
+		IL_0276: dup
+		IL_0277: ldc.i4.0
+		IL_0278: ldloc.0
+		IL_0279: stelem.ref
+		IL_027a: ldc.i4.0
+		IL_027b: ldelem.ref
+		IL_027c: castclass Modules.Array_Exotic_Property_Descriptors/Scope
+		IL_0281: ldftn object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
+		IL_0287: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_028c: ldc.i4.0
+		IL_028d: conv.r8
+		IL_028e: ldstr ""
 		IL_0293: ldc.i4.0
-		IL_0294: conv.r8
-		IL_0295: ldstr ""
-		IL_029a: ldc.i4.0
-		IL_029b: ldc.i4.1
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02a1: stloc.s 81
-		IL_02a3: ldc.i4.1
-		IL_02a4: newarr [System.Runtime]System.Object
-		IL_02a9: dup
-		IL_02aa: ldc.i4.0
-		IL_02ab: ldloc.0
-		IL_02ac: stelem.ref
-		IL_02ad: ldc.i4.0
-		IL_02ae: ldelem.ref
-		IL_02af: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_02b4: ldftn object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
-		IL_02ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02bf: ldc.i4.1
-		IL_02c0: conv.r8
-		IL_02c1: ldstr ""
-		IL_02c6: ldc.i4.0
-		IL_02c7: ldc.i4.1
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02cd: stloc.s 82
-		IL_02cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02d4: dup
-		IL_02d5: ldstr "get"
-		IL_02da: ldloc.s 81
-		IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02e1: dup
-		IL_02e2: ldstr "set"
-		IL_02e7: ldloc.s 82
-		IL_02e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02ee: dup
-		IL_02ef: ldstr "enumerable"
-		IL_02f4: ldc.i4.1
-		IL_02f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_02fa: dup
-		IL_02fb: ldstr "configurable"
-		IL_0300: ldc.i4.1
-		IL_0301: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0306: stloc.s 83
-		IL_0308: ldloc.s 8
-		IL_030a: ldstr "2"
-		IL_030f: ldloc.s 83
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0316: pop
-		IL_0317: ldstr "console"
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0321: stloc.s 82
-		IL_0323: ldloc.s 82
-		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032a: stloc.s 82
-		IL_032c: ldloc.s 8
-		IL_032e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0333: box [System.Runtime]System.Double
-		IL_0338: stloc.s 84
-		IL_033a: ldloc.s 8
-		IL_033c: ldc.r8 2
-		IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_034a: stloc.s 81
-		IL_034c: ldc.r8 2
-		IL_0355: box [System.Runtime]System.Double
-		IL_035a: ldloc.s 8
-		IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0361: stloc.s 79
-		IL_0363: ldloc.s 79
-		IL_0365: box [System.Runtime]System.Boolean
-		IL_036a: stloc.s 80
-		IL_036c: ldloc.s 82
-		IL_036e: ldstr "log"
-		IL_0373: ldloc.s 84
-		IL_0375: ldloc.s 81
-		IL_0377: ldloc.s 80
-		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_037e: pop
-		IL_037f: ldloc.s 8
-		IL_0381: ldc.r8 2
-		IL_038a: ldc.r8 7
-		IL_0393: ldc.i4.1
-		IL_0394: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0399: ldstr "console"
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a3: stloc.s 81
-		IL_03a5: ldloc.s 81
-		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ac: stloc.s 81
-		IL_03ae: ldloc.0
-		IL_03af: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
-		IL_03b4: stloc.s 82
-		IL_03b6: ldloc.s 81
-		IL_03b8: ldstr "log"
-		IL_03bd: ldloc.s 82
-		IL_03bf: ldloc.s 8
-		IL_03c1: ldc.r8 2
-		IL_03ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_03d4: pop
-		IL_03d5: ldstr "console"
-		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03df: stloc.s 82
-		IL_03e1: ldloc.s 82
-		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e8: stloc.s 82
-		IL_03ea: ldloc.s 8
-		IL_03ec: ldc.r8 2
-		IL_03f5: box [System.Runtime]System.Double
-		IL_03fa: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
-		IL_03ff: stloc.s 79
-		IL_0401: ldloc.s 79
-		IL_0403: box [System.Runtime]System.Boolean
-		IL_0408: stloc.s 80
-		IL_040a: ldloc.s 8
-		IL_040c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0411: box [System.Runtime]System.Double
-		IL_0416: stloc.s 84
-		IL_0418: ldc.r8 2
-		IL_0421: box [System.Runtime]System.Double
-		IL_0426: ldloc.s 8
-		IL_0428: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_042d: stloc.s 79
-		IL_042f: ldloc.s 79
-		IL_0431: box [System.Runtime]System.Boolean
-		IL_0436: stloc.s 85
-		IL_0438: ldloc.s 82
-		IL_043a: ldstr "log"
-		IL_043f: ldloc.s 80
-		IL_0441: ldloc.s 84
-		IL_0443: ldloc.s 85
-		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_044a: pop
-		IL_044b: ldc.i4.4
-		IL_044c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0451: dup
-		IL_0452: ldc.r8 0.0
-		IL_045b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0460: dup
-		IL_0461: ldc.r8 1
-		IL_046a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_046f: dup
-		IL_0470: ldc.r8 2
-		IL_0479: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_047e: dup
-		IL_047f: ldc.r8 3
-		IL_0488: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_048d: stloc.s 9
-		IL_048f: ldloc.s 9
-		IL_0491: ldstr "2"
-		IL_0496: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_049b: dup
-		IL_049c: ldstr "configurable"
-		IL_04a1: ldc.i4.0
-		IL_04a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_04ac: pop
+		IL_0294: ldc.i4.1
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_029a: stloc.s 68
+		IL_029c: ldc.i4.1
+		IL_029d: newarr [System.Runtime]System.Object
+		IL_02a2: dup
+		IL_02a3: ldc.i4.0
+		IL_02a4: ldloc.0
+		IL_02a5: stelem.ref
+		IL_02a6: ldc.i4.0
+		IL_02a7: ldelem.ref
+		IL_02a8: castclass Modules.Array_Exotic_Property_Descriptors/Scope
+		IL_02ad: ldftn object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
+		IL_02b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02b8: ldc.i4.1
+		IL_02b9: conv.r8
+		IL_02ba: ldstr ""
+		IL_02bf: ldc.i4.0
+		IL_02c0: ldc.i4.1
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02c6: stloc.s 69
+		IL_02c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02cd: dup
+		IL_02ce: ldstr "get"
+		IL_02d3: ldloc.s 68
+		IL_02d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02da: dup
+		IL_02db: ldstr "set"
+		IL_02e0: ldloc.s 69
+		IL_02e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02e7: dup
+		IL_02e8: ldstr "enumerable"
+		IL_02ed: ldc.i4.1
+		IL_02ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_02f3: dup
+		IL_02f4: ldstr "configurable"
+		IL_02f9: ldc.i4.1
+		IL_02fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_02ff: stloc.s 70
+		IL_0301: ldloc.s 7
+		IL_0303: ldstr "2"
+		IL_0308: ldloc.s 70
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_030f: pop
+		IL_0310: ldstr "console"
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_031a: stloc.s 69
+		IL_031c: ldloc.s 69
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0323: stloc.s 69
+		IL_0325: ldloc.s 7
+		IL_0327: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_032c: box [System.Runtime]System.Double
+		IL_0331: stloc.s 71
+		IL_0333: ldloc.s 7
+		IL_0335: ldc.r8 2
+		IL_033e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0343: stloc.s 68
+		IL_0345: ldc.r8 2
+		IL_034e: box [System.Runtime]System.Double
+		IL_0353: ldloc.s 7
+		IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_035a: stloc.s 66
+		IL_035c: ldloc.s 66
+		IL_035e: box [System.Runtime]System.Boolean
+		IL_0363: stloc.s 67
+		IL_0365: ldloc.s 69
+		IL_0367: ldstr "log"
+		IL_036c: ldloc.s 71
+		IL_036e: ldloc.s 68
+		IL_0370: ldloc.s 67
+		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0377: pop
+		IL_0378: ldloc.s 7
+		IL_037a: ldc.r8 2
+		IL_0383: ldc.r8 7
+		IL_038c: ldc.i4.1
+		IL_038d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0392: ldstr "console"
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_039c: stloc.s 68
+		IL_039e: ldloc.s 68
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a5: stloc.s 68
+		IL_03a7: ldloc.0
+		IL_03a8: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
+		IL_03ad: stloc.s 69
+		IL_03af: ldloc.s 68
+		IL_03b1: ldstr "log"
+		IL_03b6: ldloc.s 69
+		IL_03b8: ldloc.s 7
+		IL_03ba: ldc.r8 2
+		IL_03c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_03cd: pop
+		IL_03ce: ldstr "console"
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d8: stloc.s 69
+		IL_03da: ldloc.s 69
+		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e1: stloc.s 69
+		IL_03e3: ldloc.s 7
+		IL_03e5: ldc.r8 2
+		IL_03ee: box [System.Runtime]System.Double
+		IL_03f3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+		IL_03f8: stloc.s 66
+		IL_03fa: ldloc.s 66
+		IL_03fc: box [System.Runtime]System.Boolean
+		IL_0401: stloc.s 67
+		IL_0403: ldloc.s 7
+		IL_0405: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_040a: box [System.Runtime]System.Double
+		IL_040f: stloc.s 71
+		IL_0411: ldc.r8 2
+		IL_041a: box [System.Runtime]System.Double
+		IL_041f: ldloc.s 7
+		IL_0421: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0426: stloc.s 66
+		IL_0428: ldloc.s 66
+		IL_042a: box [System.Runtime]System.Boolean
+		IL_042f: stloc.s 72
+		IL_0431: ldloc.s 69
+		IL_0433: ldstr "log"
+		IL_0438: ldloc.s 67
+		IL_043a: ldloc.s 71
+		IL_043c: ldloc.s 72
+		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0443: pop
+		IL_0444: ldc.i4.4
+		IL_0445: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_044a: dup
+		IL_044b: ldc.r8 0.0
+		IL_0454: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0459: dup
+		IL_045a: ldc.r8 1
+		IL_0463: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0468: dup
+		IL_0469: ldc.r8 2
+		IL_0472: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0477: dup
+		IL_0478: ldc.r8 3
+		IL_0481: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0486: stloc.s 8
+		IL_0488: ldloc.s 8
+		IL_048a: ldstr "2"
+		IL_048f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0494: dup
+		IL_0495: ldstr "configurable"
+		IL_049a: ldc.i4.0
+		IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_04a5: pop
 		.try
 		{
-			IL_04ad: nop
-			IL_04ae: ldloc.s 9
-			IL_04b0: ldstr "length"
-			IL_04b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04ba: dup
-			IL_04bb: ldstr "value"
-			IL_04c0: ldc.r8 1
-			IL_04c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_04ce: dup
-			IL_04cf: ldstr "writable"
-			IL_04d4: ldc.i4.0
-			IL_04d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_04df: pop
-			IL_04e0: leave IL_0555
+			IL_04a6: nop
+			IL_04a7: ldloc.s 8
+			IL_04a9: ldstr "length"
+			IL_04ae: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04b3: dup
+			IL_04b4: ldstr "value"
+			IL_04b9: ldc.r8 1
+			IL_04c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_04c7: dup
+			IL_04c8: ldstr "writable"
+			IL_04cd: ldc.i4.0
+			IL_04ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_04d8: pop
+			IL_04d9: leave IL_0547
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_04e5: stloc.s 10
-			IL_04e7: ldloc.s 10
-			IL_04e9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_04ee: dup
-			IL_04ef: brtrue IL_0505
+			IL_04de: stloc.s 9
+			IL_04e0: ldloc.s 9
+			IL_04e2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04e7: dup
+			IL_04e8: brtrue IL_04fe
 
-			IL_04f4: pop
-			IL_04f5: ldloc.s 10
-			IL_04f7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04fc: dup
-			IL_04fd: brtrue IL_0511
+			IL_04ed: pop
+			IL_04ee: ldloc.s 9
+			IL_04f0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04f5: dup
+			IL_04f6: brtrue IL_050a
 
-			IL_0502: pop
-			IL_0503: rethrow
+			IL_04fb: pop
+			IL_04fc: rethrow
 
-			IL_0505: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_050a: stloc.s 11
-			IL_050c: br IL_0513
+			IL_04fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0503: stloc.s 10
+			IL_0505: br IL_050c
 
-			IL_0511: stloc.s 11
+			IL_050a: stloc.s 10
 
-			IL_0513: ldloc.s 11
-			IL_0515: stloc.s 82
-			IL_0517: ldloc.s 82
-			IL_0519: stloc.s 12
-			IL_051b: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L37C16::.ctor()
-			IL_0520: stloc.s 13
-			IL_0522: ldstr "console"
-			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_052c: stloc.s 82
-			IL_052e: ldloc.s 82
-			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0535: stloc.s 82
-			IL_0537: ldloc.s 82
-			IL_0539: ldstr "log"
-			IL_053e: ldloc.s 12
-			IL_0540: ldstr "name"
-			IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_054f: pop
-			IL_0550: leave IL_0555
+			IL_050c: ldloc.s 10
+			IL_050e: stloc.s 69
+			IL_0510: ldloc.s 69
+			IL_0512: stloc.s 11
+			IL_0514: ldstr "console"
+			IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_051e: stloc.s 69
+			IL_0520: ldloc.s 69
+			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0527: stloc.s 69
+			IL_0529: ldloc.s 69
+			IL_052b: ldstr "log"
+			IL_0530: ldloc.s 11
+			IL_0532: ldstr "name"
+			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0541: pop
+			IL_0542: leave IL_0547
 		} // end handler
 
-		IL_0555: ldloc.s 9
-		IL_0557: ldstr "length"
-		IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0561: stloc.s 82
-		IL_0563: ldloc.s 82
-		IL_0565: stloc.s 14
-		IL_0567: ldstr "console"
-		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0571: stloc.s 82
-		IL_0573: ldloc.s 82
-		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_057a: stloc.s 82
-		IL_057c: ldloc.s 9
-		IL_057e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0583: box [System.Runtime]System.Double
-		IL_0588: stloc.s 84
-		IL_058a: ldc.r8 2
-		IL_0593: box [System.Runtime]System.Double
-		IL_0598: ldloc.s 9
-		IL_059a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_059f: stloc.s 79
-		IL_05a1: ldloc.s 79
-		IL_05a3: box [System.Runtime]System.Boolean
-		IL_05a8: stloc.s 85
-		IL_05aa: ldc.r8 3
-		IL_05b3: box [System.Runtime]System.Double
-		IL_05b8: ldloc.s 9
-		IL_05ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05bf: stloc.s 79
-		IL_05c1: ldloc.s 79
-		IL_05c3: box [System.Runtime]System.Boolean
-		IL_05c8: stloc.s 80
-		IL_05ca: ldc.i4.4
-		IL_05cb: newarr [System.Runtime]System.Object
-		IL_05d0: dup
-		IL_05d1: ldc.i4.0
-		IL_05d2: ldloc.s 84
-		IL_05d4: stelem.ref
-		IL_05d5: dup
-		IL_05d6: ldc.i4.1
-		IL_05d7: ldloc.s 85
-		IL_05d9: stelem.ref
-		IL_05da: dup
-		IL_05db: ldc.i4.2
-		IL_05dc: ldloc.s 80
-		IL_05de: stelem.ref
-		IL_05df: dup
-		IL_05e0: ldc.i4.3
-		IL_05e1: ldloc.s 14
-		IL_05e3: ldstr "writable"
-		IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ed: stelem.ref
-		IL_05ee: stloc.s 86
-		IL_05f0: ldloc.s 82
-		IL_05f2: ldstr "log"
-		IL_05f7: ldloc.s 86
-		IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_05fe: pop
-		IL_05ff: ldc.i4.1
-		IL_0600: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0605: dup
-		IL_0606: ldc.r8 1
-		IL_060f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0614: stloc.s 15
-		IL_0616: ldloc.s 15
-		IL_0618: ldstr "length"
-		IL_061d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0622: dup
-		IL_0623: ldstr "writable"
-		IL_0628: ldc.i4.0
-		IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0633: pop
+		IL_0547: ldloc.s 8
+		IL_0549: ldstr "length"
+		IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0553: stloc.s 69
+		IL_0555: ldloc.s 69
+		IL_0557: stloc.s 12
+		IL_0559: ldstr "console"
+		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0563: stloc.s 69
+		IL_0565: ldloc.s 69
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_056c: stloc.s 69
+		IL_056e: ldloc.s 8
+		IL_0570: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0575: box [System.Runtime]System.Double
+		IL_057a: stloc.s 71
+		IL_057c: ldc.r8 2
+		IL_0585: box [System.Runtime]System.Double
+		IL_058a: ldloc.s 8
+		IL_058c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0591: stloc.s 66
+		IL_0593: ldloc.s 66
+		IL_0595: box [System.Runtime]System.Boolean
+		IL_059a: stloc.s 72
+		IL_059c: ldc.r8 3
+		IL_05a5: box [System.Runtime]System.Double
+		IL_05aa: ldloc.s 8
+		IL_05ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05b1: stloc.s 66
+		IL_05b3: ldloc.s 66
+		IL_05b5: box [System.Runtime]System.Boolean
+		IL_05ba: stloc.s 67
+		IL_05bc: ldc.i4.4
+		IL_05bd: newarr [System.Runtime]System.Object
+		IL_05c2: dup
+		IL_05c3: ldc.i4.0
+		IL_05c4: ldloc.s 71
+		IL_05c6: stelem.ref
+		IL_05c7: dup
+		IL_05c8: ldc.i4.1
+		IL_05c9: ldloc.s 72
+		IL_05cb: stelem.ref
+		IL_05cc: dup
+		IL_05cd: ldc.i4.2
+		IL_05ce: ldloc.s 67
+		IL_05d0: stelem.ref
+		IL_05d1: dup
+		IL_05d2: ldc.i4.3
+		IL_05d3: ldloc.s 12
+		IL_05d5: ldstr "writable"
+		IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05df: stelem.ref
+		IL_05e0: stloc.s 73
+		IL_05e2: ldloc.s 69
+		IL_05e4: ldstr "log"
+		IL_05e9: ldloc.s 73
+		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_05f0: pop
+		IL_05f1: ldc.i4.1
+		IL_05f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_05f7: dup
+		IL_05f8: ldc.r8 1
+		IL_0601: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0606: stloc.s 13
+		IL_0608: ldloc.s 13
+		IL_060a: ldstr "length"
+		IL_060f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0614: dup
+		IL_0615: ldstr "writable"
+		IL_061a: ldc.i4.0
+		IL_061b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0625: pop
 		.try
 		{
-			IL_0634: nop
-			IL_0635: ldloc.s 15
-			IL_0637: ldc.r8 1
-			IL_0640: ldc.r8 2
-			IL_0649: ldc.i4.1
-			IL_064a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_064f: leave IL_06c4
+			IL_0626: nop
+			IL_0627: ldloc.s 13
+			IL_0629: ldc.r8 1
+			IL_0632: ldc.r8 2
+			IL_063b: ldc.i4.1
+			IL_063c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0641: leave IL_06af
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0654: stloc.s 16
-			IL_0656: ldloc.s 16
-			IL_0658: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0646: stloc.s 14
+			IL_0648: ldloc.s 14
+			IL_064a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_064f: dup
+			IL_0650: brtrue IL_0666
+
+			IL_0655: pop
+			IL_0656: ldloc.s 14
+			IL_0658: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_065d: dup
-			IL_065e: brtrue IL_0674
+			IL_065e: brtrue IL_0672
 
 			IL_0663: pop
-			IL_0664: ldloc.s 16
-			IL_0666: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_066b: dup
-			IL_066c: brtrue IL_0680
+			IL_0664: rethrow
 
-			IL_0671: pop
-			IL_0672: rethrow
+			IL_0666: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_066b: stloc.s 15
+			IL_066d: br IL_0674
 
-			IL_0674: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0679: stloc.s 17
-			IL_067b: br IL_0682
+			IL_0672: stloc.s 15
 
-			IL_0680: stloc.s 17
-
-			IL_0682: ldloc.s 17
-			IL_0684: stloc.s 82
-			IL_0686: ldloc.s 82
-			IL_0688: stloc.s 18
-			IL_068a: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L47C16::.ctor()
-			IL_068f: stloc.s 19
-			IL_0691: ldstr "console"
-			IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_069b: stloc.s 82
-			IL_069d: ldloc.s 82
-			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06a4: stloc.s 82
-			IL_06a6: ldloc.s 82
-			IL_06a8: ldstr "log"
-			IL_06ad: ldloc.s 18
-			IL_06af: ldstr "name"
-			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06be: pop
-			IL_06bf: leave IL_06c4
+			IL_0674: ldloc.s 15
+			IL_0676: stloc.s 69
+			IL_0678: ldloc.s 69
+			IL_067a: stloc.s 16
+			IL_067c: ldstr "console"
+			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0686: stloc.s 69
+			IL_0688: ldloc.s 69
+			IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_068f: stloc.s 69
+			IL_0691: ldloc.s 69
+			IL_0693: ldstr "log"
+			IL_0698: ldloc.s 16
+			IL_069a: ldstr "name"
+			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06a9: pop
+			IL_06aa: leave IL_06af
 		} // end handler
 
-		IL_06c4: ldloc.s 15
-		IL_06c6: ldc.r8 0.0
-		IL_06cf: ldc.r8 3
-		IL_06d8: ldc.i4.1
-		IL_06d9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_06de: ldstr "console"
-		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06e8: stloc.s 82
-		IL_06ea: ldloc.s 82
-		IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06f1: stloc.s 82
-		IL_06f3: ldloc.s 15
-		IL_06f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_06fa: box [System.Runtime]System.Double
-		IL_06ff: stloc.s 84
-		IL_0701: ldloc.s 15
-		IL_0703: ldc.r8 0.0
-		IL_070c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0711: stloc.s 81
-		IL_0713: ldc.r8 1
-		IL_071c: box [System.Runtime]System.Double
-		IL_0721: ldloc.s 15
-		IL_0723: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0728: stloc.s 79
-		IL_072a: ldloc.s 79
-		IL_072c: box [System.Runtime]System.Boolean
-		IL_0731: stloc.s 80
-		IL_0733: ldloc.s 82
-		IL_0735: ldstr "log"
-		IL_073a: ldloc.s 84
-		IL_073c: ldloc.s 81
-		IL_073e: ldloc.s 80
-		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0745: pop
-		IL_0746: ldc.i4.0
-		IL_0747: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_074c: stloc.s 20
-		IL_074e: ldloc.s 20
-		IL_0750: ldstr "length"
-		IL_0755: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_075a: dup
-		IL_075b: ldstr "writable"
-		IL_0760: ldc.i4.0
-		IL_0761: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_076b: pop
-		IL_076c: ldstr "console"
-		IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0776: stloc.s 81
-		IL_0778: ldloc.s 81
-		IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_077f: stloc.s 81
-		IL_0781: ldloc.s 20
-		IL_0783: ldstr "0"
-		IL_0788: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_078d: dup
-		IL_078e: ldstr "value"
-		IL_0793: ldc.r8 1
-		IL_079c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_07a1: dup
-		IL_07a2: ldstr "writable"
-		IL_07a7: ldc.i4.1
-		IL_07a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07ad: dup
-		IL_07ae: ldstr "enumerable"
-		IL_07b3: ldc.i4.1
-		IL_07b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07b9: dup
-		IL_07ba: ldstr "configurable"
-		IL_07bf: ldc.i4.1
-		IL_07c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
-		IL_07ca: stloc.s 79
-		IL_07cc: ldloc.s 79
-		IL_07ce: box [System.Runtime]System.Boolean
-		IL_07d3: stloc.s 80
-		IL_07d5: ldloc.s 20
-		IL_07d7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_07dc: box [System.Runtime]System.Double
-		IL_07e1: stloc.s 84
-		IL_07e3: ldc.r8 0.0
-		IL_07ec: box [System.Runtime]System.Double
-		IL_07f1: ldloc.s 20
-		IL_07f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_07f8: stloc.s 79
-		IL_07fa: ldloc.s 79
-		IL_07fc: box [System.Runtime]System.Boolean
-		IL_0801: stloc.s 85
-		IL_0803: ldloc.s 81
-		IL_0805: ldstr "log"
-		IL_080a: ldloc.s 80
-		IL_080c: ldloc.s 84
-		IL_080e: ldloc.s 85
-		IL_0810: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0815: pop
+		IL_06af: ldloc.s 13
+		IL_06b1: ldc.r8 0.0
+		IL_06ba: ldc.r8 3
+		IL_06c3: ldc.i4.1
+		IL_06c4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_06c9: ldstr "console"
+		IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06d3: stloc.s 69
+		IL_06d5: ldloc.s 69
+		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06dc: stloc.s 69
+		IL_06de: ldloc.s 13
+		IL_06e0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_06e5: box [System.Runtime]System.Double
+		IL_06ea: stloc.s 71
+		IL_06ec: ldloc.s 13
+		IL_06ee: ldc.r8 0.0
+		IL_06f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_06fc: stloc.s 68
+		IL_06fe: ldc.r8 1
+		IL_0707: box [System.Runtime]System.Double
+		IL_070c: ldloc.s 13
+		IL_070e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0713: stloc.s 66
+		IL_0715: ldloc.s 66
+		IL_0717: box [System.Runtime]System.Boolean
+		IL_071c: stloc.s 67
+		IL_071e: ldloc.s 69
+		IL_0720: ldstr "log"
+		IL_0725: ldloc.s 71
+		IL_0727: ldloc.s 68
+		IL_0729: ldloc.s 67
+		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0730: pop
+		IL_0731: ldc.i4.0
+		IL_0732: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0737: stloc.s 17
+		IL_0739: ldloc.s 17
+		IL_073b: ldstr "length"
+		IL_0740: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0745: dup
+		IL_0746: ldstr "writable"
+		IL_074b: ldc.i4.0
+		IL_074c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0756: pop
+		IL_0757: ldstr "console"
+		IL_075c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0761: stloc.s 68
+		IL_0763: ldloc.s 68
+		IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_076a: stloc.s 68
+		IL_076c: ldloc.s 17
+		IL_076e: ldstr "0"
+		IL_0773: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0778: dup
+		IL_0779: ldstr "value"
+		IL_077e: ldc.r8 1
+		IL_0787: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_078c: dup
+		IL_078d: ldstr "writable"
+		IL_0792: ldc.i4.1
+		IL_0793: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0798: dup
+		IL_0799: ldstr "enumerable"
+		IL_079e: ldc.i4.1
+		IL_079f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_07a4: dup
+		IL_07a5: ldstr "configurable"
+		IL_07aa: ldc.i4.1
+		IL_07ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_07b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
+		IL_07b5: stloc.s 66
+		IL_07b7: ldloc.s 66
+		IL_07b9: box [System.Runtime]System.Boolean
+		IL_07be: stloc.s 67
+		IL_07c0: ldloc.s 17
+		IL_07c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_07c7: box [System.Runtime]System.Double
+		IL_07cc: stloc.s 71
+		IL_07ce: ldc.r8 0.0
+		IL_07d7: box [System.Runtime]System.Double
+		IL_07dc: ldloc.s 17
+		IL_07de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_07e3: stloc.s 66
+		IL_07e5: ldloc.s 66
+		IL_07e7: box [System.Runtime]System.Boolean
+		IL_07ec: stloc.s 72
+		IL_07ee: ldloc.s 68
+		IL_07f0: ldstr "log"
+		IL_07f5: ldloc.s 67
+		IL_07f7: ldloc.s 71
+		IL_07f9: ldloc.s 72
+		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0800: pop
 		.try
 		{
-			IL_0816: nop
-			IL_0817: ldloc.s 20
-			IL_0819: ldstr "length"
-			IL_081e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0823: dup
-			IL_0824: ldstr "value"
-			IL_0829: ldc.r8 1.5
-			IL_0832: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0837: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
+			IL_0801: nop
+			IL_0802: ldloc.s 17
+			IL_0804: ldstr "length"
+			IL_0809: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_080e: dup
+			IL_080f: ldstr "value"
+			IL_0814: ldc.r8 1.5
+			IL_081d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0822: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
+			IL_0827: pop
+			IL_0828: leave IL_0896
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_082d: stloc.s 18
+			IL_082f: ldloc.s 18
+			IL_0831: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0836: dup
+			IL_0837: brtrue IL_084d
+
 			IL_083c: pop
-			IL_083d: leave IL_08b2
-		} // end .try
-		catch [System.Runtime]System.Exception
-		{
-			IL_0842: stloc.s 21
-			IL_0844: ldloc.s 21
-			IL_0846: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_084b: dup
-			IL_084c: brtrue IL_0862
+			IL_083d: ldloc.s 18
+			IL_083f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0844: dup
+			IL_0845: brtrue IL_0859
 
-			IL_0851: pop
-			IL_0852: ldloc.s 21
-			IL_0854: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0859: dup
-			IL_085a: brtrue IL_086e
+			IL_084a: pop
+			IL_084b: rethrow
 
-			IL_085f: pop
-			IL_0860: rethrow
+			IL_084d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0852: stloc.s 19
+			IL_0854: br IL_085b
 
-			IL_0862: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0867: stloc.s 22
-			IL_0869: br IL_0870
+			IL_0859: stloc.s 19
 
-			IL_086e: stloc.s 22
-
-			IL_0870: ldloc.s 22
-			IL_0872: stloc.s 81
-			IL_0874: ldloc.s 81
-			IL_0876: stloc.s 23
-			IL_0878: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L63C16::.ctor()
-			IL_087d: stloc.s 24
-			IL_087f: ldstr "console"
-			IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0889: stloc.s 81
-			IL_088b: ldloc.s 81
-			IL_088d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0892: stloc.s 81
-			IL_0894: ldloc.s 81
-			IL_0896: ldstr "log"
-			IL_089b: ldloc.s 23
-			IL_089d: ldstr "name"
-			IL_08a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_08ac: pop
-			IL_08ad: leave IL_08b2
+			IL_085b: ldloc.s 19
+			IL_085d: stloc.s 68
+			IL_085f: ldloc.s 68
+			IL_0861: stloc.s 20
+			IL_0863: ldstr "console"
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_086d: stloc.s 68
+			IL_086f: ldloc.s 68
+			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0876: stloc.s 68
+			IL_0878: ldloc.s 68
+			IL_087a: ldstr "log"
+			IL_087f: ldloc.s 20
+			IL_0881: ldstr "name"
+			IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0890: pop
+			IL_0891: leave IL_0896
 		} // end handler
 
-		IL_08b2: ldc.i4.0
-		IL_08b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_08b8: stloc.s 25
-		IL_08ba: ldloc.s 25
-		IL_08bc: ldstr "4294967294"
-		IL_08c1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0896: ldc.i4.0
+		IL_0897: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_089c: stloc.s 21
+		IL_089e: ldloc.s 21
+		IL_08a0: ldstr "4294967294"
+		IL_08a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08aa: dup
+		IL_08ab: ldstr "value"
+		IL_08b0: ldstr "edge"
+		IL_08b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_08ba: dup
+		IL_08bb: ldstr "writable"
+		IL_08c0: ldc.i4.1
+		IL_08c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 		IL_08c6: dup
-		IL_08c7: ldstr "value"
-		IL_08cc: ldstr "edge"
-		IL_08d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_08d6: dup
-		IL_08d7: ldstr "writable"
-		IL_08dc: ldc.i4.1
-		IL_08dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_08e2: dup
-		IL_08e3: ldstr "enumerable"
-		IL_08e8: ldc.i4.1
-		IL_08e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_08ee: dup
-		IL_08ef: ldstr "configurable"
-		IL_08f4: ldc.i4.1
-		IL_08f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_08fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_08ff: pop
-		IL_0900: ldstr "console"
-		IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_090a: stloc.s 81
-		IL_090c: ldloc.s 81
-		IL_090e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0913: stloc.s 81
-		IL_0915: ldloc.s 25
-		IL_0917: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_091c: box [System.Runtime]System.Double
-		IL_0921: stloc.s 84
-		IL_0923: ldloc.s 81
-		IL_0925: ldstr "log"
-		IL_092a: ldloc.s 84
-		IL_092c: ldloc.s 25
-		IL_092e: ldc.r8 4294967294
-		IL_0937: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_093c: castclass [System.Runtime]System.String
-		IL_0941: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0946: pop
-		IL_0947: ldloc.s 25
-		IL_0949: ldc.r8 4294967295
-		IL_0952: ldstr "named"
-		IL_0957: ldc.i4.1
-		IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_095d: pop
-		IL_095e: ldstr "console"
-		IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0968: stloc.s 81
-		IL_096a: ldloc.s 81
-		IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0971: stloc.s 81
-		IL_0973: ldloc.s 25
-		IL_0975: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_097a: box [System.Runtime]System.Double
-		IL_097f: stloc.s 84
-		IL_0981: ldloc.s 81
-		IL_0983: ldstr "log"
-		IL_0988: ldloc.s 84
-		IL_098a: ldloc.s 25
-		IL_098c: ldc.r8 4294967295
-		IL_0995: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_099a: castclass [System.Runtime]System.String
-		IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_09a4: pop
-		IL_09a5: ldc.i4.0
-		IL_09a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_09ab: stloc.s 26
-		IL_09ad: ldloc.s 26
-		IL_09af: ldc.r8 2147483647
-		IL_09b8: ldstr "sparse"
-		IL_09bd: ldc.i4.1
-		IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_09c3: pop
-		IL_09c4: ldstr "console"
-		IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09ce: stloc.s 81
-		IL_09d0: ldloc.s 81
-		IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09d7: stloc.s 81
-		IL_09d9: ldloc.s 26
-		IL_09db: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_09e0: box [System.Runtime]System.Double
-		IL_09e5: stloc.s 84
-		IL_09e7: ldloc.s 26
-		IL_09e9: ldc.r8 2147483647
-		IL_09f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_09f7: castclass [System.Runtime]System.String
-		IL_09fc: stloc.s 87
-		IL_09fe: ldc.r8 2147483647
-		IL_0a07: box [System.Runtime]System.Double
-		IL_0a0c: ldloc.s 26
-		IL_0a0e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0a13: stloc.s 79
-		IL_0a15: ldloc.s 79
-		IL_0a17: box [System.Runtime]System.Boolean
-		IL_0a1c: stloc.s 85
-		IL_0a1e: ldloc.s 81
-		IL_0a20: ldstr "log"
-		IL_0a25: ldloc.s 84
-		IL_0a27: ldloc.s 87
-		IL_0a29: ldloc.s 85
-		IL_0a2b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0a30: pop
-		IL_0a31: ldstr "console"
-		IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a3b: stloc.s 81
-		IL_0a3d: ldloc.s 81
-		IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a44: stloc.s 81
-		IL_0a46: ldloc.s 26
-		IL_0a48: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
-		IL_0a4d: stloc.s 82
-		IL_0a4f: ldloc.s 26
-		IL_0a51: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0a56: box [System.Runtime]System.Double
-		IL_0a5b: stloc.s 84
-		IL_0a5d: ldc.r8 2147483647
-		IL_0a66: box [System.Runtime]System.Double
-		IL_0a6b: ldloc.s 26
-		IL_0a6d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0a72: stloc.s 79
-		IL_0a74: ldloc.s 79
-		IL_0a76: box [System.Runtime]System.Boolean
-		IL_0a7b: stloc.s 85
-		IL_0a7d: ldloc.s 81
-		IL_0a7f: ldstr "log"
-		IL_0a84: ldloc.s 82
-		IL_0a86: ldloc.s 84
-		IL_0a88: ldloc.s 85
-		IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0a8f: pop
-		IL_0a90: ldc.i4.0
-		IL_0a91: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0a96: stloc.s 27
-		IL_0a98: ldloc.s 27
-		IL_0a9a: ldc.r8 4294967295
-		IL_0aa3: ldc.i4.1
-		IL_0aa4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_08c7: ldstr "enumerable"
+		IL_08cc: ldc.i4.1
+		IL_08cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_08d2: dup
+		IL_08d3: ldstr "configurable"
+		IL_08d8: ldc.i4.1
+		IL_08d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_08e3: pop
+		IL_08e4: ldstr "console"
+		IL_08e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08ee: stloc.s 68
+		IL_08f0: ldloc.s 68
+		IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08f7: stloc.s 68
+		IL_08f9: ldloc.s 21
+		IL_08fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0900: box [System.Runtime]System.Double
+		IL_0905: stloc.s 71
+		IL_0907: ldloc.s 68
+		IL_0909: ldstr "log"
+		IL_090e: ldloc.s 71
+		IL_0910: ldloc.s 21
+		IL_0912: ldc.r8 4294967294
+		IL_091b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0920: castclass [System.Runtime]System.String
+		IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_092a: pop
+		IL_092b: ldloc.s 21
+		IL_092d: ldc.r8 4294967295
+		IL_0936: ldstr "named"
+		IL_093b: ldc.i4.1
+		IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0941: pop
+		IL_0942: ldstr "console"
+		IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_094c: stloc.s 68
+		IL_094e: ldloc.s 68
+		IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0955: stloc.s 68
+		IL_0957: ldloc.s 21
+		IL_0959: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_095e: box [System.Runtime]System.Double
+		IL_0963: stloc.s 71
+		IL_0965: ldloc.s 68
+		IL_0967: ldstr "log"
+		IL_096c: ldloc.s 71
+		IL_096e: ldloc.s 21
+		IL_0970: ldc.r8 4294967295
+		IL_0979: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_097e: castclass [System.Runtime]System.String
+		IL_0983: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0988: pop
+		IL_0989: ldc.i4.0
+		IL_098a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_098f: stloc.s 22
+		IL_0991: ldloc.s 22
+		IL_0993: ldc.r8 2147483647
+		IL_099c: ldstr "sparse"
+		IL_09a1: ldc.i4.1
+		IL_09a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_09a7: pop
+		IL_09a8: ldstr "console"
+		IL_09ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_09b2: stloc.s 68
+		IL_09b4: ldloc.s 68
+		IL_09b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_09bb: stloc.s 68
+		IL_09bd: ldloc.s 22
+		IL_09bf: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_09c4: box [System.Runtime]System.Double
+		IL_09c9: stloc.s 71
+		IL_09cb: ldloc.s 22
+		IL_09cd: ldc.r8 2147483647
+		IL_09d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_09db: castclass [System.Runtime]System.String
+		IL_09e0: stloc.s 74
+		IL_09e2: ldc.r8 2147483647
+		IL_09eb: box [System.Runtime]System.Double
+		IL_09f0: ldloc.s 22
+		IL_09f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_09f7: stloc.s 66
+		IL_09f9: ldloc.s 66
+		IL_09fb: box [System.Runtime]System.Boolean
+		IL_0a00: stloc.s 72
+		IL_0a02: ldloc.s 68
+		IL_0a04: ldstr "log"
+		IL_0a09: ldloc.s 71
+		IL_0a0b: ldloc.s 74
+		IL_0a0d: ldloc.s 72
+		IL_0a0f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0a14: pop
+		IL_0a15: ldstr "console"
+		IL_0a1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a1f: stloc.s 68
+		IL_0a21: ldloc.s 68
+		IL_0a23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a28: stloc.s 68
+		IL_0a2a: ldloc.s 22
+		IL_0a2c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+		IL_0a31: stloc.s 69
+		IL_0a33: ldloc.s 22
+		IL_0a35: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0a3a: box [System.Runtime]System.Double
+		IL_0a3f: stloc.s 71
+		IL_0a41: ldc.r8 2147483647
+		IL_0a4a: box [System.Runtime]System.Double
+		IL_0a4f: ldloc.s 22
+		IL_0a51: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0a56: stloc.s 66
+		IL_0a58: ldloc.s 66
+		IL_0a5a: box [System.Runtime]System.Boolean
+		IL_0a5f: stloc.s 72
+		IL_0a61: ldloc.s 68
+		IL_0a63: ldstr "log"
+		IL_0a68: ldloc.s 69
+		IL_0a6a: ldloc.s 71
+		IL_0a6c: ldloc.s 72
+		IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0a73: pop
+		IL_0a74: ldc.i4.0
+		IL_0a75: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0a7a: stloc.s 23
+		IL_0a7c: ldloc.s 23
+		IL_0a7e: ldc.r8 4294967295
+		IL_0a87: ldc.i4.1
+		IL_0a88: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
 		.try
 		{
-			IL_0aa9: nop
-			IL_0aaa: ldloc.s 27
-			IL_0aac: ldstr "ordinary"
-			IL_0ab1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0ab6: pop
-			IL_0ab7: leave IL_0b2c
+			IL_0a8d: nop
+			IL_0a8e: ldloc.s 23
+			IL_0a90: ldstr "ordinary"
+			IL_0a95: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0a9a: pop
+			IL_0a9b: leave IL_0b09
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0abc: stloc.s 28
-			IL_0abe: ldloc.s 28
-			IL_0ac0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0ac5: dup
-			IL_0ac6: brtrue IL_0adc
+			IL_0aa0: stloc.s 24
+			IL_0aa2: ldloc.s 24
+			IL_0aa4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0aa9: dup
+			IL_0aaa: brtrue IL_0ac0
 
-			IL_0acb: pop
-			IL_0acc: ldloc.s 28
-			IL_0ace: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0ad3: dup
-			IL_0ad4: brtrue IL_0ae8
+			IL_0aaf: pop
+			IL_0ab0: ldloc.s 24
+			IL_0ab2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ab7: dup
+			IL_0ab8: brtrue IL_0acc
 
-			IL_0ad9: pop
-			IL_0ada: rethrow
+			IL_0abd: pop
+			IL_0abe: rethrow
 
-			IL_0adc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0ae1: stloc.s 29
-			IL_0ae3: br IL_0aea
+			IL_0ac0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ac5: stloc.s 25
+			IL_0ac7: br IL_0ace
 
-			IL_0ae8: stloc.s 29
+			IL_0acc: stloc.s 25
 
-			IL_0aea: ldloc.s 29
-			IL_0aec: stloc.s 82
-			IL_0aee: ldloc.s 82
-			IL_0af0: stloc.s 30
-			IL_0af2: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L87C16::.ctor()
-			IL_0af7: stloc.s 31
-			IL_0af9: ldstr "console"
-			IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b03: stloc.s 82
-			IL_0b05: ldloc.s 82
-			IL_0b07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b0c: stloc.s 82
-			IL_0b0e: ldloc.s 82
-			IL_0b10: ldstr "log"
-			IL_0b15: ldloc.s 30
-			IL_0b17: ldstr "name"
-			IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0b26: pop
-			IL_0b27: leave IL_0b2c
+			IL_0ace: ldloc.s 25
+			IL_0ad0: stloc.s 69
+			IL_0ad2: ldloc.s 69
+			IL_0ad4: stloc.s 26
+			IL_0ad6: ldstr "console"
+			IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ae0: stloc.s 69
+			IL_0ae2: ldloc.s 69
+			IL_0ae4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ae9: stloc.s 69
+			IL_0aeb: ldloc.s 69
+			IL_0aed: ldstr "log"
+			IL_0af2: ldloc.s 26
+			IL_0af4: ldstr "name"
+			IL_0af9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0b03: pop
+			IL_0b04: leave IL_0b09
 		} // end handler
 
-		IL_0b2c: ldstr "console"
-		IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b36: stloc.s 82
-		IL_0b38: ldloc.s 82
-		IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b3f: stloc.s 82
-		IL_0b41: ldloc.s 27
-		IL_0b43: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0b48: box [System.Runtime]System.Double
-		IL_0b4d: stloc.s 84
-		IL_0b4f: ldloc.s 82
-		IL_0b51: ldstr "log"
-		IL_0b56: ldloc.s 84
-		IL_0b58: ldloc.s 27
-		IL_0b5a: ldc.r8 4294967295
-		IL_0b63: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0b68: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0b6d: pop
-		IL_0b6e: ldc.i4.1
-		IL_0b6f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0b74: dup
-		IL_0b75: ldc.r8 1
-		IL_0b7e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b83: stloc.s 32
-		IL_0b85: ldloc.s 32
-		IL_0b87: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0b8c: pop
-		IL_0b8d: ldloc.s 32
-		IL_0b8f: ldc.r8 0.0
-		IL_0b98: ldc.r8 2
-		IL_0ba1: ldc.i4.1
-		IL_0ba2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0b09: ldstr "console"
+		IL_0b0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b13: stloc.s 69
+		IL_0b15: ldloc.s 69
+		IL_0b17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b1c: stloc.s 69
+		IL_0b1e: ldloc.s 23
+		IL_0b20: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0b25: box [System.Runtime]System.Double
+		IL_0b2a: stloc.s 71
+		IL_0b2c: ldloc.s 69
+		IL_0b2e: ldstr "log"
+		IL_0b33: ldloc.s 71
+		IL_0b35: ldloc.s 23
+		IL_0b37: ldc.r8 4294967295
+		IL_0b40: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0b45: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0b4a: pop
+		IL_0b4b: ldc.i4.1
+		IL_0b4c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0b51: dup
+		IL_0b52: ldc.r8 1
+		IL_0b5b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0b60: stloc.s 27
+		IL_0b62: ldloc.s 27
+		IL_0b64: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0b69: pop
+		IL_0b6a: ldloc.s 27
+		IL_0b6c: ldc.r8 0.0
+		IL_0b75: ldc.r8 2
+		IL_0b7e: ldc.i4.1
+		IL_0b7f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
 		.try
 		{
-			IL_0ba7: nop
-			IL_0ba8: ldloc.s 32
-			IL_0baa: ldc.r8 1
-			IL_0bb3: ldc.r8 3
-			IL_0bbc: ldc.i4.1
-			IL_0bbd: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0bc2: leave IL_0c37
+			IL_0b84: nop
+			IL_0b85: ldloc.s 27
+			IL_0b87: ldc.r8 1
+			IL_0b90: ldc.r8 3
+			IL_0b99: ldc.i4.1
+			IL_0b9a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0b9f: leave IL_0c0d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0bc7: stloc.s 33
-			IL_0bc9: ldloc.s 33
-			IL_0bcb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0bd0: dup
-			IL_0bd1: brtrue IL_0be7
+			IL_0ba4: stloc.s 28
+			IL_0ba6: ldloc.s 28
+			IL_0ba8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0bad: dup
+			IL_0bae: brtrue IL_0bc4
 
-			IL_0bd6: pop
-			IL_0bd7: ldloc.s 33
-			IL_0bd9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0bde: dup
-			IL_0bdf: brtrue IL_0bf3
+			IL_0bb3: pop
+			IL_0bb4: ldloc.s 28
+			IL_0bb6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0bbb: dup
+			IL_0bbc: brtrue IL_0bd0
 
-			IL_0be4: pop
-			IL_0be5: rethrow
+			IL_0bc1: pop
+			IL_0bc2: rethrow
 
-			IL_0be7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0bec: stloc.s 34
-			IL_0bee: br IL_0bf5
+			IL_0bc4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0bc9: stloc.s 29
+			IL_0bcb: br IL_0bd2
 
-			IL_0bf3: stloc.s 34
+			IL_0bd0: stloc.s 29
 
-			IL_0bf5: ldloc.s 34
-			IL_0bf7: stloc.s 82
-			IL_0bf9: ldloc.s 82
-			IL_0bfb: stloc.s 35
-			IL_0bfd: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L97C16::.ctor()
-			IL_0c02: stloc.s 36
-			IL_0c04: ldstr "console"
-			IL_0c09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c0e: stloc.s 82
-			IL_0c10: ldloc.s 82
-			IL_0c12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c17: stloc.s 82
-			IL_0c19: ldloc.s 82
-			IL_0c1b: ldstr "log"
-			IL_0c20: ldloc.s 35
-			IL_0c22: ldstr "name"
-			IL_0c27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c2c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0c31: pop
-			IL_0c32: leave IL_0c37
+			IL_0bd2: ldloc.s 29
+			IL_0bd4: stloc.s 69
+			IL_0bd6: ldloc.s 69
+			IL_0bd8: stloc.s 30
+			IL_0bda: ldstr "console"
+			IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0be4: stloc.s 69
+			IL_0be6: ldloc.s 69
+			IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0bed: stloc.s 69
+			IL_0bef: ldloc.s 69
+			IL_0bf1: ldstr "log"
+			IL_0bf6: ldloc.s 30
+			IL_0bf8: ldstr "name"
+			IL_0bfd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c02: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0c07: pop
+			IL_0c08: leave IL_0c0d
 		} // end handler
 
-		IL_0c37: ldstr "console"
-		IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c41: stloc.s 82
-		IL_0c43: ldloc.s 82
-		IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c4a: stloc.s 82
-		IL_0c4c: ldloc.s 32
-		IL_0c4e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0c53: box [System.Runtime]System.Double
-		IL_0c58: stloc.s 84
-		IL_0c5a: ldloc.s 32
-		IL_0c5c: ldc.r8 0.0
-		IL_0c65: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0c6a: stloc.s 81
-		IL_0c6c: ldc.r8 1
-		IL_0c75: box [System.Runtime]System.Double
-		IL_0c7a: ldloc.s 32
-		IL_0c7c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0c81: stloc.s 79
-		IL_0c83: ldloc.s 79
-		IL_0c85: box [System.Runtime]System.Boolean
-		IL_0c8a: stloc.s 85
-		IL_0c8c: ldloc.s 82
-		IL_0c8e: ldstr "log"
-		IL_0c93: ldloc.s 84
-		IL_0c95: ldloc.s 81
-		IL_0c97: ldloc.s 85
-		IL_0c99: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0c9e: pop
-		IL_0c9f: ldc.i4.3
-		IL_0ca0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0ca5: dup
-		IL_0ca6: ldc.r8 1
-		IL_0caf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0cb4: dup
-		IL_0cb5: ldc.r8 2
-		IL_0cbe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0cc3: dup
-		IL_0cc4: ldc.r8 3
-		IL_0ccd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0cd2: stloc.s 37
-		IL_0cd4: ldloc.s 37
-		IL_0cd6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
-		IL_0cdb: pop
+		IL_0c0d: ldstr "console"
+		IL_0c12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c17: stloc.s 69
+		IL_0c19: ldloc.s 69
+		IL_0c1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c20: stloc.s 69
+		IL_0c22: ldloc.s 27
+		IL_0c24: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0c29: box [System.Runtime]System.Double
+		IL_0c2e: stloc.s 71
+		IL_0c30: ldloc.s 27
+		IL_0c32: ldc.r8 0.0
+		IL_0c3b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0c40: stloc.s 68
+		IL_0c42: ldc.r8 1
+		IL_0c4b: box [System.Runtime]System.Double
+		IL_0c50: ldloc.s 27
+		IL_0c52: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0c57: stloc.s 66
+		IL_0c59: ldloc.s 66
+		IL_0c5b: box [System.Runtime]System.Boolean
+		IL_0c60: stloc.s 72
+		IL_0c62: ldloc.s 69
+		IL_0c64: ldstr "log"
+		IL_0c69: ldloc.s 71
+		IL_0c6b: ldloc.s 68
+		IL_0c6d: ldloc.s 72
+		IL_0c6f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0c74: pop
+		IL_0c75: ldc.i4.3
+		IL_0c76: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0c7b: dup
+		IL_0c7c: ldc.r8 1
+		IL_0c85: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c8a: dup
+		IL_0c8b: ldc.r8 2
+		IL_0c94: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c99: dup
+		IL_0c9a: ldc.r8 3
+		IL_0ca3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ca8: stloc.s 31
+		IL_0caa: ldloc.s 31
+		IL_0cac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
+		IL_0cb1: pop
 		.try
 		{
-			IL_0cdc: nop
-			IL_0cdd: ldloc.s 37
-			IL_0cdf: ldc.r8 1
-			IL_0ce8: ldc.i4.1
-			IL_0ce9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-			IL_0cee: leave IL_0d63
+			IL_0cb2: nop
+			IL_0cb3: ldloc.s 31
+			IL_0cb5: ldc.r8 1
+			IL_0cbe: ldc.i4.1
+			IL_0cbf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+			IL_0cc4: leave IL_0d32
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0cf3: stloc.s 38
-			IL_0cf5: ldloc.s 38
-			IL_0cf7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0cfc: dup
-			IL_0cfd: brtrue IL_0d13
+			IL_0cc9: stloc.s 32
+			IL_0ccb: ldloc.s 32
+			IL_0ccd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0cd2: dup
+			IL_0cd3: brtrue IL_0ce9
 
-			IL_0d02: pop
-			IL_0d03: ldloc.s 38
-			IL_0d05: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0d0a: dup
-			IL_0d0b: brtrue IL_0d1f
+			IL_0cd8: pop
+			IL_0cd9: ldloc.s 32
+			IL_0cdb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ce0: dup
+			IL_0ce1: brtrue IL_0cf5
 
-			IL_0d10: pop
-			IL_0d11: rethrow
+			IL_0ce6: pop
+			IL_0ce7: rethrow
 
-			IL_0d13: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0d18: stloc.s 39
-			IL_0d1a: br IL_0d21
+			IL_0ce9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0cee: stloc.s 33
+			IL_0cf0: br IL_0cf7
 
-			IL_0d1f: stloc.s 39
+			IL_0cf5: stloc.s 33
 
-			IL_0d21: ldloc.s 39
-			IL_0d23: stloc.s 81
-			IL_0d25: ldloc.s 81
-			IL_0d27: stloc.s 40
-			IL_0d29: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L106C16::.ctor()
-			IL_0d2e: stloc.s 41
-			IL_0d30: ldstr "console"
-			IL_0d35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0d3a: stloc.s 81
-			IL_0d3c: ldloc.s 81
-			IL_0d3e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0d43: stloc.s 81
-			IL_0d45: ldloc.s 81
-			IL_0d47: ldstr "log"
-			IL_0d4c: ldloc.s 40
-			IL_0d4e: ldstr "name"
-			IL_0d53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d58: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0d5d: pop
-			IL_0d5e: leave IL_0d63
+			IL_0cf7: ldloc.s 33
+			IL_0cf9: stloc.s 68
+			IL_0cfb: ldloc.s 68
+			IL_0cfd: stloc.s 34
+			IL_0cff: ldstr "console"
+			IL_0d04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0d09: stloc.s 68
+			IL_0d0b: ldloc.s 68
+			IL_0d0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0d12: stloc.s 68
+			IL_0d14: ldloc.s 68
+			IL_0d16: ldstr "log"
+			IL_0d1b: ldloc.s 34
+			IL_0d1d: ldstr "name"
+			IL_0d22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d27: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0d2c: pop
+			IL_0d2d: leave IL_0d32
 		} // end handler
 
-		IL_0d63: ldstr "console"
-		IL_0d68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0d6d: stloc.s 81
-		IL_0d6f: ldloc.s 81
-		IL_0d71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d76: stloc.s 81
-		IL_0d78: ldloc.s 37
-		IL_0d7a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_0d7f: stloc.s 79
-		IL_0d81: ldloc.s 79
-		IL_0d83: box [System.Runtime]System.Boolean
-		IL_0d88: stloc.s 85
-		IL_0d8a: ldloc.s 37
-		IL_0d8c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0d91: box [System.Runtime]System.Double
-		IL_0d96: stloc.s 84
-		IL_0d98: ldc.r8 2
-		IL_0da1: box [System.Runtime]System.Double
-		IL_0da6: ldloc.s 37
-		IL_0da8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0dad: stloc.s 79
-		IL_0daf: ldloc.s 79
-		IL_0db1: box [System.Runtime]System.Boolean
-		IL_0db6: stloc.s 80
-		IL_0db8: ldloc.s 81
-		IL_0dba: ldstr "log"
-		IL_0dbf: ldloc.s 85
-		IL_0dc1: ldloc.s 84
-		IL_0dc3: ldloc.s 80
-		IL_0dc5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0dca: pop
-		IL_0dcb: ldc.i4.1
-		IL_0dcc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0dd1: dup
-		IL_0dd2: ldc.r8 5
-		IL_0ddb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0de0: stloc.s 42
-		IL_0de2: ldloc.s 42
-		IL_0de4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_0de9: pop
+		IL_0d32: ldstr "console"
+		IL_0d37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0d3c: stloc.s 68
+		IL_0d3e: ldloc.s 68
+		IL_0d40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0d45: stloc.s 68
+		IL_0d47: ldloc.s 31
+		IL_0d49: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_0d4e: stloc.s 66
+		IL_0d50: ldloc.s 66
+		IL_0d52: box [System.Runtime]System.Boolean
+		IL_0d57: stloc.s 72
+		IL_0d59: ldloc.s 31
+		IL_0d5b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0d60: box [System.Runtime]System.Double
+		IL_0d65: stloc.s 71
+		IL_0d67: ldc.r8 2
+		IL_0d70: box [System.Runtime]System.Double
+		IL_0d75: ldloc.s 31
+		IL_0d77: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0d7c: stloc.s 66
+		IL_0d7e: ldloc.s 66
+		IL_0d80: box [System.Runtime]System.Boolean
+		IL_0d85: stloc.s 67
+		IL_0d87: ldloc.s 68
+		IL_0d89: ldstr "log"
+		IL_0d8e: ldloc.s 72
+		IL_0d90: ldloc.s 71
+		IL_0d92: ldloc.s 67
+		IL_0d94: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0d99: pop
+		IL_0d9a: ldc.i4.1
+		IL_0d9b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0da0: dup
+		IL_0da1: ldc.r8 5
+		IL_0daa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0daf: stloc.s 35
+		IL_0db1: ldloc.s 35
+		IL_0db3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0db8: pop
 		.try
 		{
-			IL_0dea: nop
-			IL_0deb: ldloc.s 42
-			IL_0ded: ldc.r8 0.0
-			IL_0df6: ldc.r8 6
-			IL_0dff: ldc.i4.1
-			IL_0e00: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0e05: leave IL_0e7a
+			IL_0db9: nop
+			IL_0dba: ldloc.s 35
+			IL_0dbc: ldc.r8 0.0
+			IL_0dc5: ldc.r8 6
+			IL_0dce: ldc.i4.1
+			IL_0dcf: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0dd4: leave IL_0e42
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0e0a: stloc.s 43
-			IL_0e0c: ldloc.s 43
-			IL_0e0e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0e13: dup
-			IL_0e14: brtrue IL_0e2a
+			IL_0dd9: stloc.s 36
+			IL_0ddb: ldloc.s 36
+			IL_0ddd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0de2: dup
+			IL_0de3: brtrue IL_0df9
 
-			IL_0e19: pop
-			IL_0e1a: ldloc.s 43
-			IL_0e1c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0e21: dup
-			IL_0e22: brtrue IL_0e36
+			IL_0de8: pop
+			IL_0de9: ldloc.s 36
+			IL_0deb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0df0: dup
+			IL_0df1: brtrue IL_0e05
 
-			IL_0e27: pop
-			IL_0e28: rethrow
+			IL_0df6: pop
+			IL_0df7: rethrow
 
-			IL_0e2a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0e2f: stloc.s 44
-			IL_0e31: br IL_0e38
+			IL_0df9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0dfe: stloc.s 37
+			IL_0e00: br IL_0e07
 
-			IL_0e36: stloc.s 44
+			IL_0e05: stloc.s 37
 
-			IL_0e38: ldloc.s 44
-			IL_0e3a: stloc.s 81
-			IL_0e3c: ldloc.s 81
-			IL_0e3e: stloc.s 45
-			IL_0e40: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L115C16::.ctor()
-			IL_0e45: stloc.s 46
-			IL_0e47: ldstr "console"
-			IL_0e4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0e51: stloc.s 81
-			IL_0e53: ldloc.s 81
-			IL_0e55: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0e5a: stloc.s 81
-			IL_0e5c: ldloc.s 81
-			IL_0e5e: ldstr "log"
-			IL_0e63: ldloc.s 45
-			IL_0e65: ldstr "name"
-			IL_0e6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e6f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0e74: pop
-			IL_0e75: leave IL_0e7a
+			IL_0e07: ldloc.s 37
+			IL_0e09: stloc.s 68
+			IL_0e0b: ldloc.s 68
+			IL_0e0d: stloc.s 38
+			IL_0e0f: ldstr "console"
+			IL_0e14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e19: stloc.s 68
+			IL_0e1b: ldloc.s 68
+			IL_0e1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0e22: stloc.s 68
+			IL_0e24: ldloc.s 68
+			IL_0e26: ldstr "log"
+			IL_0e2b: ldloc.s 38
+			IL_0e2d: ldstr "name"
+			IL_0e32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e37: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0e3c: pop
+			IL_0e3d: leave IL_0e42
 		} // end handler
 		.try
 		{
-			IL_0e7a: nop
-			IL_0e7b: ldloc.s 42
-			IL_0e7d: ldc.r8 0.0
-			IL_0e86: ldc.i4.1
-			IL_0e87: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-			IL_0e8c: leave IL_0f01
+			IL_0e42: nop
+			IL_0e43: ldloc.s 35
+			IL_0e45: ldc.r8 0.0
+			IL_0e4e: ldc.i4.1
+			IL_0e4f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+			IL_0e54: leave IL_0ec2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0e91: stloc.s 47
-			IL_0e93: ldloc.s 47
-			IL_0e95: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0e9a: dup
-			IL_0e9b: brtrue IL_0eb1
+			IL_0e59: stloc.s 39
+			IL_0e5b: ldloc.s 39
+			IL_0e5d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0e62: dup
+			IL_0e63: brtrue IL_0e79
 
-			IL_0ea0: pop
-			IL_0ea1: ldloc.s 47
-			IL_0ea3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0ea8: dup
-			IL_0ea9: brtrue IL_0ebd
+			IL_0e68: pop
+			IL_0e69: ldloc.s 39
+			IL_0e6b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0e70: dup
+			IL_0e71: brtrue IL_0e85
 
-			IL_0eae: pop
-			IL_0eaf: rethrow
+			IL_0e76: pop
+			IL_0e77: rethrow
 
-			IL_0eb1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0eb6: stloc.s 48
-			IL_0eb8: br IL_0ebf
+			IL_0e79: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0e7e: stloc.s 40
+			IL_0e80: br IL_0e87
 
-			IL_0ebd: stloc.s 48
+			IL_0e85: stloc.s 40
 
-			IL_0ebf: ldloc.s 48
-			IL_0ec1: stloc.s 81
-			IL_0ec3: ldloc.s 81
-			IL_0ec5: stloc.s 49
-			IL_0ec7: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L120C16::.ctor()
-			IL_0ecc: stloc.s 50
-			IL_0ece: ldstr "console"
-			IL_0ed3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ed8: stloc.s 81
-			IL_0eda: ldloc.s 81
-			IL_0edc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ee1: stloc.s 81
-			IL_0ee3: ldloc.s 81
-			IL_0ee5: ldstr "log"
-			IL_0eea: ldloc.s 49
-			IL_0eec: ldstr "name"
-			IL_0ef1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ef6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0e87: ldloc.s 40
+			IL_0e89: stloc.s 68
+			IL_0e8b: ldloc.s 68
+			IL_0e8d: stloc.s 41
+			IL_0e8f: ldstr "console"
+			IL_0e94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e99: stloc.s 68
+			IL_0e9b: ldloc.s 68
+			IL_0e9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ea2: stloc.s 68
+			IL_0ea4: ldloc.s 68
+			IL_0ea6: ldstr "log"
+			IL_0eab: ldloc.s 41
+			IL_0ead: ldstr "name"
+			IL_0eb2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0eb7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0ebc: pop
+			IL_0ebd: leave IL_0ec2
+		} // end handler
+		.try
+		{
+			IL_0ec2: nop
+			IL_0ec3: ldloc.s 35
+			IL_0ec5: ldc.r8 7
+			IL_0ece: box [System.Runtime]System.Double
+			IL_0ed3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0ed8: pop
+			IL_0ed9: leave IL_0f47
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0ede: stloc.s 42
+			IL_0ee0: ldloc.s 42
+			IL_0ee2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0ee7: dup
+			IL_0ee8: brtrue IL_0efe
+
+			IL_0eed: pop
+			IL_0eee: ldloc.s 42
+			IL_0ef0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ef5: dup
+			IL_0ef6: brtrue IL_0f0a
+
 			IL_0efb: pop
-			IL_0efc: leave IL_0f01
+			IL_0efc: rethrow
+
+			IL_0efe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0f03: stloc.s 43
+			IL_0f05: br IL_0f0c
+
+			IL_0f0a: stloc.s 43
+
+			IL_0f0c: ldloc.s 43
+			IL_0f0e: stloc.s 68
+			IL_0f10: ldloc.s 68
+			IL_0f12: stloc.s 44
+			IL_0f14: ldstr "console"
+			IL_0f19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0f1e: stloc.s 68
+			IL_0f20: ldloc.s 68
+			IL_0f22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0f27: stloc.s 68
+			IL_0f29: ldloc.s 68
+			IL_0f2b: ldstr "log"
+			IL_0f30: ldloc.s 44
+			IL_0f32: ldstr "name"
+			IL_0f37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f3c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0f41: pop
+			IL_0f42: leave IL_0f47
 		} // end handler
 		.try
 		{
-			IL_0f01: nop
-			IL_0f02: ldloc.s 42
-			IL_0f04: ldc.r8 7
-			IL_0f0d: box [System.Runtime]System.Double
-			IL_0f12: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0f17: pop
-			IL_0f18: leave IL_0f8d
+			IL_0f47: nop
+			IL_0f48: ldloc.s 35
+			IL_0f4a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+			IL_0f4f: pop
+			IL_0f50: leave IL_0fbe
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0f1d: stloc.s 51
-			IL_0f1f: ldloc.s 51
-			IL_0f21: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0f26: dup
-			IL_0f27: brtrue IL_0f3d
+			IL_0f55: stloc.s 45
+			IL_0f57: ldloc.s 45
+			IL_0f59: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0f5e: dup
+			IL_0f5f: brtrue IL_0f75
 
-			IL_0f2c: pop
-			IL_0f2d: ldloc.s 51
-			IL_0f2f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0f34: dup
-			IL_0f35: brtrue IL_0f49
+			IL_0f64: pop
+			IL_0f65: ldloc.s 45
+			IL_0f67: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0f6c: dup
+			IL_0f6d: brtrue IL_0f81
 
-			IL_0f3a: pop
-			IL_0f3b: rethrow
+			IL_0f72: pop
+			IL_0f73: rethrow
 
-			IL_0f3d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0f42: stloc.s 52
-			IL_0f44: br IL_0f4b
+			IL_0f75: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0f7a: stloc.s 46
+			IL_0f7c: br IL_0f83
 
-			IL_0f49: stloc.s 52
+			IL_0f81: stloc.s 46
 
-			IL_0f4b: ldloc.s 52
-			IL_0f4d: stloc.s 81
-			IL_0f4f: ldloc.s 81
-			IL_0f51: stloc.s 53
-			IL_0f53: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L125C16::.ctor()
-			IL_0f58: stloc.s 54
-			IL_0f5a: ldstr "console"
-			IL_0f5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0f64: stloc.s 81
-			IL_0f66: ldloc.s 81
-			IL_0f68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0f6d: stloc.s 81
-			IL_0f6f: ldloc.s 81
-			IL_0f71: ldstr "log"
-			IL_0f76: ldloc.s 53
-			IL_0f78: ldstr "name"
-			IL_0f7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f82: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0f87: pop
-			IL_0f88: leave IL_0f8d
-		} // end handler
-		.try
-		{
-			IL_0f8d: nop
-			IL_0f8e: ldloc.s 42
-			IL_0f90: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
-			IL_0f95: pop
-			IL_0f96: leave IL_100b
-		} // end .try
-		catch [System.Runtime]System.Exception
-		{
-			IL_0f9b: stloc.s 55
-			IL_0f9d: ldloc.s 55
-			IL_0f9f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0fa4: dup
-			IL_0fa5: brtrue IL_0fbb
-
-			IL_0faa: pop
-			IL_0fab: ldloc.s 55
-			IL_0fad: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0fb2: dup
-			IL_0fb3: brtrue IL_0fc7
-
+			IL_0f83: ldloc.s 46
+			IL_0f85: stloc.s 68
+			IL_0f87: ldloc.s 68
+			IL_0f89: stloc.s 47
+			IL_0f8b: ldstr "console"
+			IL_0f90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0f95: stloc.s 68
+			IL_0f97: ldloc.s 68
+			IL_0f99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0f9e: stloc.s 68
+			IL_0fa0: ldloc.s 68
+			IL_0fa2: ldstr "log"
+			IL_0fa7: ldloc.s 47
+			IL_0fa9: ldstr "name"
+			IL_0fae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fb3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0fb8: pop
-			IL_0fb9: rethrow
-
-			IL_0fbb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0fc0: stloc.s 56
-			IL_0fc2: br IL_0fc9
-
-			IL_0fc7: stloc.s 56
-
-			IL_0fc9: ldloc.s 56
-			IL_0fcb: stloc.s 81
-			IL_0fcd: ldloc.s 81
-			IL_0fcf: stloc.s 57
-			IL_0fd1: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L130C16::.ctor()
-			IL_0fd6: stloc.s 58
-			IL_0fd8: ldstr "console"
-			IL_0fdd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0fe2: stloc.s 81
-			IL_0fe4: ldloc.s 81
-			IL_0fe6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0feb: stloc.s 81
-			IL_0fed: ldloc.s 81
-			IL_0fef: ldstr "log"
-			IL_0ff4: ldloc.s 57
-			IL_0ff6: ldstr "name"
-			IL_0ffb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1000: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_1005: pop
-			IL_1006: leave IL_100b
+			IL_0fb9: leave IL_0fbe
 		} // end handler
 
-		IL_100b: ldstr "console"
-		IL_1010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_1015: stloc.s 81
-		IL_1017: ldloc.s 81
-		IL_1019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_101e: stloc.s 81
-		IL_1020: ldloc.s 42
-		IL_1022: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_1027: stloc.s 79
-		IL_1029: ldloc.s 79
-		IL_102b: box [System.Runtime]System.Boolean
-		IL_1030: stloc.s 80
-		IL_1032: ldloc.s 42
-		IL_1034: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_1039: box [System.Runtime]System.Double
-		IL_103e: stloc.s 84
-		IL_1040: ldloc.s 81
-		IL_1042: ldstr "log"
-		IL_1047: ldloc.s 80
-		IL_1049: ldloc.s 84
-		IL_104b: ldloc.s 42
-		IL_104d: ldc.r8 0.0
-		IL_1056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_105b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_1060: pop
-		IL_1061: ldc.i4.0
-		IL_1062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_1067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_106c: stloc.s 81
-		IL_106e: ldloc.s 81
-		IL_1070: stloc.s 59
+		IL_0fbe: ldstr "console"
+		IL_0fc3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0fc8: stloc.s 68
+		IL_0fca: ldloc.s 68
+		IL_0fcc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0fd1: stloc.s 68
+		IL_0fd3: ldloc.s 35
+		IL_0fd5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_0fda: stloc.s 66
+		IL_0fdc: ldloc.s 66
+		IL_0fde: box [System.Runtime]System.Boolean
+		IL_0fe3: stloc.s 67
+		IL_0fe5: ldloc.s 35
+		IL_0fe7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0fec: box [System.Runtime]System.Double
+		IL_0ff1: stloc.s 71
+		IL_0ff3: ldloc.s 68
+		IL_0ff5: ldstr "log"
+		IL_0ffa: ldloc.s 67
+		IL_0ffc: ldloc.s 71
+		IL_0ffe: ldloc.s 35
+		IL_1000: ldc.r8 0.0
+		IL_1009: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_100e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_1013: pop
+		IL_1014: ldc.i4.0
+		IL_1015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_101a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_101f: stloc.s 68
+		IL_1021: ldloc.s 68
+		IL_1023: stloc.s 48
 		.try
 		{
-			IL_1072: nop
-			IL_1073: ldloc.s 59
-			IL_1075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_107a: stloc.s 81
-			IL_107c: ldloc.s 81
-			IL_107e: ldstr "push"
-			IL_1083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_1088: pop
-			IL_1089: leave IL_10fe
+			IL_1025: nop
+			IL_1026: ldloc.s 48
+			IL_1028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_102d: stloc.s 68
+			IL_102f: ldloc.s 68
+			IL_1031: ldstr "push"
+			IL_1036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_103b: pop
+			IL_103c: leave IL_10aa
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_108e: stloc.s 60
-			IL_1090: ldloc.s 60
-			IL_1092: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_1097: dup
-			IL_1098: brtrue IL_10ae
+			IL_1041: stloc.s 49
+			IL_1043: ldloc.s 49
+			IL_1045: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_104a: dup
+			IL_104b: brtrue IL_1061
 
-			IL_109d: pop
-			IL_109e: ldloc.s 60
-			IL_10a0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_10a5: dup
-			IL_10a6: brtrue IL_10ba
+			IL_1050: pop
+			IL_1051: ldloc.s 49
+			IL_1053: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_1058: dup
+			IL_1059: brtrue IL_106d
 
-			IL_10ab: pop
-			IL_10ac: rethrow
+			IL_105e: pop
+			IL_105f: rethrow
 
-			IL_10ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_10b3: stloc.s 61
-			IL_10b5: br IL_10bc
+			IL_1061: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1066: stloc.s 50
+			IL_1068: br IL_106f
 
-			IL_10ba: stloc.s 61
+			IL_106d: stloc.s 50
 
-			IL_10bc: ldloc.s 61
-			IL_10be: stloc.s 81
-			IL_10c0: ldloc.s 81
-			IL_10c2: stloc.s 62
-			IL_10c4: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L138C16::.ctor()
-			IL_10c9: stloc.s 63
-			IL_10cb: ldstr "console"
-			IL_10d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_10d5: stloc.s 81
-			IL_10d7: ldloc.s 81
-			IL_10d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_10de: stloc.s 81
-			IL_10e0: ldloc.s 81
-			IL_10e2: ldstr "log"
-			IL_10e7: ldloc.s 62
-			IL_10e9: ldstr "name"
-			IL_10ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_10f8: pop
-			IL_10f9: leave IL_10fe
+			IL_106f: ldloc.s 50
+			IL_1071: stloc.s 68
+			IL_1073: ldloc.s 68
+			IL_1075: stloc.s 51
+			IL_1077: ldstr "console"
+			IL_107c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1081: stloc.s 68
+			IL_1083: ldloc.s 68
+			IL_1085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_108a: stloc.s 68
+			IL_108c: ldloc.s 68
+			IL_108e: ldstr "log"
+			IL_1093: ldloc.s 51
+			IL_1095: ldstr "name"
+			IL_109a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_109f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_10a4: pop
+			IL_10a5: leave IL_10aa
 		} // end handler
 
-		IL_10fe: nop
-		IL_10ff: ldc.i4.2
-		IL_1100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_1105: dup
-		IL_1106: ldc.r8 1
-		IL_110f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1114: dup
-		IL_1115: ldc.r8 2
-		IL_111e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1123: stloc.s 64
-		IL_1125: ldloc.1
-		IL_1126: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_112b: ldloc.s 64
-		IL_112d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1132: pop
-		IL_1133: ldstr "console"
-		IL_1138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_113d: stloc.s 81
-		IL_113f: ldloc.s 81
-		IL_1141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_1146: stloc.s 81
-		IL_1148: ldloc.s 81
-		IL_114a: ldstr "log"
-		IL_114f: ldloc.s 64
-		IL_1151: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_1156: box [System.Runtime]System.Double
-		IL_115b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_1160: pop
-		IL_1161: ldc.i4.2
-		IL_1162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_1167: dup
-		IL_1168: ldc.r8 1
-		IL_1171: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1176: dup
-		IL_1177: ldc.r8 2
-		IL_1180: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1185: stloc.s 65
-		IL_1187: ldloc.s 65
-		IL_1189: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_118e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_1193: stloc.s 88
-		IL_1195: ldloc.s 88
-		IL_1197: stloc.s 66
-		IL_1199: ldloc.s 66
-		IL_119b: ldstr "length"
-		IL_11a0: ldc.r8 1
-		IL_11a9: ldc.i4.1
-		IL_11aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_10aa: nop
+		IL_10ab: ldc.i4.2
+		IL_10ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_10b1: dup
+		IL_10b2: ldc.r8 1
+		IL_10bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_10c0: dup
+		IL_10c1: ldc.r8 2
+		IL_10ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_10cf: stloc.s 52
+		IL_10d1: ldloc.1
+		IL_10d2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_10d7: ldloc.s 52
+		IL_10d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_10de: pop
+		IL_10df: ldstr "console"
+		IL_10e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_10e9: stloc.s 68
+		IL_10eb: ldloc.s 68
+		IL_10ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_10f2: stloc.s 68
+		IL_10f4: ldloc.s 68
+		IL_10f6: ldstr "log"
+		IL_10fb: ldloc.s 52
+		IL_10fd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_1102: box [System.Runtime]System.Double
+		IL_1107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_110c: pop
+		IL_110d: ldc.i4.2
+		IL_110e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1113: dup
+		IL_1114: ldc.r8 1
+		IL_111d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1122: dup
+		IL_1123: ldc.r8 2
+		IL_112c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1131: stloc.s 53
+		IL_1133: ldloc.s 53
+		IL_1135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_113a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_113f: stloc.s 75
+		IL_1141: ldloc.s 75
+		IL_1143: stloc.s 54
+		IL_1145: ldloc.s 54
+		IL_1147: ldstr "length"
+		IL_114c: ldc.r8 1
+		IL_1155: ldc.i4.1
+		IL_1156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_115b: pop
+		IL_115c: ldstr "console"
+		IL_1161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_1166: stloc.s 68
+		IL_1168: ldloc.s 68
+		IL_116a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_116f: stloc.s 68
+		IL_1171: ldloc.s 53
+		IL_1173: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_1178: box [System.Runtime]System.Double
+		IL_117d: stloc.s 71
+		IL_117f: ldc.r8 1
+		IL_1188: box [System.Runtime]System.Double
+		IL_118d: ldloc.s 53
+		IL_118f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_1194: stloc.s 66
+		IL_1196: ldloc.s 66
+		IL_1198: box [System.Runtime]System.Boolean
+		IL_119d: stloc.s 67
+		IL_119f: ldloc.s 68
+		IL_11a1: ldstr "log"
+		IL_11a6: ldloc.s 71
+		IL_11a8: ldloc.s 67
+		IL_11aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_11af: pop
-		IL_11b0: ldstr "console"
-		IL_11b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_11ba: stloc.s 81
-		IL_11bc: ldloc.s 81
-		IL_11be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_11c3: stloc.s 81
-		IL_11c5: ldloc.s 65
-		IL_11c7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_11cc: box [System.Runtime]System.Double
-		IL_11d1: stloc.s 84
-		IL_11d3: ldc.r8 1
-		IL_11dc: box [System.Runtime]System.Double
-		IL_11e1: ldloc.s 65
-		IL_11e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_11e8: stloc.s 79
-		IL_11ea: ldloc.s 79
-		IL_11ec: box [System.Runtime]System.Boolean
-		IL_11f1: stloc.s 80
-		IL_11f3: ldloc.s 81
-		IL_11f5: ldstr "log"
-		IL_11fa: ldloc.s 84
-		IL_11fc: ldloc.s 80
-		IL_11fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_1203: pop
-		IL_1204: ldc.i4.3
-		IL_1205: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_120a: dup
-		IL_120b: ldc.r8 0.0
-		IL_1214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1219: dup
-		IL_121a: ldc.r8 1
-		IL_1223: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1228: dup
-		IL_1229: ldc.r8 2
-		IL_1232: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1237: stloc.s 67
-		IL_1239: ldloc.s 67
-		IL_123b: ldstr "2"
-		IL_1240: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_1245: dup
-		IL_1246: ldstr "configurable"
-		IL_124b: ldc.i4.0
-		IL_124c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_1251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_1256: pop
-		IL_1257: ldloc.s 67
-		IL_1259: ldc.r8 1
-		IL_1262: box [System.Runtime]System.Double
-		IL_1267: ldc.r8 1
-		IL_1270: box [System.Runtime]System.Double
-		IL_1275: ldc.r8 9
-		IL_127e: box [System.Runtime]System.Double
-		IL_1283: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
-		IL_1288: stloc.s 89
-		IL_128a: ldloc.s 89
-		IL_128c: stloc.s 68
-		IL_128e: ldstr "console"
-		IL_1293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_1298: stloc.s 81
-		IL_129a: ldloc.s 81
-		IL_129c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_12a1: stloc.s 81
-		IL_12a3: ldloc.s 67
-		IL_12a5: ldc.i4.1
-		IL_12a6: newarr [System.Runtime]System.Object
-		IL_12ab: dup
-		IL_12ac: ldc.i4.0
-		IL_12ad: ldstr ","
-		IL_12b2: stelem.ref
-		IL_12b3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_12b8: stloc.s 87
-		IL_12ba: ldloc.s 68
-		IL_12bc: ldc.i4.1
-		IL_12bd: newarr [System.Runtime]System.Object
-		IL_12c2: dup
-		IL_12c3: ldc.i4.0
-		IL_12c4: ldstr ","
-		IL_12c9: stelem.ref
-		IL_12ca: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_12cf: stloc.s 90
-		IL_12d1: ldloc.s 81
-		IL_12d3: ldstr "log"
-		IL_12d8: ldloc.s 87
-		IL_12da: ldloc.s 90
-		IL_12dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_12e1: pop
-		IL_12e2: ldc.i4.0
-		IL_12e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_12e8: stloc.s 69
-		IL_12ea: ldloc.s 69
-		IL_12ec: ldc.r8 3
-		IL_12f5: ldc.i4.1
-		IL_12f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-		IL_12fb: ldstr "console"
-		IL_1300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_1305: stloc.s 81
-		IL_1307: ldloc.s 81
-		IL_1309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_130e: stloc.s 81
-		IL_1310: ldloc.s 69
-		IL_1312: ldstr "x"
-		IL_1317: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
-		IL_131c: stloc.s 91
-		IL_131e: ldloc.s 91
-		IL_1320: box [System.Runtime]System.Double
-		IL_1325: stloc.s 84
-		IL_1327: ldloc.s 69
-		IL_1329: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_132e: box [System.Runtime]System.Double
-		IL_1333: stloc.s 92
-		IL_1335: ldc.r8 0.0
-		IL_133e: box [System.Runtime]System.Double
-		IL_1343: ldloc.s 69
-		IL_1345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_134a: stloc.s 79
-		IL_134c: ldloc.s 79
-		IL_134e: box [System.Runtime]System.Boolean
-		IL_1353: stloc.s 80
-		IL_1355: ldc.r8 3
-		IL_135e: box [System.Runtime]System.Double
-		IL_1363: ldloc.s 69
-		IL_1365: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_136a: stloc.s 79
-		IL_136c: ldloc.s 79
-		IL_136e: box [System.Runtime]System.Boolean
-		IL_1373: stloc.s 85
-		IL_1375: ldc.i4.4
-		IL_1376: newarr [System.Runtime]System.Object
-		IL_137b: dup
+		IL_11b0: ldc.i4.3
+		IL_11b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_11b6: dup
+		IL_11b7: ldc.r8 0.0
+		IL_11c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_11c5: dup
+		IL_11c6: ldc.r8 1
+		IL_11cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_11d4: dup
+		IL_11d5: ldc.r8 2
+		IL_11de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_11e3: stloc.s 55
+		IL_11e5: ldloc.s 55
+		IL_11e7: ldstr "2"
+		IL_11ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_11f1: dup
+		IL_11f2: ldstr "configurable"
+		IL_11f7: ldc.i4.0
+		IL_11f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_11fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_1202: pop
+		IL_1203: ldloc.s 55
+		IL_1205: ldc.r8 1
+		IL_120e: box [System.Runtime]System.Double
+		IL_1213: ldc.r8 1
+		IL_121c: box [System.Runtime]System.Double
+		IL_1221: ldc.r8 9
+		IL_122a: box [System.Runtime]System.Double
+		IL_122f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
+		IL_1234: stloc.s 76
+		IL_1236: ldloc.s 76
+		IL_1238: stloc.s 56
+		IL_123a: ldstr "console"
+		IL_123f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_1244: stloc.s 68
+		IL_1246: ldloc.s 68
+		IL_1248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_124d: stloc.s 68
+		IL_124f: ldloc.s 55
+		IL_1251: ldc.i4.1
+		IL_1252: newarr [System.Runtime]System.Object
+		IL_1257: dup
+		IL_1258: ldc.i4.0
+		IL_1259: ldstr ","
+		IL_125e: stelem.ref
+		IL_125f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_1264: stloc.s 74
+		IL_1266: ldloc.s 56
+		IL_1268: ldc.i4.1
+		IL_1269: newarr [System.Runtime]System.Object
+		IL_126e: dup
+		IL_126f: ldc.i4.0
+		IL_1270: ldstr ","
+		IL_1275: stelem.ref
+		IL_1276: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_127b: stloc.s 77
+		IL_127d: ldloc.s 68
+		IL_127f: ldstr "log"
+		IL_1284: ldloc.s 74
+		IL_1286: ldloc.s 77
+		IL_1288: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_128d: pop
+		IL_128e: ldc.i4.0
+		IL_128f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1294: stloc.s 57
+		IL_1296: ldloc.s 57
+		IL_1298: ldc.r8 3
+		IL_12a1: ldc.i4.1
+		IL_12a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_12a7: ldstr "console"
+		IL_12ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_12b1: stloc.s 68
+		IL_12b3: ldloc.s 68
+		IL_12b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_12ba: stloc.s 68
+		IL_12bc: ldloc.s 57
+		IL_12be: ldstr "x"
+		IL_12c3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
+		IL_12c8: stloc.s 78
+		IL_12ca: ldloc.s 78
+		IL_12cc: box [System.Runtime]System.Double
+		IL_12d1: stloc.s 71
+		IL_12d3: ldloc.s 57
+		IL_12d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_12da: box [System.Runtime]System.Double
+		IL_12df: stloc.s 79
+		IL_12e1: ldc.r8 0.0
+		IL_12ea: box [System.Runtime]System.Double
+		IL_12ef: ldloc.s 57
+		IL_12f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_12f6: stloc.s 66
+		IL_12f8: ldloc.s 66
+		IL_12fa: box [System.Runtime]System.Boolean
+		IL_12ff: stloc.s 67
+		IL_1301: ldc.r8 3
+		IL_130a: box [System.Runtime]System.Double
+		IL_130f: ldloc.s 57
+		IL_1311: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_1316: stloc.s 66
+		IL_1318: ldloc.s 66
+		IL_131a: box [System.Runtime]System.Boolean
+		IL_131f: stloc.s 72
+		IL_1321: ldc.i4.4
+		IL_1322: newarr [System.Runtime]System.Object
+		IL_1327: dup
+		IL_1328: ldc.i4.0
+		IL_1329: ldloc.s 71
+		IL_132b: stelem.ref
+		IL_132c: dup
+		IL_132d: ldc.i4.1
+		IL_132e: ldloc.s 79
+		IL_1330: stelem.ref
+		IL_1331: dup
+		IL_1332: ldc.i4.2
+		IL_1333: ldloc.s 67
+		IL_1335: stelem.ref
+		IL_1336: dup
+		IL_1337: ldc.i4.3
+		IL_1338: ldloc.s 72
+		IL_133a: stelem.ref
+		IL_133b: stloc.s 73
+		IL_133d: ldloc.s 68
+		IL_133f: ldstr "log"
+		IL_1344: ldloc.s 73
+		IL_1346: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+		IL_134b: pop
+		IL_134c: ldloc.0
+		IL_134d: ldc.r8 0.0
+		IL_1356: box [System.Runtime]System.Double
+		IL_135b: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
+		IL_1360: ldc.i4.1
+		IL_1361: newarr [System.Runtime]System.Object
+		IL_1366: dup
+		IL_1367: ldc.i4.0
+		IL_1368: ldloc.0
+		IL_1369: stelem.ref
+		IL_136a: ldc.i4.0
+		IL_136b: ldelem.ref
+		IL_136c: castclass Modules.Array_Exotic_Property_Descriptors/Scope
+		IL_1371: ldftn object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
+		IL_1377: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_137c: ldc.i4.0
-		IL_137d: ldloc.s 84
-		IL_137f: stelem.ref
-		IL_1380: dup
-		IL_1381: ldc.i4.1
-		IL_1382: ldloc.s 92
-		IL_1384: stelem.ref
-		IL_1385: dup
-		IL_1386: ldc.i4.2
-		IL_1387: ldloc.s 80
-		IL_1389: stelem.ref
-		IL_138a: dup
-		IL_138b: ldc.i4.3
-		IL_138c: ldloc.s 85
-		IL_138e: stelem.ref
-		IL_138f: stloc.s 86
-		IL_1391: ldloc.s 81
-		IL_1393: ldstr "log"
-		IL_1398: ldloc.s 86
-		IL_139a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_139f: pop
-		IL_13a0: ldloc.0
-		IL_13a1: ldc.r8 0.0
-		IL_13aa: box [System.Runtime]System.Double
-		IL_13af: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
-		IL_13b4: ldc.i4.1
-		IL_13b5: newarr [System.Runtime]System.Object
-		IL_13ba: dup
-		IL_13bb: ldc.i4.0
-		IL_13bc: ldloc.0
-		IL_13bd: stelem.ref
-		IL_13be: ldc.i4.0
-		IL_13bf: ldelem.ref
-		IL_13c0: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_13c5: ldftn object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
-		IL_13cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_13d0: ldc.i4.0
-		IL_13d1: conv.r8
-		IL_13d2: ldstr ""
-		IL_13d7: ldc.i4.0
-		IL_13d8: ldc.i4.1
-		IL_13d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_13de: stloc.s 81
-		IL_13e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_13e5: dup
-		IL_13e6: ldstr "toString"
-		IL_13eb: ldloc.s 81
-		IL_13ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_13f2: stloc.s 83
-		IL_13f4: ldloc.s 83
-		IL_13f6: stloc.s 70
+		IL_137d: conv.r8
+		IL_137e: ldstr ""
+		IL_1383: ldc.i4.0
+		IL_1384: ldc.i4.1
+		IL_1385: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_138a: stloc.s 68
+		IL_138c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_1391: dup
+		IL_1392: ldstr "toString"
+		IL_1397: ldloc.s 68
+		IL_1399: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_139e: stloc.s 70
+		IL_13a0: ldloc.s 70
+		IL_13a2: stloc.s 58
 		.try
 		{
-			IL_13f8: nop
-			IL_13f9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_13fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-			IL_1403: stloc.s 81
-			IL_1405: ldloc.s 81
-			IL_1407: ldloc.s 70
-			IL_1409: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_140e: dup
-			IL_140f: ldstr "value"
-			IL_1414: ldc.r8 1
-			IL_141d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_1422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_1427: pop
-			IL_1428: leave IL_14a7
+			IL_13a4: nop
+			IL_13a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_13aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+			IL_13af: stloc.s 68
+			IL_13b1: ldloc.s 68
+			IL_13b3: ldloc.s 58
+			IL_13b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_13ba: dup
+			IL_13bb: ldstr "value"
+			IL_13c0: ldc.r8 1
+			IL_13c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_13ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_13d3: pop
+			IL_13d4: leave IL_144c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_142d: stloc.s 71
-			IL_142f: ldloc.s 71
-			IL_1431: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_1436: dup
-			IL_1437: brtrue IL_144d
+			IL_13d9: stloc.s 59
+			IL_13db: ldloc.s 59
+			IL_13dd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_13e2: dup
+			IL_13e3: brtrue IL_13f9
 
-			IL_143c: pop
-			IL_143d: ldloc.s 71
-			IL_143f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_1444: dup
-			IL_1445: brtrue IL_1459
+			IL_13e8: pop
+			IL_13e9: ldloc.s 59
+			IL_13eb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_13f0: dup
+			IL_13f1: brtrue IL_1405
 
-			IL_144a: pop
-			IL_144b: rethrow
+			IL_13f6: pop
+			IL_13f7: rethrow
 
-			IL_144d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_1452: stloc.s 72
-			IL_1454: br IL_145b
+			IL_13f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_13fe: stloc.s 60
+			IL_1400: br IL_1407
 
-			IL_1459: stloc.s 72
+			IL_1405: stloc.s 60
 
-			IL_145b: ldloc.s 72
-			IL_145d: stloc.s 81
-			IL_145f: ldloc.s 81
-			IL_1461: stloc.s 73
-			IL_1463: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope/Block_L172C16::.ctor()
-			IL_1468: stloc.s 74
-			IL_146a: ldstr "console"
-			IL_146f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1474: stloc.s 81
-			IL_1476: ldloc.s 81
-			IL_1478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_147d: stloc.s 81
-			IL_147f: ldloc.s 73
-			IL_1481: ldstr "name"
-			IL_1486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_148b: stloc.s 82
-			IL_148d: ldloc.s 81
-			IL_148f: ldstr "log"
-			IL_1494: ldloc.s 82
-			IL_1496: ldloc.0
-			IL_1497: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
-			IL_149c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_14a1: pop
-			IL_14a2: leave IL_14a7
+			IL_1407: ldloc.s 60
+			IL_1409: stloc.s 68
+			IL_140b: ldloc.s 68
+			IL_140d: stloc.s 61
+			IL_140f: ldstr "console"
+			IL_1414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1419: stloc.s 68
+			IL_141b: ldloc.s 68
+			IL_141d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1422: stloc.s 68
+			IL_1424: ldloc.s 61
+			IL_1426: ldstr "name"
+			IL_142b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1430: stloc.s 69
+			IL_1432: ldloc.s 68
+			IL_1434: ldstr "log"
+			IL_1439: ldloc.s 69
+			IL_143b: ldloc.0
+			IL_143c: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
+			IL_1441: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_1446: pop
+			IL_1447: leave IL_144c
 		} // end handler
 
-		IL_14a7: ldc.i4.0
-		IL_14a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_14ad: stloc.s 75
-		IL_14af: ldloc.s 75
-		IL_14b1: ldstr "01"
-		IL_14b6: ldstr "ordinary"
-		IL_14bb: ldc.i4.1
-		IL_14bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_14c1: pop
-		IL_14c2: ldstr "console"
-		IL_14c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_14cc: stloc.s 82
-		IL_14ce: ldloc.s 82
-		IL_14d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_14d5: stloc.s 82
-		IL_14d7: ldloc.s 75
-		IL_14d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_14de: box [System.Runtime]System.Double
-		IL_14e3: stloc.s 92
-		IL_14e5: ldloc.s 82
-		IL_14e7: ldstr "log"
-		IL_14ec: ldloc.s 92
-		IL_14ee: ldloc.s 75
-		IL_14f0: ldstr "01"
-		IL_14f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_14fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_14ff: pop
-		IL_1500: ldnull
-		IL_1501: stloc.s 76
-		IL_1503: ret
+		IL_144c: ldc.i4.0
+		IL_144d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1452: stloc.s 62
+		IL_1454: ldloc.s 62
+		IL_1456: ldstr "01"
+		IL_145b: ldstr "ordinary"
+		IL_1460: ldc.i4.1
+		IL_1461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_1466: pop
+		IL_1467: ldstr "console"
+		IL_146c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_1471: stloc.s 69
+		IL_1473: ldloc.s 69
+		IL_1475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_147a: stloc.s 69
+		IL_147c: ldloc.s 62
+		IL_147e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_1483: box [System.Runtime]System.Double
+		IL_1488: stloc.s 79
+		IL_148a: ldloc.s 69
+		IL_148c: ldstr "log"
+		IL_1491: ldloc.s 79
+		IL_1493: ldloc.s 62
+		IL_1495: ldstr "01"
+		IL_149a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_149f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_14a4: pop
+		IL_14a5: ldnull
+		IL_14a6: stloc.s 63
+		IL_14a8: ret
 	} // end of method Array_Exotic_Property_Descriptors::__js_module_init__
 
 } // end of class Modules.Array_Exotic_Property_Descriptors
@@ -2663,7 +2624,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3777
+		// Method begins at RVA 0x371f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Length_Set_Fractional_ThrowsRangeError.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Length_Set_Fractional_ThrowsRangeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2189
+				// Method begins at RVA 0x2181
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2192
+				// Method begins at RVA 0x218a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2180
+			// Method begins at RVA 0x2178
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 275 (0x113)
+		// Code size: 268 (0x10c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Length_Set_Fractional_ThrowsRangeError/Scope,
@@ -90,9 +90,8 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Array_Length_Set_Fractional_ThrowsRangeError/Scope/Block_L8C12,
-			[6] object,
-			[7] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Array_Length_Set_Fractional_ThrowsRangeError/Scope::.ctor()
@@ -119,16 +118,16 @@
 			IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
 			IL_004c: ldstr "console"
 			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0056: stloc.s 7
-			IL_0058: ldloc.s 7
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 6
 			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005f: stloc.s 7
-			IL_0061: ldloc.s 7
+			IL_005f: stloc.s 6
+			IL_0061: ldloc.s 6
 			IL_0063: ldstr "log"
 			IL_0068: ldstr "no-throw"
 			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0072: pop
-			IL_0073: leave IL_00e2
+			IL_0073: leave IL_00db
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -154,43 +153,41 @@
 			IL_00a0: stloc.3
 
 			IL_00a1: ldloc.3
-			IL_00a2: stloc.s 7
-			IL_00a4: ldloc.s 7
+			IL_00a2: stloc.s 6
+			IL_00a4: ldloc.s 6
 			IL_00a6: stloc.s 4
-			IL_00a8: newobj instance void Modules.Array_Length_Set_Fractional_ThrowsRangeError/Scope/Block_L8C12::.ctor()
-			IL_00ad: stloc.s 5
-			IL_00af: ldstr "console"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b9: stloc.s 7
-			IL_00bb: ldloc.s 7
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c2: stloc.s 7
-			IL_00c4: ldloc.s 7
-			IL_00c6: ldstr "log"
-			IL_00cb: ldloc.s 4
-			IL_00cd: ldstr "name"
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00dc: pop
-			IL_00dd: leave IL_00e2
+			IL_00a8: ldstr "console"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b2: stloc.s 6
+			IL_00b4: ldloc.s 6
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bb: stloc.s 6
+			IL_00bd: ldloc.s 6
+			IL_00bf: ldstr "log"
+			IL_00c4: ldloc.s 4
+			IL_00c6: ldstr "name"
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d5: pop
+			IL_00d6: leave IL_00db
 		} // end handler
 
-		IL_00e2: ldstr "console"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ec: stloc.s 7
-		IL_00ee: ldloc.s 7
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f5: stloc.s 7
-		IL_00f7: ldloc.s 7
-		IL_00f9: ldstr "log"
-		IL_00fe: ldloc.1
-		IL_00ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0104: box [System.Runtime]System.Double
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010e: pop
-		IL_010f: ldnull
-		IL_0110: stloc.s 6
-		IL_0112: ret
+		IL_00db: ldstr "console"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e5: stloc.s 6
+		IL_00e7: ldloc.s 6
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ee: stloc.s 6
+		IL_00f0: ldloc.s 6
+		IL_00f2: ldstr "log"
+		IL_00f7: ldloc.1
+		IL_00f8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_00fd: box [System.Runtime]System.Double
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0107: pop
+		IL_0108: ldnull
+		IL_0109: stloc.s 5
+		IL_010b: ret
 	} // end of method Array_Length_Set_Fractional_ThrowsRangeError::__js_module_init__
 
 } // end of class Modules.Array_Length_Set_Fractional_ThrowsRangeError
@@ -202,7 +199,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219b
+		// Method begins at RVA 0x2193
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b53
+				// Method begins at RVA 0x2b37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x29fc
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5c
+				// Method begins at RVA 0x2b40
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,7 +111,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a34
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -148,7 +148,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b65
+				// Method begins at RVA 0x2b49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2a88
+			// Method begins at RVA 0x2a6c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -213,7 +213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6e
+				// Method begins at RVA 0x2b52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -241,7 +241,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2ac0
+			// Method begins at RVA 0x2aa4
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -278,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b80
+				// Method begins at RVA 0x2b64
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2af8
+			// Method begins at RVA 0x2adc
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -332,7 +332,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b9b
+				// Method begins at RVA 0x2b7f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -357,7 +357,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b10
+			// Method begins at RVA 0x2af4
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -390,7 +390,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2f
+				// Method begins at RVA 0x2b13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,7 +410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b38
+				// Method begins at RVA 0x2b1c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -430,7 +430,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b41
+				// Method begins at RVA 0x2b25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -450,7 +450,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4a
+				// Method begins at RVA 0x2b2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -470,7 +470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b77
+				// Method begins at RVA 0x2b5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -490,7 +490,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b89
+				// Method begins at RVA 0x2b6d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -510,7 +510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b92
+				// Method begins at RVA 0x2b76
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -530,7 +530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ba4
+				// Method begins at RVA 0x2b88
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +551,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b26
+			// Method begins at RVA 0x2b0a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -577,7 +577,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2438 (0x986)
+		// Code size: 2410 (0x96a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope,
@@ -585,29 +585,25 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L8C12,
-			[6] class [System.Runtime]System.Exception,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L15C12,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[9] object,
+			[10] object,
 			[11] object,
 			[12] object,
-			[13] object,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[16] class [System.Runtime]System.Exception,
-			[17] object,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[14] class [System.Runtime]System.Exception,
+			[15] object,
+			[16] object,
+			[17] class [System.Runtime]System.Exception,
 			[18] object,
-			[19] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L61C12,
-			[20] class [System.Runtime]System.Exception,
+			[19] object,
+			[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[21] object,
 			[22] object,
-			[23] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L70C12,
-			[24] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[25] object,
-			[26] object,
-			[27] object
+			[23] object
 		)
 
 		IL_0000: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::.ctor()
@@ -624,35 +620,35 @@
 			IL_0021: nop
 			IL_0022: ldstr "Array"
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_002c: stloc.s 26
-			IL_002e: ldloc.s 26
+			IL_002c: stloc.s 22
+			IL_002e: ldloc.s 22
 			IL_0030: ldstr "prototype"
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003a: stloc.s 26
-			IL_003c: ldloc.s 26
+			IL_003a: stloc.s 22
+			IL_003c: ldloc.s 22
 			IL_003e: ldstr "reduce"
 			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0048: stloc.s 26
-			IL_004a: ldloc.s 26
+			IL_0048: stloc.s 22
+			IL_004a: ldloc.s 22
 			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0051: stloc.s 26
-			IL_0053: ldloc.s 26
+			IL_0051: stloc.s 22
+			IL_0053: ldloc.s 22
 			IL_0055: ldstr "call"
 			IL_005a: ldloc.1
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0060: pop
 			IL_0061: ldstr "console"
 			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006b: stloc.s 26
-			IL_006d: ldloc.s 26
+			IL_006b: stloc.s 22
+			IL_006d: ldloc.s 22
 			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0074: stloc.s 26
-			IL_0076: ldloc.s 26
+			IL_0074: stloc.s 22
+			IL_0076: ldloc.s 22
 			IL_0078: ldstr "log"
 			IL_007d: ldstr "no-throw"
 			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0087: pop
-			IL_0088: leave IL_00f7
+			IL_0088: leave IL_00f0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -678,724 +674,716 @@
 			IL_00b5: stloc.3
 
 			IL_00b6: ldloc.3
-			IL_00b7: stloc.s 26
-			IL_00b9: ldloc.s 26
+			IL_00b7: stloc.s 22
+			IL_00b9: ldloc.s 22
 			IL_00bb: stloc.s 4
-			IL_00bd: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L8C12::.ctor()
-			IL_00c2: stloc.s 5
-			IL_00c4: ldstr "console"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ce: stloc.s 26
-			IL_00d0: ldloc.s 26
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d7: stloc.s 26
-			IL_00d9: ldloc.s 26
-			IL_00db: ldstr "log"
-			IL_00e0: ldloc.s 4
-			IL_00e2: ldstr "name"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f1: pop
-			IL_00f2: leave IL_00f7
+			IL_00bd: ldstr "console"
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c7: stloc.s 22
+			IL_00c9: ldloc.s 22
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d0: stloc.s 22
+			IL_00d2: ldloc.s 22
+			IL_00d4: ldstr "log"
+			IL_00d9: ldloc.s 4
+			IL_00db: ldstr "name"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ea: pop
+			IL_00eb: leave IL_00f0
 		} // end handler
 		.try
 		{
-			IL_00f7: nop
-			IL_00f8: ldstr "Array"
-			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0102: stloc.s 26
-			IL_0104: ldloc.s 26
-			IL_0106: ldstr "prototype"
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0110: stloc.s 26
-			IL_0112: ldloc.s 26
-			IL_0114: ldstr "reduceRight"
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_011e: stloc.s 26
-			IL_0120: ldloc.s 26
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0127: stloc.s 26
-			IL_0129: ldloc.s 26
-			IL_012b: ldstr "call"
-			IL_0130: ldloc.1
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0136: pop
-			IL_0137: ldstr "console"
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0141: stloc.s 26
-			IL_0143: ldloc.s 26
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014a: stloc.s 26
-			IL_014c: ldloc.s 26
-			IL_014e: ldstr "log"
-			IL_0153: ldstr "no-throw"
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_015d: pop
-			IL_015e: leave IL_01d3
+			IL_00f0: nop
+			IL_00f1: ldstr "Array"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fb: stloc.s 22
+			IL_00fd: ldloc.s 22
+			IL_00ff: ldstr "prototype"
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0109: stloc.s 22
+			IL_010b: ldloc.s 22
+			IL_010d: ldstr "reduceRight"
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0117: stloc.s 22
+			IL_0119: ldloc.s 22
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0120: stloc.s 22
+			IL_0122: ldloc.s 22
+			IL_0124: ldstr "call"
+			IL_0129: ldloc.1
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_012f: pop
+			IL_0130: ldstr "console"
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013a: stloc.s 22
+			IL_013c: ldloc.s 22
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0143: stloc.s 22
+			IL_0145: ldloc.s 22
+			IL_0147: ldstr "log"
+			IL_014c: ldstr "no-throw"
+			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0156: pop
+			IL_0157: leave IL_01c5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0163: stloc.s 6
-			IL_0165: ldloc.s 6
-			IL_0167: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_016c: dup
-			IL_016d: brtrue IL_0183
+			IL_015c: stloc.s 5
+			IL_015e: ldloc.s 5
+			IL_0160: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0165: dup
+			IL_0166: brtrue IL_017c
 
-			IL_0172: pop
-			IL_0173: ldloc.s 6
-			IL_0175: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_017a: dup
-			IL_017b: brtrue IL_018f
+			IL_016b: pop
+			IL_016c: ldloc.s 5
+			IL_016e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0173: dup
+			IL_0174: brtrue IL_0188
 
-			IL_0180: pop
-			IL_0181: rethrow
+			IL_0179: pop
+			IL_017a: rethrow
 
-			IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0188: stloc.s 7
-			IL_018a: br IL_0191
+			IL_017c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0181: stloc.s 6
+			IL_0183: br IL_018a
 
-			IL_018f: stloc.s 7
+			IL_0188: stloc.s 6
 
-			IL_0191: ldloc.s 7
-			IL_0193: stloc.s 26
-			IL_0195: ldloc.s 26
-			IL_0197: stloc.s 8
-			IL_0199: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L15C12::.ctor()
-			IL_019e: stloc.s 9
-			IL_01a0: ldstr "console"
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01aa: stloc.s 26
-			IL_01ac: ldloc.s 26
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b3: stloc.s 26
-			IL_01b5: ldloc.s 26
-			IL_01b7: ldstr "log"
-			IL_01bc: ldloc.s 8
-			IL_01be: ldstr "name"
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01cd: pop
-			IL_01ce: leave IL_01d3
+			IL_018a: ldloc.s 6
+			IL_018c: stloc.s 22
+			IL_018e: ldloc.s 22
+			IL_0190: stloc.s 7
+			IL_0192: ldstr "console"
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_019c: stloc.s 22
+			IL_019e: ldloc.s 22
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a5: stloc.s 22
+			IL_01a7: ldloc.s 22
+			IL_01a9: ldstr "log"
+			IL_01ae: ldloc.s 7
+			IL_01b0: ldstr "name"
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01bf: pop
+			IL_01c0: leave IL_01c5
 		} // end handler
 
-		IL_01d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01d8: dup
-		IL_01d9: ldstr "length"
-		IL_01de: ldc.r8 3
-		IL_01e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_01ec: dup
-		IL_01ed: ldstr "1"
-		IL_01f2: ldstr "b"
-		IL_01f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01fc: stloc.s 10
-		IL_01fe: ldloc.0
-		IL_01ff: ldc.r8 0.0
-		IL_0208: box [System.Runtime]System.Double
-		IL_020d: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0212: ldstr "Array"
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021c: stloc.s 26
-		IL_021e: ldloc.s 26
-		IL_0220: ldstr "prototype"
+		IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01ca: dup
+		IL_01cb: ldstr "length"
+		IL_01d0: ldc.r8 3
+		IL_01d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01de: dup
+		IL_01df: ldstr "1"
+		IL_01e4: ldstr "b"
+		IL_01e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01ee: stloc.s 8
+		IL_01f0: ldloc.0
+		IL_01f1: ldc.r8 0.0
+		IL_01fa: box [System.Runtime]System.Double
+		IL_01ff: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0204: ldstr "Array"
+		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_020e: stloc.s 22
+		IL_0210: ldloc.s 22
+		IL_0212: ldstr "prototype"
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021c: stloc.s 22
+		IL_021e: ldloc.s 22
+		IL_0220: ldstr "reduce"
 		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022a: stloc.s 26
-		IL_022c: ldloc.s 26
-		IL_022e: ldstr "reduce"
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0238: stloc.s 26
-		IL_023a: ldloc.s 26
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0241: stloc.s 26
-		IL_0243: ldc.i4.1
-		IL_0244: newarr [System.Runtime]System.Object
-		IL_0249: dup
-		IL_024a: ldc.i4.0
-		IL_024b: ldloc.0
-		IL_024c: stelem.ref
-		IL_024d: ldc.i4.0
-		IL_024e: ldelem.ref
-		IL_024f: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_0254: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_025a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_025f: ldc.i4.2
-		IL_0260: conv.r8
-		IL_0261: ldstr ""
-		IL_0266: ldc.i4.0
-		IL_0267: ldc.i4.1
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_026d: stloc.s 27
-		IL_026f: ldloc.s 26
-		IL_0271: ldstr "call"
-		IL_0276: ldloc.s 10
-		IL_0278: ldloc.s 27
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_027f: stloc.s 27
-		IL_0281: ldloc.s 27
-		IL_0283: stloc.s 11
-		IL_0285: ldstr "console"
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028f: stloc.s 27
-		IL_0291: ldloc.s 27
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0298: stloc.s 27
-		IL_029a: ldloc.s 27
-		IL_029c: ldstr "log"
-		IL_02a1: ldloc.s 11
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02a8: pop
-		IL_02a9: ldstr "console"
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02b3: stloc.s 27
-		IL_02b5: ldloc.s 27
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bc: stloc.s 27
-		IL_02be: ldloc.s 27
-		IL_02c0: ldstr "log"
-		IL_02c5: ldloc.0
-		IL_02c6: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02d0: pop
-		IL_02d1: ldloc.0
-		IL_02d2: ldc.r8 0.0
-		IL_02db: box [System.Runtime]System.Double
-		IL_02e0: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_02e5: ldstr "Array"
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ef: stloc.s 27
-		IL_02f1: ldloc.s 27
-		IL_02f3: ldstr "prototype"
+		IL_022a: stloc.s 22
+		IL_022c: ldloc.s 22
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0233: stloc.s 22
+		IL_0235: ldc.i4.1
+		IL_0236: newarr [System.Runtime]System.Object
+		IL_023b: dup
+		IL_023c: ldc.i4.0
+		IL_023d: ldloc.0
+		IL_023e: stelem.ref
+		IL_023f: ldc.i4.0
+		IL_0240: ldelem.ref
+		IL_0241: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_0246: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+		IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0251: ldc.i4.2
+		IL_0252: conv.r8
+		IL_0253: ldstr ""
+		IL_0258: ldc.i4.0
+		IL_0259: ldc.i4.1
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_025f: stloc.s 23
+		IL_0261: ldloc.s 22
+		IL_0263: ldstr "call"
+		IL_0268: ldloc.s 8
+		IL_026a: ldloc.s 23
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0271: stloc.s 23
+		IL_0273: ldloc.s 23
+		IL_0275: stloc.s 9
+		IL_0277: ldstr "console"
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0281: stloc.s 23
+		IL_0283: ldloc.s 23
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028a: stloc.s 23
+		IL_028c: ldloc.s 23
+		IL_028e: ldstr "log"
+		IL_0293: ldloc.s 9
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_029a: pop
+		IL_029b: ldstr "console"
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a5: stloc.s 23
+		IL_02a7: ldloc.s 23
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ae: stloc.s 23
+		IL_02b0: ldloc.s 23
+		IL_02b2: ldstr "log"
+		IL_02b7: ldloc.0
+		IL_02b8: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02c2: pop
+		IL_02c3: ldloc.0
+		IL_02c4: ldc.r8 0.0
+		IL_02cd: box [System.Runtime]System.Double
+		IL_02d2: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_02d7: ldstr "Array"
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e1: stloc.s 23
+		IL_02e3: ldloc.s 23
+		IL_02e5: ldstr "prototype"
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ef: stloc.s 23
+		IL_02f1: ldloc.s 23
+		IL_02f3: ldstr "reduce"
 		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fd: stloc.s 27
-		IL_02ff: ldloc.s 27
-		IL_0301: ldstr "reduce"
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030b: stloc.s 27
-		IL_030d: ldloc.s 27
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0314: stloc.s 27
-		IL_0316: ldc.i4.1
-		IL_0317: newarr [System.Runtime]System.Object
-		IL_031c: dup
-		IL_031d: ldc.i4.0
-		IL_031e: ldloc.0
-		IL_031f: stelem.ref
-		IL_0320: ldc.i4.0
-		IL_0321: ldelem.ref
-		IL_0322: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_0327: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_032d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0332: ldc.i4.2
-		IL_0333: conv.r8
-		IL_0334: ldstr ""
-		IL_0339: ldc.i4.0
-		IL_033a: ldc.i4.1
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0340: stloc.s 26
-		IL_0342: ldloc.s 27
-		IL_0344: ldstr "call"
-		IL_0349: ldloc.s 10
-		IL_034b: ldloc.s 26
-		IL_034d: ldstr ""
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0357: stloc.s 26
-		IL_0359: ldloc.s 26
-		IL_035b: stloc.s 12
-		IL_035d: ldstr "console"
-		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0367: stloc.s 26
-		IL_0369: ldloc.s 26
-		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0370: stloc.s 26
-		IL_0372: ldloc.s 26
-		IL_0374: ldstr "log"
-		IL_0379: ldloc.s 12
-		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0380: pop
-		IL_0381: ldstr "console"
-		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_038b: stloc.s 26
-		IL_038d: ldloc.s 26
-		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0394: stloc.s 26
-		IL_0396: ldloc.s 26
-		IL_0398: ldstr "log"
-		IL_039d: ldloc.0
-		IL_039e: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03a8: pop
-		IL_03a9: ldloc.0
-		IL_03aa: ldc.r8 0.0
-		IL_03b3: box [System.Runtime]System.Double
-		IL_03b8: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_03bd: ldstr "Array"
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c7: stloc.s 26
-		IL_03c9: ldloc.s 26
-		IL_03cb: ldstr "prototype"
+		IL_02fd: stloc.s 23
+		IL_02ff: ldloc.s 23
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0306: stloc.s 23
+		IL_0308: ldc.i4.1
+		IL_0309: newarr [System.Runtime]System.Object
+		IL_030e: dup
+		IL_030f: ldc.i4.0
+		IL_0310: ldloc.0
+		IL_0311: stelem.ref
+		IL_0312: ldc.i4.0
+		IL_0313: ldelem.ref
+		IL_0314: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_0319: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+		IL_031f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0324: ldc.i4.2
+		IL_0325: conv.r8
+		IL_0326: ldstr ""
+		IL_032b: ldc.i4.0
+		IL_032c: ldc.i4.1
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0332: stloc.s 22
+		IL_0334: ldloc.s 23
+		IL_0336: ldstr "call"
+		IL_033b: ldloc.s 8
+		IL_033d: ldloc.s 22
+		IL_033f: ldstr ""
+		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0349: stloc.s 22
+		IL_034b: ldloc.s 22
+		IL_034d: stloc.s 10
+		IL_034f: ldstr "console"
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0359: stloc.s 22
+		IL_035b: ldloc.s 22
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0362: stloc.s 22
+		IL_0364: ldloc.s 22
+		IL_0366: ldstr "log"
+		IL_036b: ldloc.s 10
+		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0372: pop
+		IL_0373: ldstr "console"
+		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_037d: stloc.s 22
+		IL_037f: ldloc.s 22
+		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0386: stloc.s 22
+		IL_0388: ldloc.s 22
+		IL_038a: ldstr "log"
+		IL_038f: ldloc.0
+		IL_0390: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_039a: pop
+		IL_039b: ldloc.0
+		IL_039c: ldc.r8 0.0
+		IL_03a5: box [System.Runtime]System.Double
+		IL_03aa: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_03af: ldstr "Array"
+		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03b9: stloc.s 22
+		IL_03bb: ldloc.s 22
+		IL_03bd: ldstr "prototype"
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c7: stloc.s 22
+		IL_03c9: ldloc.s 22
+		IL_03cb: ldstr "reduceRight"
 		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d5: stloc.s 26
-		IL_03d7: ldloc.s 26
-		IL_03d9: ldstr "reduceRight"
-		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e3: stloc.s 26
-		IL_03e5: ldloc.s 26
-		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ec: stloc.s 26
-		IL_03ee: ldc.i4.1
-		IL_03ef: newarr [System.Runtime]System.Object
-		IL_03f4: dup
-		IL_03f5: ldc.i4.0
-		IL_03f6: ldloc.0
-		IL_03f7: stelem.ref
-		IL_03f8: ldc.i4.0
-		IL_03f9: ldelem.ref
-		IL_03fa: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_03ff: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_0405: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_040a: ldc.i4.2
-		IL_040b: conv.r8
-		IL_040c: ldstr ""
-		IL_0411: ldc.i4.0
-		IL_0412: ldc.i4.1
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0418: stloc.s 27
-		IL_041a: ldloc.s 26
-		IL_041c: ldstr "call"
-		IL_0421: ldloc.s 10
-		IL_0423: ldloc.s 27
-		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_042a: stloc.s 27
-		IL_042c: ldloc.s 27
-		IL_042e: stloc.s 13
-		IL_0430: ldstr "console"
-		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043a: stloc.s 27
-		IL_043c: ldloc.s 27
-		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0443: stloc.s 27
-		IL_0445: ldloc.s 27
-		IL_0447: ldstr "log"
-		IL_044c: ldloc.s 13
-		IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0453: pop
-		IL_0454: ldstr "console"
-		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045e: stloc.s 27
-		IL_0460: ldloc.s 27
-		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0467: stloc.s 27
-		IL_0469: ldloc.s 27
-		IL_046b: ldstr "log"
-		IL_0470: ldloc.0
-		IL_0471: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_047b: pop
-		IL_047c: ldloc.0
-		IL_047d: ldc.r8 0.0
-		IL_0486: box [System.Runtime]System.Double
-		IL_048b: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0490: ldstr "Array"
-		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_049a: stloc.s 27
-		IL_049c: ldloc.s 27
-		IL_049e: ldstr "prototype"
+		IL_03d5: stloc.s 22
+		IL_03d7: ldloc.s 22
+		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03de: stloc.s 22
+		IL_03e0: ldc.i4.1
+		IL_03e1: newarr [System.Runtime]System.Object
+		IL_03e6: dup
+		IL_03e7: ldc.i4.0
+		IL_03e8: ldloc.0
+		IL_03e9: stelem.ref
+		IL_03ea: ldc.i4.0
+		IL_03eb: ldelem.ref
+		IL_03ec: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_03f1: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+		IL_03f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_03fc: ldc.i4.2
+		IL_03fd: conv.r8
+		IL_03fe: ldstr ""
+		IL_0403: ldc.i4.0
+		IL_0404: ldc.i4.1
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_040a: stloc.s 23
+		IL_040c: ldloc.s 22
+		IL_040e: ldstr "call"
+		IL_0413: ldloc.s 8
+		IL_0415: ldloc.s 23
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_041c: stloc.s 23
+		IL_041e: ldloc.s 23
+		IL_0420: stloc.s 11
+		IL_0422: ldstr "console"
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_042c: stloc.s 23
+		IL_042e: ldloc.s 23
+		IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0435: stloc.s 23
+		IL_0437: ldloc.s 23
+		IL_0439: ldstr "log"
+		IL_043e: ldloc.s 11
+		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0445: pop
+		IL_0446: ldstr "console"
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0450: stloc.s 23
+		IL_0452: ldloc.s 23
+		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0459: stloc.s 23
+		IL_045b: ldloc.s 23
+		IL_045d: ldstr "log"
+		IL_0462: ldloc.0
+		IL_0463: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_046d: pop
+		IL_046e: ldloc.0
+		IL_046f: ldc.r8 0.0
+		IL_0478: box [System.Runtime]System.Double
+		IL_047d: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0482: ldstr "Array"
+		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_048c: stloc.s 23
+		IL_048e: ldloc.s 23
+		IL_0490: ldstr "prototype"
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_049a: stloc.s 23
+		IL_049c: ldloc.s 23
+		IL_049e: ldstr "reduceRight"
 		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04a8: stloc.s 27
-		IL_04aa: ldloc.s 27
-		IL_04ac: ldstr "reduceRight"
-		IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b6: stloc.s 27
-		IL_04b8: ldloc.s 27
-		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04bf: stloc.s 27
-		IL_04c1: ldc.i4.1
-		IL_04c2: newarr [System.Runtime]System.Object
-		IL_04c7: dup
-		IL_04c8: ldc.i4.0
-		IL_04c9: ldloc.0
-		IL_04ca: stelem.ref
-		IL_04cb: ldc.i4.0
-		IL_04cc: ldelem.ref
-		IL_04cd: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_04d2: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_04d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_04dd: ldc.i4.2
-		IL_04de: conv.r8
-		IL_04df: ldstr ""
-		IL_04e4: ldc.i4.0
-		IL_04e5: ldc.i4.1
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04eb: stloc.s 26
-		IL_04ed: ldloc.s 27
-		IL_04ef: ldstr "call"
-		IL_04f4: ldloc.s 10
-		IL_04f6: ldloc.s 26
-		IL_04f8: ldstr ""
-		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0502: stloc.s 26
-		IL_0504: ldloc.s 26
-		IL_0506: stloc.s 14
-		IL_0508: ldstr "console"
-		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0512: stloc.s 26
-		IL_0514: ldloc.s 26
-		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_051b: stloc.s 26
-		IL_051d: ldloc.s 26
-		IL_051f: ldstr "log"
-		IL_0524: ldloc.s 14
-		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_052b: pop
-		IL_052c: ldstr "console"
-		IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0536: stloc.s 26
-		IL_0538: ldloc.s 26
-		IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_053f: stloc.s 26
-		IL_0541: ldloc.s 26
-		IL_0543: ldstr "log"
-		IL_0548: ldloc.0
-		IL_0549: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0553: pop
-		IL_0554: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0559: dup
-		IL_055a: ldstr "length"
-		IL_055f: ldc.r8 2
-		IL_0568: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_056d: stloc.s 15
+		IL_04a8: stloc.s 23
+		IL_04aa: ldloc.s 23
+		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04b1: stloc.s 23
+		IL_04b3: ldc.i4.1
+		IL_04b4: newarr [System.Runtime]System.Object
+		IL_04b9: dup
+		IL_04ba: ldc.i4.0
+		IL_04bb: ldloc.0
+		IL_04bc: stelem.ref
+		IL_04bd: ldc.i4.0
+		IL_04be: ldelem.ref
+		IL_04bf: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_04c4: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+		IL_04ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_04cf: ldc.i4.2
+		IL_04d0: conv.r8
+		IL_04d1: ldstr ""
+		IL_04d6: ldc.i4.0
+		IL_04d7: ldc.i4.1
+		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04dd: stloc.s 22
+		IL_04df: ldloc.s 23
+		IL_04e1: ldstr "call"
+		IL_04e6: ldloc.s 8
+		IL_04e8: ldloc.s 22
+		IL_04ea: ldstr ""
+		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_04f4: stloc.s 22
+		IL_04f6: ldloc.s 22
+		IL_04f8: stloc.s 12
+		IL_04fa: ldstr "console"
+		IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0504: stloc.s 22
+		IL_0506: ldloc.s 22
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_050d: stloc.s 22
+		IL_050f: ldloc.s 22
+		IL_0511: ldstr "log"
+		IL_0516: ldloc.s 12
+		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_051d: pop
+		IL_051e: ldstr "console"
+		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0528: stloc.s 22
+		IL_052a: ldloc.s 22
+		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0531: stloc.s 22
+		IL_0533: ldloc.s 22
+		IL_0535: ldstr "log"
+		IL_053a: ldloc.0
+		IL_053b: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0545: pop
+		IL_0546: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_054b: dup
+		IL_054c: ldstr "length"
+		IL_0551: ldc.r8 2
+		IL_055a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_055f: stloc.s 13
 		.try
 		{
-			IL_056f: nop
-			IL_0570: ldstr "Array"
-			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_057a: stloc.s 26
-			IL_057c: ldloc.s 26
-			IL_057e: ldstr "prototype"
+			IL_0561: nop
+			IL_0562: ldstr "Array"
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_056c: stloc.s 22
+			IL_056e: ldloc.s 22
+			IL_0570: ldstr "prototype"
+			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057a: stloc.s 22
+			IL_057c: ldloc.s 22
+			IL_057e: ldstr "reduce"
 			IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0588: stloc.s 26
-			IL_058a: ldloc.s 26
-			IL_058c: ldstr "reduce"
-			IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0596: stloc.s 26
-			IL_0598: ldloc.s 26
-			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_059f: stloc.s 26
-			IL_05a1: ldnull
-			IL_05a2: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
-			IL_05a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_05ad: ldc.i4.2
-			IL_05ae: conv.r8
-			IL_05af: ldstr ""
-			IL_05b4: ldc.i4.0
-			IL_05b5: ldc.i4.1
-			IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_05bb: stloc.s 27
-			IL_05bd: ldloc.s 26
-			IL_05bf: ldstr "call"
-			IL_05c4: ldloc.s 15
-			IL_05c6: ldloc.s 27
-			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05cd: pop
-			IL_05ce: ldstr "console"
-			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05d8: stloc.s 27
-			IL_05da: ldloc.s 27
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05e1: stloc.s 27
-			IL_05e3: ldloc.s 27
-			IL_05e5: ldstr "log"
-			IL_05ea: ldstr "no-throw"
-			IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05f4: pop
-			IL_05f5: leave IL_066a
+			IL_0588: stloc.s 22
+			IL_058a: ldloc.s 22
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0591: stloc.s 22
+			IL_0593: ldnull
+			IL_0594: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
+			IL_059a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_059f: ldc.i4.2
+			IL_05a0: conv.r8
+			IL_05a1: ldstr ""
+			IL_05a6: ldc.i4.0
+			IL_05a7: ldc.i4.1
+			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_05ad: stloc.s 23
+			IL_05af: ldloc.s 22
+			IL_05b1: ldstr "call"
+			IL_05b6: ldloc.s 13
+			IL_05b8: ldloc.s 23
+			IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05bf: pop
+			IL_05c0: ldstr "console"
+			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05ca: stloc.s 23
+			IL_05cc: ldloc.s 23
+			IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05d3: stloc.s 23
+			IL_05d5: ldloc.s 23
+			IL_05d7: ldstr "log"
+			IL_05dc: ldstr "no-throw"
+			IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05e6: pop
+			IL_05e7: leave IL_0655
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05fa: stloc.s 16
-			IL_05fc: ldloc.s 16
-			IL_05fe: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05ec: stloc.s 14
+			IL_05ee: ldloc.s 14
+			IL_05f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05f5: dup
+			IL_05f6: brtrue IL_060c
+
+			IL_05fb: pop
+			IL_05fc: ldloc.s 14
+			IL_05fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_0603: dup
-			IL_0604: brtrue IL_061a
+			IL_0604: brtrue IL_0618
 
 			IL_0609: pop
-			IL_060a: ldloc.s 16
-			IL_060c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0611: dup
-			IL_0612: brtrue IL_0626
+			IL_060a: rethrow
 
-			IL_0617: pop
-			IL_0618: rethrow
+			IL_060c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0611: stloc.s 15
+			IL_0613: br IL_061a
 
-			IL_061a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_061f: stloc.s 17
-			IL_0621: br IL_0628
+			IL_0618: stloc.s 15
 
-			IL_0626: stloc.s 17
-
-			IL_0628: ldloc.s 17
-			IL_062a: stloc.s 27
-			IL_062c: ldloc.s 27
-			IL_062e: stloc.s 18
-			IL_0630: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L61C12::.ctor()
-			IL_0635: stloc.s 19
-			IL_0637: ldstr "console"
-			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0641: stloc.s 27
-			IL_0643: ldloc.s 27
-			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_064a: stloc.s 27
-			IL_064c: ldloc.s 27
-			IL_064e: ldstr "log"
-			IL_0653: ldloc.s 18
-			IL_0655: ldstr "name"
-			IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0664: pop
-			IL_0665: leave IL_066a
+			IL_061a: ldloc.s 15
+			IL_061c: stloc.s 23
+			IL_061e: ldloc.s 23
+			IL_0620: stloc.s 16
+			IL_0622: ldstr "console"
+			IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_062c: stloc.s 23
+			IL_062e: ldloc.s 23
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0635: stloc.s 23
+			IL_0637: ldloc.s 23
+			IL_0639: ldstr "log"
+			IL_063e: ldloc.s 16
+			IL_0640: ldstr "name"
+			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_064f: pop
+			IL_0650: leave IL_0655
 		} // end handler
 		.try
 		{
-			IL_066a: nop
-			IL_066b: ldstr "Array"
-			IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0675: stloc.s 27
-			IL_0677: ldloc.s 27
-			IL_0679: ldstr "prototype"
-			IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0683: stloc.s 27
-			IL_0685: ldloc.s 27
-			IL_0687: ldstr "reduceRight"
-			IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0691: stloc.s 27
-			IL_0693: ldloc.s 27
-			IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_069a: stloc.s 27
-			IL_069c: ldnull
-			IL_069d: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
-			IL_06a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_06a8: ldc.i4.2
-			IL_06a9: conv.r8
-			IL_06aa: ldstr ""
-			IL_06af: ldc.i4.0
-			IL_06b0: ldc.i4.1
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_06b6: stloc.s 26
-			IL_06b8: ldloc.s 27
-			IL_06ba: ldstr "call"
-			IL_06bf: ldloc.s 15
-			IL_06c1: ldloc.s 26
-			IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_06c8: pop
-			IL_06c9: ldstr "console"
-			IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06d3: stloc.s 26
-			IL_06d5: ldloc.s 26
-			IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06dc: stloc.s 26
-			IL_06de: ldloc.s 26
-			IL_06e0: ldstr "log"
-			IL_06e5: ldstr "no-throw"
-			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06ef: pop
-			IL_06f0: leave IL_0765
+			IL_0655: nop
+			IL_0656: ldstr "Array"
+			IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0660: stloc.s 23
+			IL_0662: ldloc.s 23
+			IL_0664: ldstr "prototype"
+			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_066e: stloc.s 23
+			IL_0670: ldloc.s 23
+			IL_0672: ldstr "reduceRight"
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_067c: stloc.s 23
+			IL_067e: ldloc.s 23
+			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0685: stloc.s 23
+			IL_0687: ldnull
+			IL_0688: ldftn object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
+			IL_068e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+			IL_0693: ldc.i4.2
+			IL_0694: conv.r8
+			IL_0695: ldstr ""
+			IL_069a: ldc.i4.0
+			IL_069b: ldc.i4.1
+			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_06a1: stloc.s 22
+			IL_06a3: ldloc.s 23
+			IL_06a5: ldstr "call"
+			IL_06aa: ldloc.s 13
+			IL_06ac: ldloc.s 22
+			IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06b3: pop
+			IL_06b4: ldstr "console"
+			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06be: stloc.s 22
+			IL_06c0: ldloc.s 22
+			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06c7: stloc.s 22
+			IL_06c9: ldloc.s 22
+			IL_06cb: ldstr "log"
+			IL_06d0: ldstr "no-throw"
+			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06da: pop
+			IL_06db: leave IL_0749
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06f5: stloc.s 20
-			IL_06f7: ldloc.s 20
-			IL_06f9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06fe: dup
-			IL_06ff: brtrue IL_0715
+			IL_06e0: stloc.s 17
+			IL_06e2: ldloc.s 17
+			IL_06e4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06e9: dup
+			IL_06ea: brtrue IL_0700
 
-			IL_0704: pop
-			IL_0705: ldloc.s 20
-			IL_0707: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_070c: dup
-			IL_070d: brtrue IL_0721
+			IL_06ef: pop
+			IL_06f0: ldloc.s 17
+			IL_06f2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06f7: dup
+			IL_06f8: brtrue IL_070c
 
-			IL_0712: pop
-			IL_0713: rethrow
+			IL_06fd: pop
+			IL_06fe: rethrow
 
-			IL_0715: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_071a: stloc.s 21
-			IL_071c: br IL_0723
+			IL_0700: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0705: stloc.s 18
+			IL_0707: br IL_070e
 
-			IL_0721: stloc.s 21
+			IL_070c: stloc.s 18
 
-			IL_0723: ldloc.s 21
-			IL_0725: stloc.s 26
-			IL_0727: ldloc.s 26
+			IL_070e: ldloc.s 18
+			IL_0710: stloc.s 22
+			IL_0712: ldloc.s 22
+			IL_0714: stloc.s 19
+			IL_0716: ldstr "console"
+			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0720: stloc.s 22
+			IL_0722: ldloc.s 22
+			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0729: stloc.s 22
-			IL_072b: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope/Block_L70C12::.ctor()
-			IL_0730: stloc.s 23
-			IL_0732: ldstr "console"
-			IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_073c: stloc.s 26
-			IL_073e: ldloc.s 26
-			IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0745: stloc.s 26
-			IL_0747: ldloc.s 26
-			IL_0749: ldstr "log"
-			IL_074e: ldloc.s 22
-			IL_0750: ldstr "name"
-			IL_0755: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_075a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_075f: pop
-			IL_0760: leave IL_0765
+			IL_072b: ldloc.s 22
+			IL_072d: ldstr "log"
+			IL_0732: ldloc.s 19
+			IL_0734: ldstr "name"
+			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0743: pop
+			IL_0744: leave IL_0749
 		} // end handler
 
-		IL_0765: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_076a: dup
-		IL_076b: ldstr "0"
-		IL_0770: ldstr "a"
-		IL_0775: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_077a: dup
-		IL_077b: ldstr "1"
-		IL_0780: ldstr "b"
-		IL_0785: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_078a: dup
-		IL_078b: ldstr "length"
-		IL_0790: ldc.r8 2
-		IL_0799: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_079e: stloc.s 24
-		IL_07a0: ldstr "console"
-		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07aa: stloc.s 26
-		IL_07ac: ldloc.s 26
-		IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07b3: stloc.s 26
-		IL_07b5: ldstr "Array"
-		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07bf: stloc.s 27
-		IL_07c1: ldloc.s 27
-		IL_07c3: ldstr "prototype"
-		IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07cd: stloc.s 27
-		IL_07cf: ldloc.s 27
-		IL_07d1: ldstr "indexOf"
-		IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07db: stloc.s 27
-		IL_07dd: ldloc.s 27
-		IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07e4: stloc.s 27
-		IL_07e6: ldloc.s 27
-		IL_07e8: ldstr "call"
-		IL_07ed: ldloc.s 24
-		IL_07ef: ldstr "b"
-		IL_07f4: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_07fd: box [System.Runtime]System.Double
-		IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0807: stloc.s 27
-		IL_0809: ldloc.s 26
-		IL_080b: ldstr "log"
-		IL_0810: ldloc.s 27
-		IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0817: pop
-		IL_0818: ldstr "console"
-		IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0822: stloc.s 27
-		IL_0824: ldloc.s 27
-		IL_0826: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_082b: stloc.s 27
-		IL_082d: ldstr "Array"
-		IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0837: stloc.s 26
-		IL_0839: ldloc.s 26
-		IL_083b: ldstr "prototype"
-		IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0845: stloc.s 26
-		IL_0847: ldloc.s 26
-		IL_0849: ldstr "indexOf"
-		IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0853: stloc.s 26
-		IL_0855: ldloc.s 26
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_085c: stloc.s 26
-		IL_085e: ldloc.s 26
-		IL_0860: ldstr "call"
-		IL_0865: ldloc.s 24
-		IL_0867: ldstr "b"
-		IL_086c: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_0875: neg
-		IL_0876: box [System.Runtime]System.Double
-		IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0880: stloc.s 26
-		IL_0882: ldloc.s 27
-		IL_0884: ldstr "log"
-		IL_0889: ldloc.s 26
-		IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0890: pop
-		IL_0891: ldstr "console"
-		IL_0896: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_089b: stloc.s 26
-		IL_089d: ldloc.s 26
-		IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08a4: stloc.s 26
-		IL_08a6: ldstr "Array"
-		IL_08ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08b0: stloc.s 27
-		IL_08b2: ldloc.s 27
-		IL_08b4: ldstr "prototype"
-		IL_08b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08be: stloc.s 27
-		IL_08c0: ldloc.s 27
-		IL_08c2: ldstr "indexOf"
-		IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08cc: stloc.s 27
-		IL_08ce: ldloc.s 27
-		IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08d5: stloc.s 27
-		IL_08d7: ldloc.s 27
-		IL_08d9: ldstr "call"
-		IL_08de: ldloc.s 24
-		IL_08e0: ldstr "b"
-		IL_08e5: ldc.r8 9999999999
-		IL_08ee: box [System.Runtime]System.Double
-		IL_08f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_08f8: stloc.s 27
-		IL_08fa: ldloc.s 26
-		IL_08fc: ldstr "log"
-		IL_0901: ldloc.s 27
-		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0908: pop
-		IL_0909: ldstr "console"
-		IL_090e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0913: stloc.s 27
-		IL_0915: ldloc.s 27
-		IL_0917: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_091c: stloc.s 27
-		IL_091e: ldstr "Array"
-		IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0928: stloc.s 26
-		IL_092a: ldloc.s 26
-		IL_092c: ldstr "prototype"
-		IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0936: stloc.s 26
-		IL_0938: ldloc.s 26
-		IL_093a: ldstr "indexOf"
-		IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0944: stloc.s 26
-		IL_0946: ldloc.s 26
-		IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_094d: stloc.s 26
-		IL_094f: ldloc.s 26
-		IL_0951: ldstr "call"
-		IL_0956: ldloc.s 24
-		IL_0958: ldstr "b"
-		IL_095d: ldc.r8 9999999999
-		IL_0966: neg
-		IL_0967: box [System.Runtime]System.Double
-		IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0971: stloc.s 26
-		IL_0973: ldloc.s 27
-		IL_0975: ldstr "log"
-		IL_097a: ldloc.s 26
-		IL_097c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0981: pop
-		IL_0982: ldnull
-		IL_0983: stloc.s 25
-		IL_0985: ret
+		IL_0749: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_074e: dup
+		IL_074f: ldstr "0"
+		IL_0754: ldstr "a"
+		IL_0759: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_075e: dup
+		IL_075f: ldstr "1"
+		IL_0764: ldstr "b"
+		IL_0769: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_076e: dup
+		IL_076f: ldstr "length"
+		IL_0774: ldc.r8 2
+		IL_077d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0782: stloc.s 20
+		IL_0784: ldstr "console"
+		IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_078e: stloc.s 22
+		IL_0790: ldloc.s 22
+		IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0797: stloc.s 22
+		IL_0799: ldstr "Array"
+		IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07a3: stloc.s 23
+		IL_07a5: ldloc.s 23
+		IL_07a7: ldstr "prototype"
+		IL_07ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07b1: stloc.s 23
+		IL_07b3: ldloc.s 23
+		IL_07b5: ldstr "indexOf"
+		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07bf: stloc.s 23
+		IL_07c1: ldloc.s 23
+		IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07c8: stloc.s 23
+		IL_07ca: ldloc.s 23
+		IL_07cc: ldstr "call"
+		IL_07d1: ldloc.s 20
+		IL_07d3: ldstr "b"
+		IL_07d8: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_07e1: box [System.Runtime]System.Double
+		IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_07eb: stloc.s 23
+		IL_07ed: ldloc.s 22
+		IL_07ef: ldstr "log"
+		IL_07f4: ldloc.s 23
+		IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_07fb: pop
+		IL_07fc: ldstr "console"
+		IL_0801: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0806: stloc.s 23
+		IL_0808: ldloc.s 23
+		IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_080f: stloc.s 23
+		IL_0811: ldstr "Array"
+		IL_0816: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_081b: stloc.s 22
+		IL_081d: ldloc.s 22
+		IL_081f: ldstr "prototype"
+		IL_0824: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0829: stloc.s 22
+		IL_082b: ldloc.s 22
+		IL_082d: ldstr "indexOf"
+		IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0837: stloc.s 22
+		IL_0839: ldloc.s 22
+		IL_083b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0840: stloc.s 22
+		IL_0842: ldloc.s 22
+		IL_0844: ldstr "call"
+		IL_0849: ldloc.s 20
+		IL_084b: ldstr "b"
+		IL_0850: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_0859: neg
+		IL_085a: box [System.Runtime]System.Double
+		IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0864: stloc.s 22
+		IL_0866: ldloc.s 23
+		IL_0868: ldstr "log"
+		IL_086d: ldloc.s 22
+		IL_086f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0874: pop
+		IL_0875: ldstr "console"
+		IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_087f: stloc.s 22
+		IL_0881: ldloc.s 22
+		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0888: stloc.s 22
+		IL_088a: ldstr "Array"
+		IL_088f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0894: stloc.s 23
+		IL_0896: ldloc.s 23
+		IL_0898: ldstr "prototype"
+		IL_089d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08a2: stloc.s 23
+		IL_08a4: ldloc.s 23
+		IL_08a6: ldstr "indexOf"
+		IL_08ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08b0: stloc.s 23
+		IL_08b2: ldloc.s 23
+		IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08b9: stloc.s 23
+		IL_08bb: ldloc.s 23
+		IL_08bd: ldstr "call"
+		IL_08c2: ldloc.s 20
+		IL_08c4: ldstr "b"
+		IL_08c9: ldc.r8 9999999999
+		IL_08d2: box [System.Runtime]System.Double
+		IL_08d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_08dc: stloc.s 23
+		IL_08de: ldloc.s 22
+		IL_08e0: ldstr "log"
+		IL_08e5: ldloc.s 23
+		IL_08e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_08ec: pop
+		IL_08ed: ldstr "console"
+		IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08f7: stloc.s 23
+		IL_08f9: ldloc.s 23
+		IL_08fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0900: stloc.s 23
+		IL_0902: ldstr "Array"
+		IL_0907: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_090c: stloc.s 22
+		IL_090e: ldloc.s 22
+		IL_0910: ldstr "prototype"
+		IL_0915: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_091a: stloc.s 22
+		IL_091c: ldloc.s 22
+		IL_091e: ldstr "indexOf"
+		IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0928: stloc.s 22
+		IL_092a: ldloc.s 22
+		IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0931: stloc.s 22
+		IL_0933: ldloc.s 22
+		IL_0935: ldstr "call"
+		IL_093a: ldloc.s 20
+		IL_093c: ldstr "b"
+		IL_0941: ldc.r8 9999999999
+		IL_094a: neg
+		IL_094b: box [System.Runtime]System.Double
+		IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_0955: stloc.s 22
+		IL_0957: ldloc.s 23
+		IL_0959: ldstr "log"
+		IL_095e: ldloc.s 22
+		IL_0960: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0965: pop
+		IL_0966: ldnull
+		IL_0967: stloc.s 21
+		IL_0969: ret
 	} // end of method Array_PrototypeMethods_ArrayLike_EdgeCases::__js_module_init__
 
 } // end of class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases
@@ -1407,7 +1395,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2bad
+		// Method begins at RVA 0x2b91
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForLetBodyBlockClosure.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForLetBodyBlockClosure.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2258
+					// Method begins at RVA 0x2242
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,13 +46,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x220a
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldc.i4.3
+				IL_0001: ldc.i4.2
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49
 				IL_0008: ldfld float64 Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::argPosition
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x223d
+				// Method begins at RVA 0x2227
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x224f
+					// Method begins at RVA 0x2239
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -119,7 +119,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2246
+				// Method begins at RVA 0x2230
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,18 +147,16 @@
 			)
 			// Method begins at RVA 0x2150
 			// Header size: 12
-			// Code size: 196 (0xc4)
+			// Code size: 174 (0xae)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[2] class Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9,
+				[2] float64,
 				[3] float64,
-				[4] float64,
-				[5] class Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49,
-				[6] float64,
-				[7] object,
-				[8] class Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9
+				[4] class Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49,
+				[5] float64,
+				[6] object
 			)
 
 			IL_0000: newobj instance void Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope::.ctor()
@@ -166,80 +164,70 @@
 			IL_0006: ldc.i4.0
 			IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_000c: stloc.1
-			IL_000d: newobj instance void Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9::.ctor()
-			IL_0012: stloc.2
-			IL_0013: ldc.r8 0.0
-			IL_001c: stloc.3
-			IL_001d: ldc.r8 2
-			IL_0026: stloc.s 4
-			// loop start (head: IL_0028)
-				IL_0028: ldloc.3
-				IL_0029: stloc.s 6
-				IL_002b: ldloc.s 6
-				IL_002d: ldloc.s 4
-				IL_002f: clt
-				IL_0031: brfalse IL_00c2
+			IL_000d: ldc.r8 0.0
+			IL_0016: stloc.2
+			IL_0017: ldc.r8 2
+			IL_0020: stloc.3
+			// loop start (head: IL_0021)
+				IL_0021: ldloc.2
+				IL_0022: stloc.s 5
+				IL_0024: ldloc.s 5
+				IL_0026: ldloc.3
+				IL_0027: clt
+				IL_0029: brfalse IL_00ac
 
-				IL_0036: newobj instance void Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::.ctor()
-				IL_003b: stloc.s 5
-				IL_003d: ldloc.3
-				IL_003e: stloc.s 6
-				IL_0040: ldloc.s 6
-				IL_0042: ldc.r8 1
-				IL_004b: add
-				IL_004c: stloc.s 6
-				IL_004e: ldloc.s 5
-				IL_0050: castclass Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49
-				IL_0055: ldloc.s 6
-				IL_0057: stfld float64 Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::argPosition
-				IL_005c: ldnull
-				IL_005d: ldftn object Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/ArrowFunction_L6C24::__js_call__(object[], object)
-				IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-				IL_0068: ldc.i4.4
-				IL_0069: newarr [System.Runtime]System.Object
+				IL_002e: newobj instance void Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::.ctor()
+				IL_0033: stloc.s 4
+				IL_0035: ldloc.2
+				IL_0036: stloc.s 5
+				IL_0038: ldloc.s 5
+				IL_003a: ldc.r8 1
+				IL_0043: add
+				IL_0044: stloc.s 5
+				IL_0046: ldloc.s 4
+				IL_0048: castclass Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49
+				IL_004d: ldloc.s 5
+				IL_004f: stfld float64 Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9/Block_L4C49::argPosition
+				IL_0054: ldnull
+				IL_0055: ldftn object Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/ArrowFunction_L6C24::__js_call__(object[], object)
+				IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+				IL_0060: ldc.i4.3
+				IL_0061: newarr [System.Runtime]System.Object
+				IL_0066: dup
+				IL_0067: ldc.i4.0
+				IL_0068: ldarg.0
+				IL_0069: stelem.ref
+				IL_006a: dup
+				IL_006b: ldc.i4.1
+				IL_006c: ldloc.0
+				IL_006d: stelem.ref
 				IL_006e: dup
-				IL_006f: ldc.i4.0
-				IL_0070: ldarg.0
-				IL_0071: stelem.ref
-				IL_0072: dup
-				IL_0073: ldc.i4.1
-				IL_0074: ldloc.0
-				IL_0075: stelem.ref
-				IL_0076: dup
-				IL_0077: ldc.i4.2
-				IL_0078: ldloc.2
-				IL_0079: stelem.ref
-				IL_007a: dup
-				IL_007b: ldc.i4.3
-				IL_007c: ldloc.s 5
-				IL_007e: stelem.ref
-				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_0089: ldc.i4.0
-				IL_008a: conv.r8
-				IL_008b: ldstr ""
-				IL_0090: ldc.i4.0
-				IL_0091: ldc.i4.0
-				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_009c: stloc.s 7
-				IL_009e: ldloc.1
-				IL_009f: ldloc.s 7
-				IL_00a1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00a6: pop
-				IL_00a7: newobj instance void Modules.ArrowFunction_ForLetBodyBlockClosure/ArrowFunction_L1C23/Scope_For_L4C9::.ctor()
-				IL_00ac: stloc.s 8
-				IL_00ae: ldloc.s 8
-				IL_00b0: stloc.2
-				IL_00b1: ldloc.3
-				IL_00b2: ldc.r8 1
-				IL_00bb: add
-				IL_00bc: stloc.3
-				IL_00bd: br IL_0028
+				IL_006f: ldc.i4.2
+				IL_0070: ldloc.s 4
+				IL_0072: stelem.ref
+				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_007d: ldc.i4.0
+				IL_007e: conv.r8
+				IL_007f: ldstr ""
+				IL_0084: ldc.i4.0
+				IL_0085: ldc.i4.0
+				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+				IL_0090: stloc.s 6
+				IL_0092: ldloc.1
+				IL_0093: ldloc.s 6
+				IL_0095: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_009a: pop
+				IL_009b: ldloc.2
+				IL_009c: ldc.r8 1
+				IL_00a5: add
+				IL_00a6: stloc.2
+				IL_00a7: br IL_0021
 			// end loop
 
-			IL_00c2: ldloc.1
-			IL_00c3: ret
+			IL_00ac: ldloc.1
+			IL_00ad: ret
 		} // end of method ArrowFunction_L1C23::__js_call__
 
 	} // end of class ArrowFunction_L1C23
@@ -251,7 +239,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2234
+			// Method begins at RVA 0x221e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -382,7 +370,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2261
+		// Method begins at RVA 0x224b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3388
+					// Method begins at RVA 0x3378
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x337f
+				// Method begins at RVA 0x336f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3391
+				// Method begins at RVA 0x3381
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x339a
+				// Method begins at RVA 0x338a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c7
+					// Method begins at RVA 0x33b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b0f
+				// Method begins at RVA 0x2b07
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d0
+					// Method begins at RVA 0x33c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b1e
+				// Method begins at RVA 0x2b16
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33fd
+						// Method begins at RVA 0x33ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2bc5
+					// Method begins at RVA 0x2bbd
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33f4
+					// Method begins at RVA 0x33e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b30
+				// Method begins at RVA 0x2b28
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ac
+					// Method begins at RVA 0x339c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33b5
+					// Method begins at RVA 0x33a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33be
+					// Method begins at RVA 0x33ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33e2
+						// Method begins at RVA 0x33d2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33eb
+						// Method begins at RVA 0x33db
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d9
+					// Method begins at RVA 0x33c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3406
+					// Method begins at RVA 0x33f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x340f
+					// Method begins at RVA 0x33ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33a3
+				// Method begins at RVA 0x3393
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x25a8
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope/Block_L51C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.0
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.0
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.0
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope/Block_L51C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3418
+				// Method begins at RVA 0x3408
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2abc
+			// Method begins at RVA 0x2ab4
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -1388,7 +1385,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3376
+			// Method begins at RVA 0x3366
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1774,7 +1771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x342a
+				// Method begins at RVA 0x341a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1800,7 +1797,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2be6
+			// Method begins at RVA 0x2bde
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1823,7 +1820,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3433
+				// Method begins at RVA 0x3423
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1847,7 +1844,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bee
+			// Method begins at RVA 0x2be6
 			// Header size: 1
 			// Code size: 11 (0xb)
 			.maxstack 8
@@ -1874,7 +1871,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3445
+					// Method begins at RVA 0x3435
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1892,7 +1889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343c
+				// Method begins at RVA 0x342c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1918,7 +1915,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2bfc
+			// Method begins at RVA 0x2bf4
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -1997,7 +1994,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x344e
+				// Method begins at RVA 0x343e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2021,7 +2018,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c9c
+			// Method begins at RVA 0x2c94
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2102,7 +2099,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3457
+				// Method begins at RVA 0x3447
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2127,7 +2124,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d2c
+			// Method begins at RVA 0x2d24
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2155,7 +2152,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3484
+					// Method begins at RVA 0x3474
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2179,7 +2176,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x329f
+				// Method begins at RVA 0x328f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2205,7 +2202,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x348d
+					// Method begins at RVA 0x347d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2229,7 +2226,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x32ae
+				// Method begins at RVA 0x329e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2259,7 +2256,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34ba
+						// Method begins at RVA 0x34aa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2283,7 +2280,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3355
+					// Method begins at RVA 0x3345
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2317,7 +2314,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34b1
+					// Method begins at RVA 0x34a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2342,7 +2339,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x32c0
+				// Method begins at RVA 0x32b0
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2435,7 +2432,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3469
+					// Method begins at RVA 0x3459
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2455,7 +2452,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3472
+					// Method begins at RVA 0x3462
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2475,7 +2472,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x347b
+					// Method begins at RVA 0x346b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2499,7 +2496,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x349f
+						// Method begins at RVA 0x348f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2519,7 +2516,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34a8
+						// Method begins at RVA 0x3498
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2537,7 +2534,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3496
+					// Method begins at RVA 0x3486
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2557,7 +2554,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34c3
+					// Method begins at RVA 0x34b3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2577,7 +2574,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34cc
+					// Method begins at RVA 0x34bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2599,7 +2596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3460
+				// Method begins at RVA 0x3450
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2626,9 +2623,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2d38
+			// Method begins at RVA 0x2d30
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope,
@@ -2637,10 +2634,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope/Block_L51C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2648,12 +2645,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::.ctor()
@@ -2663,45 +2659,45 @@
 			IL_0008: stfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2710,19 +2706,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2730,14 +2726,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2745,28 +2741,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2784,31 +2780,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2822,7 +2818,7 @@
 			IL_01d2: stfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -2841,7 +2837,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.0
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -2853,17 +2849,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -2882,7 +2878,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.0
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -2894,12 +2890,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -2909,122 +2905,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -3047,22 +3043,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.0
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -3072,8 +3068,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -3095,7 +3091,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -3121,22 +3117,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope/Block_L51C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -3152,7 +3146,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34d5
+				// Method begins at RVA 0x34c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3180,7 +3174,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x324c
+			// Method begins at RVA 0x323c
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -3240,7 +3234,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3421
+			// Method begins at RVA 0x3411
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3427,7 +3421,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x34de
+		// Method begins at RVA 0x34ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_RejectionCaught.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_RejectionCaught.verified.txt
@@ -27,7 +27,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x220d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2229
+				// Method begins at RVA 0x2216
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -71,7 +71,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2217
+			// Method begins at RVA 0x2204
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -130,13 +130,12 @@
 	{
 		// Method begins at RVA 0x2070
 		// Header size: 12
-		// Code size: 411 (0x19b)
+		// Code size: 392 (0x188)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_RejectionCaught/Scope,
 			[1] object,
-			[2] class Modules.Async_TopLevelAwait_RejectionCaught/Scope/Block_L3C16,
-			[3] object
+			[2] object
 		)
 
 		IL_0000: ldarg.0
@@ -191,14 +190,14 @@
 		IL_005f: brtrue IL_0070
 
 		IL_0064: ldloc.0
-		IL_0065: ldc.i4.3
+		IL_0065: ldc.i4.2
 		IL_0066: newarr [System.Runtime]System.Object
 		IL_006b: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 		IL_0070: ldloc.0
 		IL_0071: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 		IL_0076: ldc.i4.0
-		IL_0077: ble IL_0094
+		IL_0077: ble IL_008b
 
 		IL_007c: ldloc.0
 		IL_007d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -209,113 +208,102 @@
 		IL_0086: dup
 		IL_0087: ldc.i4.1
 		IL_0088: ldelem.ref
-		IL_0089: castclass Modules.Async_TopLevelAwait_RejectionCaught/Scope/Block_L3C16
-		IL_008e: stloc.2
-		IL_008f: dup
-		IL_0090: ldc.i4.2
-		IL_0091: ldelem.ref
-		IL_0092: stloc.3
-		IL_0093: pop
+		IL_0089: stloc.2
+		IL_008a: pop
 
-		IL_0094: ldloc.0
-		IL_0095: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_009a: switch (IL_00ab, IL_0109, IL_00fd)
+		IL_008b: ldloc.0
+		IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_0091: switch (IL_00a2, IL_00fc, IL_00f0)
 
-		IL_00ab: ldloc.0
-		IL_00ac: ldc.i4.0
-		IL_00ad: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00b2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-		IL_00b7: ldstr "boom"
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-		IL_00c1: stloc.3
-		IL_00c2: ldloc.0
-		IL_00c3: ldc.i4.2
-		IL_00c4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_00c9: ldloc.0
-		IL_00ca: ldloc.3
-		IL_00cb: ldarg.0
-		IL_00cc: ldc.i4.1
-		IL_00cd: ldloc.0
-		IL_00ce: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-		IL_00d3: ldc.i4.1
-		IL_00d4: ldstr "_pendingException"
-		IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-		IL_00de: ldloc.0
-		IL_00df: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.1
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.1
-		IL_00ea: ldloc.2
-		IL_00eb: stelem.ref
-		IL_00ec: dup
-		IL_00ed: ldc.i4.2
-		IL_00ee: ldloc.3
-		IL_00ef: stelem.ref
-		IL_00f0: pop
-		IL_00f1: ldloc.0
-		IL_00f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_00f7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-		IL_00fc: ret
+		IL_00a2: ldloc.0
+		IL_00a3: ldc.i4.0
+		IL_00a4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00a9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+		IL_00ae: ldstr "boom"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+		IL_00b8: stloc.2
+		IL_00b9: ldloc.0
+		IL_00ba: ldc.i4.2
+		IL_00bb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_00c0: ldloc.0
+		IL_00c1: ldloc.2
+		IL_00c2: ldarg.0
+		IL_00c3: ldc.i4.1
+		IL_00c4: ldloc.0
+		IL_00c5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+		IL_00ca: ldc.i4.1
+		IL_00cb: ldstr "_pendingException"
+		IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+		IL_00d5: ldloc.0
+		IL_00d6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldloc.1
+		IL_00de: stelem.ref
+		IL_00df: dup
+		IL_00e0: ldc.i4.1
+		IL_00e1: ldloc.2
+		IL_00e2: stelem.ref
+		IL_00e3: pop
+		IL_00e4: ldloc.0
+		IL_00e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_00ea: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+		IL_00ef: ret
 
-		IL_00fd: ldloc.0
-		IL_00fe: ldfld object Modules.Async_TopLevelAwait_RejectionCaught/Scope::_awaited1
-		IL_0103: pop
-		IL_0104: br IL_014d
+		IL_00f0: ldloc.0
+		IL_00f1: ldfld object Modules.Async_TopLevelAwait_RejectionCaught/Scope::_awaited1
+		IL_00f6: pop
+		IL_00f7: br IL_013a
 
-		IL_0109: ldloc.0
-		IL_010a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-		IL_010f: stloc.3
-		IL_0110: ldloc.0
-		IL_0111: ldc.i4.0
-		IL_0112: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0117: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-		IL_011c: ldloc.3
-		IL_011d: stloc.1
-		IL_011e: newobj instance void Modules.Async_TopLevelAwait_RejectionCaught/Scope/Block_L3C16::.ctor()
-		IL_0123: stloc.2
-		IL_0124: ldstr "console"
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012e: stloc.3
-		IL_012f: ldloc.3
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0135: stloc.3
-		IL_0136: ldloc.3
-		IL_0137: ldstr "log"
-		IL_013c: ldstr "caught:"
-		IL_0141: ldloc.1
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0147: pop
-		IL_0148: br IL_014d
+		IL_00fc: ldloc.0
+		IL_00fd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+		IL_0102: stloc.2
+		IL_0103: ldloc.0
+		IL_0104: ldc.i4.0
+		IL_0105: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_010a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+		IL_010f: ldloc.2
+		IL_0110: stloc.1
+		IL_0111: ldstr "console"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011b: stloc.2
+		IL_011c: ldloc.2
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0122: stloc.2
+		IL_0123: ldloc.2
+		IL_0124: ldstr "log"
+		IL_0129: ldstr "caught:"
+		IL_012e: ldloc.1
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0134: pop
+		IL_0135: br IL_013a
 
-		IL_014d: ldstr "console"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0157: stloc.3
-		IL_0158: ldloc.3
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015e: stloc.3
-		IL_015f: ldloc.3
-		IL_0160: ldstr "log"
-		IL_0165: ldstr "after"
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_016f: pop
-		IL_0170: ldloc.0
-		IL_0171: ldc.i4.m1
-		IL_0172: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_0177: ldloc.0
-		IL_0178: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-		IL_0182: ldarg.0
-		IL_0183: ldc.i4.1
-		IL_0184: newarr [System.Runtime]System.Object
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_018e: pop
-		IL_018f: ldloc.0
-		IL_0190: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_0195: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-		IL_019a: ret
+		IL_013a: ldstr "console"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0144: stloc.2
+		IL_0145: ldloc.2
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014b: stloc.2
+		IL_014c: ldloc.2
+		IL_014d: ldstr "log"
+		IL_0152: ldstr "after"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_015c: pop
+		IL_015d: ldloc.0
+		IL_015e: ldc.i4.m1
+		IL_015f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_0164: ldloc.0
+		IL_0165: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+		IL_016f: ldarg.0
+		IL_0170: ldc.i4.1
+		IL_0171: newarr [System.Runtime]System.Object
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_017b: pop
+		IL_017c: ldloc.0
+		IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_0182: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+		IL_0187: ret
 	} // end of method Async_TopLevelAwait_RejectionCaught::__js_module_async_body__
 
 } // end of class Modules.Async_TopLevelAwait_RejectionCaught
@@ -327,7 +315,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2232
+		// Method begins at RVA 0x221f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24f3
+					// Method begins at RVA 0x24d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24fc
+					// Method begins at RVA 0x24e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2505
+					// Method begins at RVA 0x24e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ea
+				// Method begins at RVA 0x24ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,15 +131,14 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 963 (0x3c3)
+			// Code size: 935 (0x3a7)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope,
 				[1] object,
-				[2] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope/Block_L10C16,
+				[2] bool,
 				[3] bool,
-				[4] bool,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: ldarg.0
@@ -172,14 +171,14 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.5
+			IL_0048: ldc.i4.4
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_008b
+			IL_005a: ble IL_0081
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -190,7 +189,7 @@
 			IL_0069: dup
 			IL_006a: ldc.i4.1
 			IL_006b: ldelem.ref
-			IL_006c: castclass Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope/Block_L10C16
+			IL_006c: unbox.any [System.Runtime]System.Boolean
 			IL_0071: stloc.2
 			IL_0072: dup
 			IL_0073: ldc.i4.2
@@ -200,318 +199,303 @@
 			IL_007b: dup
 			IL_007c: ldc.i4.3
 			IL_007d: ldelem.ref
-			IL_007e: unbox.any [System.Runtime]System.Boolean
-			IL_0083: stloc.s 4
-			IL_0085: dup
-			IL_0086: ldc.i4.4
-			IL_0087: ldelem.ref
-			IL_0088: stloc.s 5
-			IL_008a: pop
+			IL_007e: stloc.s 4
+			IL_0080: pop
 
-			IL_008b: ldloc.0
-			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_00ae, IL_0209, IL_02d2, IL_01b1, IL_017e, IL_029f)
+			IL_0081: ldloc.0
+			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0087: switch (IL_00a4, IL_01f4, IL_02b8, IL_01a2, IL_016f, IL_0285)
 
-			IL_00ae: ldstr "console"
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b8: stloc.s 5
-			IL_00ba: ldloc.s 5
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c1: stloc.s 5
-			IL_00c3: ldloc.s 5
-			IL_00c5: ldstr "log"
-			IL_00ca: ldstr "before"
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d4: pop
-			IL_00d5: ldloc.0
-			IL_00d6: ldc.i4.0
-			IL_00d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00e1: ldloc.0
-			IL_00e2: ldc.i4.0
-			IL_00e3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_00ed: ldloc.0
-			IL_00ee: ldc.i4.0
-			IL_00ef: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_00f4: ldloc.0
-			IL_00f5: ldc.i4.0
-			IL_00f6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_00fb: ldstr "console"
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0105: stloc.s 5
-			IL_0107: ldloc.s 5
-			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010e: stloc.s 5
-			IL_0110: ldloc.s 5
-			IL_0112: ldstr "log"
-			IL_0117: ldstr "try: before reject"
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0121: pop
-			IL_0122: ldstr "error"
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-			IL_012c: stloc.s 5
-			IL_012e: ldloc.0
-			IL_012f: ldc.i4.4
-			IL_0130: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0135: ldloc.0
-			IL_0136: ldloc.s 5
-			IL_0138: ldarg.0
-			IL_0139: ldc.i4.1
-			IL_013a: ldloc.0
-			IL_013b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0140: ldc.i4.3
-			IL_0141: ldstr "_pendingException"
-			IL_0146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_014b: ldloc.0
-			IL_014c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0151: dup
-			IL_0152: ldc.i4.0
-			IL_0153: ldloc.1
-			IL_0154: stelem.ref
-			IL_0155: dup
-			IL_0156: ldc.i4.1
-			IL_0157: ldloc.2
-			IL_0158: stelem.ref
-			IL_0159: dup
-			IL_015a: ldc.i4.2
-			IL_015b: ldloc.3
-			IL_015c: box [System.Runtime]System.Boolean
+			IL_00a4: ldstr "console"
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ae: stloc.s 4
+			IL_00b0: ldloc.s 4
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b7: stloc.s 4
+			IL_00b9: ldloc.s 4
+			IL_00bb: ldstr "log"
+			IL_00c0: ldstr "before"
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ca: pop
+			IL_00cb: ldloc.0
+			IL_00cc: ldc.i4.0
+			IL_00cd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00d2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00d7: ldloc.0
+			IL_00d8: ldc.i4.0
+			IL_00d9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00de: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_00e3: ldloc.0
+			IL_00e4: ldc.i4.0
+			IL_00e5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_00ea: ldloc.0
+			IL_00eb: ldc.i4.0
+			IL_00ec: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00f1: ldstr "console"
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fb: stloc.s 4
+			IL_00fd: ldloc.s 4
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0104: stloc.s 4
+			IL_0106: ldloc.s 4
+			IL_0108: ldstr "log"
+			IL_010d: ldstr "try: before reject"
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0117: pop
+			IL_0118: ldstr "error"
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_0122: stloc.s 4
+			IL_0124: ldloc.0
+			IL_0125: ldc.i4.4
+			IL_0126: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_012b: ldloc.0
+			IL_012c: ldloc.s 4
+			IL_012e: ldarg.0
+			IL_012f: ldc.i4.1
+			IL_0130: ldloc.0
+			IL_0131: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0136: ldc.i4.3
+			IL_0137: ldstr "_pendingException"
+			IL_013c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0141: ldloc.0
+			IL_0142: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0147: dup
+			IL_0148: ldc.i4.0
+			IL_0149: ldloc.1
+			IL_014a: stelem.ref
+			IL_014b: dup
+			IL_014c: ldc.i4.1
+			IL_014d: ldloc.2
+			IL_014e: box [System.Runtime]System.Boolean
+			IL_0153: stelem.ref
+			IL_0154: dup
+			IL_0155: ldc.i4.2
+			IL_0156: ldloc.3
+			IL_0157: box [System.Runtime]System.Boolean
+			IL_015c: stelem.ref
+			IL_015d: dup
+			IL_015e: ldc.i4.3
+			IL_015f: ldloc.s 4
 			IL_0161: stelem.ref
-			IL_0162: dup
-			IL_0163: ldc.i4.3
-			IL_0164: ldloc.s 4
-			IL_0166: box [System.Runtime]System.Boolean
-			IL_016b: stelem.ref
-			IL_016c: dup
-			IL_016d: ldc.i4.4
-			IL_016e: ldloc.s 5
-			IL_0170: stelem.ref
-			IL_0171: pop
-			IL_0172: ldloc.0
-			IL_0173: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0178: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_017d: ret
+			IL_0162: pop
+			IL_0163: ldloc.0
+			IL_0164: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0169: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_016e: ret
 
-			IL_017e: ldloc.0
-			IL_017f: ldfld object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope::_awaited1
-			IL_0184: pop
-			IL_0185: ldstr "console"
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_018f: stloc.s 5
-			IL_0191: ldloc.s 5
-			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0198: stloc.s 5
-			IL_019a: ldloc.s 5
-			IL_019c: ldstr "log"
-			IL_01a1: ldstr "try: after reject (should not print)"
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ab: pop
-			IL_01ac: br IL_021c
+			IL_016f: ldloc.0
+			IL_0170: ldfld object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope::_awaited1
+			IL_0175: pop
+			IL_0176: ldstr "console"
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0180: stloc.s 4
+			IL_0182: ldloc.s 4
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0189: stloc.s 4
+			IL_018b: ldloc.s 4
+			IL_018d: ldstr "log"
+			IL_0192: ldstr "try: after reject (should not print)"
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_019c: pop
+			IL_019d: br IL_0207
 
+			IL_01a2: ldloc.0
+			IL_01a3: ldc.i4.1
+			IL_01a4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01a9: ldloc.0
+			IL_01aa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01af: stloc.s 4
 			IL_01b1: ldloc.0
-			IL_01b2: ldc.i4.1
-			IL_01b3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01b8: ldloc.0
-			IL_01b9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01be: stloc.s 5
-			IL_01c0: ldloc.0
-			IL_01c1: ldc.i4.0
-			IL_01c2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01c7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01cc: ldloc.0
-			IL_01cd: ldc.i4.0
-			IL_01ce: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01d3: ldloc.s 5
-			IL_01d5: stloc.1
-			IL_01d6: newobj instance void Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope/Block_L10C16::.ctor()
-			IL_01db: stloc.2
-			IL_01dc: ldstr "console"
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e6: stloc.s 5
-			IL_01e8: ldloc.s 5
-			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ef: stloc.s 5
-			IL_01f1: ldloc.s 5
-			IL_01f3: ldstr "log"
-			IL_01f8: ldstr "catch:"
-			IL_01fd: ldloc.1
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0203: pop
-			IL_0204: br IL_021c
+			IL_01b2: ldc.i4.0
+			IL_01b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01b8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01bd: ldloc.0
+			IL_01be: ldc.i4.0
+			IL_01bf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01c4: ldloc.s 4
+			IL_01c6: stloc.1
+			IL_01c7: ldstr "console"
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01d1: stloc.s 4
+			IL_01d3: ldloc.s 4
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01da: stloc.s 4
+			IL_01dc: ldloc.s 4
+			IL_01de: ldstr "log"
+			IL_01e3: ldstr "catch:"
+			IL_01e8: ldloc.1
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01ee: pop
+			IL_01ef: br IL_0207
 
-			IL_0209: ldloc.0
-			IL_020a: ldc.i4.1
-			IL_020b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0210: ldloc.0
-			IL_0211: ldc.i4.0
-			IL_0212: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0217: br IL_021c
+			IL_01f4: ldloc.0
+			IL_01f5: ldc.i4.1
+			IL_01f6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01fb: ldloc.0
+			IL_01fc: ldc.i4.0
+			IL_01fd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0202: br IL_0207
 
-			IL_021c: ldstr "console"
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0226: stloc.s 5
-			IL_0228: ldloc.s 5
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022f: stloc.s 5
-			IL_0231: ldloc.s 5
-			IL_0233: ldstr "log"
-			IL_0238: ldstr "finally: before await"
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0242: pop
-			IL_0243: ldstr "cleanup"
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_024d: stloc.s 5
-			IL_024f: ldloc.0
-			IL_0250: ldc.i4.5
-			IL_0251: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0256: ldloc.0
-			IL_0257: ldloc.s 5
-			IL_0259: ldarg.0
-			IL_025a: ldc.i4.2
-			IL_025b: ldloc.0
-			IL_025c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0261: ldc.i4.2
-			IL_0262: ldstr "_pendingException"
-			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_026c: ldloc.0
-			IL_026d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0272: dup
-			IL_0273: ldc.i4.0
-			IL_0274: ldloc.1
-			IL_0275: stelem.ref
-			IL_0276: dup
-			IL_0277: ldc.i4.1
-			IL_0278: ldloc.2
-			IL_0279: stelem.ref
-			IL_027a: dup
-			IL_027b: ldc.i4.2
-			IL_027c: ldloc.3
-			IL_027d: box [System.Runtime]System.Boolean
-			IL_0282: stelem.ref
-			IL_0283: dup
-			IL_0284: ldc.i4.3
-			IL_0285: ldloc.s 4
-			IL_0287: box [System.Runtime]System.Boolean
-			IL_028c: stelem.ref
-			IL_028d: dup
-			IL_028e: ldc.i4.4
-			IL_028f: ldloc.s 5
-			IL_0291: stelem.ref
-			IL_0292: pop
-			IL_0293: ldloc.0
-			IL_0294: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0299: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_029e: ret
+			IL_0207: ldstr "console"
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0211: stloc.s 4
+			IL_0213: ldloc.s 4
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021a: stloc.s 4
+			IL_021c: ldloc.s 4
+			IL_021e: ldstr "log"
+			IL_0223: ldstr "finally: before await"
+			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_022d: pop
+			IL_022e: ldstr "cleanup"
+			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_0238: stloc.s 4
+			IL_023a: ldloc.0
+			IL_023b: ldc.i4.5
+			IL_023c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0241: ldloc.0
+			IL_0242: ldloc.s 4
+			IL_0244: ldarg.0
+			IL_0245: ldc.i4.2
+			IL_0246: ldloc.0
+			IL_0247: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_024c: ldc.i4.2
+			IL_024d: ldstr "_pendingException"
+			IL_0252: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0257: ldloc.0
+			IL_0258: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_025d: dup
+			IL_025e: ldc.i4.0
+			IL_025f: ldloc.1
+			IL_0260: stelem.ref
+			IL_0261: dup
+			IL_0262: ldc.i4.1
+			IL_0263: ldloc.2
+			IL_0264: box [System.Runtime]System.Boolean
+			IL_0269: stelem.ref
+			IL_026a: dup
+			IL_026b: ldc.i4.2
+			IL_026c: ldloc.3
+			IL_026d: box [System.Runtime]System.Boolean
+			IL_0272: stelem.ref
+			IL_0273: dup
+			IL_0274: ldc.i4.3
+			IL_0275: ldloc.s 4
+			IL_0277: stelem.ref
+			IL_0278: pop
+			IL_0279: ldloc.0
+			IL_027a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_027f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0284: ret
 
-			IL_029f: ldloc.0
-			IL_02a0: ldfld object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope::_awaited2
-			IL_02a5: pop
-			IL_02a6: ldstr "console"
-			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02b0: stloc.s 5
-			IL_02b2: ldloc.s 5
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b9: stloc.s 5
-			IL_02bb: ldloc.s 5
-			IL_02bd: ldstr "log"
-			IL_02c2: ldstr "finally: after await"
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02cc: pop
-			IL_02cd: br IL_02e5
+			IL_0285: ldloc.0
+			IL_0286: ldfld object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/Scope::_awaited2
+			IL_028b: pop
+			IL_028c: ldstr "console"
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0296: stloc.s 4
+			IL_0298: ldloc.s 4
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_029f: stloc.s 4
+			IL_02a1: ldloc.s 4
+			IL_02a3: ldstr "log"
+			IL_02a8: ldstr "finally: after await"
+			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02b2: pop
+			IL_02b3: br IL_02cb
 
-			IL_02d2: ldloc.0
-			IL_02d3: ldc.i4.1
-			IL_02d4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02d9: ldloc.0
-			IL_02da: ldc.i4.0
-			IL_02db: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02e0: br IL_02e5
+			IL_02b8: ldloc.0
+			IL_02b9: ldc.i4.1
+			IL_02ba: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02bf: ldloc.0
+			IL_02c0: ldc.i4.0
+			IL_02c1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02c6: br IL_02cb
 
-			IL_02e5: ldloc.0
-			IL_02e6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02eb: stloc.3
-			IL_02ec: ldloc.3
-			IL_02ed: brfalse IL_032a
+			IL_02cb: ldloc.0
+			IL_02cc: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02d1: stloc.2
+			IL_02d2: ldloc.2
+			IL_02d3: brfalse IL_0310
 
-			IL_02f2: ldloc.0
-			IL_02f3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02f8: stloc.s 5
-			IL_02fa: ldloc.0
-			IL_02fb: ldc.i4.m1
-			IL_02fc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0301: ldloc.0
-			IL_0302: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_030c: ldarg.0
-			IL_030d: ldc.i4.1
-			IL_030e: newarr [System.Runtime]System.Object
-			IL_0313: dup
-			IL_0314: ldc.i4.0
-			IL_0315: ldloc.s 5
-			IL_0317: stelem.ref
-			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_031d: pop
-			IL_031e: ldloc.0
-			IL_031f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0324: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0329: ret
+			IL_02d8: ldloc.0
+			IL_02d9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_02de: stloc.s 4
+			IL_02e0: ldloc.0
+			IL_02e1: ldc.i4.m1
+			IL_02e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02e7: ldloc.0
+			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_02f2: ldarg.0
+			IL_02f3: ldc.i4.1
+			IL_02f4: newarr [System.Runtime]System.Object
+			IL_02f9: dup
+			IL_02fa: ldc.i4.0
+			IL_02fb: ldloc.s 4
+			IL_02fd: stelem.ref
+			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0303: pop
+			IL_0304: ldloc.0
+			IL_0305: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_030a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_030f: ret
 
-			IL_032a: ldloc.0
-			IL_032b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0330: stloc.s 4
-			IL_0332: ldloc.s 4
-			IL_0334: brfalse IL_0371
+			IL_0310: ldloc.0
+			IL_0311: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0316: stloc.3
+			IL_0317: ldloc.3
+			IL_0318: brfalse IL_0355
 
-			IL_0339: ldloc.0
-			IL_033a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_033f: stloc.s 5
-			IL_0341: ldloc.0
-			IL_0342: ldc.i4.m1
-			IL_0343: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0348: ldloc.0
-			IL_0349: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0353: ldarg.0
-			IL_0354: ldc.i4.1
-			IL_0355: newarr [System.Runtime]System.Object
-			IL_035a: dup
-			IL_035b: ldc.i4.0
-			IL_035c: ldloc.s 5
-			IL_035e: stelem.ref
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0364: pop
-			IL_0365: ldloc.0
-			IL_0366: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0370: ret
+			IL_031d: ldloc.0
+			IL_031e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0323: stloc.s 4
+			IL_0325: ldloc.0
+			IL_0326: ldc.i4.m1
+			IL_0327: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_032c: ldloc.0
+			IL_032d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0337: ldarg.0
+			IL_0338: ldc.i4.1
+			IL_0339: newarr [System.Runtime]System.Object
+			IL_033e: dup
+			IL_033f: ldc.i4.0
+			IL_0340: ldloc.s 4
+			IL_0342: stelem.ref
+			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0348: pop
+			IL_0349: ldloc.0
+			IL_034a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_034f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0354: ret
 
-			IL_0371: ldstr "console"
-			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_037b: stloc.s 5
-			IL_037d: ldloc.s 5
-			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0384: stloc.s 5
-			IL_0386: ldloc.s 5
-			IL_0388: ldstr "log"
-			IL_038d: ldstr "after"
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0397: pop
-			IL_0398: ldloc.0
-			IL_0399: ldc.i4.m1
-			IL_039a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_039f: ldloc.0
-			IL_03a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03aa: ldarg.0
-			IL_03ab: ldc.i4.1
-			IL_03ac: newarr [System.Runtime]System.Object
-			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03b6: pop
-			IL_03b7: ldloc.0
-			IL_03b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03c2: ret
+			IL_0355: ldstr "console"
+			IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_035f: stloc.s 4
+			IL_0361: ldloc.s 4
+			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0368: stloc.s 4
+			IL_036a: ldloc.s 4
+			IL_036c: ldstr "log"
+			IL_0371: ldstr "after"
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_037b: pop
+			IL_037c: ldloc.0
+			IL_037d: ldc.i4.m1
+			IL_037e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0383: ldloc.0
+			IL_0384: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_038e: ldarg.0
+			IL_038f: ldc.i4.1
+			IL_0390: newarr [System.Runtime]System.Object
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_039a: pop
+			IL_039b: ldloc.0
+			IL_039c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03a6: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -527,7 +511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x250e
+				// Method begins at RVA 0x24f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -550,7 +534,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24b0
+			// Method begins at RVA 0x2494
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -589,7 +573,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24e1
+			// Method begins at RVA 0x24c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -688,7 +672,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2517
+		// Method begins at RVA 0x24fb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
@@ -31,7 +31,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2377
+					// Method begins at RVA 0x2333
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2380
+					// Method begins at RVA 0x233c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236e
+				// Method begins at RVA 0x232a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,15 +101,13 @@
 			)
 			// Method begins at RVA 0x2104
 			// Header size: 12
-			// Code size: 547 (0x223)
+			// Code size: 478 (0x1de)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope,
-				[1] class Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope/Block_L6C8,
+				[1] object,
 				[2] object,
-				[3] object,
-				[4] class Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope/Block_L10C16,
-				[5] object
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -142,185 +140,163 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.5
+			IL_0048: ldc.i4.3
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_0086
+			IL_005a: ble IL_0072
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0065: dup
 			IL_0066: ldc.i4.0
 			IL_0067: ldelem.ref
-			IL_0068: castclass Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope/Block_L6C8
-			IL_006d: stloc.1
-			IL_006e: dup
-			IL_006f: ldc.i4.1
-			IL_0070: ldelem.ref
-			IL_0071: stloc.2
-			IL_0072: dup
-			IL_0073: ldc.i4.2
-			IL_0074: ldelem.ref
-			IL_0075: stloc.3
-			IL_0076: dup
-			IL_0077: ldc.i4.3
-			IL_0078: ldelem.ref
-			IL_0079: castclass Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope/Block_L10C16
-			IL_007e: stloc.s 4
-			IL_0080: dup
-			IL_0081: ldc.i4.4
-			IL_0082: ldelem.ref
-			IL_0083: stloc.s 5
-			IL_0085: pop
+			IL_0068: stloc.1
+			IL_0069: dup
+			IL_006a: ldc.i4.1
+			IL_006b: ldelem.ref
+			IL_006c: stloc.2
+			IL_006d: dup
+			IL_006e: ldc.i4.2
+			IL_006f: ldelem.ref
+			IL_0070: stloc.3
+			IL_0071: pop
 
-			IL_0086: ldloc.0
-			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_008c: switch (IL_009d, IL_0186, IL_014f)
+			IL_0072: ldloc.0
+			IL_0073: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0078: switch (IL_0089, IL_0152, IL_0121)
 
-			IL_009d: ldstr "console"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a7: stloc.s 5
-			IL_00a9: ldloc.s 5
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b0: stloc.s 5
-			IL_00b2: ldloc.s 5
-			IL_00b4: ldstr "log"
-			IL_00b9: ldstr "Before try"
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c3: pop
-			IL_00c4: ldloc.0
-			IL_00c5: ldc.i4.0
-			IL_00c6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00cb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00d0: newobj instance void Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope/Block_L6C8::.ctor()
-			IL_00d5: stloc.1
-			IL_00d6: ldstr "console"
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e0: stloc.s 5
-			IL_00e2: ldloc.s 5
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e9: stloc.s 5
-			IL_00eb: ldloc.s 5
-			IL_00ed: ldstr "log"
-			IL_00f2: ldstr "Inside try, before await"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fc: pop
-			IL_00fd: ldstr "error value"
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-			IL_0107: stloc.s 5
-			IL_0109: ldloc.0
-			IL_010a: ldc.i4.2
-			IL_010b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0110: ldloc.0
-			IL_0111: ldloc.s 5
-			IL_0113: ldarg.0
-			IL_0114: ldc.i4.1
+			IL_0089: ldstr "console"
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0093: stloc.3
+			IL_0094: ldloc.3
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009a: stloc.3
+			IL_009b: ldloc.3
+			IL_009c: ldstr "log"
+			IL_00a1: ldstr "Before try"
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ab: pop
+			IL_00ac: ldloc.0
+			IL_00ad: ldc.i4.0
+			IL_00ae: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00b3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00b8: ldstr "console"
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c2: stloc.3
+			IL_00c3: ldloc.3
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c9: stloc.3
+			IL_00ca: ldloc.3
+			IL_00cb: ldstr "log"
+			IL_00d0: ldstr "Inside try, before await"
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00da: pop
+			IL_00db: ldstr "error value"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_00e5: stloc.3
+			IL_00e6: ldloc.0
+			IL_00e7: ldc.i4.2
+			IL_00e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00ed: ldloc.0
+			IL_00ee: ldloc.3
+			IL_00ef: ldarg.0
+			IL_00f0: ldc.i4.1
+			IL_00f1: ldloc.0
+			IL_00f2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00f7: ldc.i4.1
+			IL_00f8: ldstr "_pendingException"
+			IL_00fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0102: ldloc.0
+			IL_0103: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0108: dup
+			IL_0109: ldc.i4.0
+			IL_010a: ldloc.1
+			IL_010b: stelem.ref
+			IL_010c: dup
+			IL_010d: ldc.i4.1
+			IL_010e: ldloc.2
+			IL_010f: stelem.ref
+			IL_0110: dup
+			IL_0111: ldc.i4.2
+			IL_0112: ldloc.3
+			IL_0113: stelem.ref
+			IL_0114: pop
 			IL_0115: ldloc.0
-			IL_0116: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_011b: ldc.i4.1
-			IL_011c: ldstr "_pendingException"
-			IL_0121: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0126: ldloc.0
-			IL_0127: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012c: dup
-			IL_012d: ldc.i4.0
-			IL_012e: ldloc.1
-			IL_012f: stelem.ref
-			IL_0130: dup
-			IL_0131: ldc.i4.1
-			IL_0132: ldloc.2
-			IL_0133: stelem.ref
-			IL_0134: dup
-			IL_0135: ldc.i4.2
-			IL_0136: ldloc.3
-			IL_0137: stelem.ref
-			IL_0138: dup
-			IL_0139: ldc.i4.3
-			IL_013a: ldloc.s 4
-			IL_013c: stelem.ref
-			IL_013d: dup
-			IL_013e: ldc.i4.4
-			IL_013f: ldloc.s 5
-			IL_0141: stelem.ref
-			IL_0142: pop
-			IL_0143: ldloc.0
-			IL_0144: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0149: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_014e: ret
+			IL_0116: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_011b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0120: ret
 
-			IL_014f: ldloc.0
-			IL_0150: ldfld object Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope::_awaited1
-			IL_0155: stloc.s 5
-			IL_0157: ldloc.s 5
-			IL_0159: stloc.2
-			IL_015a: ldstr "console"
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0164: stloc.s 5
-			IL_0166: ldloc.s 5
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016d: stloc.s 5
-			IL_016f: ldloc.s 5
-			IL_0171: ldstr "log"
-			IL_0176: ldstr "This should not print"
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0180: pop
-			IL_0181: br IL_01d1
+			IL_0121: ldloc.0
+			IL_0122: ldfld object Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope::_awaited1
+			IL_0127: stloc.3
+			IL_0128: ldloc.3
+			IL_0129: stloc.1
+			IL_012a: ldstr "console"
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0134: stloc.3
+			IL_0135: ldloc.3
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013b: stloc.3
+			IL_013c: ldloc.3
+			IL_013d: ldstr "log"
+			IL_0142: ldstr "This should not print"
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_014c: pop
+			IL_014d: br IL_0190
 
-			IL_0186: ldloc.0
-			IL_0187: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_018c: stloc.s 5
-			IL_018e: ldloc.0
-			IL_018f: ldc.i4.0
-			IL_0190: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0195: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_019a: ldloc.s 5
-			IL_019c: stloc.3
-			IL_019d: newobj instance void Modules.Async_TryCatch_AwaitReject/testTryCatch/Scope/Block_L10C16::.ctor()
-			IL_01a2: stloc.s 4
-			IL_01a4: ldstr "console"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ae: stloc.s 5
-			IL_01b0: ldloc.s 5
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b7: stloc.s 5
-			IL_01b9: ldloc.s 5
-			IL_01bb: ldstr "log"
-			IL_01c0: ldstr "Caught error:"
-			IL_01c5: ldloc.3
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01cb: pop
-			IL_01cc: br IL_01d1
+			IL_0152: ldloc.0
+			IL_0153: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0158: stloc.3
+			IL_0159: ldloc.0
+			IL_015a: ldc.i4.0
+			IL_015b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0160: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0165: ldloc.3
+			IL_0166: stloc.2
+			IL_0167: ldstr "console"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0171: stloc.3
+			IL_0172: ldloc.3
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0178: stloc.3
+			IL_0179: ldloc.3
+			IL_017a: ldstr "log"
+			IL_017f: ldstr "Caught error:"
+			IL_0184: ldloc.2
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_018a: pop
+			IL_018b: br IL_0190
 
-			IL_01d1: ldstr "console"
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01db: stloc.s 5
-			IL_01dd: ldloc.s 5
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e4: stloc.s 5
-			IL_01e6: ldloc.s 5
-			IL_01e8: ldstr "log"
-			IL_01ed: ldstr "After try/catch"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01f7: pop
-			IL_01f8: ldloc.0
-			IL_01f9: ldc.i4.m1
-			IL_01fa: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01ff: ldloc.0
-			IL_0200: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_020a: ldarg.0
-			IL_020b: ldc.i4.1
-			IL_020c: newarr [System.Runtime]System.Object
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0216: pop
-			IL_0217: ldloc.0
-			IL_0218: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_021d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0222: ret
+			IL_0190: ldstr "console"
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_019a: stloc.3
+			IL_019b: ldloc.3
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a1: stloc.3
+			IL_01a2: ldloc.3
+			IL_01a3: ldstr "log"
+			IL_01a8: ldstr "After try/catch"
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b2: pop
+			IL_01b3: ldloc.0
+			IL_01b4: ldc.i4.m1
+			IL_01b5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ba: ldloc.0
+			IL_01bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01c5: ldarg.0
+			IL_01c6: ldc.i4.1
+			IL_01c7: newarr [System.Runtime]System.Object
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01d1: pop
+			IL_01d2: ldloc.0
+			IL_01d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01dd: ret
 		} // end of method testTryCatch::__js_call__
 
 	} // end of class testTryCatch
@@ -336,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2389
+				// Method begins at RVA 0x2345
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -359,7 +335,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2334
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -399,7 +375,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2365
+			// Method begins at RVA 0x2321
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -509,7 +485,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2392
+		// Method begins at RVA 0x234e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24c7
+					// Method begins at RVA 0x24ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24d0
+					// Method begins at RVA 0x24b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24be
+				// Method begins at RVA 0x24a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,15 +111,14 @@
 			)
 			// Method begins at RVA 0x2104
 			// Header size: 12
-			// Code size: 882 (0x372)
+			// Code size: 854 (0x356)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope,
-				[1] class Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope/Block_L10C14,
-				[2] object,
+				[1] object,
+				[2] bool,
 				[3] bool,
-				[4] bool,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: ldarg.0
@@ -152,25 +151,25 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.5
+			IL_0048: ldc.i4.4
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_008b
+			IL_005a: ble IL_0081
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0065: dup
 			IL_0066: ldc.i4.0
 			IL_0067: ldelem.ref
-			IL_0068: castclass Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope/Block_L10C14
-			IL_006d: stloc.1
-			IL_006e: dup
-			IL_006f: ldc.i4.1
-			IL_0070: ldelem.ref
+			IL_0068: stloc.1
+			IL_0069: dup
+			IL_006a: ldc.i4.1
+			IL_006b: ldelem.ref
+			IL_006c: unbox.any [System.Runtime]System.Boolean
 			IL_0071: stloc.2
 			IL_0072: dup
 			IL_0073: ldc.i4.2
@@ -180,292 +179,277 @@
 			IL_007b: dup
 			IL_007c: ldc.i4.3
 			IL_007d: ldelem.ref
-			IL_007e: unbox.any [System.Runtime]System.Boolean
-			IL_0083: stloc.s 4
-			IL_0085: dup
-			IL_0086: ldc.i4.4
-			IL_0087: ldelem.ref
-			IL_0088: stloc.s 5
-			IL_008a: pop
+			IL_007e: stloc.s 4
+			IL_0080: pop
 
-			IL_008b: ldloc.0
-			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_00aa, IL_01ad, IL_0281, IL_017a, IL_0249)
+			IL_0081: ldloc.0
+			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0087: switch (IL_00a0, IL_019e, IL_0267, IL_016b, IL_022f)
 
-			IL_00aa: ldstr "console"
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b4: stloc.s 5
-			IL_00b6: ldloc.s 5
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.s 5
-			IL_00c1: ldstr "log"
-			IL_00c6: ldstr "try: before"
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d0: pop
-			IL_00d1: ldloc.0
-			IL_00d2: ldc.i4.0
-			IL_00d3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00dd: ldloc.0
-			IL_00de: ldc.i4.0
-			IL_00df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_00e9: ldloc.0
-			IL_00ea: ldc.i4.0
-			IL_00eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_00f0: ldloc.0
-			IL_00f1: ldc.i4.0
-			IL_00f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_00f7: ldstr "console"
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0101: stloc.s 5
-			IL_0103: ldloc.s 5
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010a: stloc.s 5
-			IL_010c: ldloc.s 5
-			IL_010e: ldstr "log"
-			IL_0113: ldstr "try: inside"
-			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_011d: pop
-			IL_011e: ldstr "ok"
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_0128: stloc.s 5
-			IL_012a: ldloc.0
-			IL_012b: ldc.i4.3
-			IL_012c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0131: ldloc.0
-			IL_0132: ldloc.s 5
-			IL_0134: ldarg.0
-			IL_0135: ldc.i4.1
-			IL_0136: ldloc.0
-			IL_0137: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_013c: ldc.i4.1
-			IL_013d: ldstr "_pendingException"
-			IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0147: ldloc.0
-			IL_0148: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_014d: dup
-			IL_014e: ldc.i4.0
-			IL_014f: ldloc.1
-			IL_0150: stelem.ref
-			IL_0151: dup
-			IL_0152: ldc.i4.1
-			IL_0153: ldloc.2
-			IL_0154: stelem.ref
-			IL_0155: dup
-			IL_0156: ldc.i4.2
-			IL_0157: ldloc.3
-			IL_0158: box [System.Runtime]System.Boolean
+			IL_00a0: ldstr "console"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00aa: stloc.s 4
+			IL_00ac: ldloc.s 4
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b3: stloc.s 4
+			IL_00b5: ldloc.s 4
+			IL_00b7: ldstr "log"
+			IL_00bc: ldstr "try: before"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c6: pop
+			IL_00c7: ldloc.0
+			IL_00c8: ldc.i4.0
+			IL_00c9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00ce: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00d3: ldloc.0
+			IL_00d4: ldc.i4.0
+			IL_00d5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00da: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_00df: ldloc.0
+			IL_00e0: ldc.i4.0
+			IL_00e1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_00e6: ldloc.0
+			IL_00e7: ldc.i4.0
+			IL_00e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00ed: ldstr "console"
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f7: stloc.s 4
+			IL_00f9: ldloc.s 4
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0100: stloc.s 4
+			IL_0102: ldloc.s 4
+			IL_0104: ldstr "log"
+			IL_0109: ldstr "try: inside"
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0113: pop
+			IL_0114: ldstr "ok"
+			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_011e: stloc.s 4
+			IL_0120: ldloc.0
+			IL_0121: ldc.i4.3
+			IL_0122: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0127: ldloc.0
+			IL_0128: ldloc.s 4
+			IL_012a: ldarg.0
+			IL_012b: ldc.i4.1
+			IL_012c: ldloc.0
+			IL_012d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0132: ldc.i4.1
+			IL_0133: ldstr "_pendingException"
+			IL_0138: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_013d: ldloc.0
+			IL_013e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0143: dup
+			IL_0144: ldc.i4.0
+			IL_0145: ldloc.1
+			IL_0146: stelem.ref
+			IL_0147: dup
+			IL_0148: ldc.i4.1
+			IL_0149: ldloc.2
+			IL_014a: box [System.Runtime]System.Boolean
+			IL_014f: stelem.ref
+			IL_0150: dup
+			IL_0151: ldc.i4.2
+			IL_0152: ldloc.3
+			IL_0153: box [System.Runtime]System.Boolean
+			IL_0158: stelem.ref
+			IL_0159: dup
+			IL_015a: ldc.i4.3
+			IL_015b: ldloc.s 4
 			IL_015d: stelem.ref
-			IL_015e: dup
-			IL_015f: ldc.i4.3
-			IL_0160: ldloc.s 4
-			IL_0162: box [System.Runtime]System.Boolean
-			IL_0167: stelem.ref
-			IL_0168: dup
-			IL_0169: ldc.i4.4
-			IL_016a: ldloc.s 5
-			IL_016c: stelem.ref
-			IL_016d: pop
-			IL_016e: ldloc.0
-			IL_016f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0174: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0179: ret
+			IL_015e: pop
+			IL_015f: ldloc.0
+			IL_0160: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0165: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_016a: ret
 
-			IL_017a: ldloc.0
-			IL_017b: ldfld object Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope::_awaited1
-			IL_0180: pop
-			IL_0181: ldstr "console"
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_018b: stloc.s 5
-			IL_018d: ldloc.s 5
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0194: stloc.s 5
-			IL_0196: ldloc.s 5
-			IL_0198: ldstr "log"
-			IL_019d: ldstr "try: after await"
-			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01a7: pop
-			IL_01a8: br IL_01c0
+			IL_016b: ldloc.0
+			IL_016c: ldfld object Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope::_awaited1
+			IL_0171: pop
+			IL_0172: ldstr "console"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017c: stloc.s 4
+			IL_017e: ldloc.s 4
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0185: stloc.s 4
+			IL_0187: ldloc.s 4
+			IL_0189: ldstr "log"
+			IL_018e: ldstr "try: after await"
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0198: pop
+			IL_0199: br IL_01b1
 
-			IL_01ad: ldloc.0
-			IL_01ae: ldc.i4.1
-			IL_01af: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01b4: ldloc.0
-			IL_01b5: ldc.i4.0
-			IL_01b6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01bb: br IL_01c0
+			IL_019e: ldloc.0
+			IL_019f: ldc.i4.1
+			IL_01a0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01a5: ldloc.0
+			IL_01a6: ldc.i4.0
+			IL_01a7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_01ac: br IL_01b1
 
-			IL_01c0: newobj instance void Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope/Block_L10C14::.ctor()
-			IL_01c5: stloc.1
-			IL_01c6: ldstr "console"
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01d0: stloc.s 5
-			IL_01d2: ldloc.s 5
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d9: stloc.s 5
-			IL_01db: ldloc.s 5
-			IL_01dd: ldstr "log"
-			IL_01e2: ldstr "finally: before await"
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ec: pop
-			IL_01ed: ldstr "finally-await"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_01f7: stloc.s 5
-			IL_01f9: ldloc.0
-			IL_01fa: ldc.i4.4
-			IL_01fb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0200: ldloc.0
-			IL_0201: ldloc.s 5
-			IL_0203: ldarg.0
-			IL_0204: ldc.i4.2
-			IL_0205: ldloc.0
-			IL_0206: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_020b: ldc.i4.2
-			IL_020c: ldstr "_pendingException"
-			IL_0211: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0216: ldloc.0
-			IL_0217: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_021c: dup
-			IL_021d: ldc.i4.0
-			IL_021e: ldloc.1
-			IL_021f: stelem.ref
-			IL_0220: dup
-			IL_0221: ldc.i4.1
-			IL_0222: ldloc.2
-			IL_0223: stelem.ref
-			IL_0224: dup
-			IL_0225: ldc.i4.2
-			IL_0226: ldloc.3
-			IL_0227: box [System.Runtime]System.Boolean
-			IL_022c: stelem.ref
-			IL_022d: dup
-			IL_022e: ldc.i4.3
-			IL_022f: ldloc.s 4
-			IL_0231: box [System.Runtime]System.Boolean
-			IL_0236: stelem.ref
-			IL_0237: dup
-			IL_0238: ldc.i4.4
-			IL_0239: ldloc.s 5
-			IL_023b: stelem.ref
-			IL_023c: pop
-			IL_023d: ldloc.0
-			IL_023e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0243: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0248: ret
+			IL_01b1: ldstr "console"
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01bb: stloc.s 4
+			IL_01bd: ldloc.s 4
+			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c4: stloc.s 4
+			IL_01c6: ldloc.s 4
+			IL_01c8: ldstr "log"
+			IL_01cd: ldstr "finally: before await"
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01d7: pop
+			IL_01d8: ldstr "finally-await"
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_01e2: stloc.s 4
+			IL_01e4: ldloc.0
+			IL_01e5: ldc.i4.4
+			IL_01e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01eb: ldloc.0
+			IL_01ec: ldloc.s 4
+			IL_01ee: ldarg.0
+			IL_01ef: ldc.i4.2
+			IL_01f0: ldloc.0
+			IL_01f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01f6: ldc.i4.2
+			IL_01f7: ldstr "_pendingException"
+			IL_01fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0201: ldloc.0
+			IL_0202: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0207: dup
+			IL_0208: ldc.i4.0
+			IL_0209: ldloc.1
+			IL_020a: stelem.ref
+			IL_020b: dup
+			IL_020c: ldc.i4.1
+			IL_020d: ldloc.2
+			IL_020e: box [System.Runtime]System.Boolean
+			IL_0213: stelem.ref
+			IL_0214: dup
+			IL_0215: ldc.i4.2
+			IL_0216: ldloc.3
+			IL_0217: box [System.Runtime]System.Boolean
+			IL_021c: stelem.ref
+			IL_021d: dup
+			IL_021e: ldc.i4.3
+			IL_021f: ldloc.s 4
+			IL_0221: stelem.ref
+			IL_0222: pop
+			IL_0223: ldloc.0
+			IL_0224: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0229: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_022e: ret
 
-			IL_0249: ldloc.0
-			IL_024a: ldfld object Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope::_awaited2
-			IL_024f: stloc.s 5
-			IL_0251: ldloc.s 5
-			IL_0253: stloc.2
-			IL_0254: ldstr "console"
-			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_025e: stloc.s 5
-			IL_0260: ldloc.s 5
-			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0267: stloc.s 5
-			IL_0269: ldloc.s 5
-			IL_026b: ldstr "log"
-			IL_0270: ldstr "finally: after await"
-			IL_0275: ldloc.2
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_027b: pop
-			IL_027c: br IL_0294
+			IL_022f: ldloc.0
+			IL_0230: ldfld object Modules.Async_TryFinally_AwaitInFinally_Normal/test/Scope::_awaited2
+			IL_0235: stloc.s 4
+			IL_0237: ldloc.s 4
+			IL_0239: stloc.1
+			IL_023a: ldstr "console"
+			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0244: stloc.s 4
+			IL_0246: ldloc.s 4
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024d: stloc.s 4
+			IL_024f: ldloc.s 4
+			IL_0251: ldstr "log"
+			IL_0256: ldstr "finally: after await"
+			IL_025b: ldloc.1
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0261: pop
+			IL_0262: br IL_027a
 
-			IL_0281: ldloc.0
-			IL_0282: ldc.i4.1
-			IL_0283: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0288: ldloc.0
-			IL_0289: ldc.i4.0
-			IL_028a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_028f: br IL_0294
+			IL_0267: ldloc.0
+			IL_0268: ldc.i4.1
+			IL_0269: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_026e: ldloc.0
+			IL_026f: ldc.i4.0
+			IL_0270: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0275: br IL_027a
 
-			IL_0294: ldloc.0
-			IL_0295: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_029a: stloc.3
-			IL_029b: ldloc.3
-			IL_029c: brfalse IL_02d9
+			IL_027a: ldloc.0
+			IL_027b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0280: stloc.2
+			IL_0281: ldloc.2
+			IL_0282: brfalse IL_02bf
 
-			IL_02a1: ldloc.0
-			IL_02a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02a7: stloc.s 5
-			IL_02a9: ldloc.0
-			IL_02aa: ldc.i4.m1
-			IL_02ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b0: ldloc.0
-			IL_02b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02bb: ldarg.0
-			IL_02bc: ldc.i4.1
-			IL_02bd: newarr [System.Runtime]System.Object
-			IL_02c2: dup
-			IL_02c3: ldc.i4.0
-			IL_02c4: ldloc.s 5
-			IL_02c6: stelem.ref
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02cc: pop
-			IL_02cd: ldloc.0
-			IL_02ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02d8: ret
+			IL_0287: ldloc.0
+			IL_0288: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_028d: stloc.s 4
+			IL_028f: ldloc.0
+			IL_0290: ldc.i4.m1
+			IL_0291: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0296: ldloc.0
+			IL_0297: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_029c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_02a1: ldarg.0
+			IL_02a2: ldc.i4.1
+			IL_02a3: newarr [System.Runtime]System.Object
+			IL_02a8: dup
+			IL_02a9: ldc.i4.0
+			IL_02aa: ldloc.s 4
+			IL_02ac: stelem.ref
+			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02b2: pop
+			IL_02b3: ldloc.0
+			IL_02b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02b9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02be: ret
 
-			IL_02d9: ldloc.0
-			IL_02da: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02df: stloc.s 4
-			IL_02e1: ldloc.s 4
-			IL_02e3: brfalse IL_0320
+			IL_02bf: ldloc.0
+			IL_02c0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02c5: stloc.3
+			IL_02c6: ldloc.3
+			IL_02c7: brfalse IL_0304
 
-			IL_02e8: ldloc.0
-			IL_02e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_02ee: stloc.s 5
-			IL_02f0: ldloc.0
-			IL_02f1: ldc.i4.m1
-			IL_02f2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02f7: ldloc.0
-			IL_02f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0302: ldarg.0
-			IL_0303: ldc.i4.1
-			IL_0304: newarr [System.Runtime]System.Object
-			IL_0309: dup
-			IL_030a: ldc.i4.0
-			IL_030b: ldloc.s 5
-			IL_030d: stelem.ref
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0313: pop
-			IL_0314: ldloc.0
-			IL_0315: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_031a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_031f: ret
+			IL_02cc: ldloc.0
+			IL_02cd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_02d2: stloc.s 4
+			IL_02d4: ldloc.0
+			IL_02d5: ldc.i4.m1
+			IL_02d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02db: ldloc.0
+			IL_02dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02e6: ldarg.0
+			IL_02e7: ldc.i4.1
+			IL_02e8: newarr [System.Runtime]System.Object
+			IL_02ed: dup
+			IL_02ee: ldc.i4.0
+			IL_02ef: ldloc.s 4
+			IL_02f1: stelem.ref
+			IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02f7: pop
+			IL_02f8: ldloc.0
+			IL_02f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0303: ret
 
-			IL_0320: ldstr "console"
-			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_032a: stloc.s 5
-			IL_032c: ldloc.s 5
-			IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0333: stloc.s 5
-			IL_0335: ldloc.s 5
-			IL_0337: ldstr "log"
-			IL_033c: ldstr "after try/finally"
-			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0346: pop
-			IL_0347: ldloc.0
-			IL_0348: ldc.i4.m1
-			IL_0349: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_034e: ldloc.0
-			IL_034f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0354: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0359: ldarg.0
-			IL_035a: ldc.i4.1
-			IL_035b: newarr [System.Runtime]System.Object
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0365: pop
-			IL_0366: ldloc.0
-			IL_0367: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0371: ret
+			IL_0304: ldstr "console"
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_030e: stloc.s 4
+			IL_0310: ldloc.s 4
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0317: stloc.s 4
+			IL_0319: ldloc.s 4
+			IL_031b: ldstr "log"
+			IL_0320: ldstr "after try/finally"
+			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_032a: pop
+			IL_032b: ldloc.0
+			IL_032c: ldc.i4.m1
+			IL_032d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0332: ldloc.0
+			IL_0333: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0338: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_033d: ldarg.0
+			IL_033e: ldc.i4.1
+			IL_033f: newarr [System.Runtime]System.Object
+			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0349: pop
+			IL_034a: ldloc.0
+			IL_034b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0350: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0355: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -481,7 +465,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d9
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -504,7 +488,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2484
+			// Method begins at RVA 0x2468
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -543,7 +527,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b5
+			// Method begins at RVA 0x2499
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -653,7 +637,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24e2
+		// Method begins at RVA 0x24c6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2444
+						// Method begins at RVA 0x2430
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x244d
+						// Method begins at RVA 0x2439
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x243b
+					// Method begins at RVA 0x2427
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2456
+					// Method begins at RVA 0x2442
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2432
+				// Method begins at RVA 0x241e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 779 (0x30b)
+			// Code size: 757 (0x2f5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/Scope,
@@ -161,8 +161,7 @@
 				[2] bool,
 				[3] bool,
 				[4] object,
-				[5] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/Scope/Block_L14C16,
-				[6] object
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -195,14 +194,14 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.6
+			IL_0048: ldc.i4.5
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_0090
+			IL_005a: ble IL_0086
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -227,244 +226,233 @@
 			IL_0080: dup
 			IL_0081: ldc.i4.4
 			IL_0082: ldelem.ref
-			IL_0083: castclass Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/Scope/Block_L14C16
-			IL_0088: stloc.s 5
-			IL_008a: dup
-			IL_008b: ldc.i4.5
-			IL_008c: ldelem.ref
-			IL_008d: stloc.s 6
-			IL_008f: pop
+			IL_0083: stloc.s 5
+			IL_0085: pop
 
-			IL_0090: ldloc.0
-			IL_0091: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0096: switch (IL_00af, IL_026c, IL_019c, IL_01ed, IL_0190)
+			IL_0086: ldloc.0
+			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_008c: switch (IL_00a5, IL_025d, IL_018d, IL_01de, IL_0181)
 
-			IL_00af: ldstr "console"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b9: stloc.s 6
-			IL_00bb: ldloc.s 6
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c2: stloc.s 6
-			IL_00c4: ldloc.s 6
-			IL_00c6: ldstr "log"
-			IL_00cb: ldstr "start"
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d5: pop
-			IL_00d6: ldloc.0
-			IL_00d7: ldc.i4.0
-			IL_00d8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00dd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00e2: ldloc.0
-			IL_00e3: ldc.i4.0
-			IL_00e4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00ee: ldloc.0
-			IL_00ef: ldc.i4.0
-			IL_00f0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00f5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_00fa: ldloc.0
-			IL_00fb: ldc.i4.0
-			IL_00fc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0101: ldloc.0
-			IL_0102: ldc.i4.0
-			IL_0103: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0108: ldstr "console"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0112: stloc.s 6
-			IL_0114: ldloc.s 6
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011b: stloc.s 6
-			IL_011d: ldloc.s 6
-			IL_011f: ldstr "log"
-			IL_0124: ldstr "inner try: rejecting"
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012e: pop
-			IL_012f: ldstr "original"
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-			IL_0139: stloc.s 6
-			IL_013b: ldloc.0
-			IL_013c: ldc.i4.4
-			IL_013d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0142: ldloc.0
-			IL_0143: ldloc.s 6
-			IL_0145: ldarg.0
-			IL_0146: ldc.i4.1
-			IL_0147: ldloc.0
-			IL_0148: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_014d: ldc.i4.2
-			IL_014e: ldstr "_pendingException"
-			IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0158: ldloc.0
-			IL_0159: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_015e: dup
-			IL_015f: ldc.i4.0
-			IL_0160: ldloc.1
-			IL_0161: stelem.ref
-			IL_0162: dup
-			IL_0163: ldc.i4.1
-			IL_0164: ldloc.2
-			IL_0165: box [System.Runtime]System.Boolean
-			IL_016a: stelem.ref
-			IL_016b: dup
-			IL_016c: ldc.i4.2
-			IL_016d: ldloc.3
-			IL_016e: box [System.Runtime]System.Boolean
+			IL_00a5: ldstr "console"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00af: stloc.s 5
+			IL_00b1: ldloc.s 5
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.s 5
+			IL_00ba: ldloc.s 5
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "start"
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cb: pop
+			IL_00cc: ldloc.0
+			IL_00cd: ldc.i4.0
+			IL_00ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00d8: ldloc.0
+			IL_00d9: ldc.i4.0
+			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00df: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00e4: ldloc.0
+			IL_00e5: ldc.i4.0
+			IL_00e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00eb: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_00f0: ldloc.0
+			IL_00f1: ldc.i4.0
+			IL_00f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_00f7: ldloc.0
+			IL_00f8: ldc.i4.0
+			IL_00f9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00fe: ldstr "console"
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0108: stloc.s 5
+			IL_010a: ldloc.s 5
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0111: stloc.s 5
+			IL_0113: ldloc.s 5
+			IL_0115: ldstr "log"
+			IL_011a: ldstr "inner try: rejecting"
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0124: pop
+			IL_0125: ldstr "original"
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_012f: stloc.s 5
+			IL_0131: ldloc.0
+			IL_0132: ldc.i4.4
+			IL_0133: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0138: ldloc.0
+			IL_0139: ldloc.s 5
+			IL_013b: ldarg.0
+			IL_013c: ldc.i4.1
+			IL_013d: ldloc.0
+			IL_013e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0143: ldc.i4.2
+			IL_0144: ldstr "_pendingException"
+			IL_0149: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_014e: ldloc.0
+			IL_014f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0154: dup
+			IL_0155: ldc.i4.0
+			IL_0156: ldloc.1
+			IL_0157: stelem.ref
+			IL_0158: dup
+			IL_0159: ldc.i4.1
+			IL_015a: ldloc.2
+			IL_015b: box [System.Runtime]System.Boolean
+			IL_0160: stelem.ref
+			IL_0161: dup
+			IL_0162: ldc.i4.2
+			IL_0163: ldloc.3
+			IL_0164: box [System.Runtime]System.Boolean
+			IL_0169: stelem.ref
+			IL_016a: dup
+			IL_016b: ldc.i4.3
+			IL_016c: ldloc.s 4
+			IL_016e: stelem.ref
+			IL_016f: dup
+			IL_0170: ldc.i4.4
+			IL_0171: ldloc.s 5
 			IL_0173: stelem.ref
-			IL_0174: dup
-			IL_0175: ldc.i4.3
-			IL_0176: ldloc.s 4
-			IL_0178: stelem.ref
-			IL_0179: dup
-			IL_017a: ldc.i4.4
-			IL_017b: ldloc.s 5
-			IL_017d: stelem.ref
-			IL_017e: dup
-			IL_017f: ldc.i4.5
-			IL_0180: ldloc.s 6
-			IL_0182: stelem.ref
-			IL_0183: pop
-			IL_0184: ldloc.0
-			IL_0185: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_018a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_018f: ret
+			IL_0174: pop
+			IL_0175: ldloc.0
+			IL_0176: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_017b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0180: ret
 
-			IL_0190: ldloc.0
-			IL_0191: ldfld object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/Scope::_awaited1
-			IL_0196: pop
-			IL_0197: br IL_01af
+			IL_0181: ldloc.0
+			IL_0182: ldfld object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/Scope::_awaited1
+			IL_0187: pop
+			IL_0188: br IL_01a0
 
-			IL_019c: ldloc.0
-			IL_019d: ldc.i4.1
-			IL_019e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01a3: ldloc.0
-			IL_01a4: ldc.i4.0
-			IL_01a5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01aa: br IL_01af
+			IL_018d: ldloc.0
+			IL_018e: ldc.i4.1
+			IL_018f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0194: ldloc.0
+			IL_0195: ldc.i4.0
+			IL_0196: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_019b: br IL_01a0
 
-			IL_01af: ldstr "console"
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b9: stloc.s 6
-			IL_01bb: ldloc.s 6
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c2: stloc.s 6
-			IL_01c4: ldloc.s 6
-			IL_01c6: ldstr "log"
-			IL_01cb: ldstr "finally: throwing"
-			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01d5: pop
-			IL_01d6: ldstr "finally-error"
-			IL_01db: stloc.1
-			IL_01dc: ldloc.0
-			IL_01dd: ldloc.1
-			IL_01de: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01e3: br IL_01ed
+			IL_01a0: ldstr "console"
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01aa: stloc.s 5
+			IL_01ac: ldloc.s 5
+			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b3: stloc.s 5
+			IL_01b5: ldloc.s 5
+			IL_01b7: ldstr "log"
+			IL_01bc: ldstr "finally: throwing"
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c6: pop
+			IL_01c7: ldstr "finally-error"
+			IL_01cc: stloc.1
+			IL_01cd: ldloc.0
+			IL_01ce: ldloc.1
+			IL_01cf: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01d4: br IL_01de
 
-			IL_01e8: br IL_0200
+			IL_01d9: br IL_01f1
 
-			IL_01ed: ldloc.0
-			IL_01ee: ldc.i4.1
-			IL_01ef: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01f4: ldloc.0
-			IL_01f5: ldc.i4.0
-			IL_01f6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01fb: br IL_0200
+			IL_01de: ldloc.0
+			IL_01df: ldc.i4.1
+			IL_01e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01e5: ldloc.0
+			IL_01e6: ldc.i4.0
+			IL_01e7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_01ec: br IL_01f1
 
-			IL_0200: ldloc.0
-			IL_0201: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0206: stloc.2
-			IL_0207: ldloc.2
-			IL_0208: brfalse IL_0222
+			IL_01f1: ldloc.0
+			IL_01f2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01f7: stloc.2
+			IL_01f8: ldloc.2
+			IL_01f9: brfalse IL_0213
 
-			IL_020d: ldloc.0
-			IL_020e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0213: stloc.s 6
-			IL_0215: ldloc.0
-			IL_0216: ldloc.s 6
-			IL_0218: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_021d: br IL_026c
+			IL_01fe: ldloc.0
+			IL_01ff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0204: stloc.s 5
+			IL_0206: ldloc.0
+			IL_0207: ldloc.s 5
+			IL_0209: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_020e: br IL_025d
 
-			IL_0222: ldloc.0
-			IL_0223: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0228: stloc.3
-			IL_0229: ldloc.3
-			IL_022a: brfalse IL_0267
+			IL_0213: ldloc.0
+			IL_0214: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0219: stloc.3
+			IL_021a: ldloc.3
+			IL_021b: brfalse IL_0258
 
+			IL_0220: ldloc.0
+			IL_0221: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0226: stloc.s 5
+			IL_0228: ldloc.0
+			IL_0229: ldc.i4.m1
+			IL_022a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_022f: ldloc.0
-			IL_0230: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0235: stloc.s 6
-			IL_0237: ldloc.0
-			IL_0238: ldc.i4.m1
-			IL_0239: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_023e: ldloc.0
-			IL_023f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0244: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0249: ldarg.0
-			IL_024a: ldc.i4.1
-			IL_024b: newarr [System.Runtime]System.Object
-			IL_0250: dup
-			IL_0251: ldc.i4.0
-			IL_0252: ldloc.s 6
-			IL_0254: stelem.ref
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_025a: pop
-			IL_025b: ldloc.0
-			IL_025c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0261: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0266: ret
+			IL_0230: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0235: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_023a: ldarg.0
+			IL_023b: ldc.i4.1
+			IL_023c: newarr [System.Runtime]System.Object
+			IL_0241: dup
+			IL_0242: ldc.i4.0
+			IL_0243: ldloc.s 5
+			IL_0245: stelem.ref
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_024b: pop
+			IL_024c: ldloc.0
+			IL_024d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0252: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0257: ret
 
-			IL_0267: br IL_02b9
+			IL_0258: br IL_02a3
 
-			IL_026c: ldloc.0
-			IL_026d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0272: stloc.s 6
-			IL_0274: ldloc.0
-			IL_0275: ldc.i4.0
-			IL_0276: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_027b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0280: ldloc.s 6
-			IL_0282: stloc.s 4
-			IL_0284: newobj instance void Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/Scope/Block_L14C16::.ctor()
-			IL_0289: stloc.s 5
-			IL_028b: ldstr "console"
-			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0295: stloc.s 6
-			IL_0297: ldloc.s 6
-			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029e: stloc.s 6
-			IL_02a0: ldloc.s 6
-			IL_02a2: ldstr "log"
-			IL_02a7: ldstr "caught:"
-			IL_02ac: ldloc.s 4
-			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02b3: pop
-			IL_02b4: br IL_02b9
+			IL_025d: ldloc.0
+			IL_025e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0263: stloc.s 5
+			IL_0265: ldloc.0
+			IL_0266: ldc.i4.0
+			IL_0267: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_026c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0271: ldloc.s 5
+			IL_0273: stloc.s 4
+			IL_0275: ldstr "console"
+			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_027f: stloc.s 5
+			IL_0281: ldloc.s 5
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0288: stloc.s 5
+			IL_028a: ldloc.s 5
+			IL_028c: ldstr "log"
+			IL_0291: ldstr "caught:"
+			IL_0296: ldloc.s 4
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_029d: pop
+			IL_029e: br IL_02a3
 
-			IL_02b9: ldstr "console"
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c3: stloc.s 6
-			IL_02c5: ldloc.s 6
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02cc: stloc.s 6
-			IL_02ce: ldloc.s 6
-			IL_02d0: ldstr "log"
-			IL_02d5: ldstr "end"
-			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02df: pop
-			IL_02e0: ldloc.0
-			IL_02e1: ldc.i4.m1
-			IL_02e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02e7: ldloc.0
-			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02f2: ldarg.0
-			IL_02f3: ldc.i4.1
-			IL_02f4: newarr [System.Runtime]System.Object
-			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02fe: pop
-			IL_02ff: ldloc.0
-			IL_0300: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0305: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_030a: ret
+			IL_02a3: ldstr "console"
+			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02ad: stloc.s 5
+			IL_02af: ldloc.s 5
+			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b6: stloc.s 5
+			IL_02b8: ldloc.s 5
+			IL_02ba: ldstr "log"
+			IL_02bf: ldstr "end"
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02c9: pop
+			IL_02ca: ldloc.0
+			IL_02cb: ldc.i4.m1
+			IL_02cc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02d1: ldloc.0
+			IL_02d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02dc: ldarg.0
+			IL_02dd: ldc.i4.1
+			IL_02de: newarr [System.Runtime]System.Object
+			IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02e8: pop
+			IL_02e9: ldloc.0
+			IL_02ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ef: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02f4: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -480,7 +468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245f
+				// Method begins at RVA 0x244b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -503,7 +491,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x23e4
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -542,7 +530,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2429
+			// Method begins at RVA 0x2415
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -641,7 +629,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2468
+		// Method begins at RVA 0x2454
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x24dc
+						// Method begins at RVA 0x24c0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x24e5
+						// Method begins at RVA 0x24c9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24d3
+					// Method begins at RVA 0x24b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24ee
+					// Method begins at RVA 0x24d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -135,7 +135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ca
+				// Method begins at RVA 0x24ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -161,15 +161,14 @@
 			)
 			// Method begins at RVA 0x20e0
 			// Header size: 12
-			// Code size: 930 (0x3a2)
+			// Code size: 903 (0x387)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope,
 				[1] bool,
 				[2] bool,
 				[3] object,
-				[4] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope/Block_L16C16,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: ldarg.0
@@ -202,14 +201,14 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.5
+			IL_0048: ldc.i4.4
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_008b
+			IL_005a: ble IL_0081
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -230,303 +229,288 @@
 			IL_007b: dup
 			IL_007c: ldc.i4.3
 			IL_007d: ldelem.ref
-			IL_007e: castclass Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope/Block_L16C16
-			IL_0083: stloc.s 4
-			IL_0085: dup
-			IL_0086: ldc.i4.4
-			IL_0087: ldelem.ref
-			IL_0088: stloc.s 5
-			IL_008a: pop
+			IL_007e: stloc.s 4
+			IL_0080: pop
 
-			IL_008b: ldloc.0
-			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_00ae, IL_0305, IL_0196, IL_025f, IL_018a, IL_022c)
+			IL_0081: ldloc.0
+			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0087: switch (IL_00a4, IL_02f1, IL_0187, IL_024b, IL_017b, IL_0218)
 
-			IL_00ae: ldstr "console"
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b8: stloc.s 5
-			IL_00ba: ldloc.s 5
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c1: stloc.s 5
-			IL_00c3: ldloc.s 5
-			IL_00c5: ldstr "log"
-			IL_00ca: ldstr "start"
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d4: pop
-			IL_00d5: ldloc.0
-			IL_00d6: ldc.i4.0
-			IL_00d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00dc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00e1: ldloc.0
-			IL_00e2: ldc.i4.0
-			IL_00e3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00ed: ldloc.0
-			IL_00ee: ldc.i4.0
-			IL_00ef: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00f4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_00f9: ldloc.0
-			IL_00fa: ldc.i4.0
-			IL_00fb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0100: ldloc.0
-			IL_0101: ldc.i4.0
-			IL_0102: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0107: ldstr "console"
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0111: stloc.s 5
-			IL_0113: ldloc.s 5
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011a: stloc.s 5
-			IL_011c: ldloc.s 5
-			IL_011e: ldstr "log"
-			IL_0123: ldstr "inner try: rejecting"
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012d: pop
-			IL_012e: ldstr "original"
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
-			IL_0138: stloc.s 5
-			IL_013a: ldloc.0
-			IL_013b: ldc.i4.4
-			IL_013c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0141: ldloc.0
-			IL_0142: ldloc.s 5
-			IL_0144: ldarg.0
-			IL_0145: ldc.i4.1
-			IL_0146: ldloc.0
-			IL_0147: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_014c: ldc.i4.2
-			IL_014d: ldstr "_pendingException"
-			IL_0152: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0157: ldloc.0
-			IL_0158: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldloc.1
-			IL_0160: box [System.Runtime]System.Boolean
-			IL_0165: stelem.ref
-			IL_0166: dup
-			IL_0167: ldc.i4.1
-			IL_0168: ldloc.2
-			IL_0169: box [System.Runtime]System.Boolean
-			IL_016e: stelem.ref
-			IL_016f: dup
-			IL_0170: ldc.i4.2
-			IL_0171: ldloc.3
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.3
-			IL_0175: ldloc.s 4
-			IL_0177: stelem.ref
-			IL_0178: dup
-			IL_0179: ldc.i4.4
-			IL_017a: ldloc.s 5
-			IL_017c: stelem.ref
-			IL_017d: pop
-			IL_017e: ldloc.0
-			IL_017f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0184: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0189: ret
+			IL_00a4: ldstr "console"
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ae: stloc.s 4
+			IL_00b0: ldloc.s 4
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b7: stloc.s 4
+			IL_00b9: ldloc.s 4
+			IL_00bb: ldstr "log"
+			IL_00c0: ldstr "start"
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ca: pop
+			IL_00cb: ldloc.0
+			IL_00cc: ldc.i4.0
+			IL_00cd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00d2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00d7: ldloc.0
+			IL_00d8: ldc.i4.0
+			IL_00d9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00de: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00e3: ldloc.0
+			IL_00e4: ldc.i4.0
+			IL_00e5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_00ef: ldloc.0
+			IL_00f0: ldc.i4.0
+			IL_00f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_00f6: ldloc.0
+			IL_00f7: ldc.i4.0
+			IL_00f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00fd: ldstr "console"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0107: stloc.s 4
+			IL_0109: ldloc.s 4
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0110: stloc.s 4
+			IL_0112: ldloc.s 4
+			IL_0114: ldstr "log"
+			IL_0119: ldstr "inner try: rejecting"
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0123: pop
+			IL_0124: ldstr "original"
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_012e: stloc.s 4
+			IL_0130: ldloc.0
+			IL_0131: ldc.i4.4
+			IL_0132: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0137: ldloc.0
+			IL_0138: ldloc.s 4
+			IL_013a: ldarg.0
+			IL_013b: ldc.i4.1
+			IL_013c: ldloc.0
+			IL_013d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0142: ldc.i4.2
+			IL_0143: ldstr "_pendingException"
+			IL_0148: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_014d: ldloc.0
+			IL_014e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0153: dup
+			IL_0154: ldc.i4.0
+			IL_0155: ldloc.1
+			IL_0156: box [System.Runtime]System.Boolean
+			IL_015b: stelem.ref
+			IL_015c: dup
+			IL_015d: ldc.i4.1
+			IL_015e: ldloc.2
+			IL_015f: box [System.Runtime]System.Boolean
+			IL_0164: stelem.ref
+			IL_0165: dup
+			IL_0166: ldc.i4.2
+			IL_0167: ldloc.3
+			IL_0168: stelem.ref
+			IL_0169: dup
+			IL_016a: ldc.i4.3
+			IL_016b: ldloc.s 4
+			IL_016d: stelem.ref
+			IL_016e: pop
+			IL_016f: ldloc.0
+			IL_0170: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0175: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_017a: ret
 
-			IL_018a: ldloc.0
-			IL_018b: ldfld object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope::_awaited1
-			IL_0190: pop
-			IL_0191: br IL_01a9
+			IL_017b: ldloc.0
+			IL_017c: ldfld object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope::_awaited1
+			IL_0181: pop
+			IL_0182: br IL_019a
 
-			IL_0196: ldloc.0
-			IL_0197: ldc.i4.1
-			IL_0198: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_019d: ldloc.0
-			IL_019e: ldc.i4.0
-			IL_019f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_01a4: br IL_01a9
+			IL_0187: ldloc.0
+			IL_0188: ldc.i4.1
+			IL_0189: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_018e: ldloc.0
+			IL_018f: ldc.i4.0
+			IL_0190: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0195: br IL_019a
 
-			IL_01a9: ldstr "console"
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b3: stloc.s 5
-			IL_01b5: ldloc.s 5
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01bc: stloc.s 5
-			IL_01be: ldloc.s 5
-			IL_01c0: ldstr "log"
-			IL_01c5: ldstr "finally: before await"
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01cf: pop
-			IL_01d0: ldstr "cleanup"
-			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_01da: stloc.s 5
-			IL_01dc: ldloc.0
-			IL_01dd: ldc.i4.5
-			IL_01de: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01e3: ldloc.0
-			IL_01e4: ldloc.s 5
-			IL_01e6: ldarg.0
-			IL_01e7: ldc.i4.2
-			IL_01e8: ldloc.0
-			IL_01e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01ee: ldc.i4.3
-			IL_01ef: ldstr "_pendingException"
-			IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_01f9: ldloc.0
-			IL_01fa: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01ff: dup
-			IL_0200: ldc.i4.0
-			IL_0201: ldloc.1
-			IL_0202: box [System.Runtime]System.Boolean
-			IL_0207: stelem.ref
-			IL_0208: dup
-			IL_0209: ldc.i4.1
-			IL_020a: ldloc.2
-			IL_020b: box [System.Runtime]System.Boolean
-			IL_0210: stelem.ref
-			IL_0211: dup
-			IL_0212: ldc.i4.2
-			IL_0213: ldloc.3
-			IL_0214: stelem.ref
-			IL_0215: dup
-			IL_0216: ldc.i4.3
-			IL_0217: ldloc.s 4
-			IL_0219: stelem.ref
-			IL_021a: dup
-			IL_021b: ldc.i4.4
-			IL_021c: ldloc.s 5
-			IL_021e: stelem.ref
-			IL_021f: pop
-			IL_0220: ldloc.0
-			IL_0221: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0226: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_022b: ret
+			IL_019a: ldstr "console"
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01a4: stloc.s 4
+			IL_01a6: ldloc.s 4
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ad: stloc.s 4
+			IL_01af: ldloc.s 4
+			IL_01b1: ldstr "log"
+			IL_01b6: ldstr "finally: before await"
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c0: pop
+			IL_01c1: ldstr "cleanup"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_01cb: stloc.s 4
+			IL_01cd: ldloc.0
+			IL_01ce: ldc.i4.5
+			IL_01cf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01d4: ldloc.0
+			IL_01d5: ldloc.s 4
+			IL_01d7: ldarg.0
+			IL_01d8: ldc.i4.2
+			IL_01d9: ldloc.0
+			IL_01da: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01df: ldc.i4.3
+			IL_01e0: ldstr "_pendingException"
+			IL_01e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01f0: dup
+			IL_01f1: ldc.i4.0
+			IL_01f2: ldloc.1
+			IL_01f3: box [System.Runtime]System.Boolean
+			IL_01f8: stelem.ref
+			IL_01f9: dup
+			IL_01fa: ldc.i4.1
+			IL_01fb: ldloc.2
+			IL_01fc: box [System.Runtime]System.Boolean
+			IL_0201: stelem.ref
+			IL_0202: dup
+			IL_0203: ldc.i4.2
+			IL_0204: ldloc.3
+			IL_0205: stelem.ref
+			IL_0206: dup
+			IL_0207: ldc.i4.3
+			IL_0208: ldloc.s 4
+			IL_020a: stelem.ref
+			IL_020b: pop
+			IL_020c: ldloc.0
+			IL_020d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0212: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0217: ret
 
-			IL_022c: ldloc.0
-			IL_022d: ldfld object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope::_awaited2
-			IL_0232: pop
-			IL_0233: ldstr "console"
-			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_023d: stloc.s 5
-			IL_023f: ldloc.s 5
-			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0246: stloc.s 5
-			IL_0248: ldloc.s 5
-			IL_024a: ldstr "log"
-			IL_024f: ldstr "finally: after await"
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0259: pop
-			IL_025a: br IL_0272
+			IL_0218: ldloc.0
+			IL_0219: ldfld object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope::_awaited2
+			IL_021e: pop
+			IL_021f: ldstr "console"
+			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0229: stloc.s 4
+			IL_022b: ldloc.s 4
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0232: stloc.s 4
+			IL_0234: ldloc.s 4
+			IL_0236: ldstr "log"
+			IL_023b: ldstr "finally: after await"
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0245: pop
+			IL_0246: br IL_025e
 
-			IL_025f: ldloc.0
-			IL_0260: ldc.i4.1
-			IL_0261: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0266: ldloc.0
-			IL_0267: ldc.i4.0
-			IL_0268: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_026d: br IL_0272
+			IL_024b: ldloc.0
+			IL_024c: ldc.i4.1
+			IL_024d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0252: ldloc.0
+			IL_0253: ldc.i4.0
+			IL_0254: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0259: br IL_025e
 
-			IL_0272: ldloc.0
-			IL_0273: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0278: stloc.1
-			IL_0279: ldloc.1
-			IL_027a: brfalse IL_0294
+			IL_025e: ldloc.0
+			IL_025f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0264: stloc.1
+			IL_0265: ldloc.1
+			IL_0266: brfalse IL_0280
 
-			IL_027f: ldloc.0
-			IL_0280: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0285: stloc.s 5
-			IL_0287: ldloc.0
-			IL_0288: ldloc.s 5
-			IL_028a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_028f: br IL_0305
+			IL_026b: ldloc.0
+			IL_026c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0271: stloc.s 4
+			IL_0273: ldloc.0
+			IL_0274: ldloc.s 4
+			IL_0276: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_027b: br IL_02f1
 
-			IL_0294: ldloc.0
-			IL_0295: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_029a: stloc.2
-			IL_029b: ldloc.2
-			IL_029c: brfalse IL_02d9
+			IL_0280: ldloc.0
+			IL_0281: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0286: stloc.2
+			IL_0287: ldloc.2
+			IL_0288: brfalse IL_02c5
 
-			IL_02a1: ldloc.0
-			IL_02a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_02a7: stloc.s 5
-			IL_02a9: ldloc.0
-			IL_02aa: ldc.i4.m1
-			IL_02ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b0: ldloc.0
-			IL_02b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02bb: ldarg.0
-			IL_02bc: ldc.i4.1
-			IL_02bd: newarr [System.Runtime]System.Object
-			IL_02c2: dup
-			IL_02c3: ldc.i4.0
-			IL_02c4: ldloc.s 5
-			IL_02c6: stelem.ref
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02cc: pop
-			IL_02cd: ldloc.0
-			IL_02ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02d8: ret
+			IL_028d: ldloc.0
+			IL_028e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0293: stloc.s 4
+			IL_0295: ldloc.0
+			IL_0296: ldc.i4.m1
+			IL_0297: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_029c: ldloc.0
+			IL_029d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02a7: ldarg.0
+			IL_02a8: ldc.i4.1
+			IL_02a9: newarr [System.Runtime]System.Object
+			IL_02ae: dup
+			IL_02af: ldc.i4.0
+			IL_02b0: ldloc.s 4
+			IL_02b2: stelem.ref
+			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02b8: pop
+			IL_02b9: ldloc.0
+			IL_02ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02c4: ret
 
-			IL_02d9: ldstr "console"
-			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e3: stloc.s 5
-			IL_02e5: ldloc.s 5
-			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ec: stloc.s 5
-			IL_02ee: ldloc.s 5
-			IL_02f0: ldstr "log"
-			IL_02f5: ldstr "inner after finally (should not print)"
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02ff: pop
-			IL_0300: br IL_0350
+			IL_02c5: ldstr "console"
+			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02cf: stloc.s 4
+			IL_02d1: ldloc.s 4
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d8: stloc.s 4
+			IL_02da: ldloc.s 4
+			IL_02dc: ldstr "log"
+			IL_02e1: ldstr "inner after finally (should not print)"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02eb: pop
+			IL_02ec: br IL_0335
 
-			IL_0305: ldloc.0
-			IL_0306: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_030b: stloc.s 5
-			IL_030d: ldloc.0
-			IL_030e: ldc.i4.0
-			IL_030f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0314: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0319: ldloc.s 5
-			IL_031b: stloc.3
-			IL_031c: newobj instance void Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/Scope/Block_L16C16::.ctor()
-			IL_0321: stloc.s 4
-			IL_0323: ldstr "console"
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_032d: stloc.s 5
-			IL_032f: ldloc.s 5
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0336: stloc.s 5
-			IL_0338: ldloc.s 5
-			IL_033a: ldstr "log"
-			IL_033f: ldstr "caught:"
-			IL_0344: ldloc.3
-			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_034a: pop
-			IL_034b: br IL_0350
+			IL_02f1: ldloc.0
+			IL_02f2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_02f7: stloc.s 4
+			IL_02f9: ldloc.0
+			IL_02fa: ldc.i4.0
+			IL_02fb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0300: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0305: ldloc.s 4
+			IL_0307: stloc.3
+			IL_0308: ldstr "console"
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0312: stloc.s 4
+			IL_0314: ldloc.s 4
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_031b: stloc.s 4
+			IL_031d: ldloc.s 4
+			IL_031f: ldstr "log"
+			IL_0324: ldstr "caught:"
+			IL_0329: ldloc.3
+			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_032f: pop
+			IL_0330: br IL_0335
 
-			IL_0350: ldstr "console"
-			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_035a: stloc.s 5
-			IL_035c: ldloc.s 5
-			IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0363: stloc.s 5
-			IL_0365: ldloc.s 5
-			IL_0367: ldstr "log"
-			IL_036c: ldstr "end"
-			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0376: pop
-			IL_0377: ldloc.0
-			IL_0378: ldc.i4.m1
-			IL_0379: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_037e: ldloc.0
-			IL_037f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0384: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0389: ldarg.0
-			IL_038a: ldc.i4.1
-			IL_038b: newarr [System.Runtime]System.Object
-			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0395: pop
-			IL_0396: ldloc.0
-			IL_0397: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_039c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03a1: ret
+			IL_0335: ldstr "console"
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_033f: stloc.s 4
+			IL_0341: ldloc.s 4
+			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0348: stloc.s 4
+			IL_034a: ldloc.s 4
+			IL_034c: ldstr "log"
+			IL_0351: ldstr "end"
+			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_035b: pop
+			IL_035c: ldloc.0
+			IL_035d: ldc.i4.m1
+			IL_035e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0363: ldloc.0
+			IL_0364: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0369: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_036e: ldarg.0
+			IL_036f: ldc.i4.1
+			IL_0370: newarr [System.Runtime]System.Object
+			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_037a: pop
+			IL_037b: ldloc.0
+			IL_037c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0381: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0386: ret
 		} // end of method test::__js_call__
 
 	} // end of class test
@@ -542,7 +526,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f7
+				// Method begins at RVA 0x24db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -565,7 +549,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2490
+			// Method begins at RVA 0x2474
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -604,7 +588,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c1
+			// Method begins at RVA 0x24a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -703,7 +687,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2500
+		// Method begins at RVA 0x24e4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2880
+					// Method begins at RVA 0x286c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2889
+					// Method begins at RVA 0x2875
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2892
+					// Method begins at RVA 0x287e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2877
+				// Method begins at RVA 0x2863
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,16 +106,15 @@
 			)
 			// Method begins at RVA 0x20e4
 			// Header size: 12
-			// Code size: 1003 (0x3eb)
+			// Code size: 983 (0x3d7)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Throw/g/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.AsyncGenerator_Throw/g/Scope/Block_L7C14,
-				[4] bool,
-				[5] object,
-				[6] object
+				[3] bool,
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -164,13 +163,13 @@
 			IL_006b: stloc.0
 			IL_006c: ldloc.0
 			IL_006d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0072: switch (IL_0083, IL_0145, IL_0272)
+			IL_0072: switch (IL_0083, IL_0143, IL_0266)
 
 			IL_0083: ldloc.0
 			IL_0084: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
 			IL_0089: stloc.1
 			IL_008a: ldloc.1
-			IL_008b: brtrue IL_00af
+			IL_008b: brtrue IL_00ad
 
 			IL_0090: ldloc.0
 			IL_0091: ldc.i4.1
@@ -180,322 +179,320 @@
 			IL_0099: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_started
 			IL_009e: ldloc.0
 			IL_009f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parameterInitializationOnly
-			IL_00a4: stloc.s 4
-			IL_00a6: ldloc.s 4
-			IL_00a8: brfalse IL_00af
+			IL_00a4: stloc.3
+			IL_00a5: ldloc.3
+			IL_00a6: brfalse IL_00ad
 
-			IL_00ad: ldnull
-			IL_00ae: ret
+			IL_00ab: ldnull
+			IL_00ac: ret
 
-			IL_00af: ldloc.0
-			IL_00b0: ldc.i4.0
-			IL_00b1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00b6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_00bb: ldloc.0
-			IL_00bc: ldc.i4.0
-			IL_00bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00c2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_00c7: ldloc.0
-			IL_00c8: ldc.i4.0
-			IL_00c9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_00ce: ldloc.0
-			IL_00cf: ldc.i4.0
-			IL_00d0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_00d5: ldstr "console"
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00df: stloc.s 5
-			IL_00e1: ldloc.s 5
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e8: stloc.s 5
-			IL_00ea: ldloc.s 5
-			IL_00ec: ldstr "log"
-			IL_00f1: ldstr "try"
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00fb: pop
-			IL_00fc: ldloc.0
-			IL_00fd: ldc.i4.1
-			IL_00fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0103: ldloc.0
-			IL_0104: ldc.i4.m1
-			IL_0105: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_010a: ldloc.0
-			IL_010b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0115: ldarg.0
-			IL_0116: ldc.i4.1
-			IL_0117: newarr [System.Runtime]System.Object
-			IL_011c: dup
-			IL_011d: ldc.i4.0
-			IL_011e: ldc.r8 1
-			IL_0127: box [System.Runtime]System.Double
-			IL_012c: ldc.i4.0
-			IL_012d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0132: stelem.ref
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0138: pop
-			IL_0139: ldloc.0
-			IL_013a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_013f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0144: ret
+			IL_00ad: ldloc.0
+			IL_00ae: ldc.i4.0
+			IL_00af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00b4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_00b9: ldloc.0
+			IL_00ba: ldc.i4.0
+			IL_00bb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c0: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_00c5: ldloc.0
+			IL_00c6: ldc.i4.0
+			IL_00c7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_00cc: ldloc.0
+			IL_00cd: ldc.i4.0
+			IL_00ce: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_00d3: ldstr "console"
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00dd: stloc.s 4
+			IL_00df: ldloc.s 4
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e6: stloc.s 4
+			IL_00e8: ldloc.s 4
+			IL_00ea: ldstr "log"
+			IL_00ef: ldstr "try"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f9: pop
+			IL_00fa: ldloc.0
+			IL_00fb: ldc.i4.1
+			IL_00fc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0101: ldloc.0
+			IL_0102: ldc.i4.m1
+			IL_0103: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0108: ldloc.0
+			IL_0109: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_010e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0113: ldarg.0
+			IL_0114: ldc.i4.1
+			IL_0115: newarr [System.Runtime]System.Object
+			IL_011a: dup
+			IL_011b: ldc.i4.0
+			IL_011c: ldc.r8 1
+			IL_0125: box [System.Runtime]System.Double
+			IL_012a: ldc.i4.0
+			IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0130: stelem.ref
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0136: pop
+			IL_0137: ldloc.0
+			IL_0138: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_013d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0142: ret
 
-			IL_0145: ldloc.0
-			IL_0146: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_014b: stloc.s 4
-			IL_014d: ldloc.s 4
-			IL_014f: brfalse IL_018a
+			IL_0143: ldloc.0
+			IL_0144: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0149: stloc.3
+			IL_014a: ldloc.3
+			IL_014b: brfalse IL_0186
 
-			IL_0154: ldloc.0
-			IL_0155: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_015a: stloc.s 5
-			IL_015c: ldloc.0
-			IL_015d: ldloc.s 5
-			IL_015f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0164: ldloc.0
-			IL_0165: ldc.i4.1
-			IL_0166: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_016b: ldloc.0
-			IL_016c: ldc.i4.0
-			IL_016d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0172: ldloc.0
-			IL_0173: ldc.i4.0
-			IL_0174: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0179: ldloc.0
-			IL_017a: ldc.i4.0
-			IL_017b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0180: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0185: br IL_0301
+			IL_0150: ldloc.0
+			IL_0151: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_0156: stloc.s 4
+			IL_0158: ldloc.0
+			IL_0159: ldloc.s 4
+			IL_015b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0160: ldloc.0
+			IL_0161: ldc.i4.1
+			IL_0162: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0167: ldloc.0
+			IL_0168: ldc.i4.0
+			IL_0169: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_016e: ldloc.0
+			IL_016f: ldc.i4.0
+			IL_0170: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0175: ldloc.0
+			IL_0176: ldc.i4.0
+			IL_0177: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_017c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0181: br IL_02f1
 
-			IL_018a: ldloc.0
-			IL_018b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0190: stloc.s 4
-			IL_0192: ldloc.s 4
-			IL_0194: brfalse IL_01cf
+			IL_0186: ldloc.0
+			IL_0187: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_018c: stloc.3
+			IL_018d: ldloc.3
+			IL_018e: brfalse IL_01c9
 
-			IL_0199: ldloc.0
-			IL_019a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_019f: stloc.s 5
-			IL_01a1: ldloc.0
-			IL_01a2: ldloc.s 5
-			IL_01a4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_01a9: ldloc.0
-			IL_01aa: ldc.i4.0
-			IL_01ab: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01b0: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_01b5: ldloc.0
-			IL_01b6: ldc.i4.1
-			IL_01b7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_01bc: ldloc.0
-			IL_01bd: ldc.i4.0
-			IL_01be: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_01c3: ldloc.0
-			IL_01c4: ldc.i4.0
-			IL_01c5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_01ca: br IL_01d4
+			IL_0193: ldloc.0
+			IL_0194: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_0199: stloc.s 4
+			IL_019b: ldloc.0
+			IL_019c: ldloc.s 4
+			IL_019e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_01a3: ldloc.0
+			IL_01a4: ldc.i4.0
+			IL_01a5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01aa: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_01af: ldloc.0
+			IL_01b0: ldc.i4.1
+			IL_01b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_01b6: ldloc.0
+			IL_01b7: ldc.i4.0
+			IL_01b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_01bd: ldloc.0
+			IL_01be: ldc.i4.0
+			IL_01bf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_01c4: br IL_01ce
 
-			IL_01cf: br IL_0301
+			IL_01c9: br IL_02f1
 
-			IL_01d4: ldloc.0
-			IL_01d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_01da: stloc.s 5
-			IL_01dc: ldloc.0
-			IL_01dd: ldc.i4.0
-			IL_01de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_01e3: ldloc.0
-			IL_01e4: ldc.i4.0
-			IL_01e5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_01ef: ldloc.s 5
-			IL_01f1: stloc.2
-			IL_01f2: newobj instance void Modules.AsyncGenerator_Throw/g/Scope/Block_L7C14::.ctor()
-			IL_01f7: stloc.3
-			IL_01f8: ldstr "console"
-			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0202: stloc.s 5
-			IL_0204: ldloc.s 5
-			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_020b: stloc.s 5
-			IL_020d: ldstr "catch="
-			IL_0212: ldloc.2
-			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0218: stloc.s 6
-			IL_021a: ldloc.s 5
-			IL_021c: ldstr "log"
-			IL_0221: ldloc.s 6
-			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0228: pop
-			IL_0229: ldloc.0
-			IL_022a: ldc.i4.2
-			IL_022b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0230: ldloc.0
-			IL_0231: ldc.i4.m1
-			IL_0232: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0237: ldloc.0
-			IL_0238: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_023d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0242: ldarg.0
-			IL_0243: ldc.i4.1
-			IL_0244: newarr [System.Runtime]System.Object
-			IL_0249: dup
-			IL_024a: ldc.i4.0
-			IL_024b: ldc.r8 2
-			IL_0254: box [System.Runtime]System.Double
-			IL_0259: ldc.i4.0
-			IL_025a: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_025f: stelem.ref
-			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0265: pop
+			IL_01ce: ldloc.0
+			IL_01cf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_01d4: stloc.s 4
+			IL_01d6: ldloc.0
+			IL_01d7: ldc.i4.0
+			IL_01d8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_01dd: ldloc.0
+			IL_01de: ldc.i4.0
+			IL_01df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01e4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_01e9: ldloc.s 4
+			IL_01eb: stloc.2
+			IL_01ec: ldstr "console"
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f6: stloc.s 4
+			IL_01f8: ldloc.s 4
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ff: stloc.s 4
+			IL_0201: ldstr "catch="
+			IL_0206: ldloc.2
+			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_020c: stloc.s 5
+			IL_020e: ldloc.s 4
+			IL_0210: ldstr "log"
+			IL_0215: ldloc.s 5
+			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_021c: pop
+			IL_021d: ldloc.0
+			IL_021e: ldc.i4.2
+			IL_021f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0224: ldloc.0
+			IL_0225: ldc.i4.m1
+			IL_0226: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_022b: ldloc.0
+			IL_022c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0231: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0236: ldarg.0
+			IL_0237: ldc.i4.1
+			IL_0238: newarr [System.Runtime]System.Object
+			IL_023d: dup
+			IL_023e: ldc.i4.0
+			IL_023f: ldc.r8 2
+			IL_0248: box [System.Runtime]System.Double
+			IL_024d: ldc.i4.0
+			IL_024e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0253: stelem.ref
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0259: pop
+			IL_025a: ldloc.0
+			IL_025b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0260: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0265: ret
+
 			IL_0266: ldloc.0
-			IL_0267: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_026c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0271: ret
+			IL_0267: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_026c: stloc.3
+			IL_026d: ldloc.3
+			IL_026e: brfalse IL_02a9
 
-			IL_0272: ldloc.0
-			IL_0273: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0278: stloc.s 4
-			IL_027a: ldloc.s 4
-			IL_027c: brfalse IL_02b7
-
-			IL_0281: ldloc.0
-			IL_0282: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_0287: stloc.s 5
-			IL_0289: ldloc.0
-			IL_028a: ldloc.s 5
-			IL_028c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0273: ldloc.0
+			IL_0274: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_0279: stloc.s 4
+			IL_027b: ldloc.0
+			IL_027c: ldloc.s 4
+			IL_027e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0283: ldloc.0
+			IL_0284: ldc.i4.1
+			IL_0285: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_028a: ldloc.0
+			IL_028b: ldc.i4.0
+			IL_028c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
 			IL_0291: ldloc.0
-			IL_0292: ldc.i4.1
-			IL_0293: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0292: ldc.i4.0
+			IL_0293: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
 			IL_0298: ldloc.0
 			IL_0299: ldc.i4.0
-			IL_029a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_029f: ldloc.0
-			IL_02a0: ldc.i4.0
-			IL_02a1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_02a6: ldloc.0
-			IL_02a7: ldc.i4.0
-			IL_02a8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02ad: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_02b2: br IL_0301
+			IL_029a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_029f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_02a4: br IL_02f1
 
-			IL_02b7: ldloc.0
-			IL_02b8: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_02bd: stloc.s 4
+			IL_02a9: ldloc.0
+			IL_02aa: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_02af: stloc.3
+			IL_02b0: ldloc.3
+			IL_02b1: brfalse IL_02ec
+
+			IL_02b6: ldloc.0
+			IL_02b7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_02bc: stloc.s 4
+			IL_02be: ldloc.0
 			IL_02bf: ldloc.s 4
-			IL_02c1: brfalse IL_02fc
-
+			IL_02c1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
 			IL_02c6: ldloc.0
-			IL_02c7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_02cc: stloc.s 5
-			IL_02ce: ldloc.0
-			IL_02cf: ldloc.s 5
-			IL_02d1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_02d6: ldloc.0
-			IL_02d7: ldc.i4.0
-			IL_02d8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02dd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_02e2: ldloc.0
-			IL_02e3: ldc.i4.1
-			IL_02e4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_02e9: ldloc.0
-			IL_02ea: ldc.i4.0
-			IL_02eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_02f0: ldloc.0
-			IL_02f1: ldc.i4.0
-			IL_02f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_02f7: br IL_0301
+			IL_02c7: ldc.i4.0
+			IL_02c8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02cd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_02d2: ldloc.0
+			IL_02d3: ldc.i4.1
+			IL_02d4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_02d9: ldloc.0
+			IL_02da: ldc.i4.0
+			IL_02db: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_02e0: ldloc.0
+			IL_02e1: ldc.i4.0
+			IL_02e2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_02e7: br IL_02f1
 
-			IL_02fc: br IL_0301
+			IL_02ec: br IL_02f1
 
-			IL_0301: ldstr "console"
-			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_030b: stloc.s 5
-			IL_030d: ldloc.s 5
-			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0314: stloc.s 5
-			IL_0316: ldloc.s 5
-			IL_0318: ldstr "log"
-			IL_031d: ldstr "finally"
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0327: pop
-			IL_0328: br IL_032d
+			IL_02f1: ldstr "console"
+			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02fb: stloc.s 4
+			IL_02fd: ldloc.s 4
+			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0304: stloc.s 4
+			IL_0306: ldloc.s 4
+			IL_0308: ldstr "log"
+			IL_030d: ldstr "finally"
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0317: pop
+			IL_0318: br IL_031d
 
-			IL_032d: ldloc.0
-			IL_032e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0333: stloc.s 4
-			IL_0335: ldloc.s 4
-			IL_0337: brfalse IL_035b
+			IL_031d: ldloc.0
+			IL_031e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0323: stloc.3
+			IL_0324: ldloc.3
+			IL_0325: brfalse IL_0349
 
+			IL_032a: ldloc.0
+			IL_032b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0330: isinst [System.Runtime]System.Exception
+			IL_0335: dup
+			IL_0336: brtrue IL_0348
+
+			IL_033b: pop
 			IL_033c: ldloc.0
 			IL_033d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0342: isinst [System.Runtime]System.Exception
-			IL_0347: dup
-			IL_0348: brtrue IL_035a
+			IL_0342: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0347: throw
 
-			IL_034d: pop
-			IL_034e: ldloc.0
-			IL_034f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0354: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0359: throw
+			IL_0348: throw
 
-			IL_035a: throw
+			IL_0349: ldloc.0
+			IL_034a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_034f: stloc.3
+			IL_0350: ldloc.3
+			IL_0351: brfalse IL_039b
 
-			IL_035b: ldloc.0
-			IL_035c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0361: stloc.s 4
-			IL_0363: ldloc.s 4
-			IL_0365: brfalse IL_03af
+			IL_0356: ldloc.0
+			IL_0357: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_035c: stloc.s 4
+			IL_035e: ldloc.0
+			IL_035f: ldc.i4.1
+			IL_0360: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0365: ldloc.0
+			IL_0366: ldc.i4.m1
+			IL_0367: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_036c: ldloc.0
+			IL_036d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0377: ldarg.0
+			IL_0378: ldc.i4.1
+			IL_0379: newarr [System.Runtime]System.Object
+			IL_037e: dup
+			IL_037f: ldc.i4.0
+			IL_0380: ldloc.s 4
+			IL_0382: ldc.i4.1
+			IL_0383: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0388: stelem.ref
+			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_038e: pop
+			IL_038f: ldloc.0
+			IL_0390: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0395: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_039a: ret
 
-			IL_036a: ldloc.0
-			IL_036b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0370: stloc.s 5
-			IL_0372: ldloc.0
-			IL_0373: ldc.i4.1
-			IL_0374: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_0379: ldloc.0
-			IL_037a: ldc.i4.m1
-			IL_037b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0380: ldloc.0
-			IL_0381: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0386: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_038b: ldarg.0
-			IL_038c: ldc.i4.1
-			IL_038d: newarr [System.Runtime]System.Object
-			IL_0392: dup
-			IL_0393: ldc.i4.0
-			IL_0394: ldloc.s 5
-			IL_0396: ldc.i4.1
-			IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_039c: stelem.ref
-			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03a2: pop
-			IL_03a3: ldloc.0
-			IL_03a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03ae: ret
-
-			IL_03af: ldloc.0
-			IL_03b0: ldc.i4.1
-			IL_03b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_03b6: ldloc.0
-			IL_03b7: ldc.i4.m1
-			IL_03b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03bd: ldloc.0
-			IL_03be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03c8: ldarg.0
-			IL_03c9: ldc.i4.1
-			IL_03ca: newarr [System.Runtime]System.Object
-			IL_03cf: dup
-			IL_03d0: ldc.i4.0
-			IL_03d1: ldnull
-			IL_03d2: ldc.i4.1
-			IL_03d3: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_03d8: stelem.ref
-			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03de: pop
-			IL_03df: ldloc.0
-			IL_03e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03e5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03ea: ret
+			IL_039b: ldloc.0
+			IL_039c: ldc.i4.1
+			IL_039d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_03a2: ldloc.0
+			IL_03a3: ldc.i4.m1
+			IL_03a4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03a9: ldloc.0
+			IL_03aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03b4: ldarg.0
+			IL_03b5: ldc.i4.1
+			IL_03b6: newarr [System.Runtime]System.Object
+			IL_03bb: dup
+			IL_03bc: ldc.i4.0
+			IL_03bd: ldnull
+			IL_03be: ldc.i4.1
+			IL_03bf: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_03c4: stelem.ref
+			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03ca: pop
+			IL_03cb: ldloc.0
+			IL_03cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03d6: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -531,7 +528,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x289b
+				// Method begins at RVA 0x2887
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -555,7 +552,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24dc
+			// Method begins at RVA 0x24c8
 			// Header size: 12
 			// Code size: 902 (0x386)
 			.maxstack 8
@@ -954,7 +951,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x286e
+			// Method begins at RVA 0x285a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1051,7 +1048,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28a4
+		// Method begins at RVA 0x2890
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a9c
+					// Method begins at RVA 0x2a84
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aa5
+					// Method begins at RVA 0x2a8d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aae
+					// Method begins at RVA 0x2a96
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a93
+				// Method begins at RVA 0x2a7b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,16 +131,15 @@
 			)
 			// Method begins at RVA 0x20e4
 			// Header size: 12
-			// Code size: 1497 (0x5d9)
+			// Code size: 1473 (0x5c1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_TryCatchFinally/g/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.AsyncGenerator_TryCatchFinally/g/Scope/Block_L9C14,
-				[4] bool,
-				[5] object,
-				[6] object
+				[3] bool,
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -189,13 +188,13 @@
 			IL_006b: stloc.0
 			IL_006c: ldloc.0
 			IL_006d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0072: switch (IL_008b, IL_014d, IL_0259, IL_0386, IL_0533)
+			IL_0072: switch (IL_008b, IL_014b, IL_0253, IL_0376, IL_051b)
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
 			IL_0091: stloc.1
 			IL_0092: ldloc.1
-			IL_0093: brtrue IL_00b7
+			IL_0093: brtrue IL_00b5
 
 			IL_0098: ldloc.0
 			IL_0099: ldc.i4.1
@@ -205,498 +204,496 @@
 			IL_00a1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_started
 			IL_00a6: ldloc.0
 			IL_00a7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parameterInitializationOnly
-			IL_00ac: stloc.s 4
-			IL_00ae: ldloc.s 4
-			IL_00b0: brfalse IL_00b7
+			IL_00ac: stloc.3
+			IL_00ad: ldloc.3
+			IL_00ae: brfalse IL_00b5
 
-			IL_00b5: ldnull
-			IL_00b6: ret
+			IL_00b3: ldnull
+			IL_00b4: ret
 
-			IL_00b7: ldloc.0
-			IL_00b8: ldc.i4.0
-			IL_00b9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00be: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_00c3: ldloc.0
-			IL_00c4: ldc.i4.0
-			IL_00c5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00ca: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_00cf: ldloc.0
-			IL_00d0: ldc.i4.0
-			IL_00d1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_00d6: ldloc.0
-			IL_00d7: ldc.i4.0
-			IL_00d8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_00dd: ldstr "console"
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e7: stloc.s 5
-			IL_00e9: ldloc.s 5
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f0: stloc.s 5
-			IL_00f2: ldloc.s 5
-			IL_00f4: ldstr "log"
-			IL_00f9: ldstr "try1"
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0103: pop
-			IL_0104: ldloc.0
-			IL_0105: ldc.i4.1
-			IL_0106: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_010b: ldloc.0
-			IL_010c: ldc.i4.m1
-			IL_010d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0112: ldloc.0
-			IL_0113: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_011d: ldarg.0
-			IL_011e: ldc.i4.1
-			IL_011f: newarr [System.Runtime]System.Object
-			IL_0124: dup
-			IL_0125: ldc.i4.0
-			IL_0126: ldc.r8 1
-			IL_012f: box [System.Runtime]System.Double
-			IL_0134: ldc.i4.0
-			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_013a: stelem.ref
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0140: pop
-			IL_0141: ldloc.0
-			IL_0142: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0147: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_014c: ret
+			IL_00b5: ldloc.0
+			IL_00b6: ldc.i4.0
+			IL_00b7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00bc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_00c1: ldloc.0
+			IL_00c2: ldc.i4.0
+			IL_00c3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_00cd: ldloc.0
+			IL_00ce: ldc.i4.0
+			IL_00cf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_00d4: ldloc.0
+			IL_00d5: ldc.i4.0
+			IL_00d6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_00db: ldstr "console"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e5: stloc.s 4
+			IL_00e7: ldloc.s 4
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ee: stloc.s 4
+			IL_00f0: ldloc.s 4
+			IL_00f2: ldstr "log"
+			IL_00f7: ldstr "try1"
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0101: pop
+			IL_0102: ldloc.0
+			IL_0103: ldc.i4.1
+			IL_0104: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0109: ldloc.0
+			IL_010a: ldc.i4.m1
+			IL_010b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0110: ldloc.0
+			IL_0111: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_011b: ldarg.0
+			IL_011c: ldc.i4.1
+			IL_011d: newarr [System.Runtime]System.Object
+			IL_0122: dup
+			IL_0123: ldc.i4.0
+			IL_0124: ldc.r8 1
+			IL_012d: box [System.Runtime]System.Double
+			IL_0132: ldc.i4.0
+			IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0138: stelem.ref
+			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_013e: pop
+			IL_013f: ldloc.0
+			IL_0140: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0145: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_014a: ret
 
-			IL_014d: ldloc.0
-			IL_014e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0153: stloc.s 4
-			IL_0155: ldloc.s 4
-			IL_0157: brfalse IL_0192
+			IL_014b: ldloc.0
+			IL_014c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0151: stloc.3
+			IL_0152: ldloc.3
+			IL_0153: brfalse IL_018e
 
-			IL_015c: ldloc.0
-			IL_015d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_0162: stloc.s 5
-			IL_0164: ldloc.0
-			IL_0165: ldloc.s 5
-			IL_0167: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_016c: ldloc.0
-			IL_016d: ldc.i4.1
-			IL_016e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0173: ldloc.0
-			IL_0174: ldc.i4.0
-			IL_0175: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_017a: ldloc.0
-			IL_017b: ldc.i4.0
-			IL_017c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0181: ldloc.0
-			IL_0182: ldc.i4.0
-			IL_0183: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0188: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_018d: br IL_0415
+			IL_0158: ldloc.0
+			IL_0159: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_015e: stloc.s 4
+			IL_0160: ldloc.0
+			IL_0161: ldloc.s 4
+			IL_0163: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0168: ldloc.0
+			IL_0169: ldc.i4.1
+			IL_016a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_016f: ldloc.0
+			IL_0170: ldc.i4.0
+			IL_0171: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0176: ldloc.0
+			IL_0177: ldc.i4.0
+			IL_0178: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_017d: ldloc.0
+			IL_017e: ldc.i4.0
+			IL_017f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0184: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0189: br IL_0401
 
-			IL_0192: ldloc.0
-			IL_0193: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0198: stloc.s 4
-			IL_019a: ldloc.s 4
-			IL_019c: brfalse IL_01d7
+			IL_018e: ldloc.0
+			IL_018f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0194: stloc.3
+			IL_0195: ldloc.3
+			IL_0196: brfalse IL_01d1
 
-			IL_01a1: ldloc.0
-			IL_01a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_01a7: stloc.s 5
-			IL_01a9: ldloc.0
-			IL_01aa: ldloc.s 5
-			IL_01ac: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_01b1: ldloc.0
-			IL_01b2: ldc.i4.0
-			IL_01b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01b8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_01bd: ldloc.0
-			IL_01be: ldc.i4.1
-			IL_01bf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_01c4: ldloc.0
-			IL_01c5: ldc.i4.0
-			IL_01c6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_01cb: ldloc.0
-			IL_01cc: ldc.i4.0
-			IL_01cd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_01d2: br IL_02e8
+			IL_019b: ldloc.0
+			IL_019c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_01a1: stloc.s 4
+			IL_01a3: ldloc.0
+			IL_01a4: ldloc.s 4
+			IL_01a6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_01ab: ldloc.0
+			IL_01ac: ldc.i4.0
+			IL_01ad: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01b2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_01b7: ldloc.0
+			IL_01b8: ldc.i4.1
+			IL_01b9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_01be: ldloc.0
+			IL_01bf: ldc.i4.0
+			IL_01c0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_01c5: ldloc.0
+			IL_01c6: ldc.i4.0
+			IL_01c7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_01cc: br IL_02de
 
-			IL_01d7: ldstr "console"
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e1: stloc.s 5
-			IL_01e3: ldloc.s 5
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ea: stloc.s 5
-			IL_01ec: ldloc.s 5
-			IL_01ee: ldstr "log"
-			IL_01f3: ldstr "try2"
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01fd: pop
-			IL_01fe: ldc.r8 2
-			IL_0207: box [System.Runtime]System.Double
-			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_0211: stloc.s 5
-			IL_0213: ldloc.s 5
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::AwaitValue(object)
-			IL_021a: stloc.s 5
-			IL_021c: ldloc.0
-			IL_021d: ldc.i4.2
-			IL_021e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0223: ldloc.0
-			IL_0224: ldc.i4.m1
-			IL_0225: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_022a: ldloc.0
-			IL_022b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0230: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0235: ldarg.0
-			IL_0236: ldc.i4.1
-			IL_0237: newarr [System.Runtime]System.Object
-			IL_023c: dup
-			IL_023d: ldc.i4.0
-			IL_023e: ldloc.s 5
-			IL_0240: ldc.i4.0
-			IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0246: stelem.ref
-			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_024c: pop
-			IL_024d: ldloc.0
-			IL_024e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0253: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0258: ret
+			IL_01d1: ldstr "console"
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01db: stloc.s 4
+			IL_01dd: ldloc.s 4
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e4: stloc.s 4
+			IL_01e6: ldloc.s 4
+			IL_01e8: ldstr "log"
+			IL_01ed: ldstr "try2"
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01f7: pop
+			IL_01f8: ldc.r8 2
+			IL_0201: box [System.Runtime]System.Double
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_020b: stloc.s 4
+			IL_020d: ldloc.s 4
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::AwaitValue(object)
+			IL_0214: stloc.s 4
+			IL_0216: ldloc.0
+			IL_0217: ldc.i4.2
+			IL_0218: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_021d: ldloc.0
+			IL_021e: ldc.i4.m1
+			IL_021f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0224: ldloc.0
+			IL_0225: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_022f: ldarg.0
+			IL_0230: ldc.i4.1
+			IL_0231: newarr [System.Runtime]System.Object
+			IL_0236: dup
+			IL_0237: ldc.i4.0
+			IL_0238: ldloc.s 4
+			IL_023a: ldc.i4.0
+			IL_023b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0240: stelem.ref
+			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0246: pop
+			IL_0247: ldloc.0
+			IL_0248: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0252: ret
 
-			IL_0259: ldloc.0
-			IL_025a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_025f: stloc.s 4
-			IL_0261: ldloc.s 4
-			IL_0263: brfalse IL_029e
+			IL_0253: ldloc.0
+			IL_0254: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0259: stloc.3
+			IL_025a: ldloc.3
+			IL_025b: brfalse IL_0296
 
+			IL_0260: ldloc.0
+			IL_0261: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_0266: stloc.s 4
 			IL_0268: ldloc.0
-			IL_0269: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_026e: stloc.s 5
+			IL_0269: ldloc.s 4
+			IL_026b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
 			IL_0270: ldloc.0
-			IL_0271: ldloc.s 5
-			IL_0273: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0278: ldloc.0
-			IL_0279: ldc.i4.1
-			IL_027a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_027f: ldloc.0
-			IL_0280: ldc.i4.0
-			IL_0281: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0286: ldloc.0
-			IL_0287: ldc.i4.0
-			IL_0288: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_028d: ldloc.0
-			IL_028e: ldc.i4.0
-			IL_028f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0294: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0299: br IL_0415
+			IL_0271: ldc.i4.1
+			IL_0272: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0277: ldloc.0
+			IL_0278: ldc.i4.0
+			IL_0279: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_027e: ldloc.0
+			IL_027f: ldc.i4.0
+			IL_0280: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0285: ldloc.0
+			IL_0286: ldc.i4.0
+			IL_0287: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_028c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0291: br IL_0401
 
-			IL_029e: ldloc.0
-			IL_029f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_02a4: stloc.s 4
-			IL_02a6: ldloc.s 4
-			IL_02a8: brfalse IL_02e3
+			IL_0296: ldloc.0
+			IL_0297: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_029c: stloc.3
+			IL_029d: ldloc.3
+			IL_029e: brfalse IL_02d9
 
-			IL_02ad: ldloc.0
-			IL_02ae: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_02b3: stloc.s 5
-			IL_02b5: ldloc.0
-			IL_02b6: ldloc.s 5
-			IL_02b8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_02bd: ldloc.0
-			IL_02be: ldc.i4.0
-			IL_02bf: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02c4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_02c9: ldloc.0
-			IL_02ca: ldc.i4.1
-			IL_02cb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_02d0: ldloc.0
-			IL_02d1: ldc.i4.0
-			IL_02d2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_02d7: ldloc.0
-			IL_02d8: ldc.i4.0
-			IL_02d9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_02de: br IL_02e8
+			IL_02a3: ldloc.0
+			IL_02a4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_02a9: stloc.s 4
+			IL_02ab: ldloc.0
+			IL_02ac: ldloc.s 4
+			IL_02ae: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_02b3: ldloc.0
+			IL_02b4: ldc.i4.0
+			IL_02b5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02ba: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_02bf: ldloc.0
+			IL_02c0: ldc.i4.1
+			IL_02c1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_02c6: ldloc.0
+			IL_02c7: ldc.i4.0
+			IL_02c8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_02cd: ldloc.0
+			IL_02ce: ldc.i4.0
+			IL_02cf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_02d4: br IL_02de
 
-			IL_02e3: br IL_0415
+			IL_02d9: br IL_0401
 
-			IL_02e8: ldloc.0
-			IL_02e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_02ee: stloc.s 5
-			IL_02f0: ldloc.0
-			IL_02f1: ldc.i4.0
-			IL_02f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_02f7: ldloc.0
-			IL_02f8: ldc.i4.0
-			IL_02f9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02fe: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0303: ldloc.s 5
-			IL_0305: stloc.2
-			IL_0306: newobj instance void Modules.AsyncGenerator_TryCatchFinally/g/Scope/Block_L9C14::.ctor()
-			IL_030b: stloc.3
-			IL_030c: ldstr "console"
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0316: stloc.s 5
-			IL_0318: ldloc.s 5
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031f: stloc.s 5
-			IL_0321: ldstr "catch="
-			IL_0326: ldloc.2
-			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_032c: stloc.s 6
-			IL_032e: ldloc.s 5
-			IL_0330: ldstr "log"
-			IL_0335: ldloc.s 6
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_033c: pop
-			IL_033d: ldloc.0
-			IL_033e: ldc.i4.3
-			IL_033f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0344: ldloc.0
-			IL_0345: ldc.i4.m1
-			IL_0346: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_034b: ldloc.0
-			IL_034c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0351: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0356: ldarg.0
-			IL_0357: ldc.i4.1
-			IL_0358: newarr [System.Runtime]System.Object
-			IL_035d: dup
-			IL_035e: ldc.i4.0
-			IL_035f: ldc.r8 3
-			IL_0368: box [System.Runtime]System.Double
-			IL_036d: ldc.i4.0
-			IL_036e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0373: stelem.ref
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0379: pop
-			IL_037a: ldloc.0
-			IL_037b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0380: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0385: ret
+			IL_02de: ldloc.0
+			IL_02df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_02e4: stloc.s 4
+			IL_02e6: ldloc.0
+			IL_02e7: ldc.i4.0
+			IL_02e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_02ed: ldloc.0
+			IL_02ee: ldc.i4.0
+			IL_02ef: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02f4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_02f9: ldloc.s 4
+			IL_02fb: stloc.2
+			IL_02fc: ldstr "console"
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0306: stloc.s 4
+			IL_0308: ldloc.s 4
+			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_030f: stloc.s 4
+			IL_0311: ldstr "catch="
+			IL_0316: ldloc.2
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_031c: stloc.s 5
+			IL_031e: ldloc.s 4
+			IL_0320: ldstr "log"
+			IL_0325: ldloc.s 5
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_032c: pop
+			IL_032d: ldloc.0
+			IL_032e: ldc.i4.3
+			IL_032f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0334: ldloc.0
+			IL_0335: ldc.i4.m1
+			IL_0336: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_033b: ldloc.0
+			IL_033c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0341: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0346: ldarg.0
+			IL_0347: ldc.i4.1
+			IL_0348: newarr [System.Runtime]System.Object
+			IL_034d: dup
+			IL_034e: ldc.i4.0
+			IL_034f: ldc.r8 3
+			IL_0358: box [System.Runtime]System.Double
+			IL_035d: ldc.i4.0
+			IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0363: stelem.ref
+			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0369: pop
+			IL_036a: ldloc.0
+			IL_036b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0370: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0375: ret
 
-			IL_0386: ldloc.0
-			IL_0387: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_038c: stloc.s 4
-			IL_038e: ldloc.s 4
-			IL_0390: brfalse IL_03cb
+			IL_0376: ldloc.0
+			IL_0377: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_037c: stloc.3
+			IL_037d: ldloc.3
+			IL_037e: brfalse IL_03b9
 
-			IL_0395: ldloc.0
-			IL_0396: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_039b: stloc.s 5
-			IL_039d: ldloc.0
-			IL_039e: ldloc.s 5
-			IL_03a0: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_03a5: ldloc.0
-			IL_03a6: ldc.i4.1
-			IL_03a7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_03ac: ldloc.0
-			IL_03ad: ldc.i4.0
-			IL_03ae: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_03b3: ldloc.0
-			IL_03b4: ldc.i4.0
-			IL_03b5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_03ba: ldloc.0
-			IL_03bb: ldc.i4.0
-			IL_03bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03c1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_03c6: br IL_0415
+			IL_0383: ldloc.0
+			IL_0384: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_0389: stloc.s 4
+			IL_038b: ldloc.0
+			IL_038c: ldloc.s 4
+			IL_038e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0393: ldloc.0
+			IL_0394: ldc.i4.1
+			IL_0395: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_039a: ldloc.0
+			IL_039b: ldc.i4.0
+			IL_039c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03a1: ldloc.0
+			IL_03a2: ldc.i4.0
+			IL_03a3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_03a8: ldloc.0
+			IL_03a9: ldc.i4.0
+			IL_03aa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03af: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03b4: br IL_0401
 
-			IL_03cb: ldloc.0
-			IL_03cc: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_03d1: stloc.s 4
-			IL_03d3: ldloc.s 4
-			IL_03d5: brfalse IL_0410
+			IL_03b9: ldloc.0
+			IL_03ba: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_03bf: stloc.3
+			IL_03c0: ldloc.3
+			IL_03c1: brfalse IL_03fc
 
-			IL_03da: ldloc.0
-			IL_03db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_03e0: stloc.s 5
+			IL_03c6: ldloc.0
+			IL_03c7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_03cc: stloc.s 4
+			IL_03ce: ldloc.0
+			IL_03cf: ldloc.s 4
+			IL_03d1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03d6: ldloc.0
+			IL_03d7: ldc.i4.0
+			IL_03d8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03dd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
 			IL_03e2: ldloc.0
-			IL_03e3: ldloc.s 5
-			IL_03e5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_03ea: ldloc.0
-			IL_03eb: ldc.i4.0
-			IL_03ec: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03f1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_03f6: ldloc.0
-			IL_03f7: ldc.i4.1
-			IL_03f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_03fd: ldloc.0
-			IL_03fe: ldc.i4.0
-			IL_03ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0404: ldloc.0
-			IL_0405: ldc.i4.0
-			IL_0406: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_040b: br IL_0415
+			IL_03e3: ldc.i4.1
+			IL_03e4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03e9: ldloc.0
+			IL_03ea: ldc.i4.0
+			IL_03eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03f0: ldloc.0
+			IL_03f1: ldc.i4.0
+			IL_03f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_03f7: br IL_0401
 
-			IL_0410: br IL_0415
+			IL_03fc: br IL_0401
 
-			IL_0415: ldstr "console"
-			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_041f: stloc.s 5
-			IL_0421: ldloc.s 5
-			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0428: stloc.s 5
-			IL_042a: ldloc.s 5
-			IL_042c: ldstr "log"
-			IL_0431: ldstr "finally"
-			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_043b: pop
-			IL_043c: br IL_0441
+			IL_0401: ldstr "console"
+			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_040b: stloc.s 4
+			IL_040d: ldloc.s 4
+			IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0414: stloc.s 4
+			IL_0416: ldloc.s 4
+			IL_0418: ldstr "log"
+			IL_041d: ldstr "finally"
+			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0427: pop
+			IL_0428: br IL_042d
 
-			IL_0441: ldloc.0
-			IL_0442: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0447: stloc.s 4
-			IL_0449: ldloc.s 4
-			IL_044b: brfalse IL_046f
+			IL_042d: ldloc.0
+			IL_042e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0433: stloc.3
+			IL_0434: ldloc.3
+			IL_0435: brfalse IL_0459
 
-			IL_0450: ldloc.0
-			IL_0451: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0456: isinst [System.Runtime]System.Exception
-			IL_045b: dup
-			IL_045c: brtrue IL_046e
+			IL_043a: ldloc.0
+			IL_043b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0440: isinst [System.Runtime]System.Exception
+			IL_0445: dup
+			IL_0446: brtrue IL_0458
 
-			IL_0461: pop
-			IL_0462: ldloc.0
-			IL_0463: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0468: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_046d: throw
+			IL_044b: pop
+			IL_044c: ldloc.0
+			IL_044d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0452: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0457: throw
 
-			IL_046e: throw
+			IL_0458: throw
 
-			IL_046f: ldloc.0
-			IL_0470: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0475: stloc.s 4
-			IL_0477: ldloc.s 4
-			IL_0479: brfalse IL_04c3
+			IL_0459: ldloc.0
+			IL_045a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_045f: stloc.3
+			IL_0460: ldloc.3
+			IL_0461: brfalse IL_04ab
 
-			IL_047e: ldloc.0
-			IL_047f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0484: stloc.s 5
-			IL_0486: ldloc.0
-			IL_0487: ldc.i4.1
-			IL_0488: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_048d: ldloc.0
-			IL_048e: ldc.i4.m1
-			IL_048f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0494: ldloc.0
-			IL_0495: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_049a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_049f: ldarg.0
-			IL_04a0: ldc.i4.1
-			IL_04a1: newarr [System.Runtime]System.Object
-			IL_04a6: dup
-			IL_04a7: ldc.i4.0
-			IL_04a8: ldloc.s 5
-			IL_04aa: ldc.i4.1
-			IL_04ab: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_04b0: stelem.ref
-			IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_04b6: pop
-			IL_04b7: ldloc.0
-			IL_04b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04c2: ret
+			IL_0466: ldloc.0
+			IL_0467: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_046c: stloc.s 4
+			IL_046e: ldloc.0
+			IL_046f: ldc.i4.1
+			IL_0470: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0475: ldloc.0
+			IL_0476: ldc.i4.m1
+			IL_0477: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_047c: ldloc.0
+			IL_047d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0482: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0487: ldarg.0
+			IL_0488: ldc.i4.1
+			IL_0489: newarr [System.Runtime]System.Object
+			IL_048e: dup
+			IL_048f: ldc.i4.0
+			IL_0490: ldloc.s 4
+			IL_0492: ldc.i4.1
+			IL_0493: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0498: stelem.ref
+			IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_049e: pop
+			IL_049f: ldloc.0
+			IL_04a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04aa: ret
 
-			IL_04c3: ldstr "console"
-			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04cd: stloc.s 5
-			IL_04cf: ldloc.s 5
-			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04d6: stloc.s 5
-			IL_04d8: ldloc.s 5
-			IL_04da: ldstr "log"
-			IL_04df: ldstr "after"
-			IL_04e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04e9: pop
-			IL_04ea: ldloc.0
-			IL_04eb: ldc.i4.4
-			IL_04ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_04f1: ldloc.0
-			IL_04f2: ldc.i4.m1
-			IL_04f3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04f8: ldloc.0
-			IL_04f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0503: ldarg.0
-			IL_0504: ldc.i4.1
-			IL_0505: newarr [System.Runtime]System.Object
-			IL_050a: dup
-			IL_050b: ldc.i4.0
-			IL_050c: ldc.r8 4
-			IL_0515: box [System.Runtime]System.Double
-			IL_051a: ldc.i4.0
-			IL_051b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0520: stelem.ref
-			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0526: pop
-			IL_0527: ldloc.0
-			IL_0528: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_052d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0532: ret
+			IL_04ab: ldstr "console"
+			IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04b5: stloc.s 4
+			IL_04b7: ldloc.s 4
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04be: stloc.s 4
+			IL_04c0: ldloc.s 4
+			IL_04c2: ldstr "log"
+			IL_04c7: ldstr "after"
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04d1: pop
+			IL_04d2: ldloc.0
+			IL_04d3: ldc.i4.4
+			IL_04d4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_04d9: ldloc.0
+			IL_04da: ldc.i4.m1
+			IL_04db: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04e0: ldloc.0
+			IL_04e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04eb: ldarg.0
+			IL_04ec: ldc.i4.1
+			IL_04ed: newarr [System.Runtime]System.Object
+			IL_04f2: dup
+			IL_04f3: ldc.i4.0
+			IL_04f4: ldc.r8 4
+			IL_04fd: box [System.Runtime]System.Double
+			IL_0502: ldc.i4.0
+			IL_0503: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0508: stelem.ref
+			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_050e: pop
+			IL_050f: ldloc.0
+			IL_0510: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0515: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_051a: ret
 
-			IL_0533: ldloc.0
-			IL_0534: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0539: brfalse IL_057f
+			IL_051b: ldloc.0
+			IL_051c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0521: brfalse IL_0567
 
-			IL_053e: ldloc.0
-			IL_053f: ldc.i4.1
-			IL_0540: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_0545: ldloc.0
-			IL_0546: ldc.i4.m1
-			IL_0547: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_054c: ldloc.0
-			IL_054d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0552: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0557: ldarg.0
-			IL_0558: ldc.i4.1
-			IL_0559: newarr [System.Runtime]System.Object
-			IL_055e: dup
-			IL_055f: ldc.i4.0
-			IL_0560: ldloc.0
-			IL_0561: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_0566: ldc.i4.1
-			IL_0567: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_056c: stelem.ref
-			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0572: pop
-			IL_0573: ldloc.0
-			IL_0574: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0579: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_057e: ret
+			IL_0526: ldloc.0
+			IL_0527: ldc.i4.1
+			IL_0528: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_052d: ldloc.0
+			IL_052e: ldc.i4.m1
+			IL_052f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0534: ldloc.0
+			IL_0535: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_053a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_053f: ldarg.0
+			IL_0540: ldc.i4.1
+			IL_0541: newarr [System.Runtime]System.Object
+			IL_0546: dup
+			IL_0547: ldc.i4.0
+			IL_0548: ldloc.0
+			IL_0549: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_054e: ldc.i4.1
+			IL_054f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0554: stelem.ref
+			IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_055a: pop
+			IL_055b: ldloc.0
+			IL_055c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0561: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0566: ret
 
-			IL_057f: ldloc.0
-			IL_0580: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0585: brfalse IL_059d
+			IL_0567: ldloc.0
+			IL_0568: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_056d: brfalse IL_0585
 
-			IL_058a: ldloc.0
-			IL_058b: ldc.i4.0
-			IL_058c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0591: ldloc.0
-			IL_0592: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_0597: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_059c: throw
+			IL_0572: ldloc.0
+			IL_0573: ldc.i4.0
+			IL_0574: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0579: ldloc.0
+			IL_057a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_057f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0584: throw
 
-			IL_059d: ldloc.0
-			IL_059e: ldc.i4.1
-			IL_059f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_05a4: ldloc.0
-			IL_05a5: ldc.i4.m1
-			IL_05a6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05ab: ldloc.0
-			IL_05ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05b6: ldarg.0
-			IL_05b7: ldc.i4.1
-			IL_05b8: newarr [System.Runtime]System.Object
-			IL_05bd: dup
-			IL_05be: ldc.i4.0
-			IL_05bf: ldnull
-			IL_05c0: ldc.i4.1
-			IL_05c1: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_05c6: stelem.ref
-			IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05cc: pop
-			IL_05cd: ldloc.0
-			IL_05ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05d8: ret
+			IL_0585: ldloc.0
+			IL_0586: ldc.i4.1
+			IL_0587: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_058c: ldloc.0
+			IL_058d: ldc.i4.m1
+			IL_058e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0593: ldloc.0
+			IL_0594: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0599: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_059e: ldarg.0
+			IL_059f: ldc.i4.1
+			IL_05a0: newarr [System.Runtime]System.Object
+			IL_05a5: dup
+			IL_05a6: ldc.i4.0
+			IL_05a7: ldnull
+			IL_05a8: ldc.i4.1
+			IL_05a9: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_05ae: stelem.ref
+			IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05b4: pop
+			IL_05b5: ldloc.0
+			IL_05b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05c0: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -737,7 +734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab7
+				// Method begins at RVA 0x2a9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -761,7 +758,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26cc
+			// Method begins at RVA 0x26b4
 			// Header size: 12
 			// Code size: 946 (0x3b2)
 			.maxstack 8
@@ -1210,7 +1207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a8a
+			// Method begins at RVA 0x2a72
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1307,7 +1304,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ac0
+		// Method begins at RVA 0x2aa8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_BigInt_Operators.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_BigInt_Operators.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28bd
+				// Method begins at RVA 0x28a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28c6
+				// Method begins at RVA 0x28aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28cf
+				// Method begins at RVA 0x28b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28d8
+				// Method begins at RVA 0x28bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28e1
+				// Method begins at RVA 0x28c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ea
+				// Method begins at RVA 0x28ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28f3
+				// Method begins at RVA 0x28d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28fc
+				// Method begins at RVA 0x28e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28b4
+			// Method begins at RVA 0x2898
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2082 (0x822)
+		// Code size: 2054 (0x806)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_BigInt_Operators/Scope,
@@ -211,27 +211,23 @@
 			[3] class [System.Runtime]System.Exception,
 			[4] object,
 			[5] object,
-			[6] class Modules.BinaryOperator_BigInt_Operators/Scope/Block_L31C12,
-			[7] class [System.Runtime]System.Exception,
+			[6] class [System.Runtime]System.Exception,
+			[7] object,
 			[8] object,
-			[9] object,
-			[10] class Modules.BinaryOperator_BigInt_Operators/Scope/Block_L37C12,
-			[11] class [System.Runtime]System.Exception,
-			[12] object,
+			[9] class [System.Runtime]System.Exception,
+			[10] object,
+			[11] object,
+			[12] class [System.Runtime]System.Exception,
 			[13] object,
-			[14] class Modules.BinaryOperator_BigInt_Operators/Scope/Block_L43C12,
-			[15] class [System.Runtime]System.Exception,
+			[14] object,
+			[15] object,
 			[16] object,
 			[17] object,
-			[18] class Modules.BinaryOperator_BigInt_Operators/Scope/Block_L49C12,
+			[18] object,
 			[19] object,
 			[20] object,
-			[21] object,
-			[22] object,
-			[23] object,
-			[24] object,
-			[25] bool,
-			[26] object
+			[21] bool,
+			[22] object
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_BigInt_Operators/Scope::.ctor()
@@ -240,424 +236,424 @@
 		IL_0007: ldc.r8 10
 		IL_0010: box [System.Runtime]System.Double
 		IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_001a: stloc.s 20
-		IL_001c: ldloc.s 20
+		IL_001a: stloc.s 16
+		IL_001c: ldloc.s 16
 		IL_001e: stloc.1
 		IL_001f: ldc.r8 3
 		IL_0028: box [System.Runtime]System.Double
 		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_0032: stloc.s 20
-		IL_0034: ldloc.s 20
+		IL_0032: stloc.s 16
+		IL_0034: ldloc.s 16
 		IL_0036: stloc.2
 		IL_0037: ldstr "console"
 		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0041: stloc.s 21
-		IL_0043: ldloc.s 21
+		IL_0041: stloc.s 17
+		IL_0043: ldloc.s 17
 		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004a: stloc.s 21
+		IL_004a: stloc.s 17
 		IL_004c: ldloc.1
-		IL_004d: stloc.s 20
-		IL_004f: ldloc.s 20
+		IL_004d: stloc.s 16
+		IL_004f: ldloc.s 16
 		IL_0051: ldloc.2
 		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0057: stloc.s 22
-		IL_0059: ldloc.s 21
+		IL_0057: stloc.s 18
+		IL_0059: ldloc.s 17
 		IL_005b: ldstr "log"
-		IL_0060: ldloc.s 22
+		IL_0060: ldloc.s 18
 		IL_0062: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_006c: pop
 		IL_006d: ldstr "console"
 		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0077: stloc.s 21
-		IL_0079: ldloc.s 21
+		IL_0077: stloc.s 17
+		IL_0079: ldloc.s 17
 		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: stloc.s 21
+		IL_0080: stloc.s 17
 		IL_0082: ldloc.1
-		IL_0083: stloc.s 20
-		IL_0085: ldloc.s 20
+		IL_0083: stloc.s 16
+		IL_0085: ldloc.s 16
 		IL_0087: ldloc.2
 		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_008d: stloc.s 22
-		IL_008f: ldloc.s 21
+		IL_008d: stloc.s 18
+		IL_008f: ldloc.s 17
 		IL_0091: ldstr "log"
-		IL_0096: ldloc.s 22
+		IL_0096: ldloc.s 18
 		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_009d: pop
 		IL_009e: ldstr "console"
 		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a8: stloc.s 21
-		IL_00aa: ldloc.s 21
+		IL_00a8: stloc.s 17
+		IL_00aa: ldloc.s 17
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b1: stloc.s 21
+		IL_00b1: stloc.s 17
 		IL_00b3: ldloc.1
 		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b9: stloc.s 23
-		IL_00bb: ldloc.s 23
+		IL_00b9: stloc.s 19
+		IL_00bb: ldloc.s 19
 		IL_00bd: ldstr "toString"
 		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00c7: stloc.s 23
-		IL_00c9: ldloc.s 21
+		IL_00c7: stloc.s 19
+		IL_00c9: ldloc.s 17
 		IL_00cb: ldstr "log"
-		IL_00d0: ldloc.s 23
+		IL_00d0: ldloc.s 19
 		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d7: pop
 		IL_00d8: ldstr "console"
 		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e2: stloc.s 23
-		IL_00e4: ldloc.s 23
+		IL_00e2: stloc.s 19
+		IL_00e4: ldloc.s 19
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: stloc.s 23
+		IL_00eb: stloc.s 19
 		IL_00ed: ldloc.1
 		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f3: stloc.s 21
-		IL_00f5: ldloc.s 21
+		IL_00f3: stloc.s 17
+		IL_00f5: ldloc.s 17
 		IL_00f7: ldstr "toString"
 		IL_00fc: ldc.r8 16
 		IL_0105: box [System.Runtime]System.Double
 		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_010f: stloc.s 21
-		IL_0111: ldloc.s 23
+		IL_010f: stloc.s 17
+		IL_0111: ldloc.s 19
 		IL_0113: ldstr "log"
-		IL_0118: ldloc.s 21
+		IL_0118: ldloc.s 17
 		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_011f: pop
 		IL_0120: ldstr "console"
 		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012a: stloc.s 21
-		IL_012c: ldloc.s 21
+		IL_012a: stloc.s 17
+		IL_012c: ldloc.s 17
 		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0133: stloc.s 21
+		IL_0133: stloc.s 17
 		IL_0135: ldloc.1
-		IL_0136: stloc.s 20
-		IL_0138: ldloc.s 20
+		IL_0136: stloc.s 16
+		IL_0138: ldloc.s 16
 		IL_013a: ldloc.2
 		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Subtract(object, object)
-		IL_0140: stloc.s 22
-		IL_0142: ldloc.s 21
+		IL_0140: stloc.s 18
+		IL_0142: ldloc.s 17
 		IL_0144: ldstr "log"
-		IL_0149: ldloc.s 22
+		IL_0149: ldloc.s 18
 		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0150: pop
 		IL_0151: ldstr "console"
 		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015b: stloc.s 21
-		IL_015d: ldloc.s 21
+		IL_015b: stloc.s 17
+		IL_015d: ldloc.s 17
 		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0164: stloc.s 21
+		IL_0164: stloc.s 17
 		IL_0166: ldloc.1
-		IL_0167: stloc.s 20
-		IL_0169: ldloc.s 20
+		IL_0167: stloc.s 16
+		IL_0169: ldloc.s 16
 		IL_016b: ldloc.2
 		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Multiply(object, object)
-		IL_0171: stloc.s 22
-		IL_0173: ldloc.s 21
+		IL_0171: stloc.s 18
+		IL_0173: ldloc.s 17
 		IL_0175: ldstr "log"
-		IL_017a: ldloc.s 22
+		IL_017a: ldloc.s 18
 		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0181: pop
 		IL_0182: ldstr "console"
 		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018c: stloc.s 21
-		IL_018e: ldloc.s 21
+		IL_018c: stloc.s 17
+		IL_018e: ldloc.s 17
 		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 21
+		IL_0195: stloc.s 17
 		IL_0197: ldloc.1
-		IL_0198: stloc.s 20
-		IL_019a: ldloc.s 20
+		IL_0198: stloc.s 16
+		IL_019a: ldloc.s 16
 		IL_019c: ldloc.2
 		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Divide(object, object)
-		IL_01a2: stloc.s 22
-		IL_01a4: ldloc.s 21
+		IL_01a2: stloc.s 18
+		IL_01a4: ldloc.s 17
 		IL_01a6: ldstr "log"
-		IL_01ab: ldloc.s 22
+		IL_01ab: ldloc.s 18
 		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01b2: pop
 		IL_01b3: ldstr "console"
 		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bd: stloc.s 21
-		IL_01bf: ldloc.s 21
+		IL_01bd: stloc.s 17
+		IL_01bf: ldloc.s 17
 		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c6: stloc.s 21
+		IL_01c6: stloc.s 17
 		IL_01c8: ldloc.1
-		IL_01c9: stloc.s 20
-		IL_01cb: ldloc.s 20
+		IL_01c9: stloc.s 16
+		IL_01cb: ldloc.s 16
 		IL_01cd: ldloc.2
 		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
-		IL_01d3: stloc.s 22
-		IL_01d5: ldloc.s 21
+		IL_01d3: stloc.s 18
+		IL_01d5: ldloc.s 17
 		IL_01d7: ldstr "log"
-		IL_01dc: ldloc.s 22
+		IL_01dc: ldloc.s 18
 		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01e3: pop
 		IL_01e4: ldstr "console"
 		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ee: stloc.s 21
-		IL_01f0: ldloc.s 21
+		IL_01ee: stloc.s 17
+		IL_01f0: ldloc.s 17
 		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f7: stloc.s 21
+		IL_01f7: stloc.s 17
 		IL_01f9: ldloc.1
-		IL_01fa: stloc.s 20
+		IL_01fa: stloc.s 16
 		IL_01fc: ldc.r8 3
 		IL_0205: box [System.Runtime]System.Double
 		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_020f: stloc.s 24
-		IL_0211: ldloc.s 20
-		IL_0213: ldloc.s 24
+		IL_020f: stloc.s 20
+		IL_0211: ldloc.s 16
+		IL_0213: ldloc.s 20
 		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
-		IL_021a: stloc.s 22
-		IL_021c: ldloc.s 21
+		IL_021a: stloc.s 18
+		IL_021c: ldloc.s 17
 		IL_021e: ldstr "log"
-		IL_0223: ldloc.s 22
+		IL_0223: ldloc.s 18
 		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_022a: pop
 		IL_022b: ldstr "console"
 		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0235: stloc.s 21
-		IL_0237: ldloc.s 21
+		IL_0235: stloc.s 17
+		IL_0237: ldloc.s 17
 		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023e: stloc.s 21
+		IL_023e: stloc.s 17
 		IL_0240: ldloc.1
-		IL_0241: stloc.s 24
-		IL_0243: ldloc.s 24
+		IL_0241: stloc.s 20
+		IL_0243: ldloc.s 20
 		IL_0245: ldloc.2
 		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseAnd(object, object)
-		IL_024b: stloc.s 22
-		IL_024d: ldloc.s 21
+		IL_024b: stloc.s 18
+		IL_024d: ldloc.s 17
 		IL_024f: ldstr "log"
-		IL_0254: ldloc.s 22
+		IL_0254: ldloc.s 18
 		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_025b: pop
 		IL_025c: ldstr "console"
 		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0266: stloc.s 21
-		IL_0268: ldloc.s 21
+		IL_0266: stloc.s 17
+		IL_0268: ldloc.s 17
 		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026f: stloc.s 21
+		IL_026f: stloc.s 17
 		IL_0271: ldloc.1
-		IL_0272: stloc.s 24
-		IL_0274: ldloc.s 24
+		IL_0272: stloc.s 20
+		IL_0274: ldloc.s 20
 		IL_0276: ldloc.2
 		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseOr(object, object)
-		IL_027c: stloc.s 22
-		IL_027e: ldloc.s 21
+		IL_027c: stloc.s 18
+		IL_027e: ldloc.s 17
 		IL_0280: ldstr "log"
-		IL_0285: ldloc.s 22
+		IL_0285: ldloc.s 18
 		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_028c: pop
 		IL_028d: ldstr "console"
 		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0297: stloc.s 21
-		IL_0299: ldloc.s 21
+		IL_0297: stloc.s 17
+		IL_0299: ldloc.s 17
 		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a0: stloc.s 21
+		IL_02a0: stloc.s 17
 		IL_02a2: ldloc.1
-		IL_02a3: stloc.s 24
-		IL_02a5: ldloc.s 24
+		IL_02a3: stloc.s 20
+		IL_02a5: ldloc.s 20
 		IL_02a7: ldloc.2
 		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseXor(object, object)
-		IL_02ad: stloc.s 22
-		IL_02af: ldloc.s 21
+		IL_02ad: stloc.s 18
+		IL_02af: ldloc.s 17
 		IL_02b1: ldstr "log"
-		IL_02b6: ldloc.s 22
+		IL_02b6: ldloc.s 18
 		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_02bd: pop
 		IL_02be: ldstr "console"
 		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c8: stloc.s 21
-		IL_02ca: ldloc.s 21
+		IL_02c8: stloc.s 17
+		IL_02ca: ldloc.s 17
 		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d1: stloc.s 21
+		IL_02d1: stloc.s 17
 		IL_02d3: ldloc.1
-		IL_02d4: stloc.s 24
+		IL_02d4: stloc.s 20
 		IL_02d6: ldc.r8 2
 		IL_02df: box [System.Runtime]System.Double
 		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_02e9: stloc.s 20
-		IL_02eb: ldloc.s 24
-		IL_02ed: ldloc.s 20
+		IL_02e9: stloc.s 16
+		IL_02eb: ldloc.s 20
+		IL_02ed: ldloc.s 16
 		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::LeftShift(object, object)
-		IL_02f4: stloc.s 22
-		IL_02f6: ldloc.s 21
+		IL_02f4: stloc.s 18
+		IL_02f6: ldloc.s 17
 		IL_02f8: ldstr "log"
-		IL_02fd: ldloc.s 22
+		IL_02fd: ldloc.s 18
 		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0304: pop
 		IL_0305: ldstr "console"
 		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_030f: stloc.s 21
-		IL_0311: ldloc.s 21
+		IL_030f: stloc.s 17
+		IL_0311: ldloc.s 17
 		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0318: stloc.s 21
+		IL_0318: stloc.s 17
 		IL_031a: ldloc.1
-		IL_031b: stloc.s 20
+		IL_031b: stloc.s 16
 		IL_031d: ldc.r8 1
 		IL_0326: box [System.Runtime]System.Double
 		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_0330: stloc.s 24
-		IL_0332: ldloc.s 20
-		IL_0334: ldloc.s 24
+		IL_0330: stloc.s 20
+		IL_0332: ldloc.s 16
+		IL_0334: ldloc.s 20
 		IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::SignedRightShift(object, object)
-		IL_033b: stloc.s 22
-		IL_033d: ldloc.s 21
+		IL_033b: stloc.s 18
+		IL_033d: ldloc.s 17
 		IL_033f: ldstr "log"
-		IL_0344: ldloc.s 22
+		IL_0344: ldloc.s 18
 		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_034b: pop
 		IL_034c: ldstr "console"
 		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0356: stloc.s 21
-		IL_0358: ldloc.s 21
+		IL_0356: stloc.s 17
+		IL_0358: ldloc.s 17
 		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035f: stloc.s 21
+		IL_035f: stloc.s 17
 		IL_0361: ldloc.1
-		IL_0362: stloc.s 24
-		IL_0364: ldloc.s 24
+		IL_0362: stloc.s 20
+		IL_0364: ldloc.s 20
 		IL_0366: ldloc.2
 		IL_0367: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-		IL_036c: stloc.s 25
-		IL_036e: ldloc.s 25
+		IL_036c: stloc.s 21
+		IL_036e: ldloc.s 21
 		IL_0370: box [System.Runtime]System.Boolean
-		IL_0375: stloc.s 26
-		IL_0377: ldloc.s 21
+		IL_0375: stloc.s 22
+		IL_0377: ldloc.s 17
 		IL_0379: ldstr "log"
-		IL_037e: ldloc.s 26
+		IL_037e: ldloc.s 22
 		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0385: pop
 		IL_0386: ldstr "console"
 		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0390: stloc.s 21
-		IL_0392: ldloc.s 21
+		IL_0390: stloc.s 17
+		IL_0392: ldloc.s 17
 		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0399: stloc.s 21
+		IL_0399: stloc.s 17
 		IL_039b: ldloc.1
-		IL_039c: stloc.s 24
-		IL_039e: ldloc.s 24
+		IL_039c: stloc.s 20
+		IL_039e: ldloc.s 20
 		IL_03a0: ldloc.2
 		IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
-		IL_03a6: stloc.s 25
-		IL_03a8: ldloc.s 25
+		IL_03a6: stloc.s 21
+		IL_03a8: ldloc.s 21
 		IL_03aa: box [System.Runtime]System.Boolean
-		IL_03af: stloc.s 26
-		IL_03b1: ldloc.s 21
+		IL_03af: stloc.s 22
+		IL_03b1: ldloc.s 17
 		IL_03b3: ldstr "log"
-		IL_03b8: ldloc.s 26
+		IL_03b8: ldloc.s 22
 		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_03bf: pop
 		IL_03c0: ldstr "console"
 		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ca: stloc.s 21
-		IL_03cc: ldloc.s 21
+		IL_03ca: stloc.s 17
+		IL_03cc: ldloc.s 17
 		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d3: stloc.s 21
+		IL_03d3: stloc.s 17
 		IL_03d5: ldloc.1
-		IL_03d6: stloc.s 24
-		IL_03d8: ldloc.s 24
+		IL_03d6: stloc.s 20
+		IL_03d8: ldloc.s 20
 		IL_03da: ldloc.2
 		IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThanOrEqual(object, object)
-		IL_03e0: stloc.s 25
-		IL_03e2: ldloc.s 25
+		IL_03e0: stloc.s 21
+		IL_03e2: ldloc.s 21
 		IL_03e4: box [System.Runtime]System.Boolean
-		IL_03e9: stloc.s 26
-		IL_03eb: ldloc.s 21
+		IL_03e9: stloc.s 22
+		IL_03eb: ldloc.s 17
 		IL_03ed: ldstr "log"
-		IL_03f2: ldloc.s 26
+		IL_03f2: ldloc.s 22
 		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_03f9: pop
 		IL_03fa: ldstr "console"
 		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0404: stloc.s 21
-		IL_0406: ldloc.s 21
+		IL_0404: stloc.s 17
+		IL_0406: ldloc.s 17
 		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040d: stloc.s 21
+		IL_040d: stloc.s 17
 		IL_040f: ldloc.1
-		IL_0410: stloc.s 24
-		IL_0412: ldloc.s 24
+		IL_0410: stloc.s 20
+		IL_0412: ldloc.s 20
 		IL_0414: ldloc.2
 		IL_0415: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-		IL_041a: stloc.s 25
-		IL_041c: ldloc.s 25
+		IL_041a: stloc.s 21
+		IL_041c: ldloc.s 21
 		IL_041e: box [System.Runtime]System.Boolean
-		IL_0423: stloc.s 26
-		IL_0425: ldloc.s 21
+		IL_0423: stloc.s 22
+		IL_0425: ldloc.s 17
 		IL_0427: ldstr "log"
-		IL_042c: ldloc.s 26
+		IL_042c: ldloc.s 22
 		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0433: pop
 		IL_0434: ldstr "console"
 		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043e: stloc.s 21
-		IL_0440: ldloc.s 21
+		IL_043e: stloc.s 17
+		IL_0440: ldloc.s 17
 		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0447: stloc.s 21
+		IL_0447: stloc.s 17
 		IL_0449: ldloc.1
-		IL_044a: stloc.s 24
+		IL_044a: stloc.s 20
 		IL_044c: ldc.r8 10
 		IL_0455: box [System.Runtime]System.Double
 		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_045f: stloc.s 20
-		IL_0461: ldloc.s 24
-		IL_0463: ldloc.s 20
+		IL_045f: stloc.s 16
+		IL_0461: ldloc.s 20
+		IL_0463: ldloc.s 16
 		IL_0465: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_046a: stloc.s 25
-		IL_046c: ldloc.s 25
+		IL_046a: stloc.s 21
+		IL_046c: ldloc.s 21
 		IL_046e: box [System.Runtime]System.Boolean
-		IL_0473: stloc.s 26
-		IL_0475: ldloc.s 21
+		IL_0473: stloc.s 22
+		IL_0475: ldloc.s 17
 		IL_0477: ldstr "log"
-		IL_047c: ldloc.s 26
+		IL_047c: ldloc.s 22
 		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0483: pop
 		IL_0484: ldstr "console"
 		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_048e: stloc.s 21
-		IL_0490: ldloc.s 21
+		IL_048e: stloc.s 17
+		IL_0490: ldloc.s 17
 		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0497: stloc.s 21
+		IL_0497: stloc.s 17
 		IL_0499: ldloc.1
-		IL_049a: stloc.s 20
+		IL_049a: stloc.s 16
 		IL_049c: ldc.r8 10
 		IL_04a5: box [System.Runtime]System.Double
 		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_04af: stloc.s 24
-		IL_04b1: ldloc.s 20
-		IL_04b3: ldloc.s 24
+		IL_04af: stloc.s 20
+		IL_04b1: ldloc.s 16
+		IL_04b3: ldloc.s 20
 		IL_04b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04ba: stloc.s 25
-		IL_04bc: ldloc.s 25
+		IL_04ba: stloc.s 21
+		IL_04bc: ldloc.s 21
 		IL_04be: box [System.Runtime]System.Boolean
-		IL_04c3: stloc.s 26
-		IL_04c5: ldloc.s 21
+		IL_04c3: stloc.s 22
+		IL_04c5: ldloc.s 17
 		IL_04c7: ldstr "log"
-		IL_04cc: ldloc.s 26
+		IL_04cc: ldloc.s 22
 		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_04d3: pop
 		IL_04d4: ldstr "console"
 		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04de: stloc.s 21
-		IL_04e0: ldloc.s 21
+		IL_04de: stloc.s 17
+		IL_04e0: ldloc.s 17
 		IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04e7: stloc.s 21
+		IL_04e7: stloc.s 17
 		IL_04e9: ldloc.1
 		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-		IL_04ef: stloc.s 24
-		IL_04f1: ldloc.s 21
+		IL_04ef: stloc.s 20
+		IL_04f1: ldloc.s 17
 		IL_04f3: ldstr "log"
-		IL_04f8: ldloc.s 24
+		IL_04f8: ldloc.s 20
 		IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_04ff: pop
 		IL_0500: ldstr "console"
 		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_050a: stloc.s 21
-		IL_050c: ldloc.s 21
+		IL_050a: stloc.s 17
+		IL_050c: ldloc.s 17
 		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0513: stloc.s 21
+		IL_0513: stloc.s 17
 		IL_0515: ldloc.1
 		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseNot(object)
-		IL_051b: stloc.s 22
-		IL_051d: ldloc.s 21
+		IL_051b: stloc.s 18
+		IL_051d: ldloc.s 17
 		IL_051f: ldstr "log"
-		IL_0524: ldloc.s 22
+		IL_0524: ldloc.s 18
 		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_052b: pop
 		.try
@@ -665,26 +661,26 @@
 			IL_052c: nop
 			IL_052d: ldstr "console"
 			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0537: stloc.s 21
-			IL_0539: ldloc.s 21
+			IL_0537: stloc.s 17
+			IL_0539: ldloc.s 17
 			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0540: stloc.s 21
+			IL_0540: stloc.s 17
 			IL_0542: ldloc.1
-			IL_0543: stloc.s 24
+			IL_0543: stloc.s 20
 			IL_0545: ldc.r8 0.0
 			IL_054e: box [System.Runtime]System.Double
 			IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_0558: stloc.s 20
-			IL_055a: ldloc.s 24
-			IL_055c: ldloc.s 20
+			IL_0558: stloc.s 16
+			IL_055a: ldloc.s 20
+			IL_055c: ldloc.s 16
 			IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Divide(object, object)
-			IL_0563: stloc.s 22
-			IL_0565: ldloc.s 21
+			IL_0563: stloc.s 18
+			IL_0565: ldloc.s 17
 			IL_0567: ldstr "log"
-			IL_056c: ldloc.s 22
+			IL_056c: ldloc.s 18
 			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0573: pop
-			IL_0574: leave IL_05e6
+			IL_0574: leave IL_05df
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -710,241 +706,233 @@
 			IL_05a2: stloc.s 4
 
 			IL_05a4: ldloc.s 4
-			IL_05a6: stloc.s 21
-			IL_05a8: ldloc.s 21
+			IL_05a6: stloc.s 17
+			IL_05a8: ldloc.s 17
 			IL_05aa: stloc.s 5
-			IL_05ac: newobj instance void Modules.BinaryOperator_BigInt_Operators/Scope/Block_L31C12::.ctor()
-			IL_05b1: stloc.s 6
-			IL_05b3: ldstr "console"
-			IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05bd: stloc.s 21
-			IL_05bf: ldloc.s 21
-			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c6: stloc.s 21
-			IL_05c8: ldloc.s 21
-			IL_05ca: ldstr "log"
-			IL_05cf: ldloc.s 5
-			IL_05d1: ldstr "name"
-			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05e0: pop
-			IL_05e1: leave IL_05e6
+			IL_05ac: ldstr "console"
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05b6: stloc.s 17
+			IL_05b8: ldloc.s 17
+			IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05bf: stloc.s 17
+			IL_05c1: ldloc.s 17
+			IL_05c3: ldstr "log"
+			IL_05c8: ldloc.s 5
+			IL_05ca: ldstr "name"
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05d9: pop
+			IL_05da: leave IL_05df
 		} // end handler
 		.try
 		{
-			IL_05e6: nop
-			IL_05e7: ldstr "console"
-			IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05f1: stloc.s 21
-			IL_05f3: ldloc.s 21
-			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05fa: stloc.s 21
-			IL_05fc: ldloc.1
-			IL_05fd: stloc.s 20
-			IL_05ff: ldc.r8 0.0
-			IL_0608: box [System.Runtime]System.Double
-			IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_0612: stloc.s 24
-			IL_0614: ldloc.s 20
-			IL_0616: ldloc.s 24
-			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
-			IL_061d: stloc.s 22
-			IL_061f: ldloc.s 21
-			IL_0621: ldstr "log"
-			IL_0626: ldloc.s 22
-			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_062d: pop
-			IL_062e: leave IL_06a3
+			IL_05df: nop
+			IL_05e0: ldstr "console"
+			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05ea: stloc.s 17
+			IL_05ec: ldloc.s 17
+			IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05f3: stloc.s 17
+			IL_05f5: ldloc.1
+			IL_05f6: stloc.s 16
+			IL_05f8: ldc.r8 0.0
+			IL_0601: box [System.Runtime]System.Double
+			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_060b: stloc.s 20
+			IL_060d: ldloc.s 16
+			IL_060f: ldloc.s 20
+			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
+			IL_0616: stloc.s 18
+			IL_0618: ldloc.s 17
+			IL_061a: ldstr "log"
+			IL_061f: ldloc.s 18
+			IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0626: pop
+			IL_0627: leave IL_0695
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0633: stloc.s 7
-			IL_0635: ldloc.s 7
-			IL_0637: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_063c: dup
-			IL_063d: brtrue IL_0653
+			IL_062c: stloc.s 6
+			IL_062e: ldloc.s 6
+			IL_0630: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0635: dup
+			IL_0636: brtrue IL_064c
 
-			IL_0642: pop
-			IL_0643: ldloc.s 7
-			IL_0645: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_064a: dup
-			IL_064b: brtrue IL_065f
+			IL_063b: pop
+			IL_063c: ldloc.s 6
+			IL_063e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0643: dup
+			IL_0644: brtrue IL_0658
 
-			IL_0650: pop
-			IL_0651: rethrow
+			IL_0649: pop
+			IL_064a: rethrow
 
-			IL_0653: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0658: stloc.s 8
-			IL_065a: br IL_0661
+			IL_064c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0651: stloc.s 7
+			IL_0653: br IL_065a
 
-			IL_065f: stloc.s 8
+			IL_0658: stloc.s 7
 
-			IL_0661: ldloc.s 8
-			IL_0663: stloc.s 21
-			IL_0665: ldloc.s 21
-			IL_0667: stloc.s 9
-			IL_0669: newobj instance void Modules.BinaryOperator_BigInt_Operators/Scope/Block_L37C12::.ctor()
-			IL_066e: stloc.s 10
-			IL_0670: ldstr "console"
-			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_067a: stloc.s 21
-			IL_067c: ldloc.s 21
-			IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0683: stloc.s 21
-			IL_0685: ldloc.s 21
-			IL_0687: ldstr "log"
-			IL_068c: ldloc.s 9
-			IL_068e: ldstr "name"
-			IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_069d: pop
-			IL_069e: leave IL_06a3
+			IL_065a: ldloc.s 7
+			IL_065c: stloc.s 17
+			IL_065e: ldloc.s 17
+			IL_0660: stloc.s 8
+			IL_0662: ldstr "console"
+			IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_066c: stloc.s 17
+			IL_066e: ldloc.s 17
+			IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0675: stloc.s 17
+			IL_0677: ldloc.s 17
+			IL_0679: ldstr "log"
+			IL_067e: ldloc.s 8
+			IL_0680: ldstr "name"
+			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_068f: pop
+			IL_0690: leave IL_0695
 		} // end handler
 		.try
 		{
-			IL_06a3: nop
-			IL_06a4: ldstr "console"
-			IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06ae: stloc.s 21
-			IL_06b0: ldloc.s 21
-			IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b7: stloc.s 21
-			IL_06b9: ldloc.1
-			IL_06ba: stloc.s 24
-			IL_06bc: ldc.r8 1
-			IL_06c5: neg
-			IL_06c6: box [System.Runtime]System.Double
-			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_06d0: stloc.s 20
-			IL_06d2: ldloc.s 24
-			IL_06d4: ldloc.s 20
-			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
-			IL_06db: stloc.s 22
-			IL_06dd: ldloc.s 21
-			IL_06df: ldstr "log"
-			IL_06e4: ldloc.s 22
-			IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06eb: pop
-			IL_06ec: leave IL_0761
+			IL_0695: nop
+			IL_0696: ldstr "console"
+			IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06a0: stloc.s 17
+			IL_06a2: ldloc.s 17
+			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06a9: stloc.s 17
+			IL_06ab: ldloc.1
+			IL_06ac: stloc.s 20
+			IL_06ae: ldc.r8 1
+			IL_06b7: neg
+			IL_06b8: box [System.Runtime]System.Double
+			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_06c2: stloc.s 16
+			IL_06c4: ldloc.s 20
+			IL_06c6: ldloc.s 16
+			IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
+			IL_06cd: stloc.s 18
+			IL_06cf: ldloc.s 17
+			IL_06d1: ldstr "log"
+			IL_06d6: ldloc.s 18
+			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06dd: pop
+			IL_06de: leave IL_074c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06f1: stloc.s 11
-			IL_06f3: ldloc.s 11
-			IL_06f5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06e3: stloc.s 9
+			IL_06e5: ldloc.s 9
+			IL_06e7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06ec: dup
+			IL_06ed: brtrue IL_0703
+
+			IL_06f2: pop
+			IL_06f3: ldloc.s 9
+			IL_06f5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_06fa: dup
-			IL_06fb: brtrue IL_0711
+			IL_06fb: brtrue IL_070f
 
 			IL_0700: pop
-			IL_0701: ldloc.s 11
-			IL_0703: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0708: dup
-			IL_0709: brtrue IL_071d
+			IL_0701: rethrow
 
-			IL_070e: pop
-			IL_070f: rethrow
+			IL_0703: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0708: stloc.s 10
+			IL_070a: br IL_0711
 
-			IL_0711: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0716: stloc.s 12
-			IL_0718: br IL_071f
+			IL_070f: stloc.s 10
 
-			IL_071d: stloc.s 12
-
-			IL_071f: ldloc.s 12
-			IL_0721: stloc.s 21
-			IL_0723: ldloc.s 21
-			IL_0725: stloc.s 13
-			IL_0727: newobj instance void Modules.BinaryOperator_BigInt_Operators/Scope/Block_L43C12::.ctor()
-			IL_072c: stloc.s 14
-			IL_072e: ldstr "console"
-			IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0738: stloc.s 21
-			IL_073a: ldloc.s 21
-			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0741: stloc.s 21
-			IL_0743: ldloc.s 21
-			IL_0745: ldstr "log"
-			IL_074a: ldloc.s 13
-			IL_074c: ldstr "name"
-			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_075b: pop
-			IL_075c: leave IL_0761
+			IL_0711: ldloc.s 10
+			IL_0713: stloc.s 17
+			IL_0715: ldloc.s 17
+			IL_0717: stloc.s 11
+			IL_0719: ldstr "console"
+			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0723: stloc.s 17
+			IL_0725: ldloc.s 17
+			IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_072c: stloc.s 17
+			IL_072e: ldloc.s 17
+			IL_0730: ldstr "log"
+			IL_0735: ldloc.s 11
+			IL_0737: ldstr "name"
+			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0746: pop
+			IL_0747: leave IL_074c
 		} // end handler
 		.try
 		{
-			IL_0761: nop
-			IL_0762: ldstr "console"
-			IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_076c: stloc.s 21
-			IL_076e: ldloc.s 21
-			IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0775: stloc.s 21
-			IL_0777: ldloc.1
+			IL_074c: nop
+			IL_074d: ldstr "console"
+			IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0757: stloc.s 17
+			IL_0759: ldloc.s 17
+			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0760: stloc.s 17
+			IL_0762: ldloc.1
+			IL_0763: stloc.s 16
+			IL_0765: ldc.r8 1
+			IL_076e: box [System.Runtime]System.Double
+			IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
 			IL_0778: stloc.s 20
-			IL_077a: ldc.r8 1
-			IL_0783: box [System.Runtime]System.Double
-			IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_078d: stloc.s 24
-			IL_078f: ldloc.s 20
-			IL_0791: ldloc.s 24
-			IL_0793: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnsignedRightShift(object, object)
-			IL_0798: stloc.s 22
-			IL_079a: ldloc.s 21
-			IL_079c: ldstr "log"
-			IL_07a1: ldloc.s 22
-			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07a8: pop
-			IL_07a9: leave IL_081e
+			IL_077a: ldloc.s 16
+			IL_077c: ldloc.s 20
+			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnsignedRightShift(object, object)
+			IL_0783: stloc.s 18
+			IL_0785: ldloc.s 17
+			IL_0787: ldstr "log"
+			IL_078c: ldloc.s 18
+			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0793: pop
+			IL_0794: leave IL_0802
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_07ae: stloc.s 15
-			IL_07b0: ldloc.s 15
-			IL_07b2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07b7: dup
-			IL_07b8: brtrue IL_07ce
+			IL_0799: stloc.s 12
+			IL_079b: ldloc.s 12
+			IL_079d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07a2: dup
+			IL_07a3: brtrue IL_07b9
 
-			IL_07bd: pop
-			IL_07be: ldloc.s 15
-			IL_07c0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_07c5: dup
-			IL_07c6: brtrue IL_07da
+			IL_07a8: pop
+			IL_07a9: ldloc.s 12
+			IL_07ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07b0: dup
+			IL_07b1: brtrue IL_07c5
 
-			IL_07cb: pop
-			IL_07cc: rethrow
+			IL_07b6: pop
+			IL_07b7: rethrow
 
-			IL_07ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_07d3: stloc.s 16
-			IL_07d5: br IL_07dc
+			IL_07b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07be: stloc.s 13
+			IL_07c0: br IL_07c7
 
-			IL_07da: stloc.s 16
+			IL_07c5: stloc.s 13
 
-			IL_07dc: ldloc.s 16
-			IL_07de: stloc.s 21
-			IL_07e0: ldloc.s 21
+			IL_07c7: ldloc.s 13
+			IL_07c9: stloc.s 17
+			IL_07cb: ldloc.s 17
+			IL_07cd: stloc.s 14
+			IL_07cf: ldstr "console"
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d9: stloc.s 17
+			IL_07db: ldloc.s 17
+			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_07e2: stloc.s 17
-			IL_07e4: newobj instance void Modules.BinaryOperator_BigInt_Operators/Scope/Block_L49C12::.ctor()
-			IL_07e9: stloc.s 18
-			IL_07eb: ldstr "console"
-			IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07f5: stloc.s 21
-			IL_07f7: ldloc.s 21
-			IL_07f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07fe: stloc.s 21
-			IL_0800: ldloc.s 21
-			IL_0802: ldstr "log"
-			IL_0807: ldloc.s 17
-			IL_0809: ldstr "name"
-			IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0813: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0818: pop
-			IL_0819: leave IL_081e
+			IL_07e4: ldloc.s 17
+			IL_07e6: ldstr "log"
+			IL_07eb: ldloc.s 14
+			IL_07ed: ldstr "name"
+			IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07fc: pop
+			IL_07fd: leave IL_0802
 		} // end handler
 
-		IL_081e: ldnull
-		IL_081f: stloc.s 19
-		IL_0821: ret
+		IL_0802: ldnull
+		IL_0803: stloc.s 15
+		IL_0805: ret
 	} // end of method BinaryOperator_BigInt_Operators::__js_module_init__
 
 } // end of class Modules.BinaryOperator_BigInt_Operators
@@ -956,7 +944,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2905
+		// Method begins at RVA 0x28e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x2487
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2498
+				// Method begins at RVA 0x2490
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a1
+				// Method begins at RVA 0x2499
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24b3
+					// Method begins at RVA 0x24ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24bc
+					// Method begins at RVA 0x24b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24aa
+				// Method begins at RVA 0x24a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -177,7 +177,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x247c
+			// Method begins at RVA 0x2474
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -197,34 +197,33 @@
 			)
 			// Method begins at RVA 0x22ec
 			// Header size: 12
-			// Code size: 371 (0x173)
+			// Code size: 363 (0x16b)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
 				[1] object,
 				[2] object,
-				[3] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/Block_L17C20,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] string,
-				[7] object,
-				[8] bool,
-				[9] float64,
-				[10] object
+				[5] string,
+				[6] object,
+				[7] bool,
+				[8] float64,
+				[9] object
 			)
 
 			IL_0000: ldstr "console"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_000a: stloc.s 5
-			IL_000c: ldloc.s 5
+			IL_000a: stloc.s 4
+			IL_000c: ldloc.s 4
 			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0013: stloc.s 5
+			IL_0013: stloc.s 4
 			IL_0015: ldnull
 			IL_0016: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_001b: stloc.s 6
-			IL_001d: ldloc.s 5
+			IL_001b: stloc.s 5
+			IL_001d: ldloc.s 4
 			IL_001f: ldstr "log"
-			IL_0024: ldloc.s 6
+			IL_0024: ldloc.s 5
 			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_002b: pop
 			.try
@@ -234,7 +233,7 @@
 				IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
 				IL_0037: throw
 
-				IL_0038: leave IL_00fb
+				IL_0038: leave IL_00f5
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -260,90 +259,88 @@
 				IL_0065: stloc.1
 
 				IL_0066: ldloc.1
-				IL_0067: stloc.s 5
-				IL_0069: ldloc.s 5
+				IL_0067: stloc.s 4
+				IL_0069: ldloc.s 4
 				IL_006b: stloc.2
-				IL_006c: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/Block_L17C20::.ctor()
-				IL_0071: stloc.3
-				IL_0072: ldstr "console"
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_007c: stloc.s 5
-				IL_007e: ldloc.s 5
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0085: stloc.s 5
-				IL_0087: ldloc.s 5
-				IL_0089: ldstr "log"
-				IL_008e: ldloc.2
-				IL_008f: ldstr "name"
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_009e: pop
-				IL_009f: ldstr "console"
-				IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00a9: stloc.s 5
-				IL_00ab: ldloc.s 5
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00b2: stloc.s 5
-				IL_00b4: ldloc.2
-				IL_00b5: ldstr "message"
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_00c4: stloc.s 6
-				IL_00c6: ldloc.s 6
-				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00cd: stloc.s 7
-				IL_00cf: ldloc.s 7
-				IL_00d1: castclass [System.Runtime]System.String
-				IL_00d6: ldstr "without a setter"
-				IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-				IL_00e0: stloc.s 8
-				IL_00e2: ldloc.s 5
-				IL_00e4: ldstr "log"
-				IL_00e9: ldloc.s 8
-				IL_00eb: box [System.Runtime]System.Boolean
-				IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00f5: pop
-				IL_00f6: leave IL_00fb
+				IL_006c: ldstr "console"
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0076: stloc.s 4
+				IL_0078: ldloc.s 4
+				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007f: stloc.s 4
+				IL_0081: ldloc.s 4
+				IL_0083: ldstr "log"
+				IL_0088: ldloc.2
+				IL_0089: ldstr "name"
+				IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0098: pop
+				IL_0099: ldstr "console"
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00a3: stloc.s 4
+				IL_00a5: ldloc.s 4
+				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ac: stloc.s 4
+				IL_00ae: ldloc.2
+				IL_00af: ldstr "message"
+				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_00be: stloc.s 5
+				IL_00c0: ldloc.s 5
+				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c7: stloc.s 6
+				IL_00c9: ldloc.s 6
+				IL_00cb: castclass [System.Runtime]System.String
+				IL_00d0: ldstr "without a setter"
+				IL_00d5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_00da: stloc.s 7
+				IL_00dc: ldloc.s 4
+				IL_00de: ldstr "log"
+				IL_00e3: ldloc.s 7
+				IL_00e5: box [System.Runtime]System.Boolean
+				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00ef: pop
+				IL_00f0: leave IL_00f5
 			} // end handler
 
-			IL_00fb: ldarg.0
-			IL_00fc: ldc.r8 7
-			IL_0105: box [System.Runtime]System.Double
-			IL_010a: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
-			IL_010f: pop
-			IL_0110: ldstr "console"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_011a: stloc.s 5
-			IL_011c: ldloc.s 5
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0123: stloc.s 5
-			IL_0125: ldloc.s 5
-			IL_0127: ldstr "log"
-			IL_012c: ldarg.0
-			IL_012d: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
-			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0137: pop
-			IL_0138: ldstr "console"
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0142: stloc.s 5
-			IL_0144: ldloc.s 5
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014b: stloc.s 5
-			IL_014d: ldarg.0
-			IL_014e: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
-			IL_0153: stloc.s 9
-			IL_0155: ldloc.s 9
-			IL_0157: box [System.Runtime]System.Double
-			IL_015c: stloc.s 10
-			IL_015e: ldloc.s 5
-			IL_0160: ldstr "log"
-			IL_0165: ldloc.s 10
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_016c: pop
-			IL_016d: ldnull
-			IL_016e: stloc.s 4
-			IL_0170: ldloc.s 4
-			IL_0172: ret
+			IL_00f5: ldarg.0
+			IL_00f6: ldc.r8 7
+			IL_00ff: box [System.Runtime]System.Double
+			IL_0104: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
+			IL_0109: pop
+			IL_010a: ldstr "console"
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0114: stloc.s 4
+			IL_0116: ldloc.s 4
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011d: stloc.s 4
+			IL_011f: ldloc.s 4
+			IL_0121: ldstr "log"
+			IL_0126: ldarg.0
+			IL_0127: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0131: pop
+			IL_0132: ldstr "console"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013c: stloc.s 4
+			IL_013e: ldloc.s 4
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0145: stloc.s 4
+			IL_0147: ldarg.0
+			IL_0148: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
+			IL_014d: stloc.s 8
+			IL_014f: ldloc.s 8
+			IL_0151: box [System.Runtime]System.Double
+			IL_0156: stloc.s 9
+			IL_0158: ldloc.s 4
+			IL_015a: ldstr "log"
+			IL_015f: ldloc.s 9
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0166: pop
+			IL_0167: ldnull
+			IL_0168: stloc.3
+			IL_0169: ldloc.3
+			IL_016a: ret
 		} // end of method AccessorEdges::log
 
 	} // end of class AccessorEdges
@@ -355,7 +352,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2486
+			// Method begins at RVA 0x247e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -671,7 +668,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c5
+		// Method begins at RVA 0x24bd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_ThisBeforeSuper_Throws.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_ThisBeforeSuper_Throws.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227d
+				// Method begins at RVA 0x2275
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2286
+				// Method begins at RVA 0x227e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,7 +90,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228f
+				// Method begins at RVA 0x2287
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22a1
+					// Method begins at RVA 0x2299
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -134,7 +134,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22aa
+					// Method begins at RVA 0x22a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -152,7 +152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2298
+				// Method begins at RVA 0x2290
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -175,15 +175,14 @@
 			)
 			// Method begins at RVA 0x2124
 			// Header size: 12
-			// Code size: 307 (0x133)
+			// Code size: 300 (0x12c)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
 				[1] object,
 				[2] object,
-				[3] class Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/Block_L14C16,
-				[4] object,
-				[5] object
+				[3] object,
+				[4] object
 			)
 
 			.try
@@ -209,16 +208,16 @@
 				IL_0033: pop
 				IL_0034: ldstr "console"
 				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_003e: stloc.s 5
-				IL_0040: ldloc.s 5
+				IL_003e: stloc.s 4
+				IL_0040: ldloc.s 4
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0047: stloc.s 5
-				IL_0049: ldloc.s 5
+				IL_0047: stloc.s 4
+				IL_0049: ldloc.s 4
 				IL_004b: ldstr "log"
 				IL_0050: ldstr "no-throw"
 				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 				IL_005a: pop
-				IL_005b: leave IL_00c7
+				IL_005b: leave IL_00c1
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -244,58 +243,56 @@
 				IL_0088: stloc.1
 
 				IL_0089: ldloc.1
-				IL_008a: stloc.s 5
-				IL_008c: ldloc.s 5
+				IL_008a: stloc.s 4
+				IL_008c: ldloc.s 4
 				IL_008e: stloc.2
-				IL_008f: newobj instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/Block_L14C16::.ctor()
-				IL_0094: stloc.3
-				IL_0095: ldstr "console"
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_009f: stloc.s 5
-				IL_00a1: ldloc.s 5
-				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a8: stloc.s 5
-				IL_00aa: ldloc.s 5
-				IL_00ac: ldstr "log"
-				IL_00b1: ldloc.2
-				IL_00b2: ldstr "name"
-				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00c1: pop
-				IL_00c2: leave IL_00c7
+				IL_008f: ldstr "console"
+				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0099: stloc.s 4
+				IL_009b: ldloc.s 4
+				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a2: stloc.s 4
+				IL_00a4: ldloc.s 4
+				IL_00a6: ldstr "log"
+				IL_00ab: ldloc.2
+				IL_00ac: ldstr "name"
+				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00bb: pop
+				IL_00bc: leave IL_00c1
 			} // end handler
 
-			IL_00c7: ldc.i4.1
-			IL_00c8: newarr [System.Runtime]System.Object
-			IL_00cd: dup
-			IL_00ce: ldc.i4.0
-			IL_00cf: ldc.r8 5
-			IL_00d8: box [System.Runtime]System.Double
-			IL_00dd: stelem.ref
-			IL_00de: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_00e3: ldarg.0
-			IL_00e4: ldc.r8 5
-			IL_00ed: box [System.Runtime]System.Double
-			IL_00f2: call instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B::.ctor(object)
-			IL_00f7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_00fc: ldarg.0
-			IL_00fd: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeDerivedConstructorThisBinding(object)
-			IL_0102: ldstr "console"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_010c: stloc.s 5
-			IL_010e: ldloc.s 5
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0115: stloc.s 5
-			IL_0117: ldloc.s 5
-			IL_0119: ldstr "log"
-			IL_011e: ldarg.0
-			IL_011f: ldstr "x"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_012e: pop
-			IL_012f: ldnull
-			IL_0130: stloc.s 4
-			IL_0132: ret
+			IL_00c1: ldc.i4.1
+			IL_00c2: newarr [System.Runtime]System.Object
+			IL_00c7: dup
+			IL_00c8: ldc.i4.0
+			IL_00c9: ldc.r8 5
+			IL_00d2: box [System.Runtime]System.Double
+			IL_00d7: stelem.ref
+			IL_00d8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_00dd: ldarg.0
+			IL_00de: ldc.r8 5
+			IL_00e7: box [System.Runtime]System.Double
+			IL_00ec: call instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B::.ctor(object)
+			IL_00f1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_00f6: ldarg.0
+			IL_00f7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeDerivedConstructorThisBinding(object)
+			IL_00fc: ldstr "console"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0106: stloc.s 4
+			IL_0108: ldloc.s 4
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010f: stloc.s 4
+			IL_0111: ldloc.s 4
+			IL_0113: ldstr "log"
+			IL_0118: ldarg.0
+			IL_0119: ldstr "x"
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0128: pop
+			IL_0129: ldnull
+			IL_012a: stloc.3
+			IL_012b: ret
 		} // end of method D::.ctor
 
 	} // end of class D
@@ -307,7 +304,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x226c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -411,7 +408,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b3
+		// Method begins at RVA 0x22ab
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21af
+						// Method begins at RVA 0x21a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a6
+					// Method begins at RVA 0x219a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b8
+					// Method begins at RVA 0x21ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219d
+				// Method begins at RVA 0x2191
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,71 +110,69 @@
 			)
 			// Method begins at RVA 0x2104
 			// Header size: 12
-			// Code size: 113 (0x71)
+			// Code size: 101 (0x65)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L4C8,
+				[0] object,
 				[1] object,
-				[2] object,
-				[3] class [System.Runtime]System.Exception,
-				[4] object,
-				[5] bool
+				[2] class [System.Runtime]System.Exception,
+				[3] object,
+				[4] bool
 			)
 
 			.try
 			{
-				IL_0000: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/Scope/Block_L4C8::.ctor()
-				IL_0005: stloc.0
-				IL_0006: ldnull
-				IL_0007: stloc.1
-				IL_0008: ldarg.0
-				IL_0009: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope::require
-				IL_000e: ldstr "./CommonJS_Require_OptionalChain_Lib"
-				IL_0013: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-				IL_0018: stloc.s 4
-				IL_001a: ldloc.s 4
-				IL_001c: brfalse IL_0040
+				IL_0000: nop
+				IL_0001: ldnull
+				IL_0002: stloc.0
+				IL_0003: ldarg.0
+				IL_0004: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope::require
+				IL_0009: ldstr "./CommonJS_Require_OptionalChain_Lib"
+				IL_000e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+				IL_0013: stloc.3
+				IL_0014: ldloc.3
+				IL_0015: brfalse IL_0036
 
-				IL_0021: ldloc.s 4
-				IL_0023: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0028: brtrue IL_0040
+				IL_001a: ldloc.3
+				IL_001b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0020: brtrue IL_0036
 
-				IL_002d: ldloc.s 4
-				IL_002f: ldstr "value"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: stloc.s 4
-				IL_003b: br IL_0043
+				IL_0025: ldloc.3
+				IL_0026: ldstr "value"
+				IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0030: stloc.3
+				IL_0031: br IL_0038
 
-				IL_0040: ldnull
-				IL_0041: stloc.s 4
+				IL_0036: ldnull
+				IL_0037: stloc.3
 
-				IL_0043: ldloc.s 4
-				IL_0045: stloc.1
-				IL_0046: ldloc.1
-				IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_004c: stloc.s 5
-				IL_004e: ldloc.s 5
-				IL_0050: brfalse IL_005e
+				IL_0038: ldloc.3
+				IL_0039: stloc.0
+				IL_003a: ldloc.0
+				IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0040: stloc.s 4
+				IL_0042: ldloc.s 4
+				IL_0044: brfalse IL_0052
 
-				IL_0055: ldnull
-				IL_0056: stloc.2
-				IL_0057: ldloc.1
-				IL_0058: stloc.2
-				IL_0059: leave IL_006f
+				IL_0049: ldnull
+				IL_004a: stloc.1
+				IL_004b: ldloc.0
+				IL_004c: stloc.1
+				IL_004d: leave IL_0063
 
-				IL_005e: leave IL_0069
+				IL_0052: leave IL_005d
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0063: stloc.3
-				IL_0064: leave IL_0069
+				IL_0057: stloc.2
+				IL_0058: leave IL_005d
 			} // end handler
 
-			IL_0069: ldstr "missing"
-			IL_006e: ret
+			IL_005d: ldstr "missing"
+			IL_0062: ret
 
-			IL_006f: ldloc.2
-			IL_0070: ret
+			IL_0063: ldloc.1
+			IL_0064: ret
 		} // end of method loadValue::__js_call__
 
 	} // end of class loadValue
@@ -196,7 +194,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2194
+			// Method begins at RVA 0x2188
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -290,7 +288,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c1
+			// Method begins at RVA 0x21b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -350,7 +348,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ca
+		// Method begins at RVA 0x21be
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Reassigned_Number_ThrowsTypeError.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Reassigned_Number_ThrowsTypeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2141
+				// Method begins at RVA 0x2139
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214a
+				// Method begins at RVA 0x2142
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2130
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,17 +82,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 203 (0xcb)
+		// Code size: 196 (0xc4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Reassigned_Number_ThrowsTypeError/Scope,
 			[1] class [System.Runtime]System.Exception,
 			[2] object,
 			[3] object,
-			[4] class Modules.CommonJS_Require_Reassigned_Number_ThrowsTypeError/Scope/Block_L6C12,
-			[5] object,
-			[6] object[],
-			[7] object
+			[4] object,
+			[5] object[],
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Require_Reassigned_Number_ThrowsTypeError/Scope::.ctor()
@@ -105,13 +104,13 @@
 		{
 			IL_0017: nop
 			IL_0018: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_001d: stloc.s 6
+			IL_001d: stloc.s 5
 			IL_001f: ldarg.1
-			IL_0020: ldloc.s 6
+			IL_0020: ldloc.s 5
 			IL_0022: ldstr "fs"
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_002c: pop
-			IL_002d: leave IL_00c7
+			IL_002d: leave IL_00c0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -137,43 +136,41 @@
 			IL_005a: stloc.2
 
 			IL_005b: ldloc.2
-			IL_005c: stloc.s 7
-			IL_005e: ldloc.s 7
+			IL_005c: stloc.s 6
+			IL_005e: ldloc.s 6
 			IL_0060: stloc.3
-			IL_0061: newobj instance void Modules.CommonJS_Require_Reassigned_Number_ThrowsTypeError/Scope/Block_L6C12::.ctor()
-			IL_0066: stloc.s 4
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.s 7
-			IL_0074: ldloc.s 7
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007b: stloc.s 7
-			IL_007d: ldloc.s 7
-			IL_007f: ldstr "log"
-			IL_0084: ldloc.3
-			IL_0085: ldstr "name"
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0094: pop
-			IL_0095: ldstr "console"
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009f: stloc.s 7
-			IL_00a1: ldloc.s 7
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a8: stloc.s 7
-			IL_00aa: ldloc.s 7
-			IL_00ac: ldstr "log"
-			IL_00b1: ldloc.3
-			IL_00b2: ldstr "message"
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c1: pop
-			IL_00c2: leave IL_00c7
+			IL_0061: ldstr "console"
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006b: stloc.s 6
+			IL_006d: ldloc.s 6
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0074: stloc.s 6
+			IL_0076: ldloc.s 6
+			IL_0078: ldstr "log"
+			IL_007d: ldloc.3
+			IL_007e: ldstr "name"
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008d: pop
+			IL_008e: ldstr "console"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0098: stloc.s 6
+			IL_009a: ldloc.s 6
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a1: stloc.s 6
+			IL_00a3: ldloc.s 6
+			IL_00a5: ldstr "log"
+			IL_00aa: ldloc.3
+			IL_00ab: ldstr "message"
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ba: pop
+			IL_00bb: leave IL_00c0
 		} // end handler
 
-		IL_00c7: ldnull
-		IL_00c8: stloc.s 5
-		IL_00ca: ret
+		IL_00c0: ldnull
+		IL_00c1: stloc.s 4
+		IL_00c3: ret
 	} // end of method CommonJS_Require_Reassigned_Number_ThrowsTypeError::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Reassigned_Number_ThrowsTypeError
@@ -185,7 +182,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2153
+		// Method begins at RVA 0x214b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_DoWhile_NestedLet.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_DoWhile_NestedLet.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20d6
+				// Method begins at RVA 0x20ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20cd
+			// Method begins at RVA 0x20c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -62,16 +62,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 113 (0x71)
+		// Code size: 105 (0x69)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_DoWhile_NestedLet/Scope,
 			[1] float64,
-			[2] class Modules.ControlFlow_DoWhile_NestedLet/Scope/Block_L4C15,
-			[3] object,
-			[4] float64,
-			[5] object,
-			[6] object
+			[2] object,
+			[3] float64,
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_DoWhile_NestedLet/Scope::.ctor()
@@ -81,39 +80,37 @@
 		IL_0010: stloc.1
 		// loop start (head: IL_0011)
 			IL_0011: ldloc.1
-			IL_0012: stloc.s 4
-			IL_0014: ldloc.s 4
-			IL_0016: ldc.r8 10
-			IL_001f: clt
-			IL_0021: brfalse IL_0070
+			IL_0012: stloc.3
+			IL_0013: ldloc.3
+			IL_0014: ldc.r8 10
+			IL_001d: clt
+			IL_001f: brfalse IL_0068
 
-			IL_0026: newobj instance void Modules.ControlFlow_DoWhile_NestedLet/Scope/Block_L4C15::.ctor()
-			IL_002b: stloc.2
-			IL_002c: ldloc.1
-			IL_002d: ldc.r8 1
-			IL_0036: add
-			IL_0037: stloc.1
-			IL_0038: ldstr "Current value is: "
-			IL_003d: ldloc.1
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0043: stloc.s 5
-			IL_0045: ldloc.s 5
-			IL_0047: stloc.3
-			IL_0048: ldstr "console"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0052: stloc.s 6
-			IL_0054: ldloc.s 6
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005b: stloc.s 6
-			IL_005d: ldloc.s 6
-			IL_005f: ldstr "log"
-			IL_0064: ldloc.3
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006a: pop
-			IL_006b: br IL_0011
+			IL_0024: ldloc.1
+			IL_0025: ldc.r8 1
+			IL_002e: add
+			IL_002f: stloc.1
+			IL_0030: ldstr "Current value is: "
+			IL_0035: ldloc.1
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_003b: stloc.s 4
+			IL_003d: ldloc.s 4
+			IL_003f: stloc.2
+			IL_0040: ldstr "console"
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_004a: stloc.s 5
+			IL_004c: ldloc.s 5
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0053: stloc.s 5
+			IL_0055: ldloc.s 5
+			IL_0057: ldstr "log"
+			IL_005c: ldloc.2
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0062: pop
+			IL_0063: br IL_0011
 		// end loop
 
-		IL_0070: ret
+		IL_0068: ret
 	} // end of method ControlFlow_DoWhile_NestedLet::__js_module_init__
 
 } // end of class Modules.ControlFlow_DoWhile_NestedLet
@@ -125,7 +122,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20df
+		// Method begins at RVA 0x20d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x294a
+					// Method begins at RVA 0x293a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26e4
+				// Method begins at RVA 0x26d4
 				// Header size: 12
 				// Code size: 226 (0xe2)
 				.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2953
+					// Method begins at RVA 0x2943
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -168,7 +168,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27d4
+				// Method begins at RVA 0x27c4
 				// Header size: 12
 				// Code size: 80 (0x50)
 				.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2941
+				// Method begins at RVA 0x2931
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -240,7 +240,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x25b4
+			// Method begins at RVA 0x25a4
 			// Header size: 12
 			// Code size: 138 (0x8a)
 			.maxstack 8
@@ -326,7 +326,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ad
+					// Method begins at RVA 0x299d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -350,7 +350,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2830
+				// Method begins at RVA 0x2820
 				// Header size: 12
 				// Code size: 162 (0xa2)
 				.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b6
+					// Method begins at RVA 0x29a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -458,7 +458,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28e0
+				// Method begins at RVA 0x28d0
 				// Header size: 12
 				// Code size: 76 (0x4c)
 				.maxstack 8
@@ -504,7 +504,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a4
+				// Method begins at RVA 0x2994
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -530,7 +530,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x264c
+			// Method begins at RVA 0x263c
 			// Header size: 12
 			// Code size: 138 (0x8a)
 			.maxstack 8
@@ -617,7 +617,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2980
+				// Method begins at RVA 0x2970
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -641,7 +641,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2992
+					// Method begins at RVA 0x2982
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -659,7 +659,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2989
+				// Method begins at RVA 0x2979
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -679,7 +679,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x299b
+				// Method begins at RVA 0x298b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -699,7 +699,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29bf
+				// Method begins at RVA 0x29af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -723,7 +723,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29d1
+					// Method begins at RVA 0x29c1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -741,7 +741,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c8
+				// Method begins at RVA 0x29b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -761,7 +761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29da
+				// Method begins at RVA 0x29ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -783,7 +783,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2938
+			// Method begins at RVA 0x2928
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -807,7 +807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2965
+				// Method begins at RVA 0x2955
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -825,7 +825,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x295c
+			// Method begins at RVA 0x294c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -849,7 +849,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2977
+				// Method begins at RVA 0x2967
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -867,7 +867,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x296e
+			// Method begins at RVA 0x295e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -893,7 +893,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1289 (0x509)
+		// Code size: 1275 (0x4fb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope,
@@ -914,21 +914,19 @@
 			[15] class [System.Runtime]System.Exception,
 			[16] object,
 			[17] object,
-			[18] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope/Block_L41C12,
-			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[20] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+			[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[19] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+			[20] bool,
 			[21] bool,
-			[22] bool,
-			[23] object,
-			[24] class [System.Runtime]System.Exception,
+			[22] object,
+			[23] class [System.Runtime]System.Exception,
+			[24] object,
 			[25] object,
 			[26] object,
-			[27] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope/Block_L68C12,
+			[27] object,
 			[28] object,
-			[29] object,
-			[30] object,
-			[31] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[32] bool
+			[29] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[30] bool
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::.ctor()
@@ -940,7 +938,7 @@
 		IL_0016: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
 		IL_001b: ldstr "iterator"
 		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0025: stloc.s 29
+		IL_0025: stloc.s 27
 		IL_0027: ldc.i4.1
 		IL_0028: newarr [System.Runtime]System.Object
 		IL_002d: dup
@@ -958,15 +956,15 @@
 		IL_004a: ldc.i4.0
 		IL_004b: ldc.i4.1
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0051: stloc.s 30
+		IL_0051: stloc.s 28
 		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0058: stloc.s 31
-		IL_005a: ldloc.s 31
-		IL_005c: ldloc.s 29
-		IL_005e: ldloc.s 30
+		IL_0058: stloc.s 29
+		IL_005a: ldloc.s 29
+		IL_005c: ldloc.s 27
+		IL_005e: ldloc.s 28
 		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0065: pop
-		IL_0066: ldloc.s 31
+		IL_0066: ldloc.s 29
 		IL_0068: stloc.1
 		IL_0069: ldloc.1
 		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
@@ -980,25 +978,25 @@
 			// loop start (head: IL_0075)
 				IL_0075: ldloc.2
 				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_007b: stloc.s 30
-				IL_007d: ldloc.s 30
+				IL_007b: stloc.s 28
+				IL_007d: ldloc.s 28
 				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_0084: stloc.s 32
-				IL_0086: ldloc.s 32
+				IL_0084: stloc.s 30
+				IL_0086: ldloc.s 30
 				IL_0088: brtrue IL_00db
 
-				IL_008d: ldloc.s 30
+				IL_008d: ldloc.s 28
 				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_0094: stloc.s 30
-				IL_0096: ldloc.s 30
+				IL_0094: stloc.s 28
+				IL_0096: ldloc.s 28
 				IL_0098: stloc.s 5
 				IL_009a: ldstr "console"
 				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00a4: stloc.s 30
-				IL_00a6: ldloc.s 30
+				IL_00a4: stloc.s 28
+				IL_00a6: ldloc.s 28
 				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ad: stloc.s 30
-				IL_00af: ldloc.s 30
+				IL_00ad: stloc.s 28
+				IL_00af: ldloc.s 28
 				IL_00b1: ldstr "log"
 				IL_00b6: ldstr "break"
 				IL_00bb: ldloc.s 5
@@ -1035,11 +1033,11 @@
 
 		IL_00f6: ldstr "console"
 		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0100: stloc.s 30
-		IL_0102: ldloc.s 30
+		IL_0100: stloc.s 28
+		IL_0102: ldloc.s 28
 		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0109: stloc.s 30
-		IL_010b: ldloc.s 30
+		IL_0109: stloc.s 28
+		IL_010b: ldloc.s 28
 		IL_010d: ldstr "log"
 		IL_0112: ldstr "closed"
 		IL_0117: ldloc.0
@@ -1062,25 +1060,25 @@
 			// loop start (head: IL_0145)
 				IL_0145: ldloc.s 6
 				IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_014c: stloc.s 30
-				IL_014e: ldloc.s 30
+				IL_014c: stloc.s 28
+				IL_014e: ldloc.s 28
 				IL_0150: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_0155: stloc.s 32
-				IL_0157: ldloc.s 32
+				IL_0155: stloc.s 30
+				IL_0157: ldloc.s 30
 				IL_0159: brtrue IL_01a8
 
-				IL_015e: ldloc.s 30
+				IL_015e: ldloc.s 28
 				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_0165: stloc.s 30
-				IL_0167: ldloc.s 30
+				IL_0165: stloc.s 28
+				IL_0167: ldloc.s 28
 				IL_0169: stloc.s 9
 				IL_016b: ldstr "console"
 				IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0175: stloc.s 30
-				IL_0177: ldloc.s 30
+				IL_0175: stloc.s 28
+				IL_0177: ldloc.s 28
 				IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_017e: stloc.s 30
-				IL_0180: ldloc.s 30
+				IL_017e: stloc.s 28
+				IL_0180: ldloc.s 28
 				IL_0182: ldstr "log"
 				IL_0187: ldstr "normal"
 				IL_018c: ldloc.s 9
@@ -1114,11 +1112,11 @@
 
 		IL_01c6: ldstr "console"
 		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d0: stloc.s 30
-		IL_01d2: ldloc.s 30
+		IL_01d0: stloc.s 28
+		IL_01d2: ldloc.s 28
 		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d9: stloc.s 30
-		IL_01db: ldloc.s 30
+		IL_01d9: stloc.s 28
+		IL_01db: ldloc.s 28
 		IL_01dd: ldstr "log"
 		IL_01e2: ldstr "closed"
 		IL_01e7: ldloc.0
@@ -1144,25 +1142,25 @@
 				// loop start (head: IL_0216)
 					IL_0216: ldloc.s 10
 					IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_021d: stloc.s 30
-					IL_021f: ldloc.s 30
+					IL_021d: stloc.s 28
+					IL_021f: ldloc.s 28
 					IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0226: stloc.s 32
-					IL_0228: ldloc.s 32
+					IL_0226: stloc.s 30
+					IL_0228: ldloc.s 30
 					IL_022a: brtrue IL_02a5
 
-					IL_022f: ldloc.s 30
+					IL_022f: ldloc.s 28
 					IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0236: stloc.s 30
-					IL_0238: ldloc.s 30
+					IL_0236: stloc.s 28
+					IL_0238: ldloc.s 28
 					IL_023a: stloc.s 13
 					IL_023c: ldstr "console"
 					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_0246: stloc.s 30
-					IL_0248: ldloc.s 30
+					IL_0246: stloc.s 28
+					IL_0248: ldloc.s 28
 					IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_024f: stloc.s 30
-					IL_0251: ldloc.s 30
+					IL_024f: stloc.s 28
+					IL_0251: ldloc.s 28
 					IL_0253: ldstr "log"
 					IL_0258: ldstr "throw"
 					IL_025d: ldloc.s 13
@@ -1171,8 +1169,8 @@
 					IL_0265: ldstr "boom"
 					IL_026a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0274: stloc.s 30
-					IL_0276: ldloc.s 30
+					IL_0274: stloc.s 28
+					IL_0276: ldloc.s 28
 					IL_0278: stloc.s 14
 					IL_027a: ldloc.s 14
 					IL_027c: isinst [System.Runtime]System.Exception
@@ -1212,7 +1210,7 @@
 				IL_02c2: endfinally
 			} // end handler
 
-			IL_02c3: leave IL_033d
+			IL_02c3: leave IL_0336
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -1238,204 +1236,200 @@
 			IL_02f4: stloc.s 16
 
 			IL_02f6: ldloc.s 16
-			IL_02f8: stloc.s 30
-			IL_02fa: ldloc.s 30
+			IL_02f8: stloc.s 28
+			IL_02fa: ldloc.s 28
 			IL_02fc: stloc.s 17
-			IL_02fe: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope/Block_L41C12::.ctor()
-			IL_0303: stloc.s 18
-			IL_0305: ldstr "console"
-			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_030f: stloc.s 30
-			IL_0311: ldloc.s 30
-			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0318: stloc.s 30
-			IL_031a: ldloc.s 30
-			IL_031c: ldstr "log"
-			IL_0321: ldstr "caught"
-			IL_0326: ldloc.s 17
-			IL_0328: ldstr "name"
-			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0337: pop
-			IL_0338: leave IL_033d
+			IL_02fe: ldstr "console"
+			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0308: stloc.s 28
+			IL_030a: ldloc.s 28
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0311: stloc.s 28
+			IL_0313: ldloc.s 28
+			IL_0315: ldstr "log"
+			IL_031a: ldstr "caught"
+			IL_031f: ldloc.s 17
+			IL_0321: ldstr "name"
+			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0330: pop
+			IL_0331: leave IL_0336
 		} // end handler
 
-		IL_033d: ldstr "console"
-		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0347: stloc.s 30
-		IL_0349: ldloc.s 30
-		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0350: stloc.s 30
-		IL_0352: ldloc.s 30
-		IL_0354: ldstr "log"
-		IL_0359: ldstr "closed"
-		IL_035e: ldloc.0
-		IL_035f: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
-		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0369: pop
-		IL_036a: ldloc.0
-		IL_036b: ldc.r8 0.0
-		IL_0374: box [System.Runtime]System.Double
-		IL_0379: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
-		IL_037e: ldstr "iterator"
-		IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0388: stloc.s 30
-		IL_038a: ldc.i4.1
-		IL_038b: newarr [System.Runtime]System.Object
-		IL_0390: dup
-		IL_0391: ldc.i4.0
-		IL_0392: ldloc.0
-		IL_0393: stelem.ref
-		IL_0394: ldc.i4.0
-		IL_0395: ldelem.ref
-		IL_0396: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-		IL_039b: ldftn object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
-		IL_03a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0336: ldstr "console"
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0340: stloc.s 28
+		IL_0342: ldloc.s 28
+		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0349: stloc.s 28
+		IL_034b: ldloc.s 28
+		IL_034d: ldstr "log"
+		IL_0352: ldstr "closed"
+		IL_0357: ldloc.0
+		IL_0358: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0362: pop
+		IL_0363: ldloc.0
+		IL_0364: ldc.r8 0.0
+		IL_036d: box [System.Runtime]System.Double
+		IL_0372: stfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
+		IL_0377: ldstr "iterator"
+		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0381: stloc.s 28
+		IL_0383: ldc.i4.1
+		IL_0384: newarr [System.Runtime]System.Object
+		IL_0389: dup
+		IL_038a: ldc.i4.0
+		IL_038b: ldloc.0
+		IL_038c: stelem.ref
+		IL_038d: ldc.i4.0
+		IL_038e: ldelem.ref
+		IL_038f: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
+		IL_0394: ldftn object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
+		IL_039a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_039f: ldc.i4.0
+		IL_03a0: conv.r8
+		IL_03a1: ldstr ""
 		IL_03a6: ldc.i4.0
-		IL_03a7: conv.r8
-		IL_03a8: ldstr ""
-		IL_03ad: ldc.i4.0
-		IL_03ae: ldc.i4.1
-		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03a7: ldc.i4.1
+		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03ad: stloc.s 27
+		IL_03af: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03b4: stloc.s 29
-		IL_03b6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03bb: stloc.s 31
-		IL_03bd: ldloc.s 31
-		IL_03bf: ldloc.s 30
-		IL_03c1: ldloc.s 29
-		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_03c8: pop
-		IL_03c9: ldloc.s 31
-		IL_03cb: stloc.s 19
+		IL_03b6: ldloc.s 29
+		IL_03b8: ldloc.s 28
+		IL_03ba: ldloc.s 27
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_03c1: pop
+		IL_03c2: ldloc.s 29
+		IL_03c4: stloc.s 18
 		.try
 		{
-			IL_03cd: nop
-			IL_03ce: ldloc.s 19
-			IL_03d0: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_03d5: stloc.s 20
-			IL_03d7: ldc.i4.0
-			IL_03d8: stloc.s 21
-			IL_03da: ldc.i4.0
-			IL_03db: stloc.s 22
+			IL_03c6: nop
+			IL_03c7: ldloc.s 18
+			IL_03c9: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_03ce: stloc.s 19
+			IL_03d0: ldc.i4.0
+			IL_03d1: stloc.s 20
+			IL_03d3: ldc.i4.0
+			IL_03d4: stloc.s 21
 			.try
 			{
-				// loop start (head: IL_03dd)
-					IL_03dd: ldloc.s 20
-					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_03e4: stloc.s 29
-					IL_03e6: ldloc.s 29
-					IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_03ed: stloc.s 32
-					IL_03ef: ldloc.s 32
-					IL_03f1: brtrue IL_0440
+				// loop start (head: IL_03d6)
+					IL_03d6: ldloc.s 19
+					IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_03dd: stloc.s 27
+					IL_03df: ldloc.s 27
+					IL_03e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_03e6: stloc.s 30
+					IL_03e8: ldloc.s 30
+					IL_03ea: brtrue IL_0439
 
-					IL_03f6: ldloc.s 29
-					IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_03fd: stloc.s 29
-					IL_03ff: ldloc.s 29
-					IL_0401: stloc.s 23
-					IL_0403: ldstr "console"
-					IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_040d: stloc.s 29
-					IL_040f: ldloc.s 29
-					IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0416: stloc.s 29
-					IL_0418: ldloc.s 29
-					IL_041a: ldstr "log"
-					IL_041f: ldstr "iter"
-					IL_0424: ldloc.s 23
-					IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_042b: pop
-					IL_042c: br IL_03dd
+					IL_03ef: ldloc.s 27
+					IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_03f6: stloc.s 27
+					IL_03f8: ldloc.s 27
+					IL_03fa: stloc.s 22
+					IL_03fc: ldstr "console"
+					IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_0406: stloc.s 27
+					IL_0408: ldloc.s 27
+					IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_040f: stloc.s 27
+					IL_0411: ldloc.s 27
+					IL_0413: ldstr "log"
+					IL_0418: ldstr "iter"
+					IL_041d: ldloc.s 22
+					IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0424: pop
+					IL_0425: br IL_03d6
 				// end loop
-				IL_0431: ldloc.s 20
-				IL_0433: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0438: ldc.i4.1
-				IL_0439: stloc.s 22
-				IL_043b: leave IL_045e
+				IL_042a: ldloc.s 19
+				IL_042c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0431: ldc.i4.1
+				IL_0432: stloc.s 21
+				IL_0434: leave IL_0457
 
-				IL_0440: ldc.i4.1
-				IL_0441: stloc.s 21
-				IL_0443: leave IL_045e
+				IL_0439: ldc.i4.1
+				IL_043a: stloc.s 20
+				IL_043c: leave IL_0457
 			} // end .try
 			finally
 			{
+				IL_0441: ldloc.s 20
+				IL_0443: brtrue IL_0456
+
 				IL_0448: ldloc.s 21
-				IL_044a: brtrue IL_045d
+				IL_044a: brtrue IL_0456
 
-				IL_044f: ldloc.s 22
-				IL_0451: brtrue IL_045d
+				IL_044f: ldloc.s 19
+				IL_0451: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0456: ldloc.s 20
-				IL_0458: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
-
-				IL_045d: endfinally
+				IL_0456: endfinally
 			} // end handler
 
-			IL_045e: leave IL_04d8
+			IL_0457: leave IL_04ca
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0463: stloc.s 24
-			IL_0465: ldloc.s 24
-			IL_0467: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_046c: dup
-			IL_046d: brtrue IL_0483
+			IL_045c: stloc.s 23
+			IL_045e: ldloc.s 23
+			IL_0460: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0465: dup
+			IL_0466: brtrue IL_047c
 
-			IL_0472: pop
-			IL_0473: ldloc.s 24
-			IL_0475: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_047a: dup
-			IL_047b: brtrue IL_048f
+			IL_046b: pop
+			IL_046c: ldloc.s 23
+			IL_046e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0473: dup
+			IL_0474: brtrue IL_0488
 
-			IL_0480: pop
-			IL_0481: rethrow
+			IL_0479: pop
+			IL_047a: rethrow
 
-			IL_0483: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0488: stloc.s 25
-			IL_048a: br IL_0491
+			IL_047c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0481: stloc.s 24
+			IL_0483: br IL_048a
 
-			IL_048f: stloc.s 25
+			IL_0488: stloc.s 24
 
-			IL_0491: ldloc.s 25
-			IL_0493: stloc.s 29
-			IL_0495: ldloc.s 29
-			IL_0497: stloc.s 26
-			IL_0499: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope/Block_L68C12::.ctor()
-			IL_049e: stloc.s 27
-			IL_04a0: ldstr "console"
-			IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04aa: stloc.s 29
-			IL_04ac: ldloc.s 29
-			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04b3: stloc.s 29
-			IL_04b5: ldloc.s 29
-			IL_04b7: ldstr "log"
-			IL_04bc: ldstr "caught"
-			IL_04c1: ldloc.s 26
-			IL_04c3: ldstr "name"
-			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04d2: pop
-			IL_04d3: leave IL_04d8
+			IL_048a: ldloc.s 24
+			IL_048c: stloc.s 27
+			IL_048e: ldloc.s 27
+			IL_0490: stloc.s 25
+			IL_0492: ldstr "console"
+			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_049c: stloc.s 27
+			IL_049e: ldloc.s 27
+			IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04a5: stloc.s 27
+			IL_04a7: ldloc.s 27
+			IL_04a9: ldstr "log"
+			IL_04ae: ldstr "caught"
+			IL_04b3: ldloc.s 25
+			IL_04b5: ldstr "name"
+			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04c4: pop
+			IL_04c5: leave IL_04ca
 		} // end handler
 
-		IL_04d8: ldstr "console"
-		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04e2: stloc.s 29
-		IL_04e4: ldloc.s 29
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04eb: stloc.s 29
-		IL_04ed: ldloc.s 29
-		IL_04ef: ldstr "log"
-		IL_04f4: ldstr "closed2"
-		IL_04f9: ldloc.0
-		IL_04fa: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
-		IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0504: pop
-		IL_0505: ldnull
-		IL_0506: stloc.s 28
-		IL_0508: ret
+		IL_04ca: ldstr "console"
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04d4: stloc.s 27
+		IL_04d6: ldloc.s 27
+		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04dd: stloc.s 27
+		IL_04df: ldloc.s 27
+		IL_04e1: ldstr "log"
+		IL_04e6: ldstr "closed2"
+		IL_04eb: ldloc.0
+		IL_04ec: ldfld object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::closed2
+		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_04f6: pop
+		IL_04f7: ldnull
+		IL_04f8: stloc.s 26
+		IL_04fa: ret
 	} // end of method ControlFlow_ForOf_CustomIterable_IteratorProtocol::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol
@@ -1447,7 +1441,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29e3
+		// Method begins at RVA 0x29d3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2489
+				// Method begins at RVA 0x2479
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2374
+			// Method begins at RVA 0x2364
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a4
+				// Method begins at RVA 0x2494
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23a0
+			// Method begins at RVA 0x2390
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -164,7 +164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24ad
+				// Method begins at RVA 0x249d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -188,7 +188,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23e4
+			// Method begins at RVA 0x23d4
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b6
+				// Method begins at RVA 0x24a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -243,7 +243,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2400
+			// Method begins at RVA 0x23f0
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -277,7 +277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bf
+				// Method begins at RVA 0x24af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2428
+			// Method begins at RVA 0x2418
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -360,7 +360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2492
+				// Method begins at RVA 0x2482
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -380,7 +380,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249b
+				// Method begins at RVA 0x248b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -402,7 +402,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2480
+			// Method begins at RVA 0x2470
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -428,22 +428,20 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 774 (0x306)
+		// Code size: 759 (0x2f7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Cleanup_Order/Scope,
-			[1] class Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L10C4,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[3] class [System.Runtime]System.Exception,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[2] class [System.Runtime]System.Exception,
+			[3] object,
 			[4] object,
 			[5] object,
-			[6] class Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L14C16,
-			[7] object,
+			[6] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
 			[8] object,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
-			[10] object,
-			[11] object[],
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.Promise
+			[9] object[],
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Promise
 		)
 
 		IL_0000: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope::.ctor()
@@ -479,254 +477,251 @@
 		IL_004b: ldc.i4.0
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0056: stloc.s 8
-		IL_0058: ldloc.s 8
+		IL_0056: stloc.s 6
+		IL_0058: ldloc.s 6
 		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry::.ctor(object)
-		IL_005f: stloc.s 9
+		IL_005f: stloc.s 7
 		IL_0061: ldloc.0
-		IL_0062: ldloc.s 9
+		IL_0062: ldloc.s 7
 		IL_0064: stfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
 		IL_0069: ldstr "console"
 		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0073: stloc.s 8
-		IL_0075: ldloc.s 8
+		IL_0073: stloc.s 6
+		IL_0075: ldloc.s 6
 		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007c: stloc.s 8
+		IL_007c: stloc.s 6
 		IL_007e: ldstr "Object"
 		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0088: stloc.s 10
-		IL_008a: ldloc.s 10
+		IL_0088: stloc.s 8
+		IL_008a: ldloc.s 8
 		IL_008c: ldstr "prototype"
 		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0096: stloc.s 10
-		IL_0098: ldloc.s 10
+		IL_0096: stloc.s 8
+		IL_0098: ldloc.s 8
 		IL_009a: ldstr "toString"
 		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a4: stloc.s 10
-		IL_00a6: ldloc.s 10
+		IL_00a4: stloc.s 8
+		IL_00a6: ldloc.s 8
 		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ad: stloc.s 10
-		IL_00af: ldloc.s 10
+		IL_00ad: stloc.s 8
+		IL_00af: ldloc.s 8
 		IL_00b1: ldstr "call"
 		IL_00b6: ldloc.0
 		IL_00b7: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
 		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c1: stloc.s 10
-		IL_00c3: ldloc.s 8
+		IL_00c1: stloc.s 8
+		IL_00c3: ldloc.s 6
 		IL_00c5: ldstr "log"
-		IL_00ca: ldloc.s 10
+		IL_00ca: ldloc.s 8
 		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d1: pop
 		.try
 		{
-			IL_00d2: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L10C4::.ctor()
-			IL_00d7: stloc.1
-			IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00dd: stloc.2
-			IL_00de: ldloc.0
-			IL_00df: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e9: stloc.s 10
-			IL_00eb: ldloc.s 10
-			IL_00ed: ldstr "register"
-			IL_00f2: ldloc.2
-			IL_00f3: ldloc.2
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f9: pop
-			IL_00fa: ldstr "console"
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0104: stloc.s 10
-			IL_0106: ldloc.s 10
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010d: stloc.s 10
-			IL_010f: ldloc.s 10
-			IL_0111: ldstr "log"
-			IL_0116: ldstr "same target threw:"
-			IL_011b: ldc.i4.0
-			IL_011c: box [System.Runtime]System.Boolean
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0126: pop
-			IL_0127: leave IL_01cb
+			IL_00d2: nop
+			IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00d8: stloc.1
+			IL_00d9: ldloc.0
+			IL_00da: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e4: stloc.s 8
+			IL_00e6: ldloc.s 8
+			IL_00e8: ldstr "register"
+			IL_00ed: ldloc.1
+			IL_00ee: ldloc.1
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f4: pop
+			IL_00f5: ldstr "console"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ff: stloc.s 8
+			IL_0101: ldloc.s 8
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0108: stloc.s 8
+			IL_010a: ldloc.s 8
+			IL_010c: ldstr "log"
+			IL_0111: ldstr "same target threw:"
+			IL_0116: ldc.i4.0
+			IL_0117: box [System.Runtime]System.Boolean
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0121: pop
+			IL_0122: leave IL_01bc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_012c: stloc.3
-			IL_012d: ldloc.3
-			IL_012e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0133: dup
-			IL_0134: brtrue IL_0149
+			IL_0127: stloc.2
+			IL_0128: ldloc.2
+			IL_0129: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_012e: dup
+			IL_012f: brtrue IL_0144
 
-			IL_0139: pop
-			IL_013a: ldloc.3
-			IL_013b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0140: dup
-			IL_0141: brtrue IL_0155
+			IL_0134: pop
+			IL_0135: ldloc.2
+			IL_0136: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013b: dup
+			IL_013c: brtrue IL_014f
 
-			IL_0146: pop
-			IL_0147: rethrow
+			IL_0141: pop
+			IL_0142: rethrow
 
-			IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_014e: stloc.s 4
-			IL_0150: br IL_0157
+			IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0149: stloc.3
+			IL_014a: br IL_0150
 
+			IL_014f: stloc.3
+
+			IL_0150: ldloc.3
+			IL_0151: stloc.s 8
+			IL_0153: ldloc.s 8
 			IL_0155: stloc.s 4
-
-			IL_0157: ldloc.s 4
-			IL_0159: stloc.s 10
-			IL_015b: ldloc.s 10
-			IL_015d: stloc.s 5
-			IL_015f: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/Scope/Block_L14C16::.ctor()
-			IL_0164: stloc.s 6
-			IL_0166: ldstr "console"
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0170: stloc.s 10
-			IL_0172: ldloc.s 10
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0179: stloc.s 10
-			IL_017b: ldloc.s 10
-			IL_017d: ldstr "log"
-			IL_0182: ldstr "same target threw:"
-			IL_0187: ldc.i4.1
-			IL_0188: box [System.Runtime]System.Boolean
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0192: pop
-			IL_0193: ldstr "console"
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019d: stloc.s 10
-			IL_019f: ldloc.s 10
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a6: stloc.s 10
-			IL_01a8: ldloc.s 10
-			IL_01aa: ldstr "log"
-			IL_01af: ldstr "same target name:"
-			IL_01b4: ldloc.s 5
-			IL_01b6: ldstr "name"
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c5: pop
-			IL_01c6: leave IL_01cb
+			IL_0157: ldstr "console"
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0161: stloc.s 8
+			IL_0163: ldloc.s 8
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016a: stloc.s 8
+			IL_016c: ldloc.s 8
+			IL_016e: ldstr "log"
+			IL_0173: ldstr "same target threw:"
+			IL_0178: ldc.i4.1
+			IL_0179: box [System.Runtime]System.Boolean
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0183: pop
+			IL_0184: ldstr "console"
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_018e: stloc.s 8
+			IL_0190: ldloc.s 8
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0197: stloc.s 8
+			IL_0199: ldloc.s 8
+			IL_019b: ldstr "log"
+			IL_01a0: ldstr "same target name:"
+			IL_01a5: ldloc.s 4
+			IL_01a7: ldstr "name"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b6: pop
+			IL_01b7: leave IL_01bc
 		} // end handler
 
-		IL_01cb: ldc.i4.1
-		IL_01cc: newarr [System.Runtime]System.Object
-		IL_01d1: dup
-		IL_01d2: ldc.i4.0
-		IL_01d3: ldloc.0
-		IL_01d4: stelem.ref
-		IL_01d5: ldc.i4.0
-		IL_01d6: ldelem.ref
-		IL_01d7: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_01dc: ldftn object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01e7: ldc.i4.0
-		IL_01e8: conv.r8
-		IL_01e9: ldstr ""
-		IL_01ee: ldc.i4.0
-		IL_01ef: ldc.i4.1
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01f5: stloc.s 10
-		IL_01f7: ldc.i4.0
-		IL_01f8: newarr [System.Runtime]System.Object
-		IL_01fd: stloc.s 11
-		IL_01ff: ldloc.s 10
-		IL_0201: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0206: ldloc.s 11
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_020d: pop
-		IL_020e: ldnull
-		IL_020f: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13::__js_call__(object, object)
-		IL_0215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_021a: ldc.i4.1
-		IL_021b: newarr [System.Runtime]System.Object
-		IL_0220: dup
-		IL_0221: ldc.i4.0
-		IL_0222: ldloc.0
-		IL_0223: stelem.ref
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_022e: ldc.i4.1
-		IL_022f: conv.r8
-		IL_0230: ldstr ""
-		IL_0235: ldc.i4.0
-		IL_0236: ldc.i4.0
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0241: stloc.s 10
-		IL_0243: ldloc.s 10
-		IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-		IL_024a: stloc.s 12
-		IL_024c: ldloc.s 12
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0253: stloc.s 10
-		IL_0255: ldc.i4.1
-		IL_0256: newarr [System.Runtime]System.Object
-		IL_025b: dup
-		IL_025c: ldc.i4.0
-		IL_025d: ldloc.0
-		IL_025e: stelem.ref
-		IL_025f: ldc.i4.0
-		IL_0260: ldelem.ref
-		IL_0261: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_0266: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_026c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0271: ldc.i4.1
-		IL_0272: newarr [System.Runtime]System.Object
-		IL_0277: dup
-		IL_0278: ldc.i4.0
-		IL_0279: ldloc.0
-		IL_027a: stelem.ref
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0285: ldc.i4.0
-		IL_0286: conv.r8
-		IL_0287: ldstr ""
-		IL_028c: ldc.i4.0
-		IL_028d: ldc.i4.0
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0298: stloc.s 8
-		IL_029a: ldloc.s 10
-		IL_029c: ldstr "then"
-		IL_02a1: ldloc.s 8
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02a8: pop
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_02ae: pop
-		IL_02af: ldc.i4.1
-		IL_02b0: newarr [System.Runtime]System.Object
-		IL_02b5: dup
-		IL_02b6: ldc.i4.0
-		IL_02b7: ldloc.0
-		IL_02b8: stelem.ref
-		IL_02b9: ldc.i4.0
-		IL_02ba: ldelem.ref
-		IL_02bb: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_02c0: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_02c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02cb: ldc.i4.1
-		IL_02cc: newarr [System.Runtime]System.Object
-		IL_02d1: dup
-		IL_02d2: ldc.i4.0
-		IL_02d3: ldloc.0
-		IL_02d4: stelem.ref
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02df: ldc.i4.0
-		IL_02e0: conv.r8
-		IL_02e1: ldstr ""
-		IL_02e6: ldc.i4.0
+		IL_01bc: ldc.i4.1
+		IL_01bd: newarr [System.Runtime]System.Object
+		IL_01c2: dup
+		IL_01c3: ldc.i4.0
+		IL_01c4: ldloc.0
+		IL_01c5: stelem.ref
+		IL_01c6: ldc.i4.0
+		IL_01c7: ldelem.ref
+		IL_01c8: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_01cd: ldftn object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01d8: ldc.i4.0
+		IL_01d9: conv.r8
+		IL_01da: ldstr ""
+		IL_01df: ldc.i4.0
+		IL_01e0: ldc.i4.1
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01e6: stloc.s 8
+		IL_01e8: ldc.i4.0
+		IL_01e9: newarr [System.Runtime]System.Object
+		IL_01ee: stloc.s 9
+		IL_01f0: ldloc.s 8
+		IL_01f2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f7: ldloc.s 9
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01fe: pop
+		IL_01ff: ldnull
+		IL_0200: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13::__js_call__(object, object)
+		IL_0206: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_020b: ldc.i4.1
+		IL_020c: newarr [System.Runtime]System.Object
+		IL_0211: dup
+		IL_0212: ldc.i4.0
+		IL_0213: ldloc.0
+		IL_0214: stelem.ref
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_021f: ldc.i4.1
+		IL_0220: conv.r8
+		IL_0221: ldstr ""
+		IL_0226: ldc.i4.0
+		IL_0227: ldc.i4.0
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0232: stloc.s 8
+		IL_0234: ldloc.s 8
+		IL_0236: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+		IL_023b: stloc.s 10
+		IL_023d: ldloc.s 10
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0244: stloc.s 8
+		IL_0246: ldc.i4.1
+		IL_0247: newarr [System.Runtime]System.Object
+		IL_024c: dup
+		IL_024d: ldc.i4.0
+		IL_024e: ldloc.0
+		IL_024f: stelem.ref
+		IL_0250: ldc.i4.0
+		IL_0251: ldelem.ref
+		IL_0252: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_0257: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_025d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0262: ldc.i4.1
+		IL_0263: newarr [System.Runtime]System.Object
+		IL_0268: dup
+		IL_0269: ldc.i4.0
+		IL_026a: ldloc.0
+		IL_026b: stelem.ref
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0276: ldc.i4.0
+		IL_0277: conv.r8
+		IL_0278: ldstr ""
+		IL_027d: ldc.i4.0
+		IL_027e: ldc.i4.0
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0289: stloc.s 6
+		IL_028b: ldloc.s 8
+		IL_028d: ldstr "then"
+		IL_0292: ldloc.s 6
+		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0299: pop
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_029f: pop
+		IL_02a0: ldc.i4.1
+		IL_02a1: newarr [System.Runtime]System.Object
+		IL_02a6: dup
+		IL_02a7: ldc.i4.0
+		IL_02a8: ldloc.0
+		IL_02a9: stelem.ref
+		IL_02aa: ldc.i4.0
+		IL_02ab: ldelem.ref
+		IL_02ac: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_02b1: ldftn object Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+		IL_02b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02bc: ldc.i4.1
+		IL_02bd: newarr [System.Runtime]System.Object
+		IL_02c2: dup
+		IL_02c3: ldc.i4.0
+		IL_02c4: ldloc.0
+		IL_02c5: stelem.ref
+		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02d0: ldc.i4.0
+		IL_02d1: conv.r8
+		IL_02d2: ldstr ""
+		IL_02d7: ldc.i4.0
+		IL_02d8: ldc.i4.0
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02e3: stloc.s 6
+		IL_02e5: ldloc.s 6
 		IL_02e7: ldc.i4.0
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02f2: stloc.s 8
-		IL_02f4: ldloc.s 8
-		IL_02f6: ldc.i4.0
-		IL_02f7: newarr [System.Runtime]System.Object
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0301: pop
-		IL_0302: ldnull
-		IL_0303: stloc.s 7
-		IL_0305: ret
+		IL_02e8: newarr [System.Runtime]System.Object
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_02f2: pop
+		IL_02f3: ldnull
+		IL_02f4: stloc.s 5
+		IL_02f6: ret
 	} // end of method FinalizationRegistry_Cleanup_Order::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Cleanup_Order
@@ -738,7 +733,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c8
+		// Method begins at RVA 0x24b8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2359
+				// Method begins at RVA 0x2351
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22bc
+			// Method begins at RVA 0x22b4
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2362
+				// Method begins at RVA 0x235a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x22c4
 			// Header size: 12
 			// Code size: 60 (0x3c)
 			.maxstack 8
@@ -149,7 +149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x237d
+				// Method begins at RVA 0x2375
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -175,7 +175,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2314
+			// Method begins at RVA 0x230c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -220,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x236b
+				// Method begins at RVA 0x2363
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -240,7 +240,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2374
+				// Method begins at RVA 0x236c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -263,7 +263,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2350
+			// Method begins at RVA 0x2348
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -289,19 +289,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 590 (0x24e)
+		// Code size: 583 (0x247)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Unregister_Basic/Scope,
 			[1] class [System.Runtime]System.Exception,
 			[2] object,
 			[3] object,
-			[4] class Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L19C16,
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
-			[8] object[],
-			[9] object
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
+			[7] object[],
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope::.ctor()
@@ -337,12 +336,12 @@
 		IL_004b: ldc.i4.0
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0056: stloc.s 6
-		IL_0058: ldloc.s 6
+		IL_0056: stloc.s 5
+		IL_0058: ldloc.s 5
 		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry::.ctor(object)
-		IL_005f: stloc.s 7
+		IL_005f: stloc.s 6
 		IL_0061: ldloc.0
-		IL_0062: ldloc.s 7
+		IL_0062: ldloc.s 6
 		IL_0064: stfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
 		IL_0069: ldloc.0
 		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -364,34 +363,34 @@
 		IL_0097: ldc.i4.0
 		IL_0098: ldc.i4.1
 		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_009e: stloc.s 6
+		IL_009e: stloc.s 5
 		IL_00a0: ldc.i4.0
 		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: stloc.s 8
-		IL_00a8: ldloc.s 6
+		IL_00a6: stloc.s 7
+		IL_00a8: ldloc.s 5
 		IL_00aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00af: ldloc.s 8
+		IL_00af: ldloc.s 7
 		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 		IL_00b6: pop
 		IL_00b7: ldstr "console"
 		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c1: stloc.s 6
-		IL_00c3: ldloc.s 6
+		IL_00c1: stloc.s 5
+		IL_00c3: ldloc.s 5
 		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ca: stloc.s 6
+		IL_00ca: stloc.s 5
 		IL_00cc: ldloc.0
 		IL_00cd: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
 		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: stloc.s 9
-		IL_00d9: ldloc.s 9
+		IL_00d7: stloc.s 8
+		IL_00d9: ldloc.s 8
 		IL_00db: ldstr "unregister"
 		IL_00e0: ldloc.0
 		IL_00e1: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00eb: stloc.s 9
-		IL_00ed: ldloc.s 6
+		IL_00eb: stloc.s 8
+		IL_00ed: ldloc.s 5
 		IL_00ef: ldstr "log"
-		IL_00f4: ldloc.s 9
+		IL_00f4: ldloc.s 8
 		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00fb: pop
 		.try
@@ -400,8 +399,8 @@
 			IL_00fd: ldloc.0
 			IL_00fe: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
 			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0108: stloc.s 9
-			IL_010a: ldloc.s 9
+			IL_0108: stloc.s 8
+			IL_010a: ldloc.s 8
 			IL_010c: ldstr "unregister"
 			IL_0111: ldc.r8 123
 			IL_011a: box [System.Runtime]System.Double
@@ -409,18 +408,18 @@
 			IL_0124: pop
 			IL_0125: ldstr "console"
 			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_012f: stloc.s 9
-			IL_0131: ldloc.s 9
+			IL_012f: stloc.s 8
+			IL_0131: ldloc.s 8
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0138: stloc.s 9
-			IL_013a: ldloc.s 9
+			IL_0138: stloc.s 8
+			IL_013a: ldloc.s 8
 			IL_013c: ldstr "log"
 			IL_0141: ldstr "bad token threw:"
 			IL_0146: ldc.i4.0
 			IL_0147: box [System.Runtime]System.Boolean
 			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_0151: pop
-			IL_0152: leave IL_01f1
+			IL_0152: leave IL_01ea
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -446,78 +445,76 @@
 			IL_017f: stloc.2
 
 			IL_0180: ldloc.2
-			IL_0181: stloc.s 9
-			IL_0183: ldloc.s 9
+			IL_0181: stloc.s 8
+			IL_0183: ldloc.s 8
 			IL_0185: stloc.3
-			IL_0186: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/Scope/Block_L19C16::.ctor()
-			IL_018b: stloc.s 4
-			IL_018d: ldstr "console"
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0197: stloc.s 9
-			IL_0199: ldloc.s 9
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a0: stloc.s 9
-			IL_01a2: ldloc.s 9
-			IL_01a4: ldstr "log"
-			IL_01a9: ldstr "bad token threw:"
-			IL_01ae: ldc.i4.1
-			IL_01af: box [System.Runtime]System.Boolean
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01b9: pop
-			IL_01ba: ldstr "console"
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c4: stloc.s 9
-			IL_01c6: ldloc.s 9
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cd: stloc.s 9
-			IL_01cf: ldloc.s 9
-			IL_01d1: ldstr "log"
-			IL_01d6: ldstr "bad token name:"
-			IL_01db: ldloc.3
-			IL_01dc: ldstr "name"
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01eb: pop
-			IL_01ec: leave IL_01f1
+			IL_0186: ldstr "console"
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0190: stloc.s 8
+			IL_0192: ldloc.s 8
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0199: stloc.s 8
+			IL_019b: ldloc.s 8
+			IL_019d: ldstr "log"
+			IL_01a2: ldstr "bad token threw:"
+			IL_01a7: ldc.i4.1
+			IL_01a8: box [System.Runtime]System.Boolean
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b2: pop
+			IL_01b3: ldstr "console"
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01bd: stloc.s 8
+			IL_01bf: ldloc.s 8
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c6: stloc.s 8
+			IL_01c8: ldloc.s 8
+			IL_01ca: ldstr "log"
+			IL_01cf: ldstr "bad token name:"
+			IL_01d4: ldloc.3
+			IL_01d5: ldstr "name"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01e4: pop
+			IL_01e5: leave IL_01ea
 		} // end handler
 
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_01f6: pop
-		IL_01f7: ldc.i4.1
-		IL_01f8: newarr [System.Runtime]System.Object
-		IL_01fd: dup
-		IL_01fe: ldc.i4.0
-		IL_01ff: ldloc.0
-		IL_0200: stelem.ref
-		IL_0201: ldc.i4.0
-		IL_0202: ldelem.ref
-		IL_0203: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
-		IL_0208: ldftn object Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
-		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0213: ldc.i4.1
-		IL_0214: newarr [System.Runtime]System.Object
-		IL_0219: dup
-		IL_021a: ldc.i4.0
-		IL_021b: ldloc.0
-		IL_021c: stelem.ref
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_01ef: pop
+		IL_01f0: ldc.i4.1
+		IL_01f1: newarr [System.Runtime]System.Object
+		IL_01f6: dup
+		IL_01f7: ldc.i4.0
+		IL_01f8: ldloc.0
+		IL_01f9: stelem.ref
+		IL_01fa: ldc.i4.0
+		IL_01fb: ldelem.ref
+		IL_01fc: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
+		IL_0201: ldftn object Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
+		IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_020c: ldc.i4.1
+		IL_020d: newarr [System.Runtime]System.Object
+		IL_0212: dup
+		IL_0213: ldc.i4.0
+		IL_0214: ldloc.0
+		IL_0215: stelem.ref
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0220: ldc.i4.0
+		IL_0221: conv.r8
+		IL_0222: ldstr ""
 		IL_0227: ldc.i4.0
-		IL_0228: conv.r8
-		IL_0229: ldstr ""
-		IL_022e: ldc.i4.0
-		IL_022f: ldc.i4.0
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_023a: stloc.s 9
-		IL_023c: ldloc.s 9
-		IL_023e: ldc.i4.0
-		IL_023f: newarr [System.Runtime]System.Object
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0249: pop
-		IL_024a: ldnull
-		IL_024b: stloc.s 5
-		IL_024d: ret
+		IL_0228: ldc.i4.0
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0233: stloc.s 8
+		IL_0235: ldloc.s 8
+		IL_0237: ldc.i4.0
+		IL_0238: newarr [System.Runtime]System.Object
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0242: pop
+		IL_0243: ldnull
+		IL_0244: stloc.s 4
+		IL_0246: ret
 	} // end of method FinalizationRegistry_Unregister_Basic::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Unregister_Basic
@@ -529,7 +526,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2386
+		// Method begins at RVA 0x237e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2245
+				// Method begins at RVA 0x2235
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224e
+				// Method begins at RVA 0x223e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2257
+				// Method begins at RVA 0x2247
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2260
+				// Method begins at RVA 0x2250
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x223c
+			// Method begins at RVA 0x222c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 449 (0x1c1)
+		// Code size: 435 (0x1b3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_NonLiteral_RuntimeError/Scope,
@@ -130,17 +130,15 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L8C12,
-			[6] class [System.Runtime]System.Exception,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
 			[7] object,
 			[8] object,
-			[9] class Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L15C12,
-			[10] object,
+			[9] object,
+			[10] string,
 			[11] object,
-			[12] string,
-			[13] object,
-			[14] bool,
-			[15] object[]
+			[12] bool,
+			[13] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope::.ctor()
@@ -153,24 +151,24 @@
 			IL_000d: nop
 			IL_000e: ldstr "Function"
 			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0018: stloc.s 11
-			IL_001a: ldloc.s 11
+			IL_0018: stloc.s 9
+			IL_001a: ldloc.s 9
 			IL_001c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0021: ldloc.1
 			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_0027: pop
 			IL_0028: ldstr "console"
 			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0032: stloc.s 11
-			IL_0034: ldloc.s 11
+			IL_0032: stloc.s 9
+			IL_0034: ldloc.s 9
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003b: stloc.s 11
-			IL_003d: ldloc.s 11
+			IL_003b: stloc.s 9
+			IL_003d: ldloc.s 9
 			IL_003f: ldstr "log"
 			IL_0044: ldstr "call-no-error"
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_004e: pop
-			IL_004f: leave IL_00de
+			IL_004f: leave IL_00d7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -196,124 +194,120 @@
 			IL_007c: stloc.3
 
 			IL_007d: ldloc.3
-			IL_007e: stloc.s 11
-			IL_0080: ldloc.s 11
+			IL_007e: stloc.s 9
+			IL_0080: ldloc.s 9
 			IL_0082: stloc.s 4
-			IL_0084: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L8C12::.ctor()
-			IL_0089: stloc.s 5
-			IL_008b: ldstr "console"
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0095: stloc.s 11
-			IL_0097: ldloc.s 11
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009e: stloc.s 11
-			IL_00a0: ldloc.s 4
-			IL_00a2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a7: stloc.s 12
-			IL_00a9: ldloc.s 12
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b0: stloc.s 13
-			IL_00b2: ldloc.s 13
-			IL_00b4: castclass [System.Runtime]System.String
-			IL_00b9: ldstr "string literal arguments"
-			IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_00c3: stloc.s 14
-			IL_00c5: ldloc.s 11
-			IL_00c7: ldstr "log"
-			IL_00cc: ldloc.s 14
-			IL_00ce: box [System.Runtime]System.Boolean
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d8: pop
-			IL_00d9: leave IL_00de
+			IL_0084: ldstr "console"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_008e: stloc.s 9
+			IL_0090: ldloc.s 9
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0097: stloc.s 9
+			IL_0099: ldloc.s 4
+			IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00a0: stloc.s 10
+			IL_00a2: ldloc.s 10
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a9: stloc.s 11
+			IL_00ab: ldloc.s 11
+			IL_00ad: castclass [System.Runtime]System.String
+			IL_00b2: ldstr "string literal arguments"
+			IL_00b7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00bc: stloc.s 12
+			IL_00be: ldloc.s 9
+			IL_00c0: ldstr "log"
+			IL_00c5: ldloc.s 12
+			IL_00c7: box [System.Runtime]System.Boolean
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d1: pop
+			IL_00d2: leave IL_00d7
 		} // end handler
 		.try
 		{
-			IL_00de: nop
-			IL_00df: ldstr "Function"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e9: stloc.s 11
-			IL_00eb: ldc.i4.1
-			IL_00ec: newarr [System.Runtime]System.Object
-			IL_00f1: dup
-			IL_00f2: ldc.i4.0
-			IL_00f3: ldloc.1
-			IL_00f4: stelem.ref
-			IL_00f5: stloc.s 15
-			IL_00f7: ldloc.s 11
-			IL_00f9: ldloc.s 15
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0100: pop
-			IL_0101: ldstr "console"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_010b: stloc.s 11
-			IL_010d: ldloc.s 11
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.s 11
-			IL_0116: ldloc.s 11
-			IL_0118: ldstr "log"
-			IL_011d: ldstr "new-no-error"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0127: pop
-			IL_0128: leave IL_01bd
+			IL_00d7: nop
+			IL_00d8: ldstr "Function"
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e2: stloc.s 9
+			IL_00e4: ldc.i4.1
+			IL_00e5: newarr [System.Runtime]System.Object
+			IL_00ea: dup
+			IL_00eb: ldc.i4.0
+			IL_00ec: ldloc.1
+			IL_00ed: stelem.ref
+			IL_00ee: stloc.s 13
+			IL_00f0: ldloc.s 9
+			IL_00f2: ldloc.s 13
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00f9: pop
+			IL_00fa: ldstr "console"
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0104: stloc.s 9
+			IL_0106: ldloc.s 9
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010d: stloc.s 9
+			IL_010f: ldloc.s 9
+			IL_0111: ldstr "log"
+			IL_0116: ldstr "new-no-error"
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0120: pop
+			IL_0121: leave IL_01af
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_012d: stloc.s 6
-			IL_012f: ldloc.s 6
-			IL_0131: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0136: dup
-			IL_0137: brtrue IL_014d
+			IL_0126: stloc.s 5
+			IL_0128: ldloc.s 5
+			IL_012a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_012f: dup
+			IL_0130: brtrue IL_0146
 
-			IL_013c: pop
-			IL_013d: ldloc.s 6
-			IL_013f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0144: dup
-			IL_0145: brtrue IL_0159
+			IL_0135: pop
+			IL_0136: ldloc.s 5
+			IL_0138: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013d: dup
+			IL_013e: brtrue IL_0152
 
-			IL_014a: pop
-			IL_014b: rethrow
+			IL_0143: pop
+			IL_0144: rethrow
 
-			IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0152: stloc.s 7
-			IL_0154: br IL_015b
+			IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_014b: stloc.s 6
+			IL_014d: br IL_0154
 
-			IL_0159: stloc.s 7
+			IL_0152: stloc.s 6
 
-			IL_015b: ldloc.s 7
-			IL_015d: stloc.s 11
-			IL_015f: ldloc.s 11
-			IL_0161: stloc.s 8
-			IL_0163: newobj instance void Modules.Function_Constructor_NonLiteral_RuntimeError/Scope/Block_L15C12::.ctor()
-			IL_0168: stloc.s 9
-			IL_016a: ldstr "console"
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0174: stloc.s 11
-			IL_0176: ldloc.s 11
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017d: stloc.s 11
-			IL_017f: ldloc.s 8
-			IL_0181: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0186: stloc.s 12
-			IL_0188: ldloc.s 12
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018f: stloc.s 13
-			IL_0191: ldloc.s 13
-			IL_0193: castclass [System.Runtime]System.String
-			IL_0198: ldstr "string literal arguments"
-			IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_01a2: stloc.s 14
-			IL_01a4: ldloc.s 11
-			IL_01a6: ldstr "log"
-			IL_01ab: ldloc.s 14
-			IL_01ad: box [System.Runtime]System.Boolean
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b7: pop
-			IL_01b8: leave IL_01bd
+			IL_0154: ldloc.s 6
+			IL_0156: stloc.s 9
+			IL_0158: ldloc.s 9
+			IL_015a: stloc.s 7
+			IL_015c: ldstr "console"
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0166: stloc.s 9
+			IL_0168: ldloc.s 9
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 9
+			IL_0171: ldloc.s 7
+			IL_0173: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0178: stloc.s 10
+			IL_017a: ldloc.s 10
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0181: stloc.s 11
+			IL_0183: ldloc.s 11
+			IL_0185: castclass [System.Runtime]System.String
+			IL_018a: ldstr "string literal arguments"
+			IL_018f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0194: stloc.s 12
+			IL_0196: ldloc.s 9
+			IL_0198: ldstr "log"
+			IL_019d: ldloc.s 12
+			IL_019f: box [System.Runtime]System.Boolean
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a9: pop
+			IL_01aa: leave IL_01af
 		} // end handler
 
-		IL_01bd: ldnull
-		IL_01be: stloc.s 10
-		IL_01c0: ret
+		IL_01af: ldnull
+		IL_01b0: stloc.s 8
+		IL_01b2: ret
 	} // end of method Function_Constructor_NonLiteral_RuntimeError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_NonLiteral_RuntimeError
@@ -325,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2269
+		// Method begins at RVA 0x2259
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a5
+				// Method begins at RVA 0x219d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x21a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x2194
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,20 +82,19 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 303 (0x12f)
+		// Code size: 296 (0x128)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_SyntaxError/Scope,
 			[1] class [System.Runtime]System.Exception,
 			[2] object,
 			[3] object,
-			[4] class Modules.Function_Constructor_SyntaxError/Scope/Block_L6C12,
-			[5] string,
+			[4] string,
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] string,
-			[9] object,
-			[10] bool
+			[7] string,
+			[8] object,
+			[9] bool
 		)
 
 		IL_0000: newobj instance void Modules.Function_Constructor_SyntaxError/Scope::.ctor()
@@ -122,16 +121,16 @@
 
 			IL_0039: ldstr "console"
 			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0043: stloc.s 7
-			IL_0045: ldloc.s 7
+			IL_0043: stloc.s 6
+			IL_0045: ldloc.s 6
 			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004c: stloc.s 7
-			IL_004e: ldloc.s 7
+			IL_004c: stloc.s 6
+			IL_004e: ldloc.s 6
 			IL_0050: ldstr "log"
 			IL_0055: ldstr "no-error"
 			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_005f: pop
-			IL_0060: leave IL_012b
+			IL_0060: leave IL_0124
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -157,58 +156,56 @@
 			IL_008d: stloc.2
 
 			IL_008e: ldloc.2
-			IL_008f: stloc.s 7
-			IL_0091: ldloc.s 7
+			IL_008f: stloc.s 6
+			IL_0091: ldloc.s 6
 			IL_0093: stloc.3
-			IL_0094: newobj instance void Modules.Function_Constructor_SyntaxError/Scope/Block_L6C12::.ctor()
-			IL_0099: stloc.s 4
-			IL_009b: ldloc.3
-			IL_009c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a1: stloc.s 8
-			IL_00a3: ldloc.s 8
-			IL_00a5: stloc.s 5
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.s 7
-			IL_00b3: ldloc.s 7
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.s 7
-			IL_00bc: ldloc.s 5
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c3: stloc.s 9
-			IL_00c5: ldloc.s 9
-			IL_00c7: castclass [System.Runtime]System.String
-			IL_00cc: ldstr "SyntaxError"
-			IL_00d1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_00d6: stloc.s 10
-			IL_00d8: ldloc.s 7
-			IL_00da: ldstr "log"
-			IL_00df: ldloc.s 10
-			IL_00e1: box [System.Runtime]System.Boolean
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00eb: pop
-			IL_00ec: ldstr "console"
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f6: stloc.s 7
-			IL_00f8: ldloc.s 7
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ff: stloc.s 7
-			IL_0101: ldloc.s 7
-			IL_0103: ldstr "log"
-			IL_0108: ldloc.s 5
-			IL_010a: callvirt instance int32 [System.Runtime]System.String::get_Length()
-			IL_010f: conv.r8
-			IL_0110: ldc.r8 0.0
-			IL_0119: cgt
-			IL_011b: box [System.Runtime]System.Boolean
-			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0125: pop
-			IL_0126: leave IL_012b
+			IL_0094: ldloc.3
+			IL_0095: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009a: stloc.s 7
+			IL_009c: ldloc.s 7
+			IL_009e: stloc.s 4
+			IL_00a0: ldstr "console"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00aa: stloc.s 6
+			IL_00ac: ldloc.s 6
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b3: stloc.s 6
+			IL_00b5: ldloc.s 4
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bc: stloc.s 8
+			IL_00be: ldloc.s 8
+			IL_00c0: castclass [System.Runtime]System.String
+			IL_00c5: ldstr "SyntaxError"
+			IL_00ca: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_00cf: stloc.s 9
+			IL_00d1: ldloc.s 6
+			IL_00d3: ldstr "log"
+			IL_00d8: ldloc.s 9
+			IL_00da: box [System.Runtime]System.Boolean
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e4: pop
+			IL_00e5: ldstr "console"
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ef: stloc.s 6
+			IL_00f1: ldloc.s 6
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f8: stloc.s 6
+			IL_00fa: ldloc.s 6
+			IL_00fc: ldstr "log"
+			IL_0101: ldloc.s 4
+			IL_0103: callvirt instance int32 [System.Runtime]System.String::get_Length()
+			IL_0108: conv.r8
+			IL_0109: ldc.r8 0.0
+			IL_0112: cgt
+			IL_0114: box [System.Runtime]System.Boolean
+			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_011e: pop
+			IL_011f: leave IL_0124
 		} // end handler
 
-		IL_012b: ldnull
-		IL_012c: stloc.s 6
-		IL_012e: ret
+		IL_0124: ldnull
+		IL_0125: stloc.s 5
+		IL_0127: ret
 	} // end of method Function_Constructor_SyntaxError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_SyntaxError
@@ -220,7 +217,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b7
+		// Method begins at RVA 0x21af
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bd2
+					// Method begins at RVA 0x2baa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bdb
+					// Method begins at RVA 0x2bb3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2be4
+					// Method begins at RVA 0x2bbc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bc9
+				// Method begins at RVA 0x2ba1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,16 +106,15 @@
 			)
 			// Method begins at RVA 0x24f4
 			// Header size: 12
-			// Code size: 837 (0x345)
+			// Code size: 817 (0x331)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/Scope/Block_L8C14,
-				[4] bool,
-				[5] object,
-				[6] object
+				[3] bool,
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -148,7 +147,7 @@
 			IL_003f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parametersInitialized
 			IL_0044: stloc.1
 			IL_0045: ldloc.1
-			IL_0046: brtrue IL_006a
+			IL_0046: brtrue IL_0068
 
 			IL_004b: ldloc.0
 			IL_004c: ldc.i4.1
@@ -158,278 +157,276 @@
 			IL_0054: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_started
 			IL_0059: ldloc.0
 			IL_005a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parameterInitializationOnly
-			IL_005f: stloc.s 4
-			IL_0061: ldloc.s 4
-			IL_0063: brfalse IL_006a
+			IL_005f: stloc.3
+			IL_0060: ldloc.3
+			IL_0061: brfalse IL_0068
 
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0066: ldnull
+			IL_0067: ret
 
-			IL_006a: ldloc.0
-			IL_006b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0070: switch (IL_0081, IL_00e1, IL_01ff)
+			IL_0068: ldloc.0
+			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_006e: switch (IL_007f, IL_00df, IL_01f3)
 
-			IL_0081: ldloc.0
-			IL_0082: ldc.i4.0
-			IL_0083: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0088: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_008d: ldloc.0
-			IL_008e: ldc.i4.0
-			IL_008f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0094: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0099: ldloc.0
-			IL_009a: ldc.i4.0
-			IL_009b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_00a0: ldloc.0
-			IL_00a1: ldc.i4.0
-			IL_00a2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.s 5
-			IL_00b3: ldloc.s 5
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: ldstr "log"
-			IL_00c3: ldstr "g1:try"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cd: pop
-			IL_00ce: ldloc.0
-			IL_00cf: ldc.i4.1
-			IL_00d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_00d5: ldstr "T"
-			IL_00da: ldc.i4.0
-			IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_00e0: ret
+			IL_007f: ldloc.0
+			IL_0080: ldc.i4.0
+			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0086: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_008b: ldloc.0
+			IL_008c: ldc.i4.0
+			IL_008d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0092: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0097: ldloc.0
+			IL_0098: ldc.i4.0
+			IL_0099: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_009e: ldloc.0
+			IL_009f: ldc.i4.0
+			IL_00a0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_00a5: ldstr "console"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00af: stloc.s 4
+			IL_00b1: ldloc.s 4
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.s 4
+			IL_00ba: ldloc.s 4
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "g1:try"
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cb: pop
+			IL_00cc: ldloc.0
+			IL_00cd: ldc.i4.1
+			IL_00ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_00d3: ldstr "T"
+			IL_00d8: ldc.i4.0
+			IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_00de: ret
 
-			IL_00e1: ldloc.0
-			IL_00e2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_00e7: stloc.s 4
-			IL_00e9: ldloc.s 4
-			IL_00eb: brfalse IL_0126
+			IL_00df: ldloc.0
+			IL_00e0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_00e5: stloc.3
+			IL_00e6: ldloc.3
+			IL_00e7: brfalse IL_0122
 
-			IL_00f0: ldloc.0
-			IL_00f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_00f6: stloc.s 5
-			IL_00f8: ldloc.0
-			IL_00f9: ldloc.s 5
-			IL_00fb: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0100: ldloc.0
-			IL_0101: ldc.i4.1
-			IL_0102: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0107: ldloc.0
-			IL_0108: ldc.i4.0
-			IL_0109: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_010e: ldloc.0
-			IL_010f: ldc.i4.0
-			IL_0110: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0115: ldloc.0
-			IL_0116: ldc.i4.0
-			IL_0117: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_011c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0121: br IL_028e
+			IL_00ec: ldloc.0
+			IL_00ed: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_00f2: stloc.s 4
+			IL_00f4: ldloc.0
+			IL_00f5: ldloc.s 4
+			IL_00f7: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_00fc: ldloc.0
+			IL_00fd: ldc.i4.1
+			IL_00fe: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0103: ldloc.0
+			IL_0104: ldc.i4.0
+			IL_0105: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_010a: ldloc.0
+			IL_010b: ldc.i4.0
+			IL_010c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0111: ldloc.0
+			IL_0112: ldc.i4.0
+			IL_0113: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0118: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_011d: br IL_027e
 
-			IL_0126: ldloc.0
-			IL_0127: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_012c: stloc.s 4
-			IL_012e: ldloc.s 4
-			IL_0130: brfalse IL_016b
+			IL_0122: ldloc.0
+			IL_0123: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0128: stloc.3
+			IL_0129: ldloc.3
+			IL_012a: brfalse IL_0165
 
-			IL_0135: ldloc.0
-			IL_0136: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_013b: stloc.s 5
-			IL_013d: ldloc.0
-			IL_013e: ldloc.s 5
-			IL_0140: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0145: ldloc.0
-			IL_0146: ldc.i4.0
-			IL_0147: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_014c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0151: ldloc.0
-			IL_0152: ldc.i4.1
-			IL_0153: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0158: ldloc.0
-			IL_0159: ldc.i4.0
-			IL_015a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_015f: ldloc.0
-			IL_0160: ldc.i4.0
-			IL_0161: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0166: br IL_0197
+			IL_012f: ldloc.0
+			IL_0130: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0135: stloc.s 4
+			IL_0137: ldloc.0
+			IL_0138: ldloc.s 4
+			IL_013a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_013f: ldloc.0
+			IL_0140: ldc.i4.0
+			IL_0141: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0146: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_014b: ldloc.0
+			IL_014c: ldc.i4.1
+			IL_014d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0152: ldloc.0
+			IL_0153: ldc.i4.0
+			IL_0154: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0159: ldloc.0
+			IL_015a: ldc.i4.0
+			IL_015b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0160: br IL_0191
 
-			IL_016b: ldstr "console"
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0175: stloc.s 5
-			IL_0177: ldloc.s 5
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017e: stloc.s 5
-			IL_0180: ldloc.s 5
-			IL_0182: ldstr "log"
-			IL_0187: ldstr "g1:after-yield"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0191: pop
-			IL_0192: br IL_028e
+			IL_0165: ldstr "console"
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_016f: stloc.s 4
+			IL_0171: ldloc.s 4
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0178: stloc.s 4
+			IL_017a: ldloc.s 4
+			IL_017c: ldstr "log"
+			IL_0181: ldstr "g1:after-yield"
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_018b: pop
+			IL_018c: br IL_027e
 
-			IL_0197: ldloc.0
-			IL_0198: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_019d: stloc.s 5
-			IL_019f: ldloc.0
-			IL_01a0: ldc.i4.0
-			IL_01a1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_01a6: ldloc.0
-			IL_01a7: ldc.i4.0
-			IL_01a8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01ad: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_01b2: ldloc.s 5
-			IL_01b4: stloc.2
-			IL_01b5: newobj instance void Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/Scope/Block_L8C14::.ctor()
-			IL_01ba: stloc.3
-			IL_01bb: ldstr "console"
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c5: stloc.s 5
-			IL_01c7: ldloc.s 5
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ce: stloc.s 5
-			IL_01d0: ldstr "g1:catch:"
-			IL_01d5: ldloc.2
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01db: stloc.s 6
-			IL_01dd: ldloc.s 5
-			IL_01df: ldstr "log"
-			IL_01e4: ldloc.s 6
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01eb: pop
-			IL_01ec: ldloc.0
-			IL_01ed: ldc.i4.2
-			IL_01ee: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_01f3: ldstr "C"
-			IL_01f8: ldc.i4.0
-			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_01fe: ret
+			IL_0191: ldloc.0
+			IL_0192: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0197: stloc.s 4
+			IL_0199: ldloc.0
+			IL_019a: ldc.i4.0
+			IL_019b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_01a0: ldloc.0
+			IL_01a1: ldc.i4.0
+			IL_01a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01a7: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_01ac: ldloc.s 4
+			IL_01ae: stloc.2
+			IL_01af: ldstr "console"
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b9: stloc.s 4
+			IL_01bb: ldloc.s 4
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c2: stloc.s 4
+			IL_01c4: ldstr "g1:catch:"
+			IL_01c9: ldloc.2
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01cf: stloc.s 5
+			IL_01d1: ldloc.s 4
+			IL_01d3: ldstr "log"
+			IL_01d8: ldloc.s 5
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01df: pop
+			IL_01e0: ldloc.0
+			IL_01e1: ldc.i4.2
+			IL_01e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_01e7: ldstr "C"
+			IL_01ec: ldc.i4.0
+			IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_01f2: ret
 
-			IL_01ff: ldloc.0
-			IL_0200: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0205: stloc.s 4
-			IL_0207: ldloc.s 4
-			IL_0209: brfalse IL_0244
+			IL_01f3: ldloc.0
+			IL_01f4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01f9: stloc.3
+			IL_01fa: ldloc.3
+			IL_01fb: brfalse IL_0236
 
-			IL_020e: ldloc.0
-			IL_020f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0214: stloc.s 5
-			IL_0216: ldloc.0
-			IL_0217: ldloc.s 5
-			IL_0219: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0200: ldloc.0
+			IL_0201: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0206: stloc.s 4
+			IL_0208: ldloc.0
+			IL_0209: ldloc.s 4
+			IL_020b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0210: ldloc.0
+			IL_0211: ldc.i4.1
+			IL_0212: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0217: ldloc.0
+			IL_0218: ldc.i4.0
+			IL_0219: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
 			IL_021e: ldloc.0
-			IL_021f: ldc.i4.1
-			IL_0220: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_021f: ldc.i4.0
+			IL_0220: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
 			IL_0225: ldloc.0
 			IL_0226: ldc.i4.0
-			IL_0227: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_022c: ldloc.0
-			IL_022d: ldc.i4.0
-			IL_022e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0233: ldloc.0
-			IL_0234: ldc.i4.0
-			IL_0235: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_023a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_023f: br IL_028e
+			IL_0227: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_022c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0231: br IL_027e
 
-			IL_0244: ldloc.0
-			IL_0245: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_024a: stloc.s 4
+			IL_0236: ldloc.0
+			IL_0237: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_023c: stloc.3
+			IL_023d: ldloc.3
+			IL_023e: brfalse IL_0279
+
+			IL_0243: ldloc.0
+			IL_0244: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0249: stloc.s 4
+			IL_024b: ldloc.0
 			IL_024c: ldloc.s 4
-			IL_024e: brfalse IL_0289
-
+			IL_024e: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
 			IL_0253: ldloc.0
-			IL_0254: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0259: stloc.s 5
-			IL_025b: ldloc.0
-			IL_025c: ldloc.s 5
-			IL_025e: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0263: ldloc.0
-			IL_0264: ldc.i4.0
-			IL_0265: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_026a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_026f: ldloc.0
-			IL_0270: ldc.i4.1
-			IL_0271: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0276: ldloc.0
-			IL_0277: ldc.i4.0
-			IL_0278: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_027d: ldloc.0
-			IL_027e: ldc.i4.0
-			IL_027f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0284: br IL_028e
+			IL_0254: ldc.i4.0
+			IL_0255: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_025a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_025f: ldloc.0
+			IL_0260: ldc.i4.1
+			IL_0261: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0266: ldloc.0
+			IL_0267: ldc.i4.0
+			IL_0268: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_026d: ldloc.0
+			IL_026e: ldc.i4.0
+			IL_026f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0274: br IL_027e
 
-			IL_0289: br IL_028e
+			IL_0279: br IL_027e
 
-			IL_028e: ldstr "console"
-			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0298: stloc.s 5
-			IL_029a: ldloc.s 5
-			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a1: stloc.s 5
-			IL_02a3: ldloc.s 5
-			IL_02a5: ldstr "log"
-			IL_02aa: ldstr "g1:finally"
-			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02b4: pop
-			IL_02b5: br IL_02ba
+			IL_027e: ldstr "console"
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0288: stloc.s 4
+			IL_028a: ldloc.s 4
+			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0291: stloc.s 4
+			IL_0293: ldloc.s 4
+			IL_0295: ldstr "log"
+			IL_029a: ldstr "g1:finally"
+			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02a4: pop
+			IL_02a5: br IL_02aa
 
-			IL_02ba: ldloc.0
-			IL_02bb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_02c0: stloc.s 4
-			IL_02c2: ldloc.s 4
-			IL_02c4: brfalse IL_02e8
+			IL_02aa: ldloc.0
+			IL_02ab: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_02b0: stloc.3
+			IL_02b1: ldloc.3
+			IL_02b2: brfalse IL_02d6
 
+			IL_02b7: ldloc.0
+			IL_02b8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_02bd: isinst [System.Runtime]System.Exception
+			IL_02c2: dup
+			IL_02c3: brtrue IL_02d5
+
+			IL_02c8: pop
 			IL_02c9: ldloc.0
 			IL_02ca: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_02cf: isinst [System.Runtime]System.Exception
-			IL_02d4: dup
-			IL_02d5: brtrue IL_02e7
+			IL_02cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_02d4: throw
 
-			IL_02da: pop
-			IL_02db: ldloc.0
-			IL_02dc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_02e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_02e6: throw
+			IL_02d5: throw
 
-			IL_02e7: throw
+			IL_02d6: ldloc.0
+			IL_02d7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_02dc: stloc.3
+			IL_02dd: ldloc.3
+			IL_02de: brfalse IL_02fb
 
-			IL_02e8: ldloc.0
-			IL_02e9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_02ee: stloc.s 4
-			IL_02f0: ldloc.s 4
-			IL_02f2: brfalse IL_030f
+			IL_02e3: ldloc.0
+			IL_02e4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_02e9: stloc.s 4
+			IL_02eb: ldloc.0
+			IL_02ec: ldc.i4.1
+			IL_02ed: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02f2: ldloc.s 4
+			IL_02f4: ldc.i4.1
+			IL_02f5: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02fa: ret
 
-			IL_02f7: ldloc.0
-			IL_02f8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_02fd: stloc.s 5
-			IL_02ff: ldloc.0
-			IL_0300: ldc.i4.1
-			IL_0301: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0306: ldloc.s 5
-			IL_0308: ldc.i4.1
-			IL_0309: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_030e: ret
-
-			IL_030f: ldstr "console"
-			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0319: stloc.s 5
-			IL_031b: ldloc.s 5
-			IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0322: stloc.s 5
-			IL_0324: ldloc.s 5
-			IL_0326: ldstr "log"
-			IL_032b: ldstr "g1:after-try"
-			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0335: pop
-			IL_0336: ldloc.0
-			IL_0337: ldc.i4.1
-			IL_0338: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_033d: ldnull
-			IL_033e: ldc.i4.1
-			IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0344: ret
+			IL_02fb: ldstr "console"
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0305: stloc.s 4
+			IL_0307: ldloc.s 4
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_030e: stloc.s 4
+			IL_0310: ldloc.s 4
+			IL_0312: ldstr "log"
+			IL_0317: ldstr "g1:after-try"
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0321: pop
+			IL_0322: ldloc.0
+			IL_0323: ldc.i4.1
+			IL_0324: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0329: ldnull
+			IL_032a: ldc.i4.1
+			IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0330: ret
 		} // end of method g1::__js_call__
 
 	} // end of class g1
@@ -449,7 +446,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bf6
+					// Method begins at RVA 0x2bce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -469,7 +466,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bff
+					// Method begins at RVA 0x2bd7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -489,7 +486,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c08
+					// Method begins at RVA 0x2be0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -507,7 +504,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bed
+				// Method begins at RVA 0x2bc5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -531,18 +528,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2848
+			// Method begins at RVA 0x2834
 			// Header size: 12
-			// Code size: 876 (0x36c)
+			// Code size: 856 (0x358)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/Scope/Block_L36C14,
-				[4] bool,
-				[5] object,
-				[6] object
+				[3] bool,
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -575,7 +571,7 @@
 			IL_003f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parametersInitialized
 			IL_0044: stloc.1
 			IL_0045: ldloc.1
-			IL_0046: brtrue IL_006a
+			IL_0046: brtrue IL_0068
 
 			IL_004b: ldloc.0
 			IL_004c: ldc.i4.1
@@ -585,289 +581,287 @@
 			IL_0054: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_started
 			IL_0059: ldloc.0
 			IL_005a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parameterInitializationOnly
-			IL_005f: stloc.s 4
-			IL_0061: ldloc.s 4
-			IL_0063: brfalse IL_006a
+			IL_005f: stloc.3
+			IL_0060: ldloc.3
+			IL_0061: brfalse IL_0068
 
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0066: ldnull
+			IL_0067: ret
 
-			IL_006a: ldloc.0
-			IL_006b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0070: switch (IL_0081, IL_00e1, IL_01ff)
+			IL_0068: ldloc.0
+			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_006e: switch (IL_007f, IL_00df, IL_01f3)
 
-			IL_0081: ldloc.0
-			IL_0082: ldc.i4.0
-			IL_0083: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0088: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_008d: ldloc.0
-			IL_008e: ldc.i4.0
-			IL_008f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0094: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0099: ldloc.0
-			IL_009a: ldc.i4.0
-			IL_009b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_00a0: ldloc.0
-			IL_00a1: ldc.i4.0
-			IL_00a2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.s 5
-			IL_00b3: ldloc.s 5
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: ldstr "log"
-			IL_00c3: ldstr "g2:try"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cd: pop
-			IL_00ce: ldloc.0
-			IL_00cf: ldc.i4.1
-			IL_00d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_00d5: ldstr "T2"
-			IL_00da: ldc.i4.0
-			IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_00e0: ret
+			IL_007f: ldloc.0
+			IL_0080: ldc.i4.0
+			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0086: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_008b: ldloc.0
+			IL_008c: ldc.i4.0
+			IL_008d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0092: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0097: ldloc.0
+			IL_0098: ldc.i4.0
+			IL_0099: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_009e: ldloc.0
+			IL_009f: ldc.i4.0
+			IL_00a0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_00a5: ldstr "console"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00af: stloc.s 4
+			IL_00b1: ldloc.s 4
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.s 4
+			IL_00ba: ldloc.s 4
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "g2:try"
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cb: pop
+			IL_00cc: ldloc.0
+			IL_00cd: ldc.i4.1
+			IL_00ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_00d3: ldstr "T2"
+			IL_00d8: ldc.i4.0
+			IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_00de: ret
 
-			IL_00e1: ldloc.0
-			IL_00e2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_00e7: stloc.s 4
-			IL_00e9: ldloc.s 4
-			IL_00eb: brfalse IL_0126
+			IL_00df: ldloc.0
+			IL_00e0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_00e5: stloc.3
+			IL_00e6: ldloc.3
+			IL_00e7: brfalse IL_0122
 
-			IL_00f0: ldloc.0
-			IL_00f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_00f6: stloc.s 5
-			IL_00f8: ldloc.0
-			IL_00f9: ldloc.s 5
-			IL_00fb: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0100: ldloc.0
-			IL_0101: ldc.i4.1
-			IL_0102: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0107: ldloc.0
-			IL_0108: ldc.i4.0
-			IL_0109: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_010e: ldloc.0
-			IL_010f: ldc.i4.0
-			IL_0110: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0115: ldloc.0
-			IL_0116: ldc.i4.0
-			IL_0117: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_011c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0121: br IL_02b5
+			IL_00ec: ldloc.0
+			IL_00ed: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_00f2: stloc.s 4
+			IL_00f4: ldloc.0
+			IL_00f5: ldloc.s 4
+			IL_00f7: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_00fc: ldloc.0
+			IL_00fd: ldc.i4.1
+			IL_00fe: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0103: ldloc.0
+			IL_0104: ldc.i4.0
+			IL_0105: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_010a: ldloc.0
+			IL_010b: ldc.i4.0
+			IL_010c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0111: ldloc.0
+			IL_0112: ldc.i4.0
+			IL_0113: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0118: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_011d: br IL_02a5
 
-			IL_0126: ldloc.0
-			IL_0127: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_012c: stloc.s 4
-			IL_012e: ldloc.s 4
-			IL_0130: brfalse IL_016b
+			IL_0122: ldloc.0
+			IL_0123: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0128: stloc.3
+			IL_0129: ldloc.3
+			IL_012a: brfalse IL_0165
 
-			IL_0135: ldloc.0
-			IL_0136: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_013b: stloc.s 5
-			IL_013d: ldloc.0
-			IL_013e: ldloc.s 5
-			IL_0140: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0145: ldloc.0
-			IL_0146: ldc.i4.0
-			IL_0147: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_014c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0151: ldloc.0
-			IL_0152: ldc.i4.1
-			IL_0153: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0158: ldloc.0
-			IL_0159: ldc.i4.0
-			IL_015a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_015f: ldloc.0
-			IL_0160: ldc.i4.0
-			IL_0161: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0166: br IL_0197
+			IL_012f: ldloc.0
+			IL_0130: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0135: stloc.s 4
+			IL_0137: ldloc.0
+			IL_0138: ldloc.s 4
+			IL_013a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_013f: ldloc.0
+			IL_0140: ldc.i4.0
+			IL_0141: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0146: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_014b: ldloc.0
+			IL_014c: ldc.i4.1
+			IL_014d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0152: ldloc.0
+			IL_0153: ldc.i4.0
+			IL_0154: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0159: ldloc.0
+			IL_015a: ldc.i4.0
+			IL_015b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0160: br IL_0191
 
-			IL_016b: ldstr "console"
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0175: stloc.s 5
-			IL_0177: ldloc.s 5
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017e: stloc.s 5
-			IL_0180: ldloc.s 5
-			IL_0182: ldstr "log"
-			IL_0187: ldstr "g2:after-yield"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0191: pop
-			IL_0192: br IL_02b5
+			IL_0165: ldstr "console"
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_016f: stloc.s 4
+			IL_0171: ldloc.s 4
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0178: stloc.s 4
+			IL_017a: ldloc.s 4
+			IL_017c: ldstr "log"
+			IL_0181: ldstr "g2:after-yield"
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_018b: pop
+			IL_018c: br IL_02a5
 
-			IL_0197: ldloc.0
-			IL_0198: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_019d: stloc.s 5
-			IL_019f: ldloc.0
-			IL_01a0: ldc.i4.0
-			IL_01a1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_01a6: ldloc.0
-			IL_01a7: ldc.i4.0
-			IL_01a8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01ad: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_01b2: ldloc.s 5
-			IL_01b4: stloc.2
-			IL_01b5: newobj instance void Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/Scope/Block_L36C14::.ctor()
-			IL_01ba: stloc.3
-			IL_01bb: ldstr "console"
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c5: stloc.s 5
-			IL_01c7: ldloc.s 5
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ce: stloc.s 5
-			IL_01d0: ldstr "g2:catch:"
-			IL_01d5: ldloc.2
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01db: stloc.s 6
-			IL_01dd: ldloc.s 5
-			IL_01df: ldstr "log"
-			IL_01e4: ldloc.s 6
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01eb: pop
-			IL_01ec: ldloc.0
-			IL_01ed: ldc.i4.2
-			IL_01ee: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_01f3: ldstr "C2"
-			IL_01f8: ldc.i4.0
-			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_01fe: ret
+			IL_0191: ldloc.0
+			IL_0192: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0197: stloc.s 4
+			IL_0199: ldloc.0
+			IL_019a: ldc.i4.0
+			IL_019b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_01a0: ldloc.0
+			IL_01a1: ldc.i4.0
+			IL_01a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01a7: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_01ac: ldloc.s 4
+			IL_01ae: stloc.2
+			IL_01af: ldstr "console"
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b9: stloc.s 4
+			IL_01bb: ldloc.s 4
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c2: stloc.s 4
+			IL_01c4: ldstr "g2:catch:"
+			IL_01c9: ldloc.2
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01cf: stloc.s 5
+			IL_01d1: ldloc.s 4
+			IL_01d3: ldstr "log"
+			IL_01d8: ldloc.s 5
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01df: pop
+			IL_01e0: ldloc.0
+			IL_01e1: ldc.i4.2
+			IL_01e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_01e7: ldstr "C2"
+			IL_01ec: ldc.i4.0
+			IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_01f2: ret
 
-			IL_01ff: ldloc.0
-			IL_0200: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0205: stloc.s 4
-			IL_0207: ldloc.s 4
-			IL_0209: brfalse IL_0244
+			IL_01f3: ldloc.0
+			IL_01f4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01f9: stloc.3
+			IL_01fa: ldloc.3
+			IL_01fb: brfalse IL_0236
 
-			IL_020e: ldloc.0
-			IL_020f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0214: stloc.s 5
-			IL_0216: ldloc.0
-			IL_0217: ldloc.s 5
-			IL_0219: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0200: ldloc.0
+			IL_0201: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0206: stloc.s 4
+			IL_0208: ldloc.0
+			IL_0209: ldloc.s 4
+			IL_020b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0210: ldloc.0
+			IL_0211: ldc.i4.1
+			IL_0212: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0217: ldloc.0
+			IL_0218: ldc.i4.0
+			IL_0219: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
 			IL_021e: ldloc.0
-			IL_021f: ldc.i4.1
-			IL_0220: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_021f: ldc.i4.0
+			IL_0220: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
 			IL_0225: ldloc.0
 			IL_0226: ldc.i4.0
-			IL_0227: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_022c: ldloc.0
-			IL_022d: ldc.i4.0
-			IL_022e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0233: ldloc.0
-			IL_0234: ldc.i4.0
-			IL_0235: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_023a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_023f: br IL_02b5
+			IL_0227: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_022c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0231: br IL_02a5
 
-			IL_0244: ldloc.0
-			IL_0245: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_024a: stloc.s 4
+			IL_0236: ldloc.0
+			IL_0237: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_023c: stloc.3
+			IL_023d: ldloc.3
+			IL_023e: brfalse IL_0279
+
+			IL_0243: ldloc.0
+			IL_0244: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0249: stloc.s 4
+			IL_024b: ldloc.0
 			IL_024c: ldloc.s 4
-			IL_024e: brfalse IL_0289
-
+			IL_024e: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
 			IL_0253: ldloc.0
-			IL_0254: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0259: stloc.s 5
-			IL_025b: ldloc.0
-			IL_025c: ldloc.s 5
-			IL_025e: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0263: ldloc.0
-			IL_0264: ldc.i4.0
-			IL_0265: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_026a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_026f: ldloc.0
-			IL_0270: ldc.i4.1
-			IL_0271: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0276: ldloc.0
-			IL_0277: ldc.i4.0
-			IL_0278: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_027d: ldloc.0
-			IL_027e: ldc.i4.0
-			IL_027f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0284: br IL_02b5
+			IL_0254: ldc.i4.0
+			IL_0255: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_025a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_025f: ldloc.0
+			IL_0260: ldc.i4.1
+			IL_0261: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0266: ldloc.0
+			IL_0267: ldc.i4.0
+			IL_0268: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_026d: ldloc.0
+			IL_026e: ldc.i4.0
+			IL_026f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0274: br IL_02a5
 
-			IL_0289: ldstr "console"
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0293: stloc.s 5
-			IL_0295: ldloc.s 5
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029c: stloc.s 5
-			IL_029e: ldloc.s 5
-			IL_02a0: ldstr "log"
-			IL_02a5: ldstr "g2:after-catch-yield"
-			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02af: pop
-			IL_02b0: br IL_02b5
+			IL_0279: ldstr "console"
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0283: stloc.s 4
+			IL_0285: ldloc.s 4
+			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_028c: stloc.s 4
+			IL_028e: ldloc.s 4
+			IL_0290: ldstr "log"
+			IL_0295: ldstr "g2:after-catch-yield"
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_029f: pop
+			IL_02a0: br IL_02a5
 
-			IL_02b5: ldstr "console"
-			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02bf: stloc.s 5
-			IL_02c1: ldloc.s 5
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c8: stloc.s 5
-			IL_02ca: ldloc.s 5
-			IL_02cc: ldstr "log"
-			IL_02d1: ldstr "g2:finally"
-			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02db: pop
-			IL_02dc: br IL_02e1
+			IL_02a5: ldstr "console"
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02af: stloc.s 4
+			IL_02b1: ldloc.s 4
+			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b8: stloc.s 4
+			IL_02ba: ldloc.s 4
+			IL_02bc: ldstr "log"
+			IL_02c1: ldstr "g2:finally"
+			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02cb: pop
+			IL_02cc: br IL_02d1
 
-			IL_02e1: ldloc.0
-			IL_02e2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_02e7: stloc.s 4
-			IL_02e9: ldloc.s 4
-			IL_02eb: brfalse IL_030f
+			IL_02d1: ldloc.0
+			IL_02d2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_02d7: stloc.3
+			IL_02d8: ldloc.3
+			IL_02d9: brfalse IL_02fd
 
+			IL_02de: ldloc.0
+			IL_02df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_02e4: isinst [System.Runtime]System.Exception
+			IL_02e9: dup
+			IL_02ea: brtrue IL_02fc
+
+			IL_02ef: pop
 			IL_02f0: ldloc.0
 			IL_02f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_02f6: isinst [System.Runtime]System.Exception
-			IL_02fb: dup
-			IL_02fc: brtrue IL_030e
+			IL_02f6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_02fb: throw
 
-			IL_0301: pop
-			IL_0302: ldloc.0
-			IL_0303: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_030d: throw
+			IL_02fc: throw
 
-			IL_030e: throw
+			IL_02fd: ldloc.0
+			IL_02fe: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0303: stloc.3
+			IL_0304: ldloc.3
+			IL_0305: brfalse IL_0322
 
-			IL_030f: ldloc.0
-			IL_0310: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0315: stloc.s 4
-			IL_0317: ldloc.s 4
-			IL_0319: brfalse IL_0336
+			IL_030a: ldloc.0
+			IL_030b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0310: stloc.s 4
+			IL_0312: ldloc.0
+			IL_0313: ldc.i4.1
+			IL_0314: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0319: ldloc.s 4
+			IL_031b: ldc.i4.1
+			IL_031c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0321: ret
 
-			IL_031e: ldloc.0
-			IL_031f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0324: stloc.s 5
-			IL_0326: ldloc.0
-			IL_0327: ldc.i4.1
-			IL_0328: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_032d: ldloc.s 5
-			IL_032f: ldc.i4.1
-			IL_0330: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0335: ret
-
-			IL_0336: ldstr "console"
-			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0340: stloc.s 5
-			IL_0342: ldloc.s 5
-			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0349: stloc.s 5
-			IL_034b: ldloc.s 5
-			IL_034d: ldstr "log"
-			IL_0352: ldstr "g2:after-try"
-			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_035c: pop
-			IL_035d: ldloc.0
-			IL_035e: ldc.i4.1
-			IL_035f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0364: ldnull
-			IL_0365: ldc.i4.1
-			IL_0366: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_036b: ret
+			IL_0322: ldstr "console"
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_032c: stloc.s 4
+			IL_032e: ldloc.s 4
+			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0335: stloc.s 4
+			IL_0337: ldloc.s 4
+			IL_0339: ldstr "log"
+			IL_033e: ldstr "g2:after-try"
+			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0348: pop
+			IL_0349: ldloc.0
+			IL_034a: ldc.i4.1
+			IL_034b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0350: ldnull
+			IL_0351: ldc.i4.1
+			IL_0352: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0357: ret
 		} // end of method g2::__js_call__
 
 	} // end of class g2
@@ -887,7 +881,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2bc0
+			// Method begins at RVA 0x2b98
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1301,7 +1295,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c11
+		// Method begins at RVA 0x2be9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2695
+					// Method begins at RVA 0x2681
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x269e
+					// Method begins at RVA 0x268a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a7
+					// Method begins at RVA 0x2693
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268c
+				// Method begins at RVA 0x2678
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,16 +106,15 @@
 			)
 			// Method begins at RVA 0x22ec
 			// Header size: 12
-			// Code size: 907 (0x38b)
+			// Code size: 887 (0x377)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/Scope/Block_L8C14,
-				[4] bool,
-				[5] object,
-				[6] object
+				[3] bool,
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -148,7 +147,7 @@
 			IL_003f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parametersInitialized
 			IL_0044: stloc.1
 			IL_0045: ldloc.1
-			IL_0046: brtrue IL_006a
+			IL_0046: brtrue IL_0068
 
 			IL_004b: ldloc.0
 			IL_004c: ldc.i4.1
@@ -158,292 +157,290 @@
 			IL_0054: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_started
 			IL_0059: ldloc.0
 			IL_005a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parameterInitializationOnly
-			IL_005f: stloc.s 4
-			IL_0061: ldloc.s 4
-			IL_0063: brfalse IL_006a
+			IL_005f: stloc.3
+			IL_0060: ldloc.3
+			IL_0061: brfalse IL_0068
 
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0066: ldnull
+			IL_0067: ret
 
-			IL_006a: ldloc.0
-			IL_006b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0070: switch (IL_0081, IL_00ea, IL_0211)
+			IL_0068: ldloc.0
+			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_006e: switch (IL_007f, IL_00e8, IL_0205)
 
-			IL_0081: ldloc.0
-			IL_0082: ldc.i4.0
-			IL_0083: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0088: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_008d: ldloc.0
-			IL_008e: ldc.i4.0
-			IL_008f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0094: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0099: ldloc.0
-			IL_009a: ldc.i4.0
-			IL_009b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_00a0: ldloc.0
-			IL_00a1: ldc.i4.0
-			IL_00a2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.s 5
-			IL_00b3: ldloc.s 5
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: ldstr "log"
-			IL_00c3: ldstr "try"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cd: pop
-			IL_00ce: ldloc.0
-			IL_00cf: ldc.i4.1
-			IL_00d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_00d5: ldc.r8 1
-			IL_00de: box [System.Runtime]System.Double
-			IL_00e3: ldc.i4.0
-			IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_00e9: ret
+			IL_007f: ldloc.0
+			IL_0080: ldc.i4.0
+			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0086: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_008b: ldloc.0
+			IL_008c: ldc.i4.0
+			IL_008d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0092: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0097: ldloc.0
+			IL_0098: ldc.i4.0
+			IL_0099: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_009e: ldloc.0
+			IL_009f: ldc.i4.0
+			IL_00a0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_00a5: ldstr "console"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00af: stloc.s 4
+			IL_00b1: ldloc.s 4
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.s 4
+			IL_00ba: ldloc.s 4
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "try"
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cb: pop
+			IL_00cc: ldloc.0
+			IL_00cd: ldc.i4.1
+			IL_00ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_00d3: ldc.r8 1
+			IL_00dc: box [System.Runtime]System.Double
+			IL_00e1: ldc.i4.0
+			IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_00e7: ret
 
-			IL_00ea: ldloc.0
-			IL_00eb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_00f0: stloc.s 4
-			IL_00f2: ldloc.s 4
-			IL_00f4: brfalse IL_012f
+			IL_00e8: ldloc.0
+			IL_00e9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_00ee: stloc.3
+			IL_00ef: ldloc.3
+			IL_00f0: brfalse IL_012b
 
-			IL_00f9: ldloc.0
-			IL_00fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_00ff: stloc.s 5
-			IL_0101: ldloc.0
-			IL_0102: ldloc.s 5
-			IL_0104: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0109: ldloc.0
-			IL_010a: ldc.i4.1
-			IL_010b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0110: ldloc.0
-			IL_0111: ldc.i4.0
-			IL_0112: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0117: ldloc.0
-			IL_0118: ldc.i4.0
-			IL_0119: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_011e: ldloc.0
-			IL_011f: ldc.i4.0
-			IL_0120: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0125: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_012a: br IL_02c7
+			IL_00f5: ldloc.0
+			IL_00f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_00fb: stloc.s 4
+			IL_00fd: ldloc.0
+			IL_00fe: ldloc.s 4
+			IL_0100: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0105: ldloc.0
+			IL_0106: ldc.i4.1
+			IL_0107: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_010c: ldloc.0
+			IL_010d: ldc.i4.0
+			IL_010e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0113: ldloc.0
+			IL_0114: ldc.i4.0
+			IL_0115: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_011a: ldloc.0
+			IL_011b: ldc.i4.0
+			IL_011c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0121: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0126: br IL_02b7
 
-			IL_012f: ldloc.0
-			IL_0130: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0135: stloc.s 4
-			IL_0137: ldloc.s 4
-			IL_0139: brfalse IL_0174
+			IL_012b: ldloc.0
+			IL_012c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0131: stloc.3
+			IL_0132: ldloc.3
+			IL_0133: brfalse IL_016e
 
-			IL_013e: ldloc.0
-			IL_013f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0144: stloc.s 5
-			IL_0146: ldloc.0
-			IL_0147: ldloc.s 5
-			IL_0149: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_014e: ldloc.0
-			IL_014f: ldc.i4.0
-			IL_0150: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0155: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_015a: ldloc.0
-			IL_015b: ldc.i4.1
-			IL_015c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0161: ldloc.0
-			IL_0162: ldc.i4.0
-			IL_0163: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0168: ldloc.0
-			IL_0169: ldc.i4.0
-			IL_016a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_016f: br IL_01a0
+			IL_0138: ldloc.0
+			IL_0139: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_013e: stloc.s 4
+			IL_0140: ldloc.0
+			IL_0141: ldloc.s 4
+			IL_0143: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0148: ldloc.0
+			IL_0149: ldc.i4.0
+			IL_014a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_014f: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0154: ldloc.0
+			IL_0155: ldc.i4.1
+			IL_0156: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_015b: ldloc.0
+			IL_015c: ldc.i4.0
+			IL_015d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0162: ldloc.0
+			IL_0163: ldc.i4.0
+			IL_0164: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0169: br IL_019a
 
-			IL_0174: ldstr "console"
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017e: stloc.s 5
-			IL_0180: ldloc.s 5
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0187: stloc.s 5
-			IL_0189: ldloc.s 5
-			IL_018b: ldstr "log"
-			IL_0190: ldstr "after-yield"
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_019a: pop
-			IL_019b: br IL_02c7
+			IL_016e: ldstr "console"
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0178: stloc.s 4
+			IL_017a: ldloc.s 4
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0181: stloc.s 4
+			IL_0183: ldloc.s 4
+			IL_0185: ldstr "log"
+			IL_018a: ldstr "after-yield"
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0194: pop
+			IL_0195: br IL_02b7
 
-			IL_01a0: ldloc.0
-			IL_01a1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_01a6: stloc.s 5
-			IL_01a8: ldloc.0
-			IL_01a9: ldc.i4.0
-			IL_01aa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_01af: ldloc.0
-			IL_01b0: ldc.i4.0
-			IL_01b1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01b6: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_01bb: ldloc.s 5
-			IL_01bd: stloc.2
-			IL_01be: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/Scope/Block_L8C14::.ctor()
-			IL_01c3: stloc.3
-			IL_01c4: ldstr "console"
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ce: stloc.s 5
-			IL_01d0: ldloc.s 5
-			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d7: stloc.s 5
-			IL_01d9: ldstr "catch="
-			IL_01de: ldloc.2
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01e4: stloc.s 6
-			IL_01e6: ldloc.s 5
-			IL_01e8: ldstr "log"
-			IL_01ed: ldloc.s 6
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01f4: pop
-			IL_01f5: ldloc.0
-			IL_01f6: ldc.i4.2
-			IL_01f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_01fc: ldc.r8 2
-			IL_0205: box [System.Runtime]System.Double
-			IL_020a: ldc.i4.0
-			IL_020b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0210: ret
+			IL_019a: ldloc.0
+			IL_019b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_01a0: stloc.s 4
+			IL_01a2: ldloc.0
+			IL_01a3: ldc.i4.0
+			IL_01a4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_01a9: ldloc.0
+			IL_01aa: ldc.i4.0
+			IL_01ab: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01b0: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_01b5: ldloc.s 4
+			IL_01b7: stloc.2
+			IL_01b8: ldstr "console"
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c2: stloc.s 4
+			IL_01c4: ldloc.s 4
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cb: stloc.s 4
+			IL_01cd: ldstr "catch="
+			IL_01d2: ldloc.2
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01d8: stloc.s 5
+			IL_01da: ldloc.s 4
+			IL_01dc: ldstr "log"
+			IL_01e1: ldloc.s 5
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01e8: pop
+			IL_01e9: ldloc.0
+			IL_01ea: ldc.i4.2
+			IL_01eb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_01f0: ldc.r8 2
+			IL_01f9: box [System.Runtime]System.Double
+			IL_01fe: ldc.i4.0
+			IL_01ff: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0204: ret
 
-			IL_0211: ldloc.0
-			IL_0212: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0217: stloc.s 4
-			IL_0219: ldloc.s 4
-			IL_021b: brfalse IL_0256
+			IL_0205: ldloc.0
+			IL_0206: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_020b: stloc.3
+			IL_020c: ldloc.3
+			IL_020d: brfalse IL_0248
 
-			IL_0220: ldloc.0
-			IL_0221: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_0226: stloc.s 5
-			IL_0228: ldloc.0
-			IL_0229: ldloc.s 5
-			IL_022b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0212: ldloc.0
+			IL_0213: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0218: stloc.s 4
+			IL_021a: ldloc.0
+			IL_021b: ldloc.s 4
+			IL_021d: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0222: ldloc.0
+			IL_0223: ldc.i4.1
+			IL_0224: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0229: ldloc.0
+			IL_022a: ldc.i4.0
+			IL_022b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
 			IL_0230: ldloc.0
-			IL_0231: ldc.i4.1
-			IL_0232: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0231: ldc.i4.0
+			IL_0232: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
 			IL_0237: ldloc.0
 			IL_0238: ldc.i4.0
-			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_023e: ldloc.0
-			IL_023f: ldc.i4.0
-			IL_0240: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0245: ldloc.0
-			IL_0246: ldc.i4.0
-			IL_0247: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_024c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0251: br IL_02c7
+			IL_0239: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_023e: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0243: br IL_02b7
 
-			IL_0256: ldloc.0
-			IL_0257: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_025c: stloc.s 4
+			IL_0248: ldloc.0
+			IL_0249: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_024e: stloc.3
+			IL_024f: ldloc.3
+			IL_0250: brfalse IL_028b
+
+			IL_0255: ldloc.0
+			IL_0256: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_025b: stloc.s 4
+			IL_025d: ldloc.0
 			IL_025e: ldloc.s 4
-			IL_0260: brfalse IL_029b
-
+			IL_0260: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
 			IL_0265: ldloc.0
-			IL_0266: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_026b: stloc.s 5
-			IL_026d: ldloc.0
-			IL_026e: ldloc.s 5
-			IL_0270: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0275: ldloc.0
-			IL_0276: ldc.i4.0
-			IL_0277: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_027c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0281: ldloc.0
-			IL_0282: ldc.i4.1
-			IL_0283: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0288: ldloc.0
-			IL_0289: ldc.i4.0
-			IL_028a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_028f: ldloc.0
-			IL_0290: ldc.i4.0
-			IL_0291: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0296: br IL_02c7
+			IL_0266: ldc.i4.0
+			IL_0267: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_026c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0271: ldloc.0
+			IL_0272: ldc.i4.1
+			IL_0273: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0278: ldloc.0
+			IL_0279: ldc.i4.0
+			IL_027a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_027f: ldloc.0
+			IL_0280: ldc.i4.0
+			IL_0281: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0286: br IL_02b7
 
-			IL_029b: ldstr "console"
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02a5: stloc.s 5
-			IL_02a7: ldloc.s 5
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: stloc.s 5
-			IL_02b0: ldloc.s 5
-			IL_02b2: ldstr "log"
-			IL_02b7: ldstr "after-catch-yield"
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02c1: pop
-			IL_02c2: br IL_02c7
+			IL_028b: ldstr "console"
+			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0295: stloc.s 4
+			IL_0297: ldloc.s 4
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_029e: stloc.s 4
+			IL_02a0: ldloc.s 4
+			IL_02a2: ldstr "log"
+			IL_02a7: ldstr "after-catch-yield"
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02b1: pop
+			IL_02b2: br IL_02b7
 
-			IL_02c7: ldstr "console"
-			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02d1: stloc.s 5
-			IL_02d3: ldloc.s 5
-			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02da: stloc.s 5
-			IL_02dc: ldloc.s 5
-			IL_02de: ldstr "log"
-			IL_02e3: ldstr "finally"
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02ed: pop
-			IL_02ee: br IL_02f3
+			IL_02b7: ldstr "console"
+			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02c1: stloc.s 4
+			IL_02c3: ldloc.s 4
+			IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ca: stloc.s 4
+			IL_02cc: ldloc.s 4
+			IL_02ce: ldstr "log"
+			IL_02d3: ldstr "finally"
+			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02dd: pop
+			IL_02de: br IL_02e3
 
-			IL_02f3: ldloc.0
-			IL_02f4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_02f9: stloc.s 4
-			IL_02fb: ldloc.s 4
-			IL_02fd: brfalse IL_0321
+			IL_02e3: ldloc.0
+			IL_02e4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_02e9: stloc.3
+			IL_02ea: ldloc.3
+			IL_02eb: brfalse IL_030f
 
+			IL_02f0: ldloc.0
+			IL_02f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_02f6: isinst [System.Runtime]System.Exception
+			IL_02fb: dup
+			IL_02fc: brtrue IL_030e
+
+			IL_0301: pop
 			IL_0302: ldloc.0
 			IL_0303: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0308: isinst [System.Runtime]System.Exception
-			IL_030d: dup
-			IL_030e: brtrue IL_0320
+			IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_030d: throw
 
-			IL_0313: pop
-			IL_0314: ldloc.0
-			IL_0315: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_031a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_031f: throw
+			IL_030e: throw
 
-			IL_0320: throw
+			IL_030f: ldloc.0
+			IL_0310: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0315: stloc.3
+			IL_0316: ldloc.3
+			IL_0317: brfalse IL_0334
 
-			IL_0321: ldloc.0
-			IL_0322: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0327: stloc.s 4
-			IL_0329: ldloc.s 4
-			IL_032b: brfalse IL_0348
+			IL_031c: ldloc.0
+			IL_031d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0322: stloc.s 4
+			IL_0324: ldloc.0
+			IL_0325: ldc.i4.1
+			IL_0326: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_032b: ldloc.s 4
+			IL_032d: ldc.i4.1
+			IL_032e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0333: ret
 
-			IL_0330: ldloc.0
-			IL_0331: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0336: stloc.s 5
-			IL_0338: ldloc.0
-			IL_0339: ldc.i4.1
-			IL_033a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_033f: ldloc.s 5
-			IL_0341: ldc.i4.1
-			IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0347: ret
-
-			IL_0348: ldstr "console"
-			IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0352: stloc.s 5
-			IL_0354: ldloc.s 5
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_035b: stloc.s 5
-			IL_035d: ldloc.s 5
-			IL_035f: ldstr "log"
-			IL_0364: ldstr "after-try"
-			IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_036e: pop
-			IL_036f: ldloc.0
+			IL_0334: ldstr "console"
+			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_033e: stloc.s 4
+			IL_0340: ldloc.s 4
+			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0347: stloc.s 4
+			IL_0349: ldloc.s 4
+			IL_034b: ldstr "log"
+			IL_0350: ldstr "after-try"
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_035a: pop
+			IL_035b: ldloc.0
+			IL_035c: ldc.i4.1
+			IL_035d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0362: ldc.r8 3
+			IL_036b: box [System.Runtime]System.Double
 			IL_0370: ldc.i4.1
-			IL_0371: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0376: ldc.r8 3
-			IL_037f: box [System.Runtime]System.Double
-			IL_0384: ldc.i4.1
-			IL_0385: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_038a: ret
+			IL_0371: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0376: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -461,7 +458,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2683
+			// Method begins at RVA 0x266f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -714,7 +711,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26b0
+		// Method begins at RVA 0x269c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a7
+						// Method begins at RVA 0x268f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26b0
+						// Method begins at RVA 0x2698
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26b9
+						// Method begins at RVA 0x26a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x269e
+					// Method begins at RVA 0x2686
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -104,7 +104,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c2
+					// Method begins at RVA 0x26aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -122,7 +122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2695
+				// Method begins at RVA 0x267d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -148,16 +148,15 @@
 			)
 			// Method begins at RVA 0x225c
 			// Header size: 12
-			// Code size: 1060 (0x424)
+			// Code size: 1036 (0x40c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/Scope/Block_L4C6/Block_L11C16,
-				[4] bool,
-				[5] object,
-				[6] object
+				[3] bool,
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -190,7 +189,7 @@
 			IL_003f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parametersInitialized
 			IL_0044: stloc.1
 			IL_0045: ldloc.1
-			IL_0046: brtrue IL_006a
+			IL_0046: brtrue IL_0068
 
 			IL_004b: ldloc.0
 			IL_004c: ldc.i4.1
@@ -200,347 +199,345 @@
 			IL_0054: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_started
 			IL_0059: ldloc.0
 			IL_005a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parameterInitializationOnly
-			IL_005f: stloc.s 4
-			IL_0061: ldloc.s 4
-			IL_0063: brfalse IL_006a
+			IL_005f: stloc.3
+			IL_0060: ldloc.3
+			IL_0061: brfalse IL_0068
 
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0066: ldnull
+			IL_0067: ret
 
-			IL_006a: ldloc.0
-			IL_006b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0070: switch (IL_0081, IL_0137, IL_02de)
+			IL_0068: ldloc.0
+			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_006e: switch (IL_007f, IL_0135, IL_02ce)
 
-			IL_0081: ldloc.0
-			IL_0082: ldc.i4.0
-			IL_0083: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0088: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_008d: ldloc.0
-			IL_008e: ldc.i4.0
-			IL_008f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0094: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0099: ldloc.0
-			IL_009a: ldc.i4.0
-			IL_009b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_00a0: ldloc.0
-			IL_00a1: ldc.i4.0
-			IL_00a2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.s 5
-			IL_00b3: ldloc.s 5
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: ldstr "log"
-			IL_00c3: ldstr "outer-try"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cd: pop
-			IL_00ce: ldloc.0
-			IL_00cf: ldc.i4.0
-			IL_00d0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d5: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_00da: ldloc.0
-			IL_00db: ldc.i4.0
-			IL_00dc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e1: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_00e6: ldloc.0
-			IL_00e7: ldc.i4.0
-			IL_00e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_00ed: ldloc.0
-			IL_00ee: ldc.i4.0
-			IL_00ef: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_00f4: ldstr "console"
-			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00fe: stloc.s 5
-			IL_0100: ldloc.s 5
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0107: stloc.s 5
-			IL_0109: ldloc.s 5
-			IL_010b: ldstr "log"
-			IL_0110: ldstr "inner-try"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_011a: pop
-			IL_011b: ldloc.0
-			IL_011c: ldc.i4.1
-			IL_011d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0122: ldc.r8 1
-			IL_012b: box [System.Runtime]System.Double
-			IL_0130: ldc.i4.0
-			IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0136: ret
+			IL_007f: ldloc.0
+			IL_0080: ldc.i4.0
+			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0086: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_008b: ldloc.0
+			IL_008c: ldc.i4.0
+			IL_008d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0092: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0097: ldloc.0
+			IL_0098: ldc.i4.0
+			IL_0099: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_009e: ldloc.0
+			IL_009f: ldc.i4.0
+			IL_00a0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_00a5: ldstr "console"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00af: stloc.s 4
+			IL_00b1: ldloc.s 4
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.s 4
+			IL_00ba: ldloc.s 4
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "outer-try"
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cb: pop
+			IL_00cc: ldloc.0
+			IL_00cd: ldc.i4.0
+			IL_00ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_00d8: ldloc.0
+			IL_00d9: ldc.i4.0
+			IL_00da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00df: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_00e4: ldloc.0
+			IL_00e5: ldc.i4.0
+			IL_00e6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_00eb: ldloc.0
+			IL_00ec: ldc.i4.0
+			IL_00ed: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_00f2: ldstr "console"
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fc: stloc.s 4
+			IL_00fe: ldloc.s 4
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0105: stloc.s 4
+			IL_0107: ldloc.s 4
+			IL_0109: ldstr "log"
+			IL_010e: ldstr "inner-try"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0118: pop
+			IL_0119: ldloc.0
+			IL_011a: ldc.i4.1
+			IL_011b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_0120: ldc.r8 1
+			IL_0129: box [System.Runtime]System.Double
+			IL_012e: ldc.i4.0
+			IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0134: ret
 
-			IL_0137: ldloc.0
-			IL_0138: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_013d: stloc.s 4
-			IL_013f: ldloc.s 4
-			IL_0141: brfalse IL_017c
+			IL_0135: ldloc.0
+			IL_0136: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_013b: stloc.3
+			IL_013c: ldloc.3
+			IL_013d: brfalse IL_0178
 
-			IL_0146: ldloc.0
-			IL_0147: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_014c: stloc.s 5
-			IL_014e: ldloc.0
-			IL_014f: ldloc.s 5
-			IL_0151: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_0156: ldloc.0
-			IL_0157: ldc.i4.1
-			IL_0158: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_015d: ldloc.0
-			IL_015e: ldc.i4.0
-			IL_015f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0164: ldloc.0
-			IL_0165: ldc.i4.0
-			IL_0166: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_016b: ldloc.0
-			IL_016c: ldc.i4.0
-			IL_016d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0172: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0177: br IL_0247
+			IL_0142: ldloc.0
+			IL_0143: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0148: stloc.s 4
+			IL_014a: ldloc.0
+			IL_014b: ldloc.s 4
+			IL_014d: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0152: ldloc.0
+			IL_0153: ldc.i4.1
+			IL_0154: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0159: ldloc.0
+			IL_015a: ldc.i4.0
+			IL_015b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0160: ldloc.0
+			IL_0161: ldc.i4.0
+			IL_0162: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0167: ldloc.0
+			IL_0168: ldc.i4.0
+			IL_0169: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_016e: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0173: br IL_023b
 
-			IL_017c: ldloc.0
-			IL_017d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0182: stloc.s 4
-			IL_0184: ldloc.s 4
-			IL_0186: brfalse IL_01c1
+			IL_0178: ldloc.0
+			IL_0179: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_017e: stloc.3
+			IL_017f: ldloc.3
+			IL_0180: brfalse IL_01bb
 
-			IL_018b: ldloc.0
-			IL_018c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0191: stloc.s 5
-			IL_0193: ldloc.0
-			IL_0194: ldloc.s 5
-			IL_0196: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_019b: ldloc.0
-			IL_019c: ldc.i4.0
-			IL_019d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_01a7: ldloc.0
-			IL_01a8: ldc.i4.1
-			IL_01a9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_01ae: ldloc.0
-			IL_01af: ldc.i4.0
-			IL_01b0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_01b5: ldloc.0
-			IL_01b6: ldc.i4.0
-			IL_01b7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01bc: br IL_01ed
+			IL_0185: ldloc.0
+			IL_0186: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_018b: stloc.s 4
+			IL_018d: ldloc.0
+			IL_018e: ldloc.s 4
+			IL_0190: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0195: ldloc.0
+			IL_0196: ldc.i4.0
+			IL_0197: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_01a1: ldloc.0
+			IL_01a2: ldc.i4.1
+			IL_01a3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_01a8: ldloc.0
+			IL_01a9: ldc.i4.0
+			IL_01aa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_01af: ldloc.0
+			IL_01b0: ldc.i4.0
+			IL_01b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01b6: br IL_01e7
 
-			IL_01c1: ldstr "console"
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01cb: stloc.s 5
-			IL_01cd: ldloc.s 5
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d4: stloc.s 5
-			IL_01d6: ldloc.s 5
-			IL_01d8: ldstr "log"
-			IL_01dd: ldstr "inner-after"
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01e7: pop
-			IL_01e8: br IL_0247
+			IL_01bb: ldstr "console"
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c5: stloc.s 4
+			IL_01c7: ldloc.s 4
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ce: stloc.s 4
+			IL_01d0: ldloc.s 4
+			IL_01d2: ldstr "log"
+			IL_01d7: ldstr "inner-after"
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01e1: pop
+			IL_01e2: br IL_023b
 
-			IL_01ed: ldloc.0
-			IL_01ee: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_01f3: stloc.s 5
-			IL_01f5: ldloc.0
-			IL_01f6: ldc.i4.0
-			IL_01f7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_01fc: ldloc.0
-			IL_01fd: ldc.i4.0
-			IL_01fe: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0203: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0208: ldloc.s 5
-			IL_020a: stloc.2
-			IL_020b: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/Scope/Block_L4C6/Block_L11C16::.ctor()
-			IL_0210: stloc.3
-			IL_0211: ldstr "console"
-			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_021b: stloc.s 5
-			IL_021d: ldloc.s 5
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0224: stloc.s 5
-			IL_0226: ldstr "inner-catch="
-			IL_022b: ldloc.2
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0231: stloc.s 6
-			IL_0233: ldloc.s 5
-			IL_0235: ldstr "log"
-			IL_023a: ldloc.s 6
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0241: pop
-			IL_0242: br IL_0247
+			IL_01e7: ldloc.0
+			IL_01e8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_01ed: stloc.s 4
+			IL_01ef: ldloc.0
+			IL_01f0: ldc.i4.0
+			IL_01f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_01f6: ldloc.0
+			IL_01f7: ldc.i4.0
+			IL_01f8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01fd: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0202: ldloc.s 4
+			IL_0204: stloc.2
+			IL_0205: ldstr "console"
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_020f: stloc.s 4
+			IL_0211: ldloc.s 4
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0218: stloc.s 4
+			IL_021a: ldstr "inner-catch="
+			IL_021f: ldloc.2
+			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0225: stloc.s 5
+			IL_0227: ldloc.s 4
+			IL_0229: ldstr "log"
+			IL_022e: ldloc.s 5
+			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0235: pop
+			IL_0236: br IL_023b
 
-			IL_0247: ldstr "console"
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0251: stloc.s 5
-			IL_0253: ldloc.s 5
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_025a: stloc.s 5
-			IL_025c: ldloc.s 5
-			IL_025e: ldstr "log"
-			IL_0263: ldstr "inner-finally"
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_026d: pop
-			IL_026e: br IL_0273
+			IL_023b: ldstr "console"
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0245: stloc.s 4
+			IL_0247: ldloc.s 4
+			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024e: stloc.s 4
+			IL_0250: ldloc.s 4
+			IL_0252: ldstr "log"
+			IL_0257: ldstr "inner-finally"
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0261: pop
+			IL_0262: br IL_0267
 
-			IL_0273: ldloc.0
-			IL_0274: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0279: stloc.s 4
-			IL_027b: ldloc.s 4
-			IL_027d: brfalse IL_0287
+			IL_0267: ldloc.0
+			IL_0268: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_026d: stloc.3
+			IL_026e: ldloc.3
+			IL_026f: brfalse IL_0279
 
-			IL_0282: br IL_036d
+			IL_0274: br IL_0359
 
-			IL_0287: ldloc.0
-			IL_0288: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_028d: stloc.s 4
-			IL_028f: ldloc.s 4
-			IL_0291: brfalse IL_029b
+			IL_0279: ldloc.0
+			IL_027a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_027f: stloc.3
+			IL_0280: ldloc.3
+			IL_0281: brfalse IL_028b
 
-			IL_0296: br IL_036d
+			IL_0286: br IL_0359
 
-			IL_029b: ldstr "console"
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02a5: stloc.s 5
-			IL_02a7: ldloc.s 5
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: stloc.s 5
-			IL_02b0: ldloc.s 5
-			IL_02b2: ldstr "log"
-			IL_02b7: ldstr "outer-after-inner"
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02c1: pop
-			IL_02c2: ldloc.0
-			IL_02c3: ldc.i4.2
-			IL_02c4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_02c9: ldc.r8 2
-			IL_02d2: box [System.Runtime]System.Double
-			IL_02d7: ldc.i4.0
-			IL_02d8: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02dd: ret
+			IL_028b: ldstr "console"
+			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0295: stloc.s 4
+			IL_0297: ldloc.s 4
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_029e: stloc.s 4
+			IL_02a0: ldloc.s 4
+			IL_02a2: ldstr "log"
+			IL_02a7: ldstr "outer-after-inner"
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02b1: pop
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.2
+			IL_02b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_02b9: ldc.r8 2
+			IL_02c2: box [System.Runtime]System.Double
+			IL_02c7: ldc.i4.0
+			IL_02c8: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02cd: ret
 
-			IL_02de: ldloc.0
-			IL_02df: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_02e4: stloc.s 4
-			IL_02e6: ldloc.s 4
-			IL_02e8: brfalse IL_0323
+			IL_02ce: ldloc.0
+			IL_02cf: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_02d4: stloc.3
+			IL_02d5: ldloc.3
+			IL_02d6: brfalse IL_0311
 
-			IL_02ed: ldloc.0
-			IL_02ee: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_02f3: stloc.s 5
-			IL_02f5: ldloc.0
-			IL_02f6: ldloc.s 5
-			IL_02f8: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_02fd: ldloc.0
-			IL_02fe: ldc.i4.1
-			IL_02ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_0304: ldloc.0
-			IL_0305: ldc.i4.0
-			IL_0306: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_030b: ldloc.0
-			IL_030c: ldc.i4.0
-			IL_030d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0312: ldloc.0
-			IL_0313: ldc.i4.0
-			IL_0314: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0319: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_031e: br IL_036d
+			IL_02db: ldloc.0
+			IL_02dc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_02e1: stloc.s 4
+			IL_02e3: ldloc.0
+			IL_02e4: ldloc.s 4
+			IL_02e6: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_02eb: ldloc.0
+			IL_02ec: ldc.i4.1
+			IL_02ed: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_02f2: ldloc.0
+			IL_02f3: ldc.i4.0
+			IL_02f4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_02f9: ldloc.0
+			IL_02fa: ldc.i4.0
+			IL_02fb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0300: ldloc.0
+			IL_0301: ldc.i4.0
+			IL_0302: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0307: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_030c: br IL_0359
 
-			IL_0323: ldloc.0
-			IL_0324: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0329: stloc.s 4
-			IL_032b: ldloc.s 4
-			IL_032d: brfalse IL_0368
+			IL_0311: ldloc.0
+			IL_0312: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0317: stloc.3
+			IL_0318: ldloc.3
+			IL_0319: brfalse IL_0354
 
-			IL_0332: ldloc.0
-			IL_0333: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0338: stloc.s 5
+			IL_031e: ldloc.0
+			IL_031f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0324: stloc.s 4
+			IL_0326: ldloc.0
+			IL_0327: ldloc.s 4
+			IL_0329: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_032e: ldloc.0
+			IL_032f: ldc.i4.0
+			IL_0330: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0335: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
 			IL_033a: ldloc.0
-			IL_033b: ldloc.s 5
-			IL_033d: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0342: ldloc.0
-			IL_0343: ldc.i4.0
-			IL_0344: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0349: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_034e: ldloc.0
-			IL_034f: ldc.i4.1
-			IL_0350: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_0355: ldloc.0
-			IL_0356: ldc.i4.0
-			IL_0357: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_035c: ldloc.0
-			IL_035d: ldc.i4.0
-			IL_035e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0363: br IL_036d
+			IL_033b: ldc.i4.1
+			IL_033c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0341: ldloc.0
+			IL_0342: ldc.i4.0
+			IL_0343: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0348: ldloc.0
+			IL_0349: ldc.i4.0
+			IL_034a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_034f: br IL_0359
 
-			IL_0368: br IL_036d
+			IL_0354: br IL_0359
 
-			IL_036d: ldstr "console"
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0377: stloc.s 5
-			IL_0379: ldloc.s 5
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0380: stloc.s 5
-			IL_0382: ldloc.s 5
-			IL_0384: ldstr "log"
-			IL_0389: ldstr "outer-finally"
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0393: pop
-			IL_0394: br IL_0399
+			IL_0359: ldstr "console"
+			IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0363: stloc.s 4
+			IL_0365: ldloc.s 4
+			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036c: stloc.s 4
+			IL_036e: ldloc.s 4
+			IL_0370: ldstr "log"
+			IL_0375: ldstr "outer-finally"
+			IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_037f: pop
+			IL_0380: br IL_0385
 
-			IL_0399: ldloc.0
-			IL_039a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_039f: stloc.s 4
-			IL_03a1: ldloc.s 4
-			IL_03a3: brfalse IL_03c7
+			IL_0385: ldloc.0
+			IL_0386: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_038b: stloc.3
+			IL_038c: ldloc.3
+			IL_038d: brfalse IL_03b1
 
-			IL_03a8: ldloc.0
-			IL_03a9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_03ae: isinst [System.Runtime]System.Exception
-			IL_03b3: dup
-			IL_03b4: brtrue IL_03c6
+			IL_0392: ldloc.0
+			IL_0393: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0398: isinst [System.Runtime]System.Exception
+			IL_039d: dup
+			IL_039e: brtrue IL_03b0
 
-			IL_03b9: pop
-			IL_03ba: ldloc.0
-			IL_03bb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_03c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03c5: throw
+			IL_03a3: pop
+			IL_03a4: ldloc.0
+			IL_03a5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_03aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03af: throw
 
-			IL_03c6: throw
+			IL_03b0: throw
 
-			IL_03c7: ldloc.0
-			IL_03c8: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_03cd: stloc.s 4
-			IL_03cf: ldloc.s 4
-			IL_03d1: brfalse IL_03ee
+			IL_03b1: ldloc.0
+			IL_03b2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_03b7: stloc.3
+			IL_03b8: ldloc.3
+			IL_03b9: brfalse IL_03d6
 
-			IL_03d6: ldloc.0
-			IL_03d7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_03dc: stloc.s 5
-			IL_03de: ldloc.0
-			IL_03df: ldc.i4.1
-			IL_03e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_03e5: ldloc.s 5
-			IL_03e7: ldc.i4.1
-			IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_03ed: ret
+			IL_03be: ldloc.0
+			IL_03bf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_03c4: stloc.s 4
+			IL_03c6: ldloc.0
+			IL_03c7: ldc.i4.1
+			IL_03c8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_03cd: ldloc.s 4
+			IL_03cf: ldc.i4.1
+			IL_03d0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_03d5: ret
 
-			IL_03ee: ldstr "console"
-			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f8: stloc.s 5
-			IL_03fa: ldloc.s 5
-			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0401: stloc.s 5
-			IL_0403: ldloc.s 5
-			IL_0405: ldstr "log"
-			IL_040a: ldstr "after-all"
-			IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0414: pop
-			IL_0415: ldloc.0
-			IL_0416: ldc.i4.1
-			IL_0417: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_041c: ldnull
-			IL_041d: ldc.i4.1
-			IL_041e: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0423: ret
+			IL_03d6: ldstr "console"
+			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03e0: stloc.s 4
+			IL_03e2: ldloc.s 4
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e9: stloc.s 4
+			IL_03eb: ldloc.s 4
+			IL_03ed: ldstr "log"
+			IL_03f2: ldstr "after-all"
+			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03fc: pop
+			IL_03fd: ldloc.0
+			IL_03fe: ldc.i4.1
+			IL_03ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0404: ldnull
+			IL_0405: ldc.i4.1
+			IL_0406: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_040b: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -558,7 +555,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2674
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -767,7 +764,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26cb
+		// Method begins at RVA 0x26b3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x252f
+					// Method begins at RVA 0x251f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2538
+					// Method begins at RVA 0x2528
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2541
+					// Method begins at RVA 0x2531
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2526
+				// Method begins at RVA 0x2516
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,19 +104,18 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2294
+			// Method begins at RVA 0x228c
 			// Header size: 12
-			// Code size: 637 (0x27d)
+			// Code size: 629 (0x275)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/Scope,
 				[1] bool,
 				[2] object,
-				[3] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/Scope/Block_L7C14,
-				[4] object,
-				[5] bool,
-				[6] object,
-				[7] object
+				[3] object,
+				[4] bool,
+				[5] object,
+				[6] object
 			)
 
 			IL_0000: ldarg.0
@@ -159,8 +158,8 @@
 			IL_0054: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_started
 			IL_0059: ldloc.0
 			IL_005a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_parameterInitializationOnly
-			IL_005f: stloc.s 5
-			IL_0061: ldloc.s 5
+			IL_005f: stloc.s 4
+			IL_0061: ldloc.s 4
 			IL_0063: brfalse IL_006a
 
 			IL_0068: ldnull
@@ -186,11 +185,11 @@
 			IL_009e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
 			IL_00a3: ldstr "console"
 			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ad: stloc.s 6
-			IL_00af: ldloc.s 6
+			IL_00ad: stloc.s 5
+			IL_00af: ldloc.s 5
 			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b6: stloc.s 6
-			IL_00b8: ldloc.s 6
+			IL_00b6: stloc.s 5
+			IL_00b8: ldloc.s 5
 			IL_00ba: ldstr "log"
 			IL_00bf: ldstr "try"
 			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
@@ -206,15 +205,15 @@
 
 			IL_00e6: ldloc.0
 			IL_00e7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_00ec: stloc.s 5
-			IL_00ee: ldloc.s 5
+			IL_00ec: stloc.s 4
+			IL_00ee: ldloc.s 4
 			IL_00f0: brfalse IL_012b
 
 			IL_00f5: ldloc.0
 			IL_00f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_00fb: stloc.s 6
+			IL_00fb: stloc.s 5
 			IL_00fd: ldloc.0
-			IL_00fe: ldloc.s 6
+			IL_00fe: ldloc.s 5
 			IL_0100: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
 			IL_0105: ldloc.0
 			IL_0106: ldc.i4.1
@@ -229,19 +228,19 @@
 			IL_011b: ldc.i4.0
 			IL_011c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_0121: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0126: br IL_01ed
+			IL_0126: br IL_01e5
 
 			IL_012b: ldloc.0
 			IL_012c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0131: stloc.s 5
-			IL_0133: ldloc.s 5
+			IL_0131: stloc.s 4
+			IL_0133: ldloc.s 4
 			IL_0135: brfalse IL_0170
 
 			IL_013a: ldloc.0
 			IL_013b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0140: stloc.s 6
+			IL_0140: stloc.s 5
 			IL_0142: ldloc.0
-			IL_0143: ldloc.s 6
+			IL_0143: ldloc.s 5
 			IL_0145: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
 			IL_014a: ldloc.0
 			IL_014b: ldc.i4.0
@@ -258,11 +257,11 @@
 			IL_0166: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
 			IL_016b: br IL_0175
 
-			IL_0170: br IL_01ed
+			IL_0170: br IL_01e5
 
 			IL_0175: ldloc.0
 			IL_0176: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_017b: stloc.s 6
+			IL_017b: stloc.s 5
 			IL_017d: ldloc.0
 			IL_017e: ldc.i4.0
 			IL_017f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
@@ -270,97 +269,95 @@
 			IL_0185: ldc.i4.0
 			IL_0186: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_018b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0190: ldloc.s 6
+			IL_0190: ldloc.s 5
 			IL_0192: stloc.2
-			IL_0193: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/Scope/Block_L7C14::.ctor()
-			IL_0198: stloc.3
-			IL_0199: ldstr "console"
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a3: stloc.s 6
-			IL_01a5: ldloc.s 6
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ac: stloc.s 6
-			IL_01ae: ldstr "catch="
-			IL_01b3: ldloc.2
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01b9: stloc.s 7
-			IL_01bb: ldloc.s 6
-			IL_01bd: ldstr "log"
-			IL_01c2: ldloc.s 7
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c9: pop
-			IL_01ca: ldloc.2
-			IL_01cb: stloc.s 4
+			IL_0193: ldstr "console"
+			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_019d: stloc.s 5
+			IL_019f: ldloc.s 5
+			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a6: stloc.s 5
+			IL_01a8: ldstr "catch="
+			IL_01ad: ldloc.2
+			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01b3: stloc.s 6
+			IL_01b5: ldloc.s 5
+			IL_01b7: ldstr "log"
+			IL_01bc: ldloc.s 6
+			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c3: pop
+			IL_01c4: ldloc.2
+			IL_01c5: stloc.3
+			IL_01c6: ldloc.0
+			IL_01c7: ldloc.3
+			IL_01c8: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
 			IL_01cd: ldloc.0
-			IL_01ce: ldloc.s 4
-			IL_01d0: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_01d5: ldloc.0
-			IL_01d6: ldc.i4.1
-			IL_01d7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_01dc: ldloc.0
-			IL_01dd: ldc.i4.0
-			IL_01de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_01e3: br IL_01ed
+			IL_01ce: ldc.i4.1
+			IL_01cf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_01d4: ldloc.0
+			IL_01d5: ldc.i4.0
+			IL_01d6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_01db: br IL_01e5
 
-			IL_01e8: br IL_01ed
+			IL_01e0: br IL_01e5
 
-			IL_01ed: ldstr "console"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f7: stloc.s 6
-			IL_01f9: ldloc.s 6
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0200: stloc.s 6
-			IL_0202: ldloc.s 6
-			IL_0204: ldstr "log"
-			IL_0209: ldstr "finally"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0213: pop
-			IL_0214: br IL_0219
+			IL_01e5: ldstr "console"
+			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ef: stloc.s 5
+			IL_01f1: ldloc.s 5
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f8: stloc.s 5
+			IL_01fa: ldloc.s 5
+			IL_01fc: ldstr "log"
+			IL_0201: ldstr "finally"
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_020b: pop
+			IL_020c: br IL_0211
 
-			IL_0219: ldloc.0
-			IL_021a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
-			IL_021f: stloc.s 5
-			IL_0221: ldloc.s 5
-			IL_0223: brfalse IL_0247
+			IL_0211: ldloc.0
+			IL_0212: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingException
+			IL_0217: stloc.s 4
+			IL_0219: ldloc.s 4
+			IL_021b: brfalse IL_023f
 
-			IL_0228: ldloc.0
-			IL_0229: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_022e: isinst [System.Runtime]System.Exception
-			IL_0233: dup
-			IL_0234: brtrue IL_0246
+			IL_0220: ldloc.0
+			IL_0221: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0226: isinst [System.Runtime]System.Exception
+			IL_022b: dup
+			IL_022c: brtrue IL_023e
 
-			IL_0239: pop
-			IL_023a: ldloc.0
-			IL_023b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
-			IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0245: throw
+			IL_0231: pop
+			IL_0232: ldloc.0
+			IL_0233: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingException
+			IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_023d: throw
 
-			IL_0246: throw
+			IL_023e: throw
 
-			IL_0247: ldloc.0
-			IL_0248: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
-			IL_024d: stloc.s 5
-			IL_024f: ldloc.s 5
-			IL_0251: brfalse IL_026e
+			IL_023f: ldloc.0
+			IL_0240: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasGenPendingReturn
+			IL_0245: stloc.s 4
+			IL_0247: ldloc.s 4
+			IL_0249: brfalse IL_0266
 
+			IL_024e: ldloc.0
+			IL_024f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
+			IL_0254: stloc.s 5
 			IL_0256: ldloc.0
-			IL_0257: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genPendingReturnValue
-			IL_025c: stloc.s 6
-			IL_025e: ldloc.0
+			IL_0257: ldc.i4.1
+			IL_0258: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_025d: ldloc.s 5
 			IL_025f: ldc.i4.1
-			IL_0260: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0265: ldloc.s 6
-			IL_0267: ldc.i4.1
-			IL_0268: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_026d: ret
+			IL_0260: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0265: ret
 
-			IL_026e: ldloc.0
-			IL_026f: ldc.i4.1
-			IL_0270: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0275: ldnull
-			IL_0276: ldc.i4.1
-			IL_0277: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_027c: ret
+			IL_0266: ldloc.0
+			IL_0267: ldc.i4.1
+			IL_0268: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_026d: ldnull
+			IL_026e: ldc.i4.1
+			IL_026f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0274: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -379,7 +376,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x254a
+				// Method begins at RVA 0x253a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -399,7 +396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2553
+				// Method begins at RVA 0x2543
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -420,7 +417,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x251d
+			// Method begins at RVA 0x250d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -446,7 +443,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 549 (0x225)
+		// Code size: 542 (0x21e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope,
@@ -456,11 +453,10 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope/Block_L24C12,
+			[7] object,
 			[8] object,
 			[9] object,
-			[10] object,
-			[11] object
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope::.ctor()
@@ -480,58 +476,58 @@
 		IL_0023: ldc.i4.1
 		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002e: stloc.s 10
-		IL_0030: ldloc.s 10
+		IL_002e: stloc.s 9
+		IL_0030: ldloc.s 9
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: nop
 		IL_0035: ldloc.1
 		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0040: stloc.s 10
-		IL_0042: ldloc.s 10
+		IL_0040: stloc.s 9
+		IL_0042: ldloc.s 9
 		IL_0044: stloc.2
 		IL_0045: ldloc.2
 		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004b: stloc.s 10
-		IL_004d: ldloc.s 10
+		IL_004b: stloc.s 9
+		IL_004d: ldloc.s 9
 		IL_004f: ldstr "next"
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0059: stloc.s 10
-		IL_005b: ldloc.s 10
+		IL_0059: stloc.s 9
+		IL_005b: ldloc.s 9
 		IL_005d: stloc.3
 		IL_005e: ldstr "console"
 		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0068: stloc.s 10
-		IL_006a: ldloc.s 10
+		IL_0068: stloc.s 9
+		IL_006a: ldloc.s 9
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0071: stloc.s 10
+		IL_0071: stloc.s 9
 		IL_0073: ldstr "r1.value="
 		IL_0078: ldloc.3
 		IL_0079: ldstr "value"
 		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0088: stloc.s 11
-		IL_008a: ldloc.s 10
+		IL_0088: stloc.s 10
+		IL_008a: ldloc.s 9
 		IL_008c: ldstr "log"
-		IL_0091: ldloc.s 11
+		IL_0091: ldloc.s 10
 		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0098: pop
 		IL_0099: ldstr "console"
 		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: stloc.s 10
-		IL_00a5: ldloc.s 10
+		IL_00a3: stloc.s 9
+		IL_00a5: ldloc.s 9
 		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 10
+		IL_00ac: stloc.s 9
 		IL_00ae: ldstr "r1.done="
 		IL_00b3: ldloc.3
 		IL_00b4: ldstr "done"
 		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00c3: stloc.s 11
-		IL_00c5: ldloc.s 10
+		IL_00c3: stloc.s 10
+		IL_00c5: ldloc.s 9
 		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 11
+		IL_00cc: ldloc.s 10
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d3: pop
 		.try
@@ -539,24 +535,24 @@
 			IL_00d4: nop
 			IL_00d5: ldloc.2
 			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00db: stloc.s 10
-			IL_00dd: ldloc.s 10
+			IL_00db: stloc.s 9
+			IL_00dd: ldloc.s 9
 			IL_00df: ldstr "throw"
 			IL_00e4: ldstr "boom"
 			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00ee: pop
 			IL_00ef: ldstr "console"
 			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f9: stloc.s 10
-			IL_00fb: ldloc.s 10
+			IL_00f9: stloc.s 9
+			IL_00fb: ldloc.s 9
 			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0102: stloc.s 10
-			IL_0104: ldloc.s 10
+			IL_0102: stloc.s 9
+			IL_0104: ldloc.s 9
 			IL_0106: ldstr "log"
 			IL_010b: ldstr "throw-returned"
 			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0115: pop
-			IL_0116: leave IL_018f
+			IL_0116: leave IL_0188
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -582,75 +578,73 @@
 			IL_0147: stloc.s 5
 
 			IL_0149: ldloc.s 5
-			IL_014b: stloc.s 10
-			IL_014d: ldloc.s 10
+			IL_014b: stloc.s 9
+			IL_014d: ldloc.s 9
 			IL_014f: stloc.s 6
-			IL_0151: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope/Block_L24C12::.ctor()
-			IL_0156: stloc.s 7
-			IL_0158: ldstr "console"
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0162: stloc.s 10
-			IL_0164: ldloc.s 10
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016b: stloc.s 10
-			IL_016d: ldstr "caught="
-			IL_0172: ldloc.s 6
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0179: stloc.s 11
+			IL_0151: ldstr "console"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015b: stloc.s 9
+			IL_015d: ldloc.s 9
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0164: stloc.s 9
+			IL_0166: ldstr "caught="
+			IL_016b: ldloc.s 6
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0172: stloc.s 10
+			IL_0174: ldloc.s 9
+			IL_0176: ldstr "log"
 			IL_017b: ldloc.s 10
-			IL_017d: ldstr "log"
-			IL_0182: ldloc.s 11
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0189: pop
-			IL_018a: leave IL_018f
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0182: pop
+			IL_0183: leave IL_0188
 		} // end handler
 
-		IL_018f: ldloc.2
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 10
-		IL_0197: ldloc.s 10
-		IL_0199: ldstr "next"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_01a3: stloc.s 10
-		IL_01a5: ldloc.s 10
-		IL_01a7: stloc.s 8
-		IL_01a9: ldstr "console"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b3: stloc.s 10
-		IL_01b5: ldloc.s 10
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bc: stloc.s 10
-		IL_01be: ldstr "r2.value="
-		IL_01c3: ldloc.s 8
-		IL_01c5: ldstr "value"
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01d4: stloc.s 11
+		IL_0188: ldloc.2
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018e: stloc.s 9
+		IL_0190: ldloc.s 9
+		IL_0192: ldstr "next"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_019c: stloc.s 9
+		IL_019e: ldloc.s 9
+		IL_01a0: stloc.s 7
+		IL_01a2: ldstr "console"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ac: stloc.s 9
+		IL_01ae: ldloc.s 9
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: stloc.s 9
+		IL_01b7: ldstr "r2.value="
+		IL_01bc: ldloc.s 7
+		IL_01be: ldstr "value"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01cd: stloc.s 10
+		IL_01cf: ldloc.s 9
+		IL_01d1: ldstr "log"
 		IL_01d6: ldloc.s 10
-		IL_01d8: ldstr "log"
-		IL_01dd: ldloc.s 11
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01e4: pop
-		IL_01e5: ldstr "console"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ef: stloc.s 10
-		IL_01f1: ldloc.s 10
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f8: stloc.s 10
-		IL_01fa: ldstr "r2.done="
-		IL_01ff: ldloc.s 8
-		IL_0201: ldstr "done"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0210: stloc.s 11
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01dd: pop
+		IL_01de: ldstr "console"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e8: stloc.s 9
+		IL_01ea: ldloc.s 9
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f1: stloc.s 9
+		IL_01f3: ldstr "r2.done="
+		IL_01f8: ldloc.s 7
+		IL_01fa: ldstr "done"
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0209: stloc.s 10
+		IL_020b: ldloc.s 9
+		IL_020d: ldstr "log"
 		IL_0212: ldloc.s 10
-		IL_0214: ldstr "log"
-		IL_0219: ldloc.s 11
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0220: pop
-		IL_0221: ldnull
-		IL_0222: stloc.s 9
-		IL_0224: ret
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0219: pop
+		IL_021a: ldnull
+		IL_021b: stloc.s 8
+		IL_021d: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow
@@ -662,7 +656,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x255c
+		// Method begins at RVA 0x254c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24c2
+					// Method begins at RVA 0x24ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24cb
+					// Method begins at RVA 0x24c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b9
+				// Method begins at RVA 0x24b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2294
+			// Method begins at RVA 0x228c
 			// Header size: 12
 			// Code size: 528 (0x210)
 			.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d4
+				// Method begins at RVA 0x24cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24dd
+				// Method begins at RVA 0x24d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -363,7 +363,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b0
+			// Method begins at RVA 0x24a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -389,7 +389,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 549 (0x225)
+		// Code size: 542 (0x21e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ThrowWhileSuspended/Scope,
@@ -399,11 +399,10 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Generator_TryFinally_ThrowWhileSuspended/Scope/Block_L22C12,
+			[7] object,
 			[8] object,
 			[9] object,
-			[10] object,
-			[11] object
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/Scope::.ctor()
@@ -423,58 +422,58 @@
 		IL_0023: ldc.i4.1
 		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002e: stloc.s 10
-		IL_0030: ldloc.s 10
+		IL_002e: stloc.s 9
+		IL_0030: ldloc.s 9
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: nop
 		IL_0035: ldloc.1
 		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0040: stloc.s 10
-		IL_0042: ldloc.s 10
+		IL_0040: stloc.s 9
+		IL_0042: ldloc.s 9
 		IL_0044: stloc.2
 		IL_0045: ldloc.2
 		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004b: stloc.s 10
-		IL_004d: ldloc.s 10
+		IL_004b: stloc.s 9
+		IL_004d: ldloc.s 9
 		IL_004f: ldstr "next"
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0059: stloc.s 10
-		IL_005b: ldloc.s 10
+		IL_0059: stloc.s 9
+		IL_005b: ldloc.s 9
 		IL_005d: stloc.3
 		IL_005e: ldstr "console"
 		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0068: stloc.s 10
-		IL_006a: ldloc.s 10
+		IL_0068: stloc.s 9
+		IL_006a: ldloc.s 9
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0071: stloc.s 10
+		IL_0071: stloc.s 9
 		IL_0073: ldstr "r1.value="
 		IL_0078: ldloc.3
 		IL_0079: ldstr "value"
 		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0088: stloc.s 11
-		IL_008a: ldloc.s 10
+		IL_0088: stloc.s 10
+		IL_008a: ldloc.s 9
 		IL_008c: ldstr "log"
-		IL_0091: ldloc.s 11
+		IL_0091: ldloc.s 10
 		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0098: pop
 		IL_0099: ldstr "console"
 		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: stloc.s 10
-		IL_00a5: ldloc.s 10
+		IL_00a3: stloc.s 9
+		IL_00a5: ldloc.s 9
 		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 10
+		IL_00ac: stloc.s 9
 		IL_00ae: ldstr "r1.done="
 		IL_00b3: ldloc.3
 		IL_00b4: ldstr "done"
 		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00c3: stloc.s 11
-		IL_00c5: ldloc.s 10
+		IL_00c3: stloc.s 10
+		IL_00c5: ldloc.s 9
 		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 11
+		IL_00cc: ldloc.s 10
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d3: pop
 		.try
@@ -482,24 +481,24 @@
 			IL_00d4: nop
 			IL_00d5: ldloc.2
 			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00db: stloc.s 10
-			IL_00dd: ldloc.s 10
+			IL_00db: stloc.s 9
+			IL_00dd: ldloc.s 9
 			IL_00df: ldstr "throw"
 			IL_00e4: ldstr "boom"
 			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00ee: pop
 			IL_00ef: ldstr "console"
 			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f9: stloc.s 10
-			IL_00fb: ldloc.s 10
+			IL_00f9: stloc.s 9
+			IL_00fb: ldloc.s 9
 			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0102: stloc.s 10
-			IL_0104: ldloc.s 10
+			IL_0102: stloc.s 9
+			IL_0104: ldloc.s 9
 			IL_0106: ldstr "log"
 			IL_010b: ldstr "throw-returned"
 			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0115: pop
-			IL_0116: leave IL_018f
+			IL_0116: leave IL_0188
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -525,75 +524,73 @@
 			IL_0147: stloc.s 5
 
 			IL_0149: ldloc.s 5
-			IL_014b: stloc.s 10
-			IL_014d: ldloc.s 10
+			IL_014b: stloc.s 9
+			IL_014d: ldloc.s 9
 			IL_014f: stloc.s 6
-			IL_0151: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/Scope/Block_L22C12::.ctor()
-			IL_0156: stloc.s 7
-			IL_0158: ldstr "console"
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0162: stloc.s 10
-			IL_0164: ldloc.s 10
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016b: stloc.s 10
-			IL_016d: ldstr "caught="
-			IL_0172: ldloc.s 6
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0179: stloc.s 11
+			IL_0151: ldstr "console"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015b: stloc.s 9
+			IL_015d: ldloc.s 9
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0164: stloc.s 9
+			IL_0166: ldstr "caught="
+			IL_016b: ldloc.s 6
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0172: stloc.s 10
+			IL_0174: ldloc.s 9
+			IL_0176: ldstr "log"
 			IL_017b: ldloc.s 10
-			IL_017d: ldstr "log"
-			IL_0182: ldloc.s 11
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0189: pop
-			IL_018a: leave IL_018f
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0182: pop
+			IL_0183: leave IL_0188
 		} // end handler
 
-		IL_018f: ldloc.2
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 10
-		IL_0197: ldloc.s 10
-		IL_0199: ldstr "next"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_01a3: stloc.s 10
-		IL_01a5: ldloc.s 10
-		IL_01a7: stloc.s 8
-		IL_01a9: ldstr "console"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b3: stloc.s 10
-		IL_01b5: ldloc.s 10
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bc: stloc.s 10
-		IL_01be: ldstr "r2.value="
-		IL_01c3: ldloc.s 8
-		IL_01c5: ldstr "value"
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01d4: stloc.s 11
+		IL_0188: ldloc.2
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018e: stloc.s 9
+		IL_0190: ldloc.s 9
+		IL_0192: ldstr "next"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_019c: stloc.s 9
+		IL_019e: ldloc.s 9
+		IL_01a0: stloc.s 7
+		IL_01a2: ldstr "console"
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ac: stloc.s 9
+		IL_01ae: ldloc.s 9
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: stloc.s 9
+		IL_01b7: ldstr "r2.value="
+		IL_01bc: ldloc.s 7
+		IL_01be: ldstr "value"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01cd: stloc.s 10
+		IL_01cf: ldloc.s 9
+		IL_01d1: ldstr "log"
 		IL_01d6: ldloc.s 10
-		IL_01d8: ldstr "log"
-		IL_01dd: ldloc.s 11
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01e4: pop
-		IL_01e5: ldstr "console"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ef: stloc.s 10
-		IL_01f1: ldloc.s 10
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f8: stloc.s 10
-		IL_01fa: ldstr "r2.done="
-		IL_01ff: ldloc.s 8
-		IL_0201: ldstr "done"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0210: stloc.s 11
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01dd: pop
+		IL_01de: ldstr "console"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e8: stloc.s 9
+		IL_01ea: ldloc.s 9
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f1: stloc.s 9
+		IL_01f3: ldstr "r2.done="
+		IL_01f8: ldloc.s 7
+		IL_01fa: ldstr "done"
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0209: stloc.s 10
+		IL_020b: ldloc.s 9
+		IL_020d: ldstr "log"
 		IL_0212: ldloc.s 10
-		IL_0214: ldstr "log"
-		IL_0219: ldloc.s 11
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0220: pop
-		IL_0221: ldnull
-		IL_0222: stloc.s 9
-		IL_0224: ret
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0219: pop
+		IL_021a: ldnull
+		IL_021b: stloc.s 8
+		IL_021d: ret
 	} // end of method Generator_TryFinally_ThrowWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ThrowWhileSuspended
@@ -605,7 +602,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24e6
+		// Method begins at RVA 0x24de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/HIRBlockScopeElisionTests.cs
+++ b/tests/Jroc.Tests/HIRBlockScopeElisionTests.cs
@@ -30,15 +30,31 @@ public class HIRBlockScopeElisionTests
     }
 
     [Fact]
-    public void TryParseMethod_BlockWithLexicalBinding_RequestsScopeInstance()
+    public void TryParseMethod_BlockWithUncapturedLexicalBindings_DoesNotRequestScopeInstance()
     {
         var (method, _) = ParseFunctionExpression("""
             var findGraphNode = function(obj) {
                 for (var i = 0; i < this.length; i++) {
-                    let current = this[i];
-                    if (current.pos == obj.pos) { return current; }
+                    const step = i * 2;
+                    const start = step + 1;
+                    if (start == obj.pos) { return step; }
                 }
                 return false;
+            };
+            """);
+
+        Assert.All(EnumerateBlocks(method.Body), block => Assert.Null(block.ScopeName));
+    }
+
+    [Fact]
+    public void TryParseMethod_BlockWithCapturedLexicalBinding_RequestsScopeInstance()
+    {
+        var (method, _) = ParseFunctionExpression("""
+            var makeReader = function() {
+                {
+                    let current = 42;
+                    return () => current;
+                }
             };
             """);
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2dec
+					// Method begins at RVA 0x2de4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -208,7 +208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2de3
+				// Method begins at RVA 0x2ddb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -309,7 +309,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2df5
+				// Method begins at RVA 0x2ded
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -404,7 +404,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2dda
+			// Method begins at RVA 0x2dd2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -527,7 +527,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e12
+				// Method begins at RVA 0x2e0a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -583,7 +583,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e1b
+				// Method begins at RVA 0x2e13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -632,7 +632,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e24
+				// Method begins at RVA 0x2e1c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -681,7 +681,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e2d
+				// Method begins at RVA 0x2e25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -745,7 +745,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e36
+				// Method begins at RVA 0x2e2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -805,7 +805,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e48
+					// Method begins at RVA 0x2e40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -823,7 +823,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e3f
+				// Method begins at RVA 0x2e37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -928,7 +928,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e51
+				// Method begins at RVA 0x2e49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1033,7 +1033,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e5a
+				// Method begins at RVA 0x2e52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1086,7 +1086,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e87
+					// Method begins at RVA 0x2e7f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1110,7 +1110,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d04
+				// Method begins at RVA 0x2cfc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1136,7 +1136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e90
+					// Method begins at RVA 0x2e88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1160,7 +1160,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d13
+				// Method begins at RVA 0x2d0b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1190,7 +1190,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ebd
+						// Method begins at RVA 0x2eb5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1214,7 +1214,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2db9
+					// Method begins at RVA 0x2db1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -1248,7 +1248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2eb4
+					// Method begins at RVA 0x2eac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1273,7 +1273,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d24
+				// Method begins at RVA 0x2d1c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -1366,7 +1366,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e6c
+					// Method begins at RVA 0x2e64
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1386,7 +1386,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e75
+					// Method begins at RVA 0x2e6d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1406,7 +1406,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e7e
+					// Method begins at RVA 0x2e76
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1430,7 +1430,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ea2
+						// Method begins at RVA 0x2e9a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1450,7 +1450,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2eab
+						// Method begins at RVA 0x2ea3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1468,7 +1468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e99
+					// Method begins at RVA 0x2e91
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1488,7 +1488,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ec6
+					// Method begins at RVA 0x2ebe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1508,7 +1508,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ecf
+					// Method begins at RVA 0x2ec7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1530,7 +1530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e63
+				// Method begins at RVA 0x2e5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1559,7 +1559,7 @@
 			)
 			// Method begins at RVA 0x2794
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope,
@@ -1568,10 +1568,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope/Block_L61C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -1579,12 +1579,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -1594,45 +1593,45 @@
 			IL_0008: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -1641,19 +1640,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -1661,14 +1660,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -1676,28 +1675,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -1715,31 +1714,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -1753,7 +1752,7 @@
 			IL_01d2: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -1772,7 +1771,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1784,17 +1783,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1813,7 +1812,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1825,12 +1824,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1840,122 +1839,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1978,22 +1977,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -2003,8 +2002,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -2026,7 +2025,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -2052,22 +2051,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope/Block_L61C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -2083,7 +2080,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ed8
+				// Method begins at RVA 0x2ed0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2111,7 +2108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2ca8
+			// Method begins at RVA 0x2ca0
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -2180,7 +2177,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2dfe
+			// Method begins at RVA 0x2df6
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2453,7 +2450,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ee1
+		// Method begins at RVA 0x2ed9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3367
+					// Method begins at RVA 0x3357
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x335e
+				// Method begins at RVA 0x334e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3370
+				// Method begins at RVA 0x3360
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3379
+				// Method begins at RVA 0x3369
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a6
+					// Method begins at RVA 0x3396
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ac0
+				// Method begins at RVA 0x2ab8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33af
+					// Method begins at RVA 0x339f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2acf
+				// Method begins at RVA 0x2ac7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33dc
+						// Method begins at RVA 0x33cc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2b75
+					// Method begins at RVA 0x2b6d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d3
+					// Method begins at RVA 0x33c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ae0
+				// Method begins at RVA 0x2ad8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x338b
+					// Method begins at RVA 0x337b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3394
+					// Method begins at RVA 0x3384
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x339d
+					// Method begins at RVA 0x338d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33c1
+						// Method begins at RVA 0x33b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33ca
+						// Method begins at RVA 0x33ba
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33b8
+					// Method begins at RVA 0x33a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33e5
+					// Method begins at RVA 0x33d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ee
+					// Method begins at RVA 0x33de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3382
+				// Method begins at RVA 0x3372
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x2550
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope/Block_L54C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope/Block_L54C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33f7
+				// Method begins at RVA 0x33e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2a64
+			// Method begins at RVA 0x2a5c
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3355
+			// Method begins at RVA 0x3345
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1606,7 +1603,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3409
+				// Method begins at RVA 0x33f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1632,7 +1629,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2b96
+			// Method begins at RVA 0x2b8e
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -1657,7 +1654,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3412
+				// Method begins at RVA 0x3402
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1683,7 +1680,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2ba8
+			// Method begins at RVA 0x2ba0
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -1712,7 +1709,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3424
+					// Method begins at RVA 0x3414
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1730,7 +1727,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x341b
+				// Method begins at RVA 0x340b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1756,7 +1753,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2bbc
+			// Method begins at RVA 0x2bb4
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -1835,7 +1832,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x342d
+				// Method begins at RVA 0x341d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1859,7 +1856,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c5c
+			// Method begins at RVA 0x2c54
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -1940,7 +1937,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3436
+				// Method begins at RVA 0x3426
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1965,7 +1962,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cec
+			// Method begins at RVA 0x2ce4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1993,7 +1990,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3463
+					// Method begins at RVA 0x3453
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2017,7 +2014,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3268
+				// Method begins at RVA 0x3258
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2043,7 +2040,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x346c
+					// Method begins at RVA 0x345c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2067,7 +2064,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3277
+				// Method begins at RVA 0x3267
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2097,7 +2094,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3499
+						// Method begins at RVA 0x3489
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2121,7 +2118,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x331d
+					// Method begins at RVA 0x330d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2155,7 +2152,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3490
+					// Method begins at RVA 0x3480
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2180,7 +2177,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3288
+				// Method begins at RVA 0x3278
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2273,7 +2270,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3448
+					// Method begins at RVA 0x3438
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2293,7 +2290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3451
+					// Method begins at RVA 0x3441
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2313,7 +2310,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x345a
+					// Method begins at RVA 0x344a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2337,7 +2334,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x347e
+						// Method begins at RVA 0x346e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2357,7 +2354,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3487
+						// Method begins at RVA 0x3477
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2375,7 +2372,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3475
+					// Method begins at RVA 0x3465
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2395,7 +2392,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a2
+					// Method begins at RVA 0x3492
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2415,7 +2412,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ab
+					// Method begins at RVA 0x349b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2437,7 +2434,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343f
+				// Method begins at RVA 0x342f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2464,9 +2461,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2cf8
+			// Method begins at RVA 0x2cf0
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope,
@@ -2475,10 +2472,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope/Block_L53C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2486,12 +2483,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -2501,45 +2497,45 @@
 			IL_0008: stfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2548,19 +2544,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2568,14 +2564,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2583,28 +2579,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2622,31 +2618,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2660,7 +2656,7 @@
 			IL_01d2: stfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -2679,7 +2675,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -2691,17 +2687,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -2720,7 +2716,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -2732,12 +2728,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -2747,122 +2743,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -2885,22 +2881,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -2910,8 +2906,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -2933,7 +2929,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -2959,22 +2955,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope/Block_L53C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -2990,7 +2984,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b4
+				// Method begins at RVA 0x34a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3018,7 +3012,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x320c
+			// Method begins at RVA 0x31fc
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3082,7 +3076,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3400
+			// Method begins at RVA 0x33f0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3295,7 +3289,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34c6
+				// Method begins at RVA 0x34b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3319,7 +3313,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x333e
+			// Method begins at RVA 0x332e
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -3341,7 +3335,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x34bd
+			// Method begins at RVA 0x34ad
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3419,7 +3413,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x34cf
+		// Method begins at RVA 0x34bf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x354b
+					// Method begins at RVA 0x353b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3542
+				// Method begins at RVA 0x3532
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3554
+				// Method begins at RVA 0x3544
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x355d
+				// Method begins at RVA 0x354d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x358a
+					// Method begins at RVA 0x357a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c58
+				// Method begins at RVA 0x2c50
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3593
+					// Method begins at RVA 0x3583
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c67
+				// Method begins at RVA 0x2c5f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35c0
+						// Method begins at RVA 0x35b0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2d0d
+					// Method begins at RVA 0x2d05
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35b7
+					// Method begins at RVA 0x35a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c78
+				// Method begins at RVA 0x2c70
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x356f
+					// Method begins at RVA 0x355f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3578
+					// Method begins at RVA 0x3568
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3581
+					// Method begins at RVA 0x3571
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35a5
+						// Method begins at RVA 0x3595
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35ae
+						// Method begins at RVA 0x359e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x359c
+					// Method begins at RVA 0x358c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35c9
+					// Method begins at RVA 0x35b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35d2
+					// Method begins at RVA 0x35c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3566
+				// Method begins at RVA 0x3556
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x26e8
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope/Block_L56C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope/Block_L56C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35db
+				// Method begins at RVA 0x35cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2bfc
+			// Method begins at RVA 0x2bf4
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3539
+			// Method begins at RVA 0x3529
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1642,7 +1639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3623
+					// Method begins at RVA 0x3613
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1660,7 +1657,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x361a
+				// Method begins at RVA 0x360a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1686,7 +1683,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2d30
+			// Method begins at RVA 0x2d28
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -1765,7 +1762,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x362c
+				// Method begins at RVA 0x361c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1789,7 +1786,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dd0
+			// Method begins at RVA 0x2dc8
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -1870,7 +1867,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3635
+				// Method begins at RVA 0x3625
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1895,7 +1892,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e60
+			// Method begins at RVA 0x2e58
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1923,7 +1920,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3662
+					// Method begins at RVA 0x3652
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1947,7 +1944,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3440
+				// Method begins at RVA 0x3430
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1973,7 +1970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x366b
+					// Method begins at RVA 0x365b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1997,7 +1994,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x344f
+				// Method begins at RVA 0x343f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2027,7 +2024,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3698
+						// Method begins at RVA 0x3688
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2051,7 +2048,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3515
+					// Method begins at RVA 0x3505
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2085,7 +2082,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x368f
+					// Method begins at RVA 0x367f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2110,7 +2107,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3480
+				// Method begins at RVA 0x3470
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2203,7 +2200,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3647
+					// Method begins at RVA 0x3637
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2223,7 +2220,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3650
+					// Method begins at RVA 0x3640
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2243,7 +2240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3659
+					// Method begins at RVA 0x3649
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2267,7 +2264,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x367d
+						// Method begins at RVA 0x366d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2287,7 +2284,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3686
+						// Method begins at RVA 0x3676
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2305,7 +2302,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3674
+					// Method begins at RVA 0x3664
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2325,7 +2322,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36a1
+					// Method begins at RVA 0x3691
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2345,7 +2342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36aa
+					// Method begins at RVA 0x369a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2367,7 +2364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x363e
+				// Method begins at RVA 0x362e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2394,9 +2391,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2e6c
+			// Method begins at RVA 0x2e64
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope,
@@ -2405,10 +2402,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope/Block_L56C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2416,12 +2413,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -2431,45 +2427,45 @@
 			IL_0008: stfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2478,19 +2474,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2498,14 +2494,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2513,28 +2509,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2552,31 +2548,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2590,7 +2586,7 @@
 			IL_01d2: stfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -2609,7 +2605,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -2621,17 +2617,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -2650,7 +2646,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -2662,12 +2658,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -2677,122 +2673,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -2815,22 +2811,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -2840,8 +2836,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -2863,7 +2859,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -2889,22 +2885,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope/Block_L56C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -2920,7 +2914,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b3
+				// Method begins at RVA 0x36a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2948,7 +2942,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3380
+			// Method begins at RVA 0x3370
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3007,7 +3001,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3611
+					// Method begins at RVA 0x3601
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3031,7 +3025,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x345e
+				// Method begins at RVA 0x344e
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -3066,7 +3060,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3608
+				// Method begins at RVA 0x35f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3093,7 +3087,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x33dc
+			// Method begins at RVA 0x33cc
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -3170,7 +3164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35f6
+					// Method begins at RVA 0x35e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3190,7 +3184,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35ff
+					// Method begins at RVA 0x35ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3208,7 +3202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ed
+				// Method begins at RVA 0x35dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3235,7 +3229,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35e4
+			// Method begins at RVA 0x35d4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3546,7 +3540,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c5
+				// Method begins at RVA 0x36b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3569,7 +3563,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3536
+			// Method begins at RVA 0x3526
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -3594,7 +3588,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x36bc
+			// Method begins at RVA 0x36ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3690,7 +3684,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x36ce
+		// Method begins at RVA 0x36be
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48c0
+					// Method begins at RVA 0x48a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48b7
+				// Method begins at RVA 0x4897
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48c9
+				// Method begins at RVA 0x48a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48d2
+				// Method begins at RVA 0x48b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48ff
+					// Method begins at RVA 0x48df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fe4
+				// Method begins at RVA 0x2fdc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4908
+					// Method begins at RVA 0x48e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ff3
+				// Method begins at RVA 0x2feb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4935
+						// Method begins at RVA 0x4915
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3099
+					// Method begins at RVA 0x3091
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x492c
+					// Method begins at RVA 0x490c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3004
+				// Method begins at RVA 0x2ffc
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48e4
+					// Method begins at RVA 0x48c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48ed
+					// Method begins at RVA 0x48cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48f6
+					// Method begins at RVA 0x48d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x491a
+						// Method begins at RVA 0x48fa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4923
+						// Method begins at RVA 0x4903
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4911
+					// Method begins at RVA 0x48f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x493e
+					// Method begins at RVA 0x491e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4947
+					// Method begins at RVA 0x4927
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48db
+				// Method begins at RVA 0x48bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x2a74
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope/Block_L55C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope/Block_L55C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4950
+				// Method begins at RVA 0x4930
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x2f88
+			// Method begins at RVA 0x2f80
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x48ae
+			// Method begins at RVA 0x488e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1617,7 +1614,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4998
+					// Method begins at RVA 0x4978
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1635,7 +1632,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x498f
+				// Method begins at RVA 0x496f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1661,7 +1658,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x30bc
+			// Method begins at RVA 0x30b4
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -1740,7 +1737,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49a1
+				// Method begins at RVA 0x4981
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1764,7 +1761,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x315c
+			// Method begins at RVA 0x3154
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -1845,7 +1842,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49aa
+				// Method begins at RVA 0x498a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1870,7 +1867,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31ec
+			// Method begins at RVA 0x31e4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1898,7 +1895,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49d7
+					// Method begins at RVA 0x49b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1922,7 +1919,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37cc
+				// Method begins at RVA 0x37bc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1948,7 +1945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49e0
+					// Method begins at RVA 0x49c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1972,7 +1969,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37db
+				// Method begins at RVA 0x37cb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2002,7 +1999,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4a0d
+						// Method begins at RVA 0x49ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2026,7 +2023,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x38a1
+					// Method begins at RVA 0x3891
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2060,7 +2057,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a04
+					// Method begins at RVA 0x49e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2085,7 +2082,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x380c
+				// Method begins at RVA 0x37fc
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2178,7 +2175,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49bc
+					// Method begins at RVA 0x499c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2198,7 +2195,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49c5
+					// Method begins at RVA 0x49a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2218,7 +2215,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49ce
+					// Method begins at RVA 0x49ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2242,7 +2239,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x49f2
+						// Method begins at RVA 0x49d2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2262,7 +2259,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x49fb
+						// Method begins at RVA 0x49db
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2280,7 +2277,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49e9
+					// Method begins at RVA 0x49c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2300,7 +2297,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a16
+					// Method begins at RVA 0x49f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2320,7 +2317,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a1f
+					// Method begins at RVA 0x49ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2342,7 +2339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49b3
+				// Method begins at RVA 0x4993
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2369,9 +2366,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x31f8
+			// Method begins at RVA 0x31f0
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope,
@@ -2380,10 +2377,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope/Block_L56C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2391,12 +2388,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::.ctor()
@@ -2406,45 +2402,45 @@
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2453,19 +2449,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2473,14 +2469,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2488,28 +2484,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2527,31 +2523,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2565,7 +2561,7 @@
 			IL_01d2: stfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -2584,7 +2580,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -2596,17 +2592,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -2625,7 +2621,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -2637,12 +2633,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -2652,122 +2648,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -2790,22 +2786,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -2815,8 +2811,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -2838,7 +2834,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -2864,22 +2860,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope/Block_L56C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -2895,7 +2889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a28
+				// Method begins at RVA 0x4a08
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2923,7 +2917,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x370c
+			// Method begins at RVA 0x36fc
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -2982,7 +2976,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4986
+					// Method begins at RVA 0x4966
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3006,7 +3000,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37ea
+				// Method begins at RVA 0x37da
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -3041,7 +3035,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x497d
+				// Method begins at RVA 0x495d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3068,7 +3062,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3768
+			// Method begins at RVA 0x3758
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -3145,7 +3139,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x496b
+					// Method begins at RVA 0x494b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3165,7 +3159,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4974
+					// Method begins at RVA 0x4954
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3183,7 +3177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4962
+				// Method begins at RVA 0x4942
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3210,7 +3204,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4959
+			// Method begins at RVA 0x4939
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3521,7 +3515,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a45
+				// Method begins at RVA 0x4a25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3547,7 +3541,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x38c4
+			// Method begins at RVA 0x38b4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3581,7 +3575,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a84
+					// Method begins at RVA 0x4a64
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3599,7 +3593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a7b
+				// Method begins at RVA 0x4a5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3625,7 +3619,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x38e4
+			// Method begins at RVA 0x38d4
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -3704,7 +3698,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a8d
+				// Method begins at RVA 0x4a6d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3728,7 +3722,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3984
+			// Method begins at RVA 0x3974
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3809,7 +3803,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a96
+				// Method begins at RVA 0x4a76
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3834,7 +3828,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3a14
+			// Method begins at RVA 0x3a04
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3862,7 +3856,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ac3
+					// Method begins at RVA 0x4aa3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3886,7 +3880,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ff4
+				// Method begins at RVA 0x3fdc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3912,7 +3906,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4acc
+					// Method begins at RVA 0x4aac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3936,7 +3930,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4003
+				// Method begins at RVA 0x3feb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3966,7 +3960,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4af9
+						// Method begins at RVA 0x4ad9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3990,7 +3984,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x40c9
+					// Method begins at RVA 0x40b1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -4024,7 +4018,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4af0
+					// Method begins at RVA 0x4ad0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4049,7 +4043,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4034
+				// Method begins at RVA 0x401c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4142,7 +4136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4aa8
+					// Method begins at RVA 0x4a88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4162,7 +4156,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ab1
+					// Method begins at RVA 0x4a91
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4182,7 +4176,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4aba
+					// Method begins at RVA 0x4a9a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4206,7 +4200,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ade
+						// Method begins at RVA 0x4abe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4226,7 +4220,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ae7
+						// Method begins at RVA 0x4ac7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4244,7 +4238,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ad5
+					// Method begins at RVA 0x4ab5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4264,7 +4258,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b02
+					// Method begins at RVA 0x4ae2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4284,7 +4278,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b0b
+					// Method begins at RVA 0x4aeb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4306,7 +4300,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a9f
+				// Method begins at RVA 0x4a7f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4333,9 +4327,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3a20
+			// Method begins at RVA 0x3a10
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope,
@@ -4344,10 +4338,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope/Block_L58C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -4355,12 +4349,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -4370,45 +4363,45 @@
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -4417,19 +4410,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -4437,14 +4430,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -4452,28 +4445,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -4491,31 +4484,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -4529,7 +4522,7 @@
 			IL_01d2: stfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -4548,7 +4541,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -4560,17 +4553,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -4589,7 +4582,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -4601,12 +4594,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -4616,122 +4609,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -4754,22 +4747,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -4779,8 +4772,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -4802,7 +4795,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -4828,22 +4821,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope/Block_L58C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -4859,7 +4850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b14
+				// Method begins at RVA 0x4af4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4887,7 +4878,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3f34
+			// Method begins at RVA 0x3f1c
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -4946,7 +4937,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a72
+					// Method begins at RVA 0x4a52
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4970,7 +4961,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4012
+				// Method begins at RVA 0x3ffa
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -5005,7 +4996,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a69
+				// Method begins at RVA 0x4a49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5032,7 +5023,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3f90
+			// Method begins at RVA 0x3f78
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -5110,7 +5101,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a57
+					// Method begins at RVA 0x4a37
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5130,7 +5121,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a60
+					// Method begins at RVA 0x4a40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5148,7 +5139,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a4e
+				// Method begins at RVA 0x4a2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5176,7 +5167,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4a31
+			// Method begins at RVA 0x4a11
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5520,7 +5511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b3c
+				// Method begins at RVA 0x4b1c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5546,7 +5537,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x40ec
+			// Method begins at RVA 0x40d4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5576,7 +5567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b45
+				// Method begins at RVA 0x4b25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5602,7 +5593,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x410c
+			// Method begins at RVA 0x40f4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5636,7 +5627,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b57
+					// Method begins at RVA 0x4b37
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5654,7 +5645,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b4e
+				// Method begins at RVA 0x4b2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5680,7 +5671,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x412c
+			// Method begins at RVA 0x4114
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -5759,7 +5750,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b60
+				// Method begins at RVA 0x4b40
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5783,7 +5774,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x41cc
+			// Method begins at RVA 0x41b4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -5864,7 +5855,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b69
+				// Method begins at RVA 0x4b49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5889,7 +5880,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x425c
+			// Method begins at RVA 0x4244
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5917,7 +5908,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b96
+					// Method begins at RVA 0x4b76
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5941,7 +5932,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x47d8
+				// Method begins at RVA 0x47b8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -5967,7 +5958,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b9f
+					// Method begins at RVA 0x4b7f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5991,7 +5982,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x47e7
+				// Method begins at RVA 0x47c7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -6021,7 +6012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bcc
+						// Method begins at RVA 0x4bac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6045,7 +6036,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x488d
+					// Method begins at RVA 0x486d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -6079,7 +6070,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bc3
+					// Method begins at RVA 0x4ba3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6104,7 +6095,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x47f8
+				// Method begins at RVA 0x47d8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -6197,7 +6188,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b7b
+					// Method begins at RVA 0x4b5b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6217,7 +6208,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b84
+					// Method begins at RVA 0x4b64
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6237,7 +6228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b8d
+					// Method begins at RVA 0x4b6d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6261,7 +6252,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bb1
+						// Method begins at RVA 0x4b91
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6281,7 +6272,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bba
+						// Method begins at RVA 0x4b9a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6299,7 +6290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ba8
+					// Method begins at RVA 0x4b88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6319,7 +6310,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bd5
+					// Method begins at RVA 0x4bb5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6339,7 +6330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bde
+					// Method begins at RVA 0x4bbe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6361,7 +6352,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b72
+				// Method begins at RVA 0x4b52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6388,9 +6379,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4268
+			// Method begins at RVA 0x4250
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope,
@@ -6399,10 +6390,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope/Block_L53C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -6410,12 +6401,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::.ctor()
@@ -6425,45 +6415,45 @@
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -6472,19 +6462,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -6492,14 +6482,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -6507,28 +6497,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -6546,31 +6536,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -6584,7 +6574,7 @@
 			IL_01d2: stfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -6603,7 +6593,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -6615,17 +6605,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -6644,7 +6634,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -6656,12 +6646,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -6671,122 +6661,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -6809,22 +6799,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -6834,8 +6824,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -6857,7 +6847,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -6883,22 +6873,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope/Block_L53C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -6914,7 +6902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4be7
+				// Method begins at RVA 0x4bc7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6942,7 +6930,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x477c
+			// Method begins at RVA 0x475c
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -7009,7 +6997,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4b1d
+			// Method begins at RVA 0x4afd
 			// Header size: 1
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -7219,7 +7207,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4bf0
+		// Method begins at RVA 0x4bd0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3894
+					// Method begins at RVA 0x3884
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x388b
+				// Method begins at RVA 0x387b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x389d
+				// Method begins at RVA 0x388d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38a6
+				// Method begins at RVA 0x3896
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38d3
+					// Method begins at RVA 0x38c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fa8
+				// Method begins at RVA 0x2fa0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38dc
+					// Method begins at RVA 0x38cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fb7
+				// Method begins at RVA 0x2faf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3909
+						// Method begins at RVA 0x38f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x305d
+					// Method begins at RVA 0x3055
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3900
+					// Method begins at RVA 0x38f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fc8
+				// Method begins at RVA 0x2fc0
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38b8
+					// Method begins at RVA 0x38a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38c1
+					// Method begins at RVA 0x38b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38ca
+					// Method begins at RVA 0x38ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38ee
+						// Method begins at RVA 0x38de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38f7
+						// Method begins at RVA 0x38e7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38e5
+					// Method begins at RVA 0x38d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3912
+					// Method begins at RVA 0x3902
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x391b
+					// Method begins at RVA 0x390b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38af
+				// Method begins at RVA 0x389f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x2a38
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope/Block_L66C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope/Block_L66C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3924
+				// Method begins at RVA 0x3914
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2f4c
+			// Method begins at RVA 0x2f44
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3882
+			// Method begins at RVA 0x3872
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1923,7 +1920,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3962
+				// Method begins at RVA 0x3952
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1949,7 +1946,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3080
+			// Method begins at RVA 0x3078
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1979,7 +1976,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x396b
+				// Method begins at RVA 0x395b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2005,7 +2002,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x30a0
+			// Method begins at RVA 0x3098
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2035,7 +2032,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3974
+				// Method begins at RVA 0x3964
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2061,7 +2058,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x30c0
+			// Method begins at RVA 0x30b8
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2091,7 +2088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x397d
+				// Method begins at RVA 0x396d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2117,7 +2114,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x30e0
+			// Method begins at RVA 0x30d8
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2151,7 +2148,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x398f
+					// Method begins at RVA 0x397f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2169,7 +2166,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3986
+				// Method begins at RVA 0x3976
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2195,7 +2192,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3100
+			// Method begins at RVA 0x30f8
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -2274,7 +2271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3998
+				// Method begins at RVA 0x3988
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2298,7 +2295,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31a0
+			// Method begins at RVA 0x3198
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2379,7 +2376,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39a1
+				// Method begins at RVA 0x3991
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2404,7 +2401,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3230
+			// Method begins at RVA 0x3228
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2432,7 +2429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39ce
+					// Method begins at RVA 0x39be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2456,7 +2453,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37ac
+				// Method begins at RVA 0x379c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2482,7 +2479,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39d7
+					// Method begins at RVA 0x39c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2506,7 +2503,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37bb
+				// Method begins at RVA 0x37ab
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2536,7 +2533,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3a04
+						// Method begins at RVA 0x39f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2560,7 +2557,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3861
+					// Method begins at RVA 0x3851
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2594,7 +2591,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39fb
+					// Method begins at RVA 0x39eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2619,7 +2616,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37cc
+				// Method begins at RVA 0x37bc
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2712,7 +2709,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39b3
+					// Method begins at RVA 0x39a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2732,7 +2729,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39bc
+					// Method begins at RVA 0x39ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2752,7 +2749,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39c5
+					// Method begins at RVA 0x39b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2776,7 +2773,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x39e9
+						// Method begins at RVA 0x39d9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2796,7 +2793,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x39f2
+						// Method begins at RVA 0x39e2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2814,7 +2811,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39e0
+					// Method begins at RVA 0x39d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2834,7 +2831,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a0d
+					// Method begins at RVA 0x39fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2854,7 +2851,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a16
+					// Method begins at RVA 0x3a06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2876,7 +2873,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39aa
+				// Method begins at RVA 0x399a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2903,9 +2900,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x323c
+			// Method begins at RVA 0x3234
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope,
@@ -2914,10 +2911,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope/Block_L57C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2925,12 +2922,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -2940,45 +2936,45 @@
 			IL_0008: stfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2987,19 +2983,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -3007,14 +3003,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -3022,28 +3018,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -3061,31 +3057,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -3099,7 +3095,7 @@
 			IL_01d2: stfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -3118,7 +3114,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -3130,17 +3126,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -3159,7 +3155,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -3171,12 +3167,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -3186,122 +3182,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -3324,22 +3320,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -3349,8 +3345,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -3372,7 +3368,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -3398,22 +3394,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope/Block_L57C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -3429,7 +3423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a1f
+				// Method begins at RVA 0x3a0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3457,7 +3451,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3750
+			// Method begins at RVA 0x3740
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3537,7 +3531,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x392d
+			// Method begins at RVA 0x391d
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3884,7 +3878,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3a28
+		// Method begins at RVA 0x3a18
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40bc
+					// Method begins at RVA 0x40a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40b3
+				// Method begins at RVA 0x409b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40c5
+				// Method begins at RVA 0x40ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40ce
+				// Method begins at RVA 0x40b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40fb
+					// Method begins at RVA 0x40e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f9c
+				// Method begins at RVA 0x2f94
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4104
+					// Method begins at RVA 0x40ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fab
+				// Method begins at RVA 0x2fa3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4131
+						// Method begins at RVA 0x4119
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3051
+					// Method begins at RVA 0x3049
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4128
+					// Method begins at RVA 0x4110
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fbc
+				// Method begins at RVA 0x2fb4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40e0
+					// Method begins at RVA 0x40c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40e9
+					// Method begins at RVA 0x40d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40f2
+					// Method begins at RVA 0x40da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4116
+						// Method begins at RVA 0x40fe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x411f
+						// Method begins at RVA 0x4107
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x410d
+					// Method begins at RVA 0x40f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x413a
+					// Method begins at RVA 0x4122
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4143
+					// Method begins at RVA 0x412b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40d7
+				// Method begins at RVA 0x40bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x2a2c
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope/Block_L66C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope/Block_L66C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x414c
+				// Method begins at RVA 0x4134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x2f40
+			// Method begins at RVA 0x2f38
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x40aa
+			// Method begins at RVA 0x4092
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1784,7 +1781,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4169
+				// Method begins at RVA 0x4151
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1810,7 +1807,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3074
+			// Method begins at RVA 0x306c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1840,7 +1837,56 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4172
+				// Method begins at RVA 0x415a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Import_LiveBindings_Cycle_A/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 3d 00 00 02
+			)
+			// Method begins at RVA 0x308b
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::incA
+			IL_0006: ret
+		} // end of method FunctionExpression_L4C26::__js_call__
+
+	} // end of class FunctionExpression_L4C26
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L5C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4163
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1872,55 +1918,6 @@
 			.maxstack 8
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::incA
-			IL_0006: ret
-		} // end of method FunctionExpression_L4C26::__js_call__
-
-	} // end of class FunctionExpression_L4C26
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L5C31
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x417b
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Import_LiveBindings_Cycle_A/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 3d 00 00 02
-			)
-			// Method begins at RVA 0x309b
-			// Header size: 1
-			// Code size: 7 (0x7)
-			.maxstack 8
-
-			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::getBFromA
 			IL_0006: ret
 		} // end of method FunctionExpression_L5C31::__js_call__
@@ -1938,7 +1935,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4184
+				// Method begins at RVA 0x416c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1964,7 +1961,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x30a4
+			// Method begins at RVA 0x309c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -2002,7 +1999,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x418d
+				// Method begins at RVA 0x4175
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2028,7 +2025,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x30dc
+			// Method begins at RVA 0x30d4
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -2075,7 +2072,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x419f
+					// Method begins at RVA 0x4187
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2093,7 +2090,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4196
+				// Method begins at RVA 0x417e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2119,7 +2116,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x310c
+			// Method begins at RVA 0x3104
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -2198,7 +2195,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41a8
+				// Method begins at RVA 0x4190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2222,7 +2219,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31ac
+			// Method begins at RVA 0x31a4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2303,7 +2300,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41b1
+				// Method begins at RVA 0x4199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2328,7 +2325,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x323c
+			// Method begins at RVA 0x3234
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2356,7 +2353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41de
+					// Method begins at RVA 0x41c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2380,7 +2377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37b8
+				// Method begins at RVA 0x37a8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2406,7 +2403,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41e7
+					// Method begins at RVA 0x41cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2430,7 +2427,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37c7
+				// Method begins at RVA 0x37b7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2460,7 +2457,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4214
+						// Method begins at RVA 0x41fc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2484,7 +2481,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x386d
+					// Method begins at RVA 0x385d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2518,7 +2515,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x420b
+					// Method begins at RVA 0x41f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2543,7 +2540,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37d8
+				// Method begins at RVA 0x37c8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2636,7 +2633,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41c3
+					// Method begins at RVA 0x41ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2656,7 +2653,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41cc
+					// Method begins at RVA 0x41b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2676,7 +2673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41d5
+					// Method begins at RVA 0x41bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2700,7 +2697,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x41f9
+						// Method begins at RVA 0x41e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2720,7 +2717,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4202
+						// Method begins at RVA 0x41ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2738,7 +2735,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41f0
+					// Method begins at RVA 0x41d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2758,7 +2755,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x421d
+					// Method begins at RVA 0x4205
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2778,7 +2775,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4226
+					// Method begins at RVA 0x420e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2800,7 +2797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41ba
+				// Method begins at RVA 0x41a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2827,9 +2824,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3248
+			// Method begins at RVA 0x3240
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope,
@@ -2838,10 +2835,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope/Block_L64C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2849,12 +2846,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::.ctor()
@@ -2864,45 +2860,45 @@
 			IL_0008: stfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2911,19 +2907,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2931,14 +2927,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2946,28 +2942,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2985,31 +2981,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -3023,7 +3019,7 @@
 			IL_01d2: stfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -3042,7 +3038,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -3054,17 +3050,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -3083,7 +3079,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -3095,12 +3091,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -3110,122 +3106,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -3248,22 +3244,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -3273,8 +3269,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -3296,7 +3292,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -3322,22 +3318,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope/Block_L64C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -3353,7 +3347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x422f
+				// Method begins at RVA 0x4217
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3381,7 +3375,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x375c
+			// Method begins at RVA 0x374c
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3451,7 +3445,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4155
+			// Method begins at RVA 0x413d
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3739,7 +3733,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x424c
+				// Method begins at RVA 0x4234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3765,7 +3759,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3890
+			// Method begins at RVA 0x3880
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3795,7 +3789,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4255
+				// Method begins at RVA 0x423d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3821,7 +3815,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x38af
+			// Method begins at RVA 0x389f
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3844,7 +3838,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x425e
+				// Method begins at RVA 0x4246
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3870,7 +3864,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x38b7
+			// Method begins at RVA 0x38a7
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3893,7 +3887,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4267
+				// Method begins at RVA 0x424f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3919,7 +3913,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x38c0
+			// Method begins at RVA 0x38b0
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -3957,7 +3951,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4270
+				// Method begins at RVA 0x4258
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3983,7 +3977,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x38f8
+			// Method begins at RVA 0x38e8
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -4030,7 +4024,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4282
+					// Method begins at RVA 0x426a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4048,7 +4042,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4279
+				// Method begins at RVA 0x4261
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4074,7 +4068,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3928
+			// Method begins at RVA 0x3918
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -4153,7 +4147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x428b
+				// Method begins at RVA 0x4273
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4177,7 +4171,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x39c8
+			// Method begins at RVA 0x39b8
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -4258,7 +4252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4294
+				// Method begins at RVA 0x427c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4283,7 +4277,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3a58
+			// Method begins at RVA 0x3a48
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4311,7 +4305,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42c1
+					// Method begins at RVA 0x42a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4335,7 +4329,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3fd4
+				// Method begins at RVA 0x3fbc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -4361,7 +4355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42ca
+					// Method begins at RVA 0x42b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4385,7 +4379,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3fe3
+				// Method begins at RVA 0x3fcb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -4415,7 +4409,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x42f7
+						// Method begins at RVA 0x42df
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4439,7 +4433,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4089
+					// Method begins at RVA 0x4071
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -4473,7 +4467,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42ee
+					// Method begins at RVA 0x42d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4498,7 +4492,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ff4
+				// Method begins at RVA 0x3fdc
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4591,7 +4585,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42a6
+					// Method begins at RVA 0x428e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4611,7 +4605,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42af
+					// Method begins at RVA 0x4297
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4631,7 +4625,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42b8
+					// Method begins at RVA 0x42a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4655,7 +4649,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x42dc
+						// Method begins at RVA 0x42c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4675,7 +4669,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x42e5
+						// Method begins at RVA 0x42cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4693,7 +4687,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x42d3
+					// Method begins at RVA 0x42bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4713,7 +4707,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4300
+					// Method begins at RVA 0x42e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4733,7 +4727,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4309
+					// Method begins at RVA 0x42f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4755,7 +4749,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x429d
+				// Method begins at RVA 0x4285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4782,9 +4776,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3a64
+			// Method begins at RVA 0x3a54
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope,
@@ -4793,10 +4787,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope/Block_L64C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -4804,12 +4798,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::.ctor()
@@ -4819,45 +4812,45 @@
 			IL_0008: stfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -4866,19 +4859,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -4886,14 +4879,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -4901,28 +4894,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -4940,31 +4933,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -4978,7 +4971,7 @@
 			IL_01d2: stfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -4997,7 +4990,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -5009,17 +5002,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -5038,7 +5031,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -5050,12 +5043,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -5065,122 +5058,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -5203,22 +5196,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -5228,8 +5221,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -5251,7 +5244,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -5277,22 +5270,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope/Block_L64C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -5308,7 +5299,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4312
+				// Method begins at RVA 0x42fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5336,7 +5327,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3f78
+			// Method begins at RVA 0x3f60
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -5406,7 +5397,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4238
+			// Method begins at RVA 0x4220
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5686,7 +5677,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x431b
+		// Method begins at RVA 0x4303
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3358
+					// Method begins at RVA 0x3348
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x334f
+				// Method begins at RVA 0x333f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3361
+				// Method begins at RVA 0x3351
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x336a
+				// Method begins at RVA 0x335a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3397
+					// Method begins at RVA 0x3387
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a8c
+				// Method begins at RVA 0x2a84
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a0
+					// Method begins at RVA 0x3390
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a9b
+				// Method begins at RVA 0x2a93
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33cd
+						// Method begins at RVA 0x33bd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2b41
+					// Method begins at RVA 0x2b39
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c4
+					// Method begins at RVA 0x33b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2aac
+				// Method begins at RVA 0x2aa4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x337c
+					// Method begins at RVA 0x336c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3385
+					// Method begins at RVA 0x3375
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x338e
+					// Method begins at RVA 0x337e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33b2
+						// Method begins at RVA 0x33a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33bb
+						// Method begins at RVA 0x33ab
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a9
+					// Method begins at RVA 0x3399
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d6
+					// Method begins at RVA 0x33c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33df
+					// Method begins at RVA 0x33cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3373
+				// Method begins at RVA 0x3363
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x251c
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope/Block_L55C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope/Block_L55C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33e8
+				// Method begins at RVA 0x33d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x2a28
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3346
+			// Method begins at RVA 0x3336
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1609,7 +1606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3405
+				// Method begins at RVA 0x33f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1635,7 +1632,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b64
+			// Method begins at RVA 0x2b5c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1665,7 +1662,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x340e
+				// Method begins at RVA 0x33fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1691,7 +1688,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b83
+			// Method begins at RVA 0x2b7b
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1714,7 +1711,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3417
+				// Method begins at RVA 0x3407
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1740,7 +1737,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b8c
+			// Method begins at RVA 0x2b84
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1782,7 +1779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3429
+					// Method begins at RVA 0x3419
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1800,7 +1797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3420
+				// Method begins at RVA 0x3410
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1826,7 +1823,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2bc4
+			// Method begins at RVA 0x2bbc
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -1905,7 +1902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3432
+				// Method begins at RVA 0x3422
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1929,7 +1926,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c64
+			// Method begins at RVA 0x2c5c
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2010,7 +2007,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343b
+				// Method begins at RVA 0x342b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2035,7 +2032,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cf4
+			// Method begins at RVA 0x2cec
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2063,7 +2060,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3468
+					// Method begins at RVA 0x3458
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2087,7 +2084,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3270
+				// Method begins at RVA 0x3260
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2113,7 +2110,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3471
+					// Method begins at RVA 0x3461
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2137,7 +2134,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x327f
+				// Method begins at RVA 0x326f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2167,7 +2164,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x349e
+						// Method begins at RVA 0x348e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2191,7 +2188,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3325
+					// Method begins at RVA 0x3315
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2225,7 +2222,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3495
+					// Method begins at RVA 0x3485
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2250,7 +2247,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3290
+				// Method begins at RVA 0x3280
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2343,7 +2340,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x344d
+					// Method begins at RVA 0x343d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2363,7 +2360,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3456
+					// Method begins at RVA 0x3446
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2383,7 +2380,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x345f
+					// Method begins at RVA 0x344f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2407,7 +2404,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3483
+						// Method begins at RVA 0x3473
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2427,7 +2424,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x348c
+						// Method begins at RVA 0x347c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2445,7 +2442,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x347a
+					// Method begins at RVA 0x346a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2465,7 +2462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a7
+					// Method begins at RVA 0x3497
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2485,7 +2482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34b0
+					// Method begins at RVA 0x34a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2507,7 +2504,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3444
+				// Method begins at RVA 0x3434
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2534,9 +2531,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2d00
+			// Method begins at RVA 0x2cf8
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope,
@@ -2545,10 +2542,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope/Block_L55C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2556,12 +2553,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -2571,45 +2567,45 @@
 			IL_0008: stfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2618,19 +2614,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2638,14 +2634,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2653,28 +2649,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2692,31 +2688,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2730,7 +2726,7 @@
 			IL_01d2: stfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -2749,7 +2745,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -2761,17 +2757,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -2790,7 +2786,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -2802,12 +2798,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -2817,122 +2813,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -2955,22 +2951,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -2980,8 +2976,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -3003,7 +2999,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -3029,22 +3025,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope/Block_L55C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -3060,7 +3054,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b9
+				// Method begins at RVA 0x34a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3088,7 +3082,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x3214
+			// Method begins at RVA 0x3204
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3154,7 +3148,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x33f1
+			// Method begins at RVA 0x33e1
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3380,7 +3374,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x34c2
+		// Method begins at RVA 0x34b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3608
+					// Method begins at RVA 0x35f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ff
+				// Method begins at RVA 0x35ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3611
+				// Method begins at RVA 0x3601
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x361a
+				// Method begins at RVA 0x360a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3647
+					// Method begins at RVA 0x3637
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d14
+				// Method begins at RVA 0x2d0c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3650
+					// Method begins at RVA 0x3640
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d23
+				// Method begins at RVA 0x2d1b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x367d
+						// Method begins at RVA 0x366d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2dc9
+					// Method begins at RVA 0x2dc1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3674
+					// Method begins at RVA 0x3664
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d34
+				// Method begins at RVA 0x2d2c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x362c
+					// Method begins at RVA 0x361c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3635
+					// Method begins at RVA 0x3625
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x363e
+					// Method begins at RVA 0x362e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3662
+						// Method begins at RVA 0x3652
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x366b
+						// Method begins at RVA 0x365b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3659
+					// Method begins at RVA 0x3649
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3686
+					// Method begins at RVA 0x3676
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x368f
+					// Method begins at RVA 0x367f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3623
+				// Method begins at RVA 0x3613
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x27a4
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope/Block_L62C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope/Block_L62C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3698
+				// Method begins at RVA 0x3688
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2cb8
+			// Method begins at RVA 0x2cb0
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35f6
+			// Method begins at RVA 0x35e6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1759,7 +1756,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b5
+				// Method begins at RVA 0x36a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1785,7 +1782,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2dec
+			// Method begins at RVA 0x2de4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1815,7 +1812,56 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36be
+				// Method begins at RVA 0x36ae
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Import_Namespace_Esm_Basic_Lib/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 2e 00 00 02
+			)
+			// Method begins at RVA 0x2e03
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::inc
+			IL_0006: ret
+		} // end of method FunctionExpression_L4C25::__js_call__
+
+	} // end of class FunctionExpression_L4C25
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L5C29
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x36b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1847,55 +1893,6 @@
 			.maxstack 8
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::inc
-			IL_0006: ret
-		} // end of method FunctionExpression_L4C25::__js_call__
-
-	} // end of class FunctionExpression_L4C25
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L5C29
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x36c7
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Import_Namespace_Esm_Basic_Lib/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 2e 00 00 02
-			)
-			// Method begins at RVA 0x2e13
-			// Header size: 1
-			// Code size: 7 (0x7)
-			.maxstack 8
-
-			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::getX
 			IL_0006: ret
 		} // end of method FunctionExpression_L5C29::__js_call__
@@ -1913,7 +1910,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d0
+				// Method begins at RVA 0x36c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1939,7 +1936,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2e1c
+			// Method begins at RVA 0x2e14
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1977,7 +1974,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d9
+				// Method begins at RVA 0x36c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2003,7 +2000,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2e54
+			// Method begins at RVA 0x2e4c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2037,7 +2034,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36eb
+					// Method begins at RVA 0x36db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2055,7 +2052,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e2
+				// Method begins at RVA 0x36d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2081,7 +2078,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2e74
+			// Method begins at RVA 0x2e6c
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -2160,7 +2157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36f4
+				// Method begins at RVA 0x36e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2184,7 +2181,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f14
+			// Method begins at RVA 0x2f0c
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2265,7 +2262,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36fd
+				// Method begins at RVA 0x36ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2290,7 +2287,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fa4
+			// Method begins at RVA 0x2f9c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2318,7 +2315,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x372a
+					// Method begins at RVA 0x371a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2342,7 +2339,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3520
+				// Method begins at RVA 0x3510
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2368,7 +2365,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3733
+					// Method begins at RVA 0x3723
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2392,7 +2389,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x352f
+				// Method begins at RVA 0x351f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2422,7 +2419,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3760
+						// Method begins at RVA 0x3750
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2446,7 +2443,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x35d5
+					// Method begins at RVA 0x35c5
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2480,7 +2477,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3757
+					// Method begins at RVA 0x3747
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2505,7 +2502,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3540
+				// Method begins at RVA 0x3530
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2598,7 +2595,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x370f
+					// Method begins at RVA 0x36ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2618,7 +2615,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3718
+					// Method begins at RVA 0x3708
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2638,7 +2635,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3721
+					// Method begins at RVA 0x3711
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2662,7 +2659,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3745
+						// Method begins at RVA 0x3735
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2682,7 +2679,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x374e
+						// Method begins at RVA 0x373e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2700,7 +2697,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x373c
+					// Method begins at RVA 0x372c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2720,7 +2717,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3769
+					// Method begins at RVA 0x3759
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2740,7 +2737,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3772
+					// Method begins at RVA 0x3762
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2762,7 +2759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3706
+				// Method begins at RVA 0x36f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2789,9 +2786,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2fb0
+			// Method begins at RVA 0x2fa8
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope,
@@ -2800,10 +2797,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope/Block_L60C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2811,12 +2808,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -2826,45 +2822,45 @@
 			IL_0008: stfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2873,19 +2869,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2893,14 +2889,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2908,28 +2904,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2947,31 +2943,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2985,7 +2981,7 @@
 			IL_01d2: stfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -3004,7 +3000,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -3016,17 +3012,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -3045,7 +3041,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -3057,12 +3053,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -3072,122 +3068,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -3210,22 +3206,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -3235,8 +3231,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -3258,7 +3254,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -3284,22 +3280,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope/Block_L60C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -3315,7 +3309,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x377b
+				// Method begins at RVA 0x376b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3343,7 +3337,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x34c4
+			// Method begins at RVA 0x34b4
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3411,7 +3405,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x36a1
+			// Method begins at RVA 0x3691
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3684,7 +3678,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3784
+		// Method begins at RVA 0x3774
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dec
+					// Method begins at RVA 0x3dd4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3de3
+				// Method begins at RVA 0x3dcb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3df5
+				// Method begins at RVA 0x3ddd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3dfe
+				// Method begins at RVA 0x3de6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e2b
+					// Method begins at RVA 0x3e13
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2da8
+				// Method begins at RVA 0x2da0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e34
+					// Method begins at RVA 0x3e1c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2db7
+				// Method begins at RVA 0x2daf
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e61
+						// Method begins at RVA 0x3e49
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2e5d
+					// Method begins at RVA 0x2e55
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e58
+					// Method begins at RVA 0x3e40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dc8
+				// Method begins at RVA 0x2dc0
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e10
+					// Method begins at RVA 0x3df8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e19
+					// Method begins at RVA 0x3e01
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e22
+					// Method begins at RVA 0x3e0a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e46
+						// Method begins at RVA 0x3e2e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e4f
+						// Method begins at RVA 0x3e37
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e3d
+					// Method begins at RVA 0x3e25
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e6a
+					// Method begins at RVA 0x3e52
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e73
+					// Method begins at RVA 0x3e5b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e07
+				// Method begins at RVA 0x3def
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x2838
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope/Block_L60C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope/Block_L60C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e7c
+				// Method begins at RVA 0x3e64
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d4c
+			// Method begins at RVA 0x2d44
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3dda
+			// Method begins at RVA 0x3dc2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1742,7 +1739,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e8e
+				// Method begins at RVA 0x3e76
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1768,7 +1765,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2e7e
+			// Method begins at RVA 0x2e76
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1795,7 +1792,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ea0
+					// Method begins at RVA 0x3e88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1813,7 +1810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e97
+				// Method begins at RVA 0x3e7f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1839,7 +1836,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2e88
+			// Method begins at RVA 0x2e80
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -1918,7 +1915,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ea9
+				// Method begins at RVA 0x3e91
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1942,7 +1939,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f28
+			// Method begins at RVA 0x2f20
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -2023,7 +2020,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3eb2
+				// Method begins at RVA 0x3e9a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2048,7 +2045,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fb8
+			// Method begins at RVA 0x2fb0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2076,7 +2073,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3edf
+					// Method begins at RVA 0x3ec7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2100,7 +2097,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3534
+				// Method begins at RVA 0x3524
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2126,7 +2123,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ee8
+					// Method begins at RVA 0x3ed0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2150,7 +2147,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3543
+				// Method begins at RVA 0x3533
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2180,7 +2177,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3f15
+						// Method begins at RVA 0x3efd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2204,7 +2201,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x35e9
+					// Method begins at RVA 0x35d9
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2238,7 +2235,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f0c
+					// Method begins at RVA 0x3ef4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2263,7 +2260,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3554
+				// Method begins at RVA 0x3544
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2356,7 +2353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ec4
+					// Method begins at RVA 0x3eac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2376,7 +2373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ecd
+					// Method begins at RVA 0x3eb5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2396,7 +2393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ed6
+					// Method begins at RVA 0x3ebe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2420,7 +2417,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3efa
+						// Method begins at RVA 0x3ee2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2440,7 +2437,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3f03
+						// Method begins at RVA 0x3eeb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2458,7 +2455,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ef1
+					// Method begins at RVA 0x3ed9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2478,7 +2475,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f1e
+					// Method begins at RVA 0x3f06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2498,7 +2495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f27
+					// Method begins at RVA 0x3f0f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2520,7 +2517,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ebb
+				// Method begins at RVA 0x3ea3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2547,9 +2544,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2fc4
+			// Method begins at RVA 0x2fbc
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope,
@@ -2558,10 +2555,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope/Block_L55C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -2569,12 +2566,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::.ctor()
@@ -2584,45 +2580,45 @@
 			IL_0008: stfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -2631,19 +2627,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -2651,14 +2647,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -2666,28 +2662,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -2705,31 +2701,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -2743,7 +2739,7 @@
 			IL_01d2: stfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -2762,7 +2758,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -2774,17 +2770,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -2803,7 +2799,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -2815,12 +2811,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -2830,122 +2826,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -2968,22 +2964,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -2993,8 +2989,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -3016,7 +3012,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -3042,22 +3038,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope/Block_L55C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -3073,7 +3067,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f30
+				// Method begins at RVA 0x3f18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3101,7 +3095,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x34d8
+			// Method begins at RVA 0x34c8
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -3166,7 +3160,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3e85
+			// Method begins at RVA 0x3e6d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3361,7 +3355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f42
+				// Method begins at RVA 0x3f2a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3387,7 +3381,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4b 00 00 02
 			)
-			// Method begins at RVA 0x360c
+			// Method begins at RVA 0x35fc
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3432,7 +3426,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3f39
+			// Method begins at RVA 0x3f21
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3523,7 +3517,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f54
+				// Method begins at RVA 0x3f3c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3549,7 +3543,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x364e
+			// Method begins at RVA 0x363e
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3576,7 +3570,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f66
+					// Method begins at RVA 0x3f4e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3594,7 +3588,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f5d
+				// Method begins at RVA 0x3f45
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3620,7 +3614,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3658
+			// Method begins at RVA 0x3648
 			// Header size: 12
 			// Code size: 145 (0x91)
 			.maxstack 8
@@ -3699,7 +3693,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f6f
+				// Method begins at RVA 0x3f57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3723,7 +3717,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x36f8
+			// Method begins at RVA 0x36e8
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -3804,7 +3798,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f78
+				// Method begins at RVA 0x3f60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3829,7 +3823,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3788
+			// Method begins at RVA 0x3778
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3857,7 +3851,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fa5
+					// Method begins at RVA 0x3f8d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3881,7 +3875,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d04
+				// Method begins at RVA 0x3cec
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3907,7 +3901,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fae
+					// Method begins at RVA 0x3f96
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3931,7 +3925,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d13
+				// Method begins at RVA 0x3cfb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3961,7 +3955,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3fdb
+						// Method begins at RVA 0x3fc3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3985,7 +3979,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3db9
+					// Method begins at RVA 0x3da1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -4019,7 +4013,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fd2
+					// Method begins at RVA 0x3fba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4044,7 +4038,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d24
+				// Method begins at RVA 0x3d0c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4137,7 +4131,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f8a
+					// Method begins at RVA 0x3f72
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4157,7 +4151,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f93
+					// Method begins at RVA 0x3f7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4177,7 +4171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f9c
+					// Method begins at RVA 0x3f84
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4201,7 +4195,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3fc0
+						// Method begins at RVA 0x3fa8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4221,7 +4215,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3fc9
+						// Method begins at RVA 0x3fb1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4239,7 +4233,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fb7
+					// Method begins at RVA 0x3f9f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4259,7 +4253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fe4
+					// Method begins at RVA 0x3fcc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4279,7 +4273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fed
+					// Method begins at RVA 0x3fd5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4301,7 +4295,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f81
+				// Method begins at RVA 0x3f69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4328,9 +4322,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3794
+			// Method begins at RVA 0x3784
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope,
@@ -4339,10 +4333,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope/Block_L55C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -4350,12 +4344,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::.ctor()
@@ -4365,45 +4358,45 @@
 			IL_0008: stfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -4412,19 +4405,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -4432,14 +4425,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -4447,28 +4440,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -4486,31 +4479,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -4524,7 +4517,7 @@
 			IL_01d2: stfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -4543,7 +4536,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -4555,17 +4548,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -4584,7 +4577,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -4596,12 +4589,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -4611,122 +4604,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -4749,22 +4742,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -4774,8 +4767,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -4797,7 +4790,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -4823,22 +4816,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope/Block_L55C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -4854,7 +4845,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ff6
+				// Method begins at RVA 0x3fde
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4882,7 +4873,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3ca8
+			// Method begins at RVA 0x3c90
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -4947,7 +4938,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3f4b
+			// Method begins at RVA 0x3f33
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5134,7 +5125,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3fff
+		// Method begins at RVA 0x3fe7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2afe
+			// Method begins at RVA 0x2af6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -129,7 +129,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b1b
+				// Method begins at RVA 0x2b13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -185,7 +185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b24
+				// Method begins at RVA 0x2b1c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2d
+				// Method begins at RVA 0x2b25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -288,7 +288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b36
+				// Method begins at RVA 0x2b2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -341,7 +341,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b48
+					// Method begins at RVA 0x2b40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3f
+				// Method begins at RVA 0x2b37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -464,7 +464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b51
+				// Method begins at RVA 0x2b49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -569,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b5a
+				// Method begins at RVA 0x2b52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -622,7 +622,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b87
+					// Method begins at RVA 0x2b7f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -646,7 +646,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a28
+				// Method begins at RVA 0x2a20
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -672,7 +672,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b90
+					// Method begins at RVA 0x2b88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -696,7 +696,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a37
+				// Method begins at RVA 0x2a2f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -726,7 +726,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bbd
+						// Method begins at RVA 0x2bb5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -750,7 +750,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2add
+					// Method begins at RVA 0x2ad5
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -784,7 +784,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bb4
+					// Method begins at RVA 0x2bac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -809,7 +809,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a48
+				// Method begins at RVA 0x2a40
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -902,7 +902,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b6c
+					// Method begins at RVA 0x2b64
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -922,7 +922,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b75
+					// Method begins at RVA 0x2b6d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -942,7 +942,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b7e
+					// Method begins at RVA 0x2b76
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -966,7 +966,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ba2
+						// Method begins at RVA 0x2b9a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -986,7 +986,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bab
+						// Method begins at RVA 0x2ba3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1004,7 +1004,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b99
+					// Method begins at RVA 0x2b91
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1024,7 +1024,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bc6
+					// Method begins at RVA 0x2bbe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1044,7 +1044,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bcf
+					// Method begins at RVA 0x2bc7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1066,7 +1066,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b63
+				// Method begins at RVA 0x2b5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1095,7 +1095,7 @@
 			)
 			// Method begins at RVA 0x24b8
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope,
@@ -1104,10 +1104,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope/Block_L60C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -1115,12 +1115,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -1130,45 +1129,45 @@
 			IL_0008: stfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -1177,19 +1176,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -1197,14 +1196,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -1212,28 +1211,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -1251,31 +1250,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -1289,7 +1288,7 @@
 			IL_01d2: stfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -1308,7 +1307,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1320,17 +1319,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1349,7 +1348,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1361,12 +1360,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1376,122 +1375,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1514,22 +1513,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1539,8 +1538,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1562,7 +1561,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1588,22 +1587,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope/Block_L60C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1619,7 +1616,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd8
+				// Method begins at RVA 0x2bd0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1647,7 +1644,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x29cc
+			// Method begins at RVA 0x29c4
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1715,7 +1712,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b07
+			// Method begins at RVA 0x2aff
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1963,7 +1960,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2be1
+		// Method begins at RVA 0x2bd9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a4c
+					// Method begins at RVA 0x2a44
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a43
+				// Method begins at RVA 0x2a3b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a55
+				// Method begins at RVA 0x2a4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a5e
+				// Method begins at RVA 0x2a56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a8b
+					// Method begins at RVA 0x2a83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -327,7 +327,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2964
+				// Method begins at RVA 0x295c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a94
+					// Method begins at RVA 0x2a8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +377,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2973
+				// Method begins at RVA 0x296b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -407,7 +407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ac1
+						// Method begins at RVA 0x2ab9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -431,7 +431,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2a19
+					// Method begins at RVA 0x2a11
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -465,7 +465,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ab8
+					// Method begins at RVA 0x2ab0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -490,7 +490,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2984
+				// Method begins at RVA 0x297c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -583,7 +583,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a70
+					// Method begins at RVA 0x2a68
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -603,7 +603,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a79
+					// Method begins at RVA 0x2a71
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -623,7 +623,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a82
+					// Method begins at RVA 0x2a7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2aa6
+						// Method begins at RVA 0x2a9e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -667,7 +667,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2aaf
+						// Method begins at RVA 0x2aa7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a9d
+					// Method begins at RVA 0x2a95
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aca
+					// Method begins at RVA 0x2ac2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -725,7 +725,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad3
+					// Method begins at RVA 0x2acb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -747,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a67
+				// Method begins at RVA 0x2a5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +776,7 @@
 			)
 			// Method begins at RVA 0x23f4
 			// Header size: 12
-			// Code size: 1271 (0x4f7)
+			// Code size: 1264 (0x4f0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope,
@@ -785,10 +785,10 @@
 				[3] class [System.Runtime]System.Exception,
 				[4] object,
 				[5] object,
-				[6] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope/Block_L59C16,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
@@ -796,12 +796,11 @@
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[18] object,
 				[19] object,
 				[20] object,
-				[21] object,
-				[22] object[]
+				[21] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::.ctor()
@@ -811,45 +810,45 @@
 			IL_0008: stfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldc.i4.0
 			IL_0018: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_001d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::NotEqual(object, object)
-			IL_0022: stloc.s 9
-			IL_0024: ldloc.s 9
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
 			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: stloc.s 10
-			IL_002d: ldloc.s 10
+			IL_002b: stloc.s 9
+			IL_002d: ldloc.s 9
 			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0034: stloc.s 9
-			IL_0036: ldloc.s 9
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
 			IL_0038: brfalse IL_0070
 
 			IL_003d: ldloc.0
 			IL_003e: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
 			IL_0043: ldstr "__esModule"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
+			IL_004d: stloc.s 7
+			IL_004f: ldloc.s 7
 			IL_0051: ldc.i4.1
 			IL_0052: box [System.Runtime]System.Boolean
 			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_005c: stloc.s 9
-			IL_005e: ldloc.s 9
+			IL_005c: stloc.s 8
+			IL_005e: ldloc.s 8
 			IL_0060: box [System.Runtime]System.Boolean
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: stloc.s 13
+			IL_0065: stloc.s 10
+			IL_0067: ldloc.s 10
+			IL_0069: stloc.s 12
 			IL_006b: br IL_0074
 
-			IL_0070: ldloc.s 10
-			IL_0072: stloc.s 13
+			IL_0070: ldloc.s 9
+			IL_0072: stloc.s 12
 
-			IL_0074: ldloc.s 13
+			IL_0074: ldloc.s 12
 			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
+			IL_007b: stloc.s 8
+			IL_007d: ldloc.s 8
 			IL_007f: brfalse IL_008b
 
 			IL_0084: ldloc.0
@@ -858,19 +857,19 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-			IL_0091: stloc.s 8
-			IL_0093: ldloc.s 8
+			IL_0091: stloc.s 7
+			IL_0093: ldloc.s 7
 			IL_0095: ldc.i4.0
 			IL_0096: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_00a0: stloc.s 9
-			IL_00a2: ldloc.s 9
+			IL_00a0: stloc.s 8
+			IL_00a2: ldloc.s 8
 			IL_00a4: box [System.Runtime]System.Boolean
-			IL_00a9: stloc.s 10
-			IL_00ab: ldloc.s 10
+			IL_00a9: stloc.s 9
+			IL_00ab: ldloc.s 9
 			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b2: stloc.s 9
-			IL_00b4: ldloc.s 9
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 8
 			IL_00b6: brtrue IL_0121
 
 			IL_00bb: ldloc.0
@@ -878,14 +877,14 @@
 			IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00c6: ldstr "object"
 			IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldloc.s 9
+			IL_00d0: stloc.s 8
+			IL_00d2: ldloc.s 8
 			IL_00d4: box [System.Runtime]System.Boolean
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
+			IL_00d9: stloc.s 10
+			IL_00db: ldloc.s 10
 			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e2: stloc.s 9
-			IL_00e4: ldloc.s 9
+			IL_00e2: stloc.s 8
+			IL_00e4: ldloc.s 8
 			IL_00e6: brfalse IL_0114
 
 			IL_00eb: ldloc.0
@@ -893,28 +892,28 @@
 			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 			IL_00f6: ldstr "function"
 			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: box [System.Runtime]System.Boolean
-			IL_0109: stloc.s 14
-			IL_010b: ldloc.s 14
-			IL_010d: stloc.s 15
+			IL_0109: stloc.s 13
+			IL_010b: ldloc.s 13
+			IL_010d: stloc.s 14
 			IL_010f: br IL_0118
 
-			IL_0114: ldloc.s 11
-			IL_0116: stloc.s 15
+			IL_0114: ldloc.s 10
+			IL_0116: stloc.s 14
 
-			IL_0118: ldloc.s 15
-			IL_011a: stloc.s 16
+			IL_0118: ldloc.s 14
+			IL_011a: stloc.s 15
 			IL_011c: br IL_0125
 
-			IL_0121: ldloc.s 10
-			IL_0123: stloc.s 16
+			IL_0121: ldloc.s 9
+			IL_0123: stloc.s 15
 
-			IL_0125: ldloc.s 16
+			IL_0125: ldloc.s 15
 			IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012c: stloc.s 9
-			IL_012e: ldloc.s 9
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
 			IL_0130: brfalse IL_015d
 
 			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -932,31 +931,31 @@
 
 			IL_015d: ldstr "Object"
 			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 8
+			IL_0167: stloc.s 7
+			IL_0169: ldloc.s 7
 			IL_016b: ldstr "prototype"
 			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.s 8
-			IL_0177: ldloc.s 8
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
 			IL_0179: ldstr "hasOwnProperty"
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 8
+			IL_0183: stloc.s 7
+			IL_0185: ldloc.s 7
 			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
+			IL_018c: stloc.s 7
 			IL_018e: ldloc.0
 			IL_018f: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-			IL_0194: stloc.s 17
-			IL_0196: ldloc.s 8
+			IL_0194: stloc.s 16
+			IL_0196: ldloc.s 7
 			IL_0198: ldstr "call"
-			IL_019d: ldloc.s 17
+			IL_019d: ldloc.s 16
 			IL_019f: ldstr "__jroc_esm_namespace"
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01a9: stloc.s 17
-			IL_01ab: ldloc.s 17
+			IL_01a9: stloc.s 16
+			IL_01ab: ldloc.s 16
 			IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
 			IL_01b6: brfalse IL_01cc
 
 			IL_01bb: ldloc.0
@@ -970,7 +969,7 @@
 			IL_01d2: stfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::ns
 			IL_01d7: ldloc.0
 			IL_01d8: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::ns
-			IL_01dd: stloc.s 17
+			IL_01dd: stloc.s 16
 			IL_01df: ldc.i4.2
 			IL_01e0: newarr [System.Runtime]System.Object
 			IL_01e5: dup
@@ -989,7 +988,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: ldc.i4.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0206: stloc.s 8
+			IL_0206: stloc.s 7
 			IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_020d: dup
 			IL_020e: ldstr "enumerable"
@@ -1001,17 +1000,17 @@
 			IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0225: dup
 			IL_0226: ldstr "get"
-			IL_022b: ldloc.s 8
+			IL_022b: ldloc.s 7
 			IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0232: stloc.s 18
-			IL_0234: ldloc.s 17
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
 			IL_0236: ldstr "default"
-			IL_023b: ldloc.s 18
+			IL_023b: ldloc.s 17
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0242: pop
 			IL_0243: ldloc.0
 			IL_0244: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::ns
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 16
 			IL_024b: ldc.i4.2
 			IL_024c: newarr [System.Runtime]System.Object
 			IL_0251: dup
@@ -1030,7 +1029,7 @@
 			IL_026b: ldc.i4.0
 			IL_026c: ldc.i4.1
 			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0272: stloc.s 8
+			IL_0272: stloc.s 7
 			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0279: dup
 			IL_027a: ldstr "enumerable"
@@ -1042,12 +1041,12 @@
 			IL_028c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0291: dup
 			IL_0292: ldstr "get"
-			IL_0297: ldloc.s 8
+			IL_0297: ldloc.s 7
 			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_029e: stloc.s 18
-			IL_02a0: ldloc.s 17
+			IL_029e: stloc.s 17
+			IL_02a0: ldloc.s 16
 			IL_02a2: ldstr "module.exports"
-			IL_02a7: ldloc.s 18
+			IL_02a7: ldloc.s 17
 			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_02ae: pop
 			IL_02af: ldloc.0
@@ -1057,122 +1056,122 @@
 			// loop start (head: IL_02bb)
 				IL_02bb: ldloc.1
 				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_02c1: stloc.s 17
-				IL_02c3: ldloc.s 17
+				IL_02c1: stloc.s 16
+				IL_02c3: ldloc.s 16
 				IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_02ca: stloc.s 9
-				IL_02cc: ldloc.s 9
+				IL_02ca: stloc.s 8
+				IL_02cc: ldloc.s 8
 				IL_02ce: brtrue IL_0457
 
-				IL_02d3: ldloc.s 17
+				IL_02d3: ldloc.s 16
 				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_02da: stloc.s 17
-				IL_02dc: ldloc.s 17
+				IL_02da: stloc.s 16
+				IL_02dc: ldloc.s 16
 				IL_02de: stloc.2
 				IL_02df: ldstr "Object"
 				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_02e9: stloc.s 17
-				IL_02eb: ldloc.s 17
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
 				IL_02ed: ldstr "prototype"
 				IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02f7: stloc.s 17
-				IL_02f9: ldloc.s 17
+				IL_02f7: stloc.s 16
+				IL_02f9: ldloc.s 16
 				IL_02fb: ldstr "hasOwnProperty"
 				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0305: stloc.s 17
-				IL_0307: ldloc.s 17
+				IL_0305: stloc.s 16
+				IL_0307: ldloc.s 16
 				IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_030e: stloc.s 17
-				IL_0310: ldloc.s 17
+				IL_030e: stloc.s 16
+				IL_0310: ldloc.s 16
 				IL_0312: ldstr "call"
 				IL_0317: ldloc.0
 				IL_0318: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
 				IL_031d: ldloc.2
 				IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0323: stloc.s 17
-				IL_0325: ldloc.s 17
+				IL_0323: stloc.s 16
+				IL_0325: ldloc.s 16
 				IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_032c: ldc.i4.0
 				IL_032d: ceq
-				IL_032f: stloc.s 9
-				IL_0331: ldloc.s 9
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
 				IL_0333: brfalse IL_033d
 
 				IL_0338: br IL_0452
 
 				IL_033d: ldloc.2
-				IL_033e: stloc.s 17
-				IL_0340: ldloc.s 17
+				IL_033e: stloc.s 16
+				IL_0340: ldloc.s 16
 				IL_0342: ldstr "default"
 				IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_034c: stloc.s 9
-				IL_034e: ldloc.s 9
+				IL_034c: stloc.s 8
+				IL_034e: ldloc.s 8
 				IL_0350: box [System.Runtime]System.Boolean
-				IL_0355: stloc.s 10
-				IL_0357: ldloc.s 10
+				IL_0355: stloc.s 9
+				IL_0357: ldloc.s 9
 				IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_035e: stloc.s 9
-				IL_0360: ldloc.s 9
+				IL_035e: stloc.s 8
+				IL_0360: ldloc.s 8
 				IL_0362: brtrue IL_038a
 
 				IL_0367: ldloc.2
-				IL_0368: stloc.s 17
-				IL_036a: ldloc.s 17
+				IL_0368: stloc.s 16
+				IL_036a: ldloc.s 16
 				IL_036c: ldstr "module.exports"
 				IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0376: stloc.s 9
-				IL_0378: ldloc.s 9
+				IL_0376: stloc.s 8
+				IL_0378: ldloc.s 8
 				IL_037a: box [System.Runtime]System.Boolean
-				IL_037f: stloc.s 11
-				IL_0381: ldloc.s 11
-				IL_0383: stloc.s 19
+				IL_037f: stloc.s 10
+				IL_0381: ldloc.s 10
+				IL_0383: stloc.s 18
 				IL_0385: br IL_038e
 
-				IL_038a: ldloc.s 10
-				IL_038c: stloc.s 19
+				IL_038a: ldloc.s 9
+				IL_038c: stloc.s 18
 
-				IL_038e: ldloc.s 19
+				IL_038e: ldloc.s 18
 				IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0395: stloc.s 9
-				IL_0397: ldloc.s 9
+				IL_0395: stloc.s 8
+				IL_0397: ldloc.s 8
 				IL_0399: brtrue IL_03c1
 
 				IL_039e: ldloc.2
-				IL_039f: stloc.s 17
-				IL_03a1: ldloc.s 17
+				IL_039f: stloc.s 16
+				IL_03a1: ldloc.s 16
 				IL_03a3: ldstr "__esModule"
 				IL_03a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03ad: stloc.s 9
-				IL_03af: ldloc.s 9
+				IL_03ad: stloc.s 8
+				IL_03af: ldloc.s 8
 				IL_03b1: box [System.Runtime]System.Boolean
-				IL_03b6: stloc.s 10
-				IL_03b8: ldloc.s 10
-				IL_03ba: stloc.s 19
+				IL_03b6: stloc.s 9
+				IL_03b8: ldloc.s 9
+				IL_03ba: stloc.s 18
 				IL_03bc: br IL_03c1
 
-				IL_03c1: ldloc.s 19
+				IL_03c1: ldloc.s 18
 				IL_03c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03c8: stloc.s 9
-				IL_03ca: ldloc.s 9
+				IL_03c8: stloc.s 8
+				IL_03ca: ldloc.s 8
 				IL_03cc: brtrue IL_03f4
 
 				IL_03d1: ldloc.2
-				IL_03d2: stloc.s 17
-				IL_03d4: ldloc.s 17
+				IL_03d2: stloc.s 16
+				IL_03d4: ldloc.s 16
 				IL_03d6: ldstr "__jroc_esm_namespace"
 				IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03e0: stloc.s 9
-				IL_03e2: ldloc.s 9
+				IL_03e0: stloc.s 8
+				IL_03e2: ldloc.s 8
 				IL_03e4: box [System.Runtime]System.Boolean
-				IL_03e9: stloc.s 10
-				IL_03eb: ldloc.s 10
-				IL_03ed: stloc.s 19
+				IL_03e9: stloc.s 9
+				IL_03eb: ldloc.s 9
+				IL_03ed: stloc.s 18
 				IL_03ef: br IL_03f4
 
-				IL_03f4: ldloc.s 19
+				IL_03f4: ldloc.s 18
 				IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03fb: stloc.s 9
-				IL_03fd: ldloc.s 9
+				IL_03fb: stloc.s 8
+				IL_03fd: ldloc.s 8
 				IL_03ff: brfalse IL_0409
 
 				IL_0404: br IL_0452
@@ -1195,22 +1194,22 @@
 				IL_0429: ldc.i4.0
 				IL_042a: ldc.i4.1
 				IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0430: stloc.s 17
+				IL_0430: stloc.s 16
 				IL_0432: ldc.i4.1
 				IL_0433: newarr [System.Runtime]System.Object
 				IL_0438: dup
 				IL_0439: ldc.i4.0
 				IL_043a: ldloc.2
 				IL_043b: stelem.ref
-				IL_043c: stloc.s 22
-				IL_043e: ldloc.s 17
+				IL_043c: stloc.s 21
+				IL_043e: ldloc.s 16
 				IL_0440: ldc.i4.1
 				IL_0441: newarr [System.Runtime]System.Object
 				IL_0446: dup
 				IL_0447: ldc.i4.0
 				IL_0448: ldarg.0
 				IL_0449: stelem.ref
-				IL_044a: ldloc.s 22
+				IL_044a: ldloc.s 21
 				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 				IL_0451: pop
 
@@ -1220,8 +1219,8 @@
 			{
 				IL_0457: ldloc.0
 				IL_0458: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::mod
-				IL_045d: stloc.s 17
-				IL_045f: ldloc.s 17
+				IL_045d: stloc.s 16
+				IL_045f: ldloc.s 16
 				IL_0461: ldstr "__jroc_esm_namespace"
 				IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_046b: dup
@@ -1243,7 +1242,7 @@
 				IL_049b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 				IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 				IL_04a5: pop
-				IL_04a6: leave IL_04ea
+				IL_04a6: leave IL_04e3
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -1269,22 +1268,20 @@
 				IL_04d4: stloc.s 4
 
 				IL_04d6: ldloc.s 4
-				IL_04d8: stloc.s 17
-				IL_04da: ldloc.s 17
+				IL_04d8: stloc.s 16
+				IL_04da: ldloc.s 16
 				IL_04dc: stloc.s 5
-				IL_04de: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope/Block_L59C16::.ctor()
-				IL_04e3: stloc.s 6
-				IL_04e5: leave IL_04ea
+				IL_04de: leave IL_04e3
 			} // end handler
 
-			IL_04ea: ldloc.0
-			IL_04eb: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::ns
-			IL_04f0: ret
+			IL_04e3: ldloc.0
+			IL_04e4: ldfld object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::ns
+			IL_04e9: ret
 
-			IL_04f1: ldnull
-			IL_04f2: stloc.s 7
-			IL_04f4: ldloc.s 7
-			IL_04f6: ret
+			IL_04ea: ldnull
+			IL_04eb: stloc.s 6
+			IL_04ed: ldloc.s 6
+			IL_04ef: ret
 		} // end of method __jroc_esm_namespace::__js_call__
 
 	} // end of class __jroc_esm_namespace
@@ -1300,7 +1297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2adc
+				// Method begins at RVA 0x2ad4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2908
+			// Method begins at RVA 0x2900
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -1391,7 +1388,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a3a
+			// Method begins at RVA 0x2a32
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1635,7 +1632,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ae5
+			// Method begins at RVA 0x2add
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1695,7 +1692,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2aee
+		// Method begins at RVA 0x2ae6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x325e
+						// Method begins at RVA 0x3214
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3255
+					// Method begins at RVA 0x320b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x324c
+				// Method begins at RVA 0x3202
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,22 +103,20 @@
 			)
 			// Method begins at RVA 0x2478
 			// Header size: 12
-			// Code size: 285 (0x11d)
+			// Code size: 271 (0x10f)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0,
-				[1] float64,
+				[0] float64,
+				[1] object,
 				[2] object,
-				[3] object,
-				[4] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0/Block_L218C1,
-				[5] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[3] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[4] object,
+				[5] float64,
 				[6] object,
-				[7] float64,
-				[8] object,
-				[9] object[],
-				[10] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
-				[11] float64,
-				[12] object
+				[7] object[],
+				[8] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[9] float64,
+				[10] object
 			)
 
 			IL_0000: ldarg.3
@@ -128,102 +126,99 @@
 			IL_000f: box [System.Runtime]System.Double
 			IL_0014: starg.s timeLimitSeconds
 
-			IL_0016: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0::.ctor()
-			IL_001b: stloc.0
-			IL_001c: ldc.r8 0.0
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0031: stloc.s 6
-			IL_0033: ldloc.s 6
-			IL_0035: ldstr "now"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003f: stloc.s 6
-			IL_0041: ldloc.s 6
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: stloc.s 6
-			IL_0047: ldarg.0
-			IL_0048: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 6
-			IL_0051: ldarg.3
-			IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0057: ldloc.s 7
-			IL_0059: mul
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_005f: stloc.s 8
-			IL_0061: ldloc.s 8
-			IL_0063: stloc.3
-			// loop start (head: IL_0064)
-				IL_0064: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/Scope/Block_L211C0/Block_L218C1::.ctor()
-				IL_0069: stloc.s 4
-				IL_006b: ldc.i4.1
-				IL_006c: newarr [System.Runtime]System.Object
-				IL_0071: dup
-				IL_0072: ldc.i4.0
-				IL_0073: ldarg.0
-				IL_0074: stelem.ref
-				IL_0075: stloc.s 9
-				IL_0077: ldloc.s 9
-				IL_0079: ldc.i4.1
-				IL_007a: newarr [System.Runtime]System.Object
-				IL_007f: dup
-				IL_0080: ldc.i4.0
+			IL_0016: ldc.r8 0.0
+			IL_001f: stloc.0
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_002b: stloc.s 4
+			IL_002d: ldloc.s 4
+			IL_002f: ldstr "now"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: stloc.1
+			IL_003e: ldloc.1
+			IL_003f: stloc.s 4
+			IL_0041: ldarg.0
+			IL_0042: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_0047: stloc.s 5
+			IL_0049: ldloc.s 4
+			IL_004b: ldarg.3
+			IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0051: ldloc.s 5
+			IL_0053: mul
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0059: stloc.s 6
+			IL_005b: ldloc.s 6
+			IL_005d: stloc.2
+			// loop start (head: IL_005e)
+				IL_005e: nop
+				IL_005f: ldc.i4.1
+				IL_0060: newarr [System.Runtime]System.Object
+				IL_0065: dup
+				IL_0066: ldc.i4.0
+				IL_0067: ldarg.0
+				IL_0068: stelem.ref
+				IL_0069: stloc.s 7
+				IL_006b: ldloc.s 7
+				IL_006d: ldc.i4.1
+				IL_006e: newarr [System.Runtime]System.Object
+				IL_0073: dup
+				IL_0074: ldc.i4.0
+				IL_0075: ldarg.2
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stelem.ref
+				IL_007c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
 				IL_0081: ldarg.2
-				IL_0082: box [System.Runtime]System.Double
-				IL_0087: stelem.ref
-				IL_0088: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_008d: ldarg.2
-				IL_008e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], float64)
-				IL_0093: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_0098: stloc.s 10
-				IL_009a: ldloc.s 10
-				IL_009c: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_00a1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_00a6: ldstr "prototype"
-				IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-				IL_00b0: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_00b5: ldloc.s 10
-				IL_00b7: stloc.s 5
-				IL_00b9: ldloc.s 5
-				IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve>(!!0)
-				IL_00c0: stloc.s 10
-				IL_00c2: ldloc.s 10
-				IL_00c4: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
-				IL_00c9: pop
-				IL_00ca: ldloc.1
-				IL_00cb: ldc.r8 1
-				IL_00d4: add
-				IL_00d5: stloc.1
-				IL_00d6: ldarg.0
-				IL_00d7: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-				IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00e1: stloc.s 6
-				IL_00e3: ldloc.s 6
-				IL_00e5: ldstr "now"
-				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00ef: stloc.s 6
-				IL_00f1: ldloc.s 6
-				IL_00f3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f8: stloc.s 7
-				IL_00fa: ldloc.3
-				IL_00fb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0100: stloc.s 11
-				IL_0102: ldloc.s 7
-				IL_0104: ldloc.s 11
-				IL_0106: clt
-				IL_0108: brfalse IL_0112
+				IL_0082: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], float64)
+				IL_0087: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_008c: stloc.s 8
+				IL_008e: ldloc.s 8
+				IL_0090: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0095: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_009a: ldstr "prototype"
+				IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+				IL_00a4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_00a9: ldloc.s 8
+				IL_00ab: stloc.3
+				IL_00ac: ldloc.3
+				IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve>(!!0)
+				IL_00b2: stloc.s 8
+				IL_00b4: ldloc.s 8
+				IL_00b6: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+				IL_00bb: pop
+				IL_00bc: ldloc.0
+				IL_00bd: ldc.r8 1
+				IL_00c6: add
+				IL_00c7: stloc.0
+				IL_00c8: ldarg.0
+				IL_00c9: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+				IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d3: stloc.s 4
+				IL_00d5: ldloc.s 4
+				IL_00d7: ldstr "now"
+				IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00e1: stloc.s 4
+				IL_00e3: ldloc.s 4
+				IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ea: stloc.s 5
+				IL_00ec: ldloc.2
+				IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f2: stloc.s 9
+				IL_00f4: ldloc.s 5
+				IL_00f6: ldloc.s 9
+				IL_00f8: clt
+				IL_00fa: brfalse IL_0104
 
-				IL_010d: br IL_0064
+				IL_00ff: br IL_005e
 			// end loop
 
-			IL_0112: ldloc.1
-			IL_0113: box [System.Runtime]System.Double
-			IL_0118: stloc.s 12
-			IL_011a: ldloc.s 12
-			IL_011c: ret
+			IL_0104: ldloc.0
+			IL_0105: box [System.Runtime]System.Double
+			IL_010a: stloc.s 10
+			IL_010c: ldloc.s 10
+			IL_010e: ret
 		} // end of method ArrowFunction_L210C23::__js_call__
 
 	} // end of class ArrowFunction_L210C23
@@ -254,7 +249,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3267
+				// Method begins at RVA 0x321d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -281,7 +276,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x25a4
+			// Method begins at RVA 0x2594
 			// Header size: 12
 			// Code size: 594 (0x252)
 			.maxstack 8
@@ -534,7 +529,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x313e
+				// Method begins at RVA 0x30f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -554,7 +549,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3147
+				// Method begins at RVA 0x30fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -574,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3150
+				// Method begins at RVA 0x3106
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -602,7 +597,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x316b
+						// Method begins at RVA 0x3121
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -626,7 +621,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x317d
+							// Method begins at RVA 0x3133
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -644,7 +639,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3174
+						// Method begins at RVA 0x312a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -662,7 +657,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3162
+					// Method begins at RVA 0x3118
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -690,7 +685,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3198
+							// Method begins at RVA 0x314e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -708,7 +703,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318f
+						// Method begins at RVA 0x3145
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -726,7 +721,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3186
+					// Method begins at RVA 0x313c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -750,7 +745,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31aa
+						// Method begins at RVA 0x3160
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -768,7 +763,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31a1
+					// Method begins at RVA 0x3157
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -786,7 +781,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3159
+				// Method begins at RVA 0x310f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -806,7 +801,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b3
+				// Method begins at RVA 0x3169
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -830,7 +825,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c5
+					// Method begins at RVA 0x317b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -848,7 +843,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31bc
+				// Method begins at RVA 0x3172
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -876,7 +871,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2868
+			// Method begins at RVA 0x2858
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -925,7 +920,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b3c
+			// Method begins at RVA 0x2b14
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -995,27 +990,24 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2900
+			// Method begins at RVA 0x28f0
 			// Header size: 12
-			// Code size: 560 (0x230)
+			// Code size: 534 (0x216)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26,
+				[0] float64,
 				[1] float64,
 				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75,
+				[5] float64,
 				[6] float64,
 				[7] float64,
 				[8] float64,
 				[9] float64,
 				[10] float64,
 				[11] float64,
-				[12] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29,
-				[13] float64,
-				[14] float64,
-				[15] float64
+				[12] float64
 			)
 
 			IL_0000: ldarg.2
@@ -1028,266 +1020,260 @@
 			IL_0013: ldc.r8 2
 			IL_001c: div
 			IL_001d: cgt
-			IL_001f: brfalse IL_013d
+			IL_001f: brfalse IL_012a
 
-			IL_0024: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
-			IL_0029: stloc.0
-			IL_002a: ldarg.1
-			IL_002b: ldc.r8 32
-			IL_0034: ldarg.2
-			IL_0035: mul
-			IL_0036: add
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: stloc.s 15
-			IL_003b: ldloc.s 15
-			IL_003d: ldarg.3
-			IL_003e: cgt
-			IL_0040: brfalse IL_006b
+			IL_0024: ldarg.1
+			IL_0025: ldc.r8 32
+			IL_002e: ldarg.2
+			IL_002f: mul
+			IL_0030: add
+			IL_0031: stloc.0
+			IL_0032: ldloc.0
+			IL_0033: stloc.s 12
+			IL_0035: ldloc.s 12
+			IL_0037: ldarg.3
+			IL_0038: cgt
+			IL_003a: brfalse IL_0065
 
-			IL_0045: ldarg.1
-			IL_0046: stloc.2
-			// loop start (head: IL_0047)
-				IL_0047: ldloc.2
-				IL_0048: stloc.s 15
-				IL_004a: ldloc.s 15
-				IL_004c: ldarg.3
-				IL_004d: clt
-				IL_004f: brfalse IL_0069
+			IL_003f: ldarg.1
+			IL_0040: stloc.1
+			// loop start (head: IL_0041)
+				IL_0041: ldloc.1
+				IL_0042: stloc.s 12
+				IL_0044: ldloc.s 12
+				IL_0046: ldarg.3
+				IL_0047: clt
+				IL_0049: brfalse IL_0063
 
-				IL_0054: ldarg.0
-				IL_0055: ldloc.2
-				IL_0056: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-				IL_005b: pop
-				IL_005c: ldloc.2
-				IL_005d: ldarg.2
-				IL_005e: add
-				IL_005f: stloc.s 15
-				IL_0061: ldloc.s 15
-				IL_0063: stloc.2
-				IL_0064: br IL_0047
+				IL_004e: ldarg.0
+				IL_004f: ldloc.1
+				IL_0050: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+				IL_0055: pop
+				IL_0056: ldloc.1
+				IL_0057: ldarg.2
+				IL_0058: add
+				IL_0059: stloc.s 12
+				IL_005b: ldloc.s 12
+				IL_005d: stloc.1
+				IL_005e: br IL_0041
 			// end loop
 
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_0063: ldnull
+			IL_0064: ret
 
-			IL_006b: ldarg.3
-			IL_006c: conv.i4
-			IL_006d: conv.u4
-			IL_006e: ldc.r8 5
-			IL_0077: conv.i4
-			IL_0078: shr.un
-			IL_0079: conv.r.un
-			IL_007a: stloc.s 15
-			IL_007c: ldloc.s 15
-			IL_007e: stloc.3
-			IL_007f: ldarg.1
-			IL_0080: stloc.s 4
-			// loop start (head: IL_0082)
-				IL_0082: ldloc.s 4
-				IL_0084: stloc.s 15
-				IL_0086: ldloc.s 15
-				IL_0088: ldloc.1
-				IL_0089: clt
-				IL_008b: brfalse IL_013b
+			IL_0065: ldarg.3
+			IL_0066: conv.i4
+			IL_0067: conv.u4
+			IL_0068: ldc.r8 5
+			IL_0071: conv.i4
+			IL_0072: shr.un
+			IL_0073: conv.r.un
+			IL_0074: stloc.s 12
+			IL_0076: ldloc.s 12
+			IL_0078: stloc.2
+			IL_0079: ldarg.1
+			IL_007a: stloc.3
+			// loop start (head: IL_007b)
+				IL_007b: ldloc.3
+				IL_007c: stloc.s 12
+				IL_007e: ldloc.s 12
+				IL_0080: ldloc.0
+				IL_0081: clt
+				IL_0083: brfalse IL_0128
 
-				IL_0090: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
-				IL_0095: stloc.s 5
-				IL_0097: ldloc.s 4
-				IL_0099: stloc.s 15
-				IL_009b: ldloc.s 15
-				IL_009d: conv.i4
-				IL_009e: conv.u4
-				IL_009f: ldc.r8 5
-				IL_00a8: conv.i4
-				IL_00a9: shr.un
-				IL_00aa: conv.r.un
-				IL_00ab: stloc.s 15
-				IL_00ad: ldloc.s 15
-				IL_00af: stloc.s 6
-				IL_00b1: ldloc.s 4
-				IL_00b3: stloc.s 15
-				IL_00b5: ldloc.s 15
-				IL_00b7: conv.i4
-				IL_00b8: ldc.r8 31
-				IL_00c1: conv.i4
-				IL_00c2: and
-				IL_00c3: conv.r8
-				IL_00c4: stloc.s 15
-				IL_00c6: ldloc.s 15
-				IL_00c8: stloc.s 7
-				IL_00ca: ldc.r8 1
-				IL_00d3: conv.i4
-				IL_00d4: ldloc.s 7
-				IL_00d6: conv.i4
-				IL_00d7: shl
-				IL_00d8: conv.r8
-				IL_00d9: stloc.s 15
-				IL_00db: ldloc.s 15
-				IL_00dd: stloc.s 8
-				// loop start (head: IL_00df)
-					IL_00df: nop
-					IL_00e0: ldarg.0
-					IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_00e6: ldloc.s 6
-					IL_00e8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_00ed: stloc.s 15
-					IL_00ef: ldloc.s 15
-					IL_00f1: stloc.s 15
-					IL_00f3: ldloc.s 15
-					IL_00f5: conv.i4
-					IL_00f6: ldloc.s 8
-					IL_00f8: conv.i4
-					IL_00f9: or
-					IL_00fa: conv.r8
-					IL_00fb: stloc.s 15
-					IL_00fd: ldarg.0
-					IL_00fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_0103: ldloc.s 6
-					IL_0105: ldloc.s 15
-					IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_010c: ldloc.s 6
-					IL_010e: ldarg.2
-					IL_010f: add
-					IL_0110: stloc.s 15
-					IL_0112: ldloc.s 15
-					IL_0114: stloc.s 6
-					IL_0116: ldloc.s 6
-					IL_0118: stloc.s 15
-					IL_011a: ldloc.s 15
-					IL_011c: ldloc.3
-					IL_011d: cgt
-					IL_011f: ldc.i4.0
-					IL_0120: ceq
-					IL_0122: brfalse IL_012c
+				IL_0088: ldloc.3
+				IL_0089: stloc.s 12
+				IL_008b: ldloc.s 12
+				IL_008d: conv.i4
+				IL_008e: conv.u4
+				IL_008f: ldc.r8 5
+				IL_0098: conv.i4
+				IL_0099: shr.un
+				IL_009a: conv.r.un
+				IL_009b: stloc.s 12
+				IL_009d: ldloc.s 12
+				IL_009f: stloc.s 4
+				IL_00a1: ldloc.3
+				IL_00a2: stloc.s 12
+				IL_00a4: ldloc.s 12
+				IL_00a6: conv.i4
+				IL_00a7: ldc.r8 31
+				IL_00b0: conv.i4
+				IL_00b1: and
+				IL_00b2: conv.r8
+				IL_00b3: stloc.s 12
+				IL_00b5: ldloc.s 12
+				IL_00b7: stloc.s 5
+				IL_00b9: ldc.r8 1
+				IL_00c2: conv.i4
+				IL_00c3: ldloc.s 5
+				IL_00c5: conv.i4
+				IL_00c6: shl
+				IL_00c7: conv.r8
+				IL_00c8: stloc.s 12
+				IL_00ca: ldloc.s 12
+				IL_00cc: stloc.s 6
+				// loop start (head: IL_00ce)
+					IL_00ce: nop
+					IL_00cf: ldarg.0
+					IL_00d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00d5: ldloc.s 4
+					IL_00d7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00dc: stloc.s 12
+					IL_00de: ldloc.s 12
+					IL_00e0: stloc.s 12
+					IL_00e2: ldloc.s 12
+					IL_00e4: conv.i4
+					IL_00e5: ldloc.s 6
+					IL_00e7: conv.i4
+					IL_00e8: or
+					IL_00e9: conv.r8
+					IL_00ea: stloc.s 12
+					IL_00ec: ldarg.0
+					IL_00ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00f2: ldloc.s 4
+					IL_00f4: ldloc.s 12
+					IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_00fb: ldloc.s 4
+					IL_00fd: ldarg.2
+					IL_00fe: add
+					IL_00ff: stloc.s 12
+					IL_0101: ldloc.s 12
+					IL_0103: stloc.s 4
+					IL_0105: ldloc.s 4
+					IL_0107: stloc.s 12
+					IL_0109: ldloc.s 12
+					IL_010b: ldloc.2
+					IL_010c: cgt
+					IL_010e: ldc.i4.0
+					IL_010f: ceq
+					IL_0111: brfalse IL_011b
 
-					IL_0127: br IL_00df
+					IL_0116: br IL_00ce
 				// end loop
 
-				IL_012c: ldloc.s 4
-				IL_012e: ldarg.2
-				IL_012f: add
-				IL_0130: stloc.s 15
-				IL_0132: ldloc.s 15
-				IL_0134: stloc.s 4
-				IL_0136: br IL_0082
+				IL_011b: ldloc.3
+				IL_011c: ldarg.2
+				IL_011d: add
+				IL_011e: stloc.s 12
+				IL_0120: ldloc.s 12
+				IL_0122: stloc.3
+				IL_0123: br IL_007b
 			// end loop
 
-			IL_013b: ldnull
-			IL_013c: ret
+			IL_0128: ldnull
+			IL_0129: ret
 
-			IL_013d: ldarg.1
-			IL_013e: stloc.s 9
-			IL_0140: ldloc.s 9
-			IL_0142: stloc.s 15
-			IL_0144: ldloc.s 15
-			IL_0146: conv.i4
-			IL_0147: conv.u4
-			IL_0148: ldc.r8 5
-			IL_0151: conv.i4
-			IL_0152: shr.un
-			IL_0153: conv.r.un
-			IL_0154: stloc.s 15
-			IL_0156: ldloc.s 15
-			IL_0158: stloc.s 10
-			IL_015a: ldarg.0
-			IL_015b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0160: ldloc.s 10
-			IL_0162: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0167: stloc.s 15
-			IL_0169: ldloc.s 15
-			IL_016b: stloc.s 11
-			// loop start (head: IL_016d)
-				IL_016d: ldloc.s 9
-				IL_016f: stloc.s 15
-				IL_0171: ldloc.s 15
-				IL_0173: ldarg.3
-				IL_0174: clt
-				IL_0176: brfalse IL_021f
+			IL_012a: ldarg.1
+			IL_012b: stloc.s 7
+			IL_012d: ldloc.s 7
+			IL_012f: stloc.s 12
+			IL_0131: ldloc.s 12
+			IL_0133: conv.i4
+			IL_0134: conv.u4
+			IL_0135: ldc.r8 5
+			IL_013e: conv.i4
+			IL_013f: shr.un
+			IL_0140: conv.r.un
+			IL_0141: stloc.s 12
+			IL_0143: ldloc.s 12
+			IL_0145: stloc.s 8
+			IL_0147: ldarg.0
+			IL_0148: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_014d: ldloc.s 8
+			IL_014f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0154: stloc.s 12
+			IL_0156: ldloc.s 12
+			IL_0158: stloc.s 9
+			// loop start (head: IL_015a)
+				IL_015a: ldloc.s 7
+				IL_015c: stloc.s 12
+				IL_015e: ldloc.s 12
+				IL_0160: ldarg.3
+				IL_0161: clt
+				IL_0163: brfalse IL_0205
 
-				IL_017b: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
-				IL_0180: stloc.s 12
-				IL_0182: ldloc.s 9
-				IL_0184: stloc.s 15
-				IL_0186: ldloc.s 15
-				IL_0188: conv.i4
-				IL_0189: ldc.r8 31
-				IL_0192: conv.i4
-				IL_0193: and
-				IL_0194: conv.r8
-				IL_0195: stloc.s 15
-				IL_0197: ldloc.s 15
-				IL_0199: stloc.s 13
-				IL_019b: ldc.r8 1
-				IL_01a4: conv.i4
-				IL_01a5: ldloc.s 13
-				IL_01a7: conv.i4
-				IL_01a8: shl
-				IL_01a9: conv.r8
-				IL_01aa: stloc.s 15
-				IL_01ac: ldloc.s 11
-				IL_01ae: conv.i4
-				IL_01af: ldloc.s 15
-				IL_01b1: conv.i4
-				IL_01b2: or
-				IL_01b3: conv.r8
-				IL_01b4: stloc.s 15
-				IL_01b6: ldloc.s 15
-				IL_01b8: stloc.s 11
-				IL_01ba: ldloc.s 9
-				IL_01bc: ldarg.2
-				IL_01bd: add
-				IL_01be: stloc.s 15
-				IL_01c0: ldloc.s 15
-				IL_01c2: stloc.s 9
-				IL_01c4: ldloc.s 9
-				IL_01c6: stloc.s 15
-				IL_01c8: ldloc.s 15
-				IL_01ca: conv.i4
-				IL_01cb: conv.u4
-				IL_01cc: ldc.r8 5
-				IL_01d5: conv.i4
-				IL_01d6: shr.un
-				IL_01d7: conv.r.un
-				IL_01d8: stloc.s 15
-				IL_01da: ldloc.s 15
-				IL_01dc: stloc.s 14
-				IL_01de: ldloc.s 14
-				IL_01e0: stloc.s 15
-				IL_01e2: ldloc.s 15
-				IL_01e4: ldloc.s 10
-				IL_01e6: ceq
-				IL_01e8: ldc.i4.0
-				IL_01e9: ceq
-				IL_01eb: brfalse IL_021a
+				IL_0168: ldloc.s 7
+				IL_016a: stloc.s 12
+				IL_016c: ldloc.s 12
+				IL_016e: conv.i4
+				IL_016f: ldc.r8 31
+				IL_0178: conv.i4
+				IL_0179: and
+				IL_017a: conv.r8
+				IL_017b: stloc.s 12
+				IL_017d: ldloc.s 12
+				IL_017f: stloc.s 10
+				IL_0181: ldc.r8 1
+				IL_018a: conv.i4
+				IL_018b: ldloc.s 10
+				IL_018d: conv.i4
+				IL_018e: shl
+				IL_018f: conv.r8
+				IL_0190: stloc.s 12
+				IL_0192: ldloc.s 9
+				IL_0194: conv.i4
+				IL_0195: ldloc.s 12
+				IL_0197: conv.i4
+				IL_0198: or
+				IL_0199: conv.r8
+				IL_019a: stloc.s 12
+				IL_019c: ldloc.s 12
+				IL_019e: stloc.s 9
+				IL_01a0: ldloc.s 7
+				IL_01a2: ldarg.2
+				IL_01a3: add
+				IL_01a4: stloc.s 12
+				IL_01a6: ldloc.s 12
+				IL_01a8: stloc.s 7
+				IL_01aa: ldloc.s 7
+				IL_01ac: stloc.s 12
+				IL_01ae: ldloc.s 12
+				IL_01b0: conv.i4
+				IL_01b1: conv.u4
+				IL_01b2: ldc.r8 5
+				IL_01bb: conv.i4
+				IL_01bc: shr.un
+				IL_01bd: conv.r.un
+				IL_01be: stloc.s 12
+				IL_01c0: ldloc.s 12
+				IL_01c2: stloc.s 11
+				IL_01c4: ldloc.s 11
+				IL_01c6: stloc.s 12
+				IL_01c8: ldloc.s 12
+				IL_01ca: ldloc.s 8
+				IL_01cc: ceq
+				IL_01ce: ldc.i4.0
+				IL_01cf: ceq
+				IL_01d1: brfalse IL_0200
 
-				IL_01f0: ldarg.0
-				IL_01f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_01f6: ldloc.s 10
-				IL_01f8: ldloc.s 11
-				IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_01ff: ldloc.s 14
-				IL_0201: stloc.s 15
-				IL_0203: ldloc.s 15
-				IL_0205: stloc.s 10
-				IL_0207: ldarg.0
-				IL_0208: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_020d: ldloc.s 10
-				IL_020f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_0214: stloc.s 15
-				IL_0216: ldloc.s 15
-				IL_0218: stloc.s 11
+				IL_01d6: ldarg.0
+				IL_01d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01dc: ldloc.s 8
+				IL_01de: ldloc.s 9
+				IL_01e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01e5: ldloc.s 11
+				IL_01e7: stloc.s 12
+				IL_01e9: ldloc.s 12
+				IL_01eb: stloc.s 8
+				IL_01ed: ldarg.0
+				IL_01ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01f3: ldloc.s 8
+				IL_01f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_01fa: stloc.s 12
+				IL_01fc: ldloc.s 12
+				IL_01fe: stloc.s 9
 
-				IL_021a: br IL_016d
+				IL_0200: br IL_015a
 			// end loop
 
-			IL_021f: ldarg.0
-			IL_0220: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0225: ldloc.s 10
-			IL_0227: ldloc.s 11
-			IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_022e: ldnull
-			IL_022f: ret
+			IL_0205: ldarg.0
+			IL_0206: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_020b: ldloc.s 8
+			IL_020d: ldloc.s 9
+			IL_020f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0214: ldnull
+			IL_0215: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1298,7 +1284,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ba0
+			// Method begins at RVA 0x2b78
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1362,7 +1348,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28b8
+			// Method begins at RVA 0x28a8
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1410,7 +1396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ce
+				// Method begins at RVA 0x3184
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1430,7 +1416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31d7
+				// Method begins at RVA 0x318d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1454,7 +1440,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31e9
+					// Method begins at RVA 0x319f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1472,7 +1458,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e0
+				// Method begins at RVA 0x3196
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1492,7 +1478,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f2
+				// Method begins at RVA 0x31a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1520,7 +1506,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x320d
+						// Method begins at RVA 0x31c3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1538,7 +1524,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3204
+					// Method begins at RVA 0x31ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1556,7 +1542,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31fb
+				// Method begins at RVA 0x31b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1580,7 +1566,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321f
+					// Method begins at RVA 0x31d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1604,7 +1590,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3231
+						// Method begins at RVA 0x31e7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1622,7 +1608,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3228
+					// Method begins at RVA 0x31de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1640,7 +1626,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3216
+				// Method begins at RVA 0x31cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1664,7 +1650,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3243
+					// Method begins at RVA 0x31f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1682,7 +1668,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x323a
+				// Method begins at RVA 0x31f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1712,7 +1698,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2804
+			// Method begins at RVA 0x27f4
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -1768,109 +1754,106 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bfc
+			// Method begins at RVA 0x2bd4
 			// Header size: 12
-			// Code size: 217 (0xd9)
+			// Code size: 209 (0xd1)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_runSieve/Block_L133C2,
+				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] float64,
-				[6] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
-				[7] object
+				[5] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
+				[6] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
 			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
-			IL_000b: stloc.s 5
-			IL_000d: ldloc.s 5
+			IL_000b: stloc.s 4
+			IL_000d: ldloc.s 4
 			IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::ceil(float64)
-			IL_0014: stloc.s 5
-			IL_0016: ldloc.s 5
+			IL_0014: stloc.s 4
+			IL_0016: ldloc.s 4
 			IL_0018: stloc.0
 			IL_0019: ldc.r8 1
 			IL_0022: stloc.1
 			// loop start (head: IL_0023)
 				IL_0023: ldloc.1
-				IL_0024: stloc.s 5
-				IL_0026: ldloc.s 5
+				IL_0024: stloc.s 4
+				IL_0026: ldloc.s 4
 				IL_0028: ldloc.0
 				IL_0029: clt
-				IL_002b: brfalse IL_00d7
+				IL_002b: brfalse IL_00cf
 
-				IL_0030: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_runSieve/Block_L133C2::.ctor()
-				IL_0035: stloc.2
-				IL_0036: ldloc.1
-				IL_0037: stloc.s 5
-				IL_0039: ldloc.s 5
-				IL_003b: ldc.r8 2
-				IL_0044: mul
-				IL_0045: stloc.s 5
-				IL_0047: ldloc.s 5
-				IL_0049: ldc.r8 1
-				IL_0052: add
-				IL_0053: stloc.s 5
-				IL_0055: ldloc.s 5
-				IL_0057: stloc.3
-				IL_0058: ldloc.1
-				IL_0059: stloc.s 5
-				IL_005b: ldloc.s 5
-				IL_005d: ldloc.1
-				IL_005e: mul
-				IL_005f: stloc.s 5
-				IL_0061: ldloc.s 5
-				IL_0063: ldc.r8 2
-				IL_006c: mul
-				IL_006d: stloc.s 5
-				IL_006f: ldloc.s 5
+				IL_0030: ldloc.1
+				IL_0031: stloc.s 4
+				IL_0033: ldloc.s 4
+				IL_0035: ldc.r8 2
+				IL_003e: mul
+				IL_003f: stloc.s 4
+				IL_0041: ldloc.s 4
+				IL_0043: ldc.r8 1
+				IL_004c: add
+				IL_004d: stloc.s 4
+				IL_004f: ldloc.s 4
+				IL_0051: stloc.2
+				IL_0052: ldloc.1
+				IL_0053: stloc.s 4
+				IL_0055: ldloc.s 4
+				IL_0057: ldloc.1
+				IL_0058: mul
+				IL_0059: stloc.s 4
+				IL_005b: ldloc.s 4
+				IL_005d: ldc.r8 2
+				IL_0066: mul
+				IL_0067: stloc.s 4
+				IL_0069: ldloc.s 4
+				IL_006b: ldloc.1
+				IL_006c: add
+				IL_006d: stloc.s 4
+				IL_006f: ldloc.s 4
 				IL_0071: ldloc.1
 				IL_0072: add
-				IL_0073: stloc.s 5
-				IL_0075: ldloc.s 5
-				IL_0077: ldloc.1
-				IL_0078: add
-				IL_0079: stloc.s 5
-				IL_007b: ldloc.s 5
-				IL_007d: stloc.s 4
-				IL_007f: ldarg.0
-				IL_0080: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
-				IL_008a: stloc.s 6
-				IL_008c: ldloc.s 6
-				IL_008e: ldloc.s 4
-				IL_0090: ldloc.3
-				IL_0091: ldarg.0
-				IL_0092: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
-				IL_0097: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
-				IL_009c: pop
-				IL_009d: ldarg.0
-				IL_009e: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
-				IL_00a8: stloc.s 6
-				IL_00aa: ldloc.1
-				IL_00ab: stloc.s 5
-				IL_00ad: ldloc.s 5
-				IL_00af: ldc.r8 1
-				IL_00b8: add
-				IL_00b9: stloc.s 5
-				IL_00bb: ldloc.s 5
-				IL_00bd: box [System.Runtime]System.Double
-				IL_00c2: stloc.s 7
-				IL_00c4: ldloc.s 6
-				IL_00c6: ldloc.s 7
-				IL_00c8: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(object)
-				IL_00cd: stloc.s 5
-				IL_00cf: ldloc.s 5
-				IL_00d1: stloc.1
-				IL_00d2: br IL_0023
+				IL_0073: stloc.s 4
+				IL_0075: ldloc.s 4
+				IL_0077: stloc.3
+				IL_0078: ldarg.0
+				IL_0079: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
+				IL_007e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
+				IL_0083: stloc.s 5
+				IL_0085: ldloc.s 5
+				IL_0087: ldloc.3
+				IL_0088: ldloc.2
+				IL_0089: ldarg.0
+				IL_008a: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
+				IL_008f: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
+				IL_0094: pop
+				IL_0095: ldarg.0
+				IL_0096: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
+				IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
+				IL_00a0: stloc.s 5
+				IL_00a2: ldloc.1
+				IL_00a3: stloc.s 4
+				IL_00a5: ldloc.s 4
+				IL_00a7: ldc.r8 1
+				IL_00b0: add
+				IL_00b1: stloc.s 4
+				IL_00b3: ldloc.s 4
+				IL_00b5: box [System.Runtime]System.Double
+				IL_00ba: stloc.s 6
+				IL_00bc: ldloc.s 5
+				IL_00be: ldloc.s 6
+				IL_00c0: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(object)
+				IL_00c5: stloc.s 4
+				IL_00c7: ldloc.s 4
+				IL_00c9: stloc.1
+				IL_00ca: br IL_0023
 			// end loop
 
-			IL_00d7: ldarg.0
-			IL_00d8: ret
+			IL_00cf: ldarg.0
+			IL_00d0: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
@@ -1879,7 +1862,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fc4
+			// Method begins at RVA 0x2f8c
 			// Header size: 12
 			// Code size: 112 (0x70)
 			.maxstack 8
@@ -1946,19 +1929,18 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3040
+			// Method begins at RVA 0x3008
 			// Header size: 12
-			// Code size: 233 (0xe9)
+			// Code size: 215 (0xd7)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_getPrimes/Block_L157C1,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] float64,
 				[2] float64,
 				[3] float64,
-				[4] float64,
-				[5] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
-				[6] object,
-				[7] bool
+				[4] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
+				[5] object,
+				[6] bool
 			)
 
 			IL_0000: ldarg.1
@@ -1968,85 +1950,83 @@
 			IL_000f: box [System.Runtime]System.Double
 			IL_0014: starg.s max
 
-			IL_0016: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_getPrimes/Block_L157C1::.ctor()
-			IL_001b: stloc.0
-			IL_001c: ldc.i4.1
-			IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0022: dup
-			IL_0023: ldc.r8 2
-			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0031: stloc.1
-			IL_0032: ldc.r8 1
-			IL_003b: stloc.2
-			IL_003c: ldc.r8 0.0
-			IL_0045: stloc.3
-			// loop start (head: IL_0046)
-				IL_0046: ldloc.2
-				IL_0047: stloc.s 4
-				IL_0049: ldloc.s 4
-				IL_004b: ldarg.0
-				IL_004c: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
-				IL_0051: clt
-				IL_0053: brfalse IL_00e7
+			IL_0016: ldc.i4.1
+			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_001c: dup
+			IL_001d: ldc.r8 2
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_002b: stloc.0
+			IL_002c: ldc.r8 1
+			IL_0035: stloc.1
+			IL_0036: ldc.r8 0.0
+			IL_003f: stloc.2
+			// loop start (head: IL_0040)
+				IL_0040: ldloc.1
+				IL_0041: stloc.3
+				IL_0042: ldloc.3
+				IL_0043: ldarg.0
+				IL_0044: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
+				IL_0049: clt
+				IL_004b: brfalse IL_00d5
 
-				IL_0058: ldloc.3
-				IL_0059: stloc.s 4
-				IL_005b: ldloc.s 4
-				IL_005d: ldarg.1
-				IL_005e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0063: clt
-				IL_0065: ldc.i4.0
-				IL_0066: ceq
-				IL_0068: brfalse IL_0072
+				IL_0050: ldloc.2
+				IL_0051: stloc.3
+				IL_0052: ldloc.3
+				IL_0053: ldarg.1
+				IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0059: clt
+				IL_005b: ldc.i4.0
+				IL_005c: ceq
+				IL_005e: brfalse IL_0068
 
-				IL_006d: br IL_00e7
+				IL_0063: br IL_00d5
 
-				IL_0072: ldarg.0
-				IL_0073: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
-				IL_007d: stloc.s 5
-				IL_007f: ldloc.2
-				IL_0080: box [System.Runtime]System.Double
-				IL_0085: stloc.s 6
-				IL_0087: ldloc.s 5
-				IL_0089: ldloc.s 6
-				IL_008b: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
-				IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
-				IL_0095: ldc.i4.0
-				IL_0096: ceq
-				IL_0098: stloc.s 7
-				IL_009a: ldloc.s 7
-				IL_009c: brfalse IL_00d6
+				IL_0068: ldarg.0
+				IL_0069: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
+				IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
+				IL_0073: stloc.s 4
+				IL_0075: ldloc.1
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stloc.s 5
+				IL_007d: ldloc.s 4
+				IL_007f: ldloc.s 5
+				IL_0081: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
+				IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
+				IL_008b: ldc.i4.0
+				IL_008c: ceq
+				IL_008e: stloc.s 6
+				IL_0090: ldloc.s 6
+				IL_0092: brfalse IL_00c4
 
-				IL_00a1: ldloc.2
-				IL_00a2: stloc.s 4
-				IL_00a4: ldloc.s 4
-				IL_00a6: ldc.r8 2
-				IL_00af: mul
-				IL_00b0: stloc.s 4
-				IL_00b2: ldloc.s 4
-				IL_00b4: ldc.r8 1
-				IL_00bd: add
-				IL_00be: stloc.s 4
-				IL_00c0: ldloc.s 4
-				IL_00c2: box [System.Runtime]System.Double
-				IL_00c7: stloc.s 6
-				IL_00c9: ldloc.1
-				IL_00ca: ldloc.s 6
-				IL_00cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00d1: stloc.s 4
-				IL_00d3: ldloc.s 4
-				IL_00d5: stloc.3
+				IL_0097: ldloc.1
+				IL_0098: stloc.3
+				IL_0099: ldloc.3
+				IL_009a: ldc.r8 2
+				IL_00a3: mul
+				IL_00a4: stloc.3
+				IL_00a5: ldloc.3
+				IL_00a6: ldc.r8 1
+				IL_00af: add
+				IL_00b0: stloc.3
+				IL_00b1: ldloc.3
+				IL_00b2: box [System.Runtime]System.Double
+				IL_00b7: stloc.s 5
+				IL_00b9: ldloc.0
+				IL_00ba: ldloc.s 5
+				IL_00bc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00c1: stloc.3
+				IL_00c2: ldloc.3
+				IL_00c3: stloc.2
 
-				IL_00d6: ldloc.2
-				IL_00d7: ldc.r8 1
-				IL_00e0: add
-				IL_00e1: stloc.2
-				IL_00e2: br IL_0046
+				IL_00c4: ldloc.1
+				IL_00c5: ldc.r8 1
+				IL_00ce: add
+				IL_00cf: stloc.1
+				IL_00d0: br IL_0040
 			// end loop
 
-			IL_00e7: ldloc.1
-			IL_00e8: ret
+			IL_00d5: ldloc.0
+			IL_00d6: ret
 		} // end of method PrimeSieve::getPrimes
 
 		.method public hidebysig 
@@ -2057,9 +2037,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ce4
+			// Method begins at RVA 0x2cb4
 			// Header size: 12
-			// Code size: 721 (0x2d1)
+			// Code size: 714 (0x2ca)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -2067,15 +2047,14 @@
 				[2] float64,
 				[3] object,
 				[4] object,
-				[5] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_validatePrimeCount/Block_L187C2,
-				[6] object,
-				[7] float64,
+				[5] object,
+				[6] float64,
+				[7] object,
 				[8] object,
-				[9] object,
-				[10] bool,
-				[11] object,
-				[12] string,
-				[13] string
+				[9] bool,
+				[10] object,
+				[11] string,
+				[12] string
 			)
 
 			IL_0000: ldc.r8 100
@@ -2116,17 +2095,17 @@
 			IL_00af: stloc.1
 			IL_00b0: ldarg.0
 			IL_00b1: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::countPrimes()
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
+			IL_00b6: stloc.s 6
+			IL_00b8: ldloc.s 6
 			IL_00ba: stloc.2
 			IL_00bb: ldloc.0
 			IL_00bc: box [System.Runtime]System.Double
-			IL_00c1: stloc.s 8
+			IL_00c1: stloc.s 7
 			IL_00c3: ldarg.0
-			IL_00c4: ldloc.s 8
+			IL_00c4: ldloc.s 7
 			IL_00c6: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::getPrimes(object)
-			IL_00cb: stloc.s 9
-			IL_00cd: ldloc.s 9
+			IL_00cb: stloc.s 8
+			IL_00cd: ldloc.s 8
 			IL_00cf: stloc.3
 			IL_00d0: ldc.i4.0
 			IL_00d1: box [System.Runtime]System.Boolean
@@ -2136,167 +2115,165 @@
 			IL_00de: box [System.Runtime]System.Double
 			IL_00e3: ldloc.1
 			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-			IL_00e9: stloc.s 10
-			IL_00eb: ldloc.s 10
-			IL_00ed: brfalse IL_01eb
+			IL_00e9: stloc.s 9
+			IL_00eb: ldloc.s 9
+			IL_00ed: brfalse IL_01e4
 
-			IL_00f2: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_validatePrimeCount/Block_L187C2::.ctor()
-			IL_00f7: stloc.s 5
-			IL_00f9: ldloc.1
-			IL_00fa: ldarg.0
-			IL_00fb: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0105: stloc.s 9
-			IL_0107: ldloc.s 9
-			IL_0109: stloc.s 6
-			IL_010b: ldloc.s 6
-			IL_010d: stloc.s 9
-			IL_010f: ldloc.2
-			IL_0110: box [System.Runtime]System.Double
-			IL_0115: stloc.s 8
-			IL_0117: ldloc.s 9
-			IL_0119: ldloc.s 8
-			IL_011b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_0120: stloc.s 10
-			IL_0122: ldloc.s 10
-			IL_0124: box [System.Runtime]System.Boolean
-			IL_0129: stloc.s 11
-			IL_012b: ldloc.s 11
-			IL_012d: stloc.s 4
-			IL_012f: ldloc.s 4
-			IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0136: ldc.i4.0
-			IL_0137: ceq
-			IL_0139: stloc.s 10
-			IL_013b: ldloc.s 10
-			IL_013d: brfalse IL_01e6
+			IL_00f2: ldloc.1
+			IL_00f3: ldarg.0
+			IL_00f4: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00fe: stloc.s 8
+			IL_0100: ldloc.s 8
+			IL_0102: stloc.s 5
+			IL_0104: ldloc.s 5
+			IL_0106: stloc.s 8
+			IL_0108: ldloc.2
+			IL_0109: box [System.Runtime]System.Double
+			IL_010e: stloc.s 7
+			IL_0110: ldloc.s 8
+			IL_0112: ldloc.s 7
+			IL_0114: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+			IL_0119: stloc.s 9
+			IL_011b: ldloc.s 9
+			IL_011d: box [System.Runtime]System.Boolean
+			IL_0122: stloc.s 10
+			IL_0124: ldloc.s 10
+			IL_0126: stloc.s 4
+			IL_0128: ldloc.s 4
+			IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_012f: ldc.i4.0
+			IL_0130: ceq
+			IL_0132: stloc.s 9
+			IL_0134: ldloc.s 9
+			IL_0136: brfalse IL_01df
 
-			IL_0142: ldstr "console"
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_014c: stloc.s 9
-			IL_014e: ldloc.s 9
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0155: stloc.s 9
-			IL_0157: ldarg.0
-			IL_0158: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_015d: box [System.Runtime]System.Double
-			IL_0162: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0167: stloc.s 12
-			IL_0169: ldstr "Limit for "
-			IL_016e: ldloc.s 12
-			IL_0170: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0175: stloc.s 12
-			IL_0177: ldloc.s 12
-			IL_0179: ldstr " should be "
-			IL_017e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0183: stloc.s 12
-			IL_0185: ldloc.s 6
-			IL_0187: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_018c: stloc.s 13
-			IL_018e: ldloc.s 12
-			IL_0190: ldloc.s 13
-			IL_0192: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0197: stloc.s 13
-			IL_0199: ldloc.s 13
-			IL_019b: ldstr " "
-			IL_01a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a5: stloc.s 13
-			IL_01a7: ldloc.2
-			IL_01a8: box [System.Runtime]System.Double
-			IL_01ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b2: stloc.s 12
-			IL_01b4: ldstr "but result contains "
-			IL_01b9: ldloc.s 12
-			IL_01bb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c0: stloc.s 12
-			IL_01c2: ldloc.s 12
-			IL_01c4: ldstr " primes"
-			IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ce: stloc.s 12
-			IL_01d0: ldloc.s 9
-			IL_01d2: ldstr "log"
-			IL_01d7: ldstr "\nError: invalid result."
-			IL_01dc: ldloc.s 13
-			IL_01de: ldloc.s 12
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01e5: pop
+			IL_013b: ldstr "console"
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0145: stloc.s 8
+			IL_0147: ldloc.s 8
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014e: stloc.s 8
+			IL_0150: ldarg.0
+			IL_0151: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_0156: box [System.Runtime]System.Double
+			IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0160: stloc.s 11
+			IL_0162: ldstr "Limit for "
+			IL_0167: ldloc.s 11
+			IL_0169: call string [System.Runtime]System.String::Concat(string, string)
+			IL_016e: stloc.s 11
+			IL_0170: ldloc.s 11
+			IL_0172: ldstr " should be "
+			IL_0177: call string [System.Runtime]System.String::Concat(string, string)
+			IL_017c: stloc.s 11
+			IL_017e: ldloc.s 5
+			IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0185: stloc.s 12
+			IL_0187: ldloc.s 11
+			IL_0189: ldloc.s 12
+			IL_018b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0190: stloc.s 12
+			IL_0192: ldloc.s 12
+			IL_0194: ldstr " "
+			IL_0199: call string [System.Runtime]System.String::Concat(string, string)
+			IL_019e: stloc.s 12
+			IL_01a0: ldloc.2
+			IL_01a1: box [System.Runtime]System.Double
+			IL_01a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ab: stloc.s 11
+			IL_01ad: ldstr "but result contains "
+			IL_01b2: ldloc.s 11
+			IL_01b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b9: stloc.s 11
+			IL_01bb: ldloc.s 11
+			IL_01bd: ldstr " primes"
+			IL_01c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c7: stloc.s 11
+			IL_01c9: ldloc.s 8
+			IL_01cb: ldstr "log"
+			IL_01d0: ldstr "\nError: invalid result."
+			IL_01d5: ldloc.s 12
+			IL_01d7: ldloc.s 11
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01de: pop
 
-			IL_01e6: br IL_0268
+			IL_01df: br IL_0261
 
-			IL_01eb: ldstr "console"
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f5: stloc.s 9
-			IL_01f7: ldloc.s 9
-			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fe: stloc.s 9
-			IL_0200: ldloc.2
-			IL_0201: box [System.Runtime]System.Double
-			IL_0206: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020b: stloc.s 12
-			IL_020d: ldstr "Warning: cannot validate result of "
-			IL_0212: ldloc.s 12
-			IL_0214: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0219: stloc.s 12
-			IL_021b: ldloc.s 12
-			IL_021d: ldstr " primes:"
-			IL_0222: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0227: stloc.s 12
-			IL_0229: ldarg.0
-			IL_022a: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
-			IL_022f: box [System.Runtime]System.Double
-			IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0239: stloc.s 13
-			IL_023b: ldstr "limit "
-			IL_0240: ldloc.s 13
-			IL_0242: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0247: stloc.s 13
-			IL_0249: ldloc.s 13
-			IL_024b: ldstr " is not in the known list of number of primes!"
-			IL_0250: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0255: stloc.s 13
-			IL_0257: ldloc.s 9
-			IL_0259: ldstr "log"
-			IL_025e: ldloc.s 12
-			IL_0260: ldloc.s 13
-			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0267: pop
+			IL_01e4: ldstr "console"
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ee: stloc.s 8
+			IL_01f0: ldloc.s 8
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f7: stloc.s 8
+			IL_01f9: ldloc.2
+			IL_01fa: box [System.Runtime]System.Double
+			IL_01ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0204: stloc.s 11
+			IL_0206: ldstr "Warning: cannot validate result of "
+			IL_020b: ldloc.s 11
+			IL_020d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0212: stloc.s 11
+			IL_0214: ldloc.s 11
+			IL_0216: ldstr " primes:"
+			IL_021b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0220: stloc.s 11
+			IL_0222: ldarg.0
+			IL_0223: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSize
+			IL_0228: box [System.Runtime]System.Double
+			IL_022d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0232: stloc.s 12
+			IL_0234: ldstr "limit "
+			IL_0239: ldloc.s 12
+			IL_023b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0240: stloc.s 12
+			IL_0242: ldloc.s 12
+			IL_0244: ldstr " is not in the known list of number of primes!"
+			IL_0249: call string [System.Runtime]System.String::Concat(string, string)
+			IL_024e: stloc.s 12
+			IL_0250: ldloc.s 8
+			IL_0252: ldstr "log"
+			IL_0257: ldloc.s 11
+			IL_0259: ldloc.s 12
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0260: pop
 
-			IL_0268: ldarg.1
-			IL_0269: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_026e: stloc.s 10
-			IL_0270: ldloc.s 10
-			IL_0272: brfalse IL_02c5
+			IL_0261: ldarg.1
+			IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0267: stloc.s 9
+			IL_0269: ldloc.s 9
+			IL_026b: brfalse IL_02be
 
-			IL_0277: ldstr "console"
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0281: stloc.s 9
-			IL_0283: ldloc.s 9
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_028a: stloc.s 9
-			IL_028c: ldloc.0
-			IL_028d: box [System.Runtime]System.Double
-			IL_0292: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0297: stloc.s 13
-			IL_0299: ldstr "\nThe first "
-			IL_029e: ldloc.s 13
-			IL_02a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a5: stloc.s 13
-			IL_02a7: ldloc.s 13
-			IL_02a9: ldstr " found primes are:"
-			IL_02ae: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02b3: stloc.s 13
-			IL_02b5: ldloc.s 9
-			IL_02b7: ldstr "log"
-			IL_02bc: ldloc.s 13
-			IL_02be: ldloc.3
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02c4: pop
+			IL_0270: ldstr "console"
+			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_027a: stloc.s 8
+			IL_027c: ldloc.s 8
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0283: stloc.s 8
+			IL_0285: ldloc.0
+			IL_0286: box [System.Runtime]System.Double
+			IL_028b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0290: stloc.s 12
+			IL_0292: ldstr "\nThe first "
+			IL_0297: ldloc.s 12
+			IL_0299: call string [System.Runtime]System.String::Concat(string, string)
+			IL_029e: stloc.s 12
+			IL_02a0: ldloc.s 12
+			IL_02a2: ldstr " found primes are:"
+			IL_02a7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02ac: stloc.s 12
+			IL_02ae: ldloc.s 8
+			IL_02b0: ldstr "log"
+			IL_02b5: ldloc.s 12
+			IL_02b7: ldloc.3
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02bd: pop
 
-			IL_02c5: ldloc.s 4
-			IL_02c7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02cc: stloc.s 10
-			IL_02ce: ldloc.s 10
-			IL_02d0: ret
+			IL_02be: ldloc.s 4
+			IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02c5: stloc.s 9
+			IL_02c7: ldloc.s 9
+			IL_02c9: ret
 		} // end of method PrimeSieve::validatePrimeCount
 
 	} // end of class PrimeSieve
@@ -2330,7 +2307,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3135
+			// Method begins at RVA 0x30eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2360,7 +2337,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3270
+				// Method begins at RVA 0x3226
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2373,7 +2350,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x3278
+				// Method begins at RVA 0x322e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2388,7 +2365,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3280
+				// Method begins at RVA 0x3236
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2406,7 +2383,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x3295
+				// Method begins at RVA 0x324b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2421,7 +2398,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x329d
+				// Method begins at RVA 0x3253
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2439,7 +2416,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x32b2
+				// Method begins at RVA 0x3268
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2454,7 +2431,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x32ba
+				// Method begins at RVA 0x3270
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2472,7 +2449,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x32cf
+				// Method begins at RVA 0x3285
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2487,7 +2464,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x32d7
+				// Method begins at RVA 0x328d
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2948,7 +2925,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x32ec
+		// Method begins at RVA 0x32a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39a0
+				// Method begins at RVA 0x3994
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24c4
+			// Method begins at RVA 0x24bc
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39a9
+				// Method begins at RVA 0x399d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24f0
+			// Method begins at RVA 0x24e8
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39b2
+				// Method begins at RVA 0x39a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -168,7 +168,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2520
+			// Method begins at RVA 0x2518
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -256,7 +256,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39c4
+					// Method begins at RVA 0x39b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,7 +280,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3844
+				// Method begins at RVA 0x3838
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -320,7 +320,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39cd
+					// Method begins at RVA 0x39c1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3870
+				// Method begins at RVA 0x3864
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -376,7 +376,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39d6
+					// Method begins at RVA 0x39ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -394,7 +394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39bb
+				// Method begins at RVA 0x39af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -419,7 +419,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25b0
+			// Method begins at RVA 0x25a8
 			// Header size: 12
 			// Code size: 943 (0x3af)
 			.maxstack 8
@@ -816,7 +816,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39df
+				// Method begins at RVA 0x39d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -844,7 +844,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x297c
+			// Method begins at RVA 0x2974
 			// Header size: 12
 			// Code size: 224 (0xe0)
 			.maxstack 8
@@ -974,7 +974,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x39f1
+					// Method begins at RVA 0x39e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -992,7 +992,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39e8
+				// Method begins at RVA 0x39dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1017,7 +1017,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a68
+			// Method begins at RVA 0x2a60
 			// Header size: 12
 			// Code size: 177 (0xb1)
 			.maxstack 8
@@ -1114,7 +1114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a03
+					// Method begins at RVA 0x39f7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1132,7 +1132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x39fa
+				// Method begins at RVA 0x39ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1157,7 +1157,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b28
+			// Method begins at RVA 0x2b20
 			// Header size: 12
 			// Code size: 155 (0x9b)
 			.maxstack 8
@@ -1251,7 +1251,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a15
+					// Method begins at RVA 0x3a09
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1269,7 +1269,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a0c
+				// Method begins at RVA 0x3a00
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1296,7 +1296,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2bd0
+			// Method begins at RVA 0x2bc8
 			// Header size: 12
 			// Code size: 562 (0x232)
 			.maxstack 8
@@ -1521,7 +1521,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a1e
+				// Method begins at RVA 0x3a12
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1545,7 +1545,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e10
+			// Method begins at RVA 0x2e08
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1601,7 +1601,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a30
+					// Method begins at RVA 0x3a24
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1626,7 +1626,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x388c
+				// Method begins at RVA 0x3880
 				// Header size: 12
 				// Code size: 136 (0x88)
 				.maxstack 8
@@ -1714,7 +1714,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a27
+				// Method begins at RVA 0x3a1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1742,7 +1742,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2e58
+			// Method begins at RVA 0x2e50
 			// Header size: 12
 			// Code size: 375 (0x177)
 			.maxstack 8
@@ -1909,7 +1909,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a4b
+					// Method begins at RVA 0x3a3f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1934,7 +1934,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3920
+				// Method begins at RVA 0x3914
 				// Header size: 12
 				// Code size: 107 (0x6b)
 				.maxstack 8
@@ -2015,7 +2015,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a42
+					// Method begins at RVA 0x3a36
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2035,7 +2035,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3a54
+					// Method begins at RVA 0x3a48
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2053,7 +2053,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a39
+				// Method begins at RVA 0x3a2d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2079,9 +2079,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2fdc
+			// Method begins at RVA 0x2fd4
 			// Header size: 12
-			// Code size: 2140 (0x85c)
+			// Code size: 2133 (0x855)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -2099,7 +2099,7 @@
 				[12] object,
 				[13] object,
 				[14] object,
-				[15] class Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35,
+				[15] object,
 				[16] object,
 				[17] object,
 				[18] object,
@@ -2107,57 +2107,56 @@
 				[20] object,
 				[21] object,
 				[22] object,
-				[23] object,
-				[24] string,
+				[23] string,
+				[24] object,
 				[25] object,
 				[26] object,
 				[27] object,
 				[28] object,
 				[29] object,
 				[30] object,
-				[31] object,
-				[32] object[],
-				[33] bool,
-				[34] string,
-				[35] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[31] object[],
+				[32] bool,
+				[33] string,
+				[34] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[35] object,
 				[36] object,
 				[37] object,
 				[38] object,
-				[39] object,
-				[40] string
+				[39] string
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldstr "process"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0010: stloc.s 31
-			IL_0012: ldloc.s 31
+			IL_0010: stloc.s 30
+			IL_0012: ldloc.s 30
 			IL_0014: ldstr "argv"
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001e: stloc.s 31
-			IL_0020: ldloc.s 31
+			IL_001e: stloc.s 30
+			IL_0020: ldloc.s 30
 			IL_0022: ldc.r8 2
 			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0030: stloc.s 31
-			IL_0032: ldloc.s 31
+			IL_0030: stloc.s 30
+			IL_0032: ldloc.s 30
 			IL_0034: stloc.1
 			IL_0035: ldstr "process"
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003f: stloc.s 31
-			IL_0041: ldloc.s 31
+			IL_003f: stloc.s 30
+			IL_0041: ldloc.s 30
 			IL_0043: ldstr "argv"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: stloc.s 31
-			IL_004f: ldloc.s 31
+			IL_004d: stloc.s 30
+			IL_004f: ldloc.s 30
 			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.s 31
-			IL_0058: ldloc.s 31
+			IL_0056: stloc.s 30
+			IL_0058: ldloc.s 30
 			IL_005a: ldstr "includes"
 			IL_005f: ldstr "--skip-empty"
 			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0069: stloc.s 31
-			IL_006b: ldloc.s 31
+			IL_0069: stloc.s 30
+			IL_006b: ldloc.s 30
 			IL_006d: stloc.2
 			IL_006e: ldc.i4.1
 			IL_006f: newarr [System.Runtime]System.Object
@@ -2165,15 +2164,15 @@
 			IL_0075: ldc.i4.0
 			IL_0076: ldarg.0
 			IL_0077: stelem.ref
-			IL_0078: stloc.s 32
+			IL_0078: stloc.s 31
 			IL_007a: ldarg.0
 			IL_007b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0080: ldloc.s 32
+			IL_0080: ldloc.s 31
 			IL_0082: ldarg.0
 			IL_0083: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
 			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_008d: stloc.s 31
-			IL_008f: ldloc.s 31
+			IL_008d: stloc.s 30
+			IL_008f: ldloc.s 30
 			IL_0091: stloc.3
 			IL_0092: ldc.i4.1
 			IL_0093: newarr [System.Runtime]System.Object
@@ -2181,15 +2180,15 @@
 			IL_0099: ldc.i4.0
 			IL_009a: ldarg.0
 			IL_009b: stelem.ref
-			IL_009c: stloc.s 32
+			IL_009c: stloc.s 31
 			IL_009e: ldarg.0
 			IL_009f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00a4: ldloc.s 32
+			IL_00a4: ldloc.s 31
 			IL_00a6: ldarg.0
 			IL_00a7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
 			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00b1: stloc.s 31
-			IL_00b3: ldloc.s 31
+			IL_00b1: stloc.s 30
+			IL_00b3: ldloc.s 30
 			IL_00b5: stloc.s 4
 			IL_00b7: ldc.i4.1
 			IL_00b8: newarr [System.Runtime]System.Object
@@ -2197,15 +2196,15 @@
 			IL_00be: ldc.i4.0
 			IL_00bf: ldarg.0
 			IL_00c0: stelem.ref
-			IL_00c1: stloc.s 32
+			IL_00c1: stloc.s 31
 			IL_00c3: ldarg.0
 			IL_00c4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00c9: ldloc.s 32
+			IL_00c9: ldloc.s 31
 			IL_00cb: ldarg.0
 			IL_00cc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
 			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d6: stloc.s 31
-			IL_00d8: ldloc.s 31
+			IL_00d6: stloc.s 30
+			IL_00d8: ldloc.s 30
 			IL_00da: stloc.s 5
 			IL_00dc: ldc.i4.1
 			IL_00dd: newarr [System.Runtime]System.Object
@@ -2213,15 +2212,15 @@
 			IL_00e3: ldc.i4.0
 			IL_00e4: ldarg.0
 			IL_00e5: stelem.ref
-			IL_00e6: stloc.s 32
+			IL_00e6: stloc.s 31
 			IL_00e8: ldarg.0
 			IL_00e9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00ee: ldloc.s 32
+			IL_00ee: ldloc.s 31
 			IL_00f0: ldarg.0
 			IL_00f1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
 			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00fb: stloc.s 31
-			IL_00fd: ldloc.s 31
+			IL_00fb: stloc.s 30
+			IL_00fd: ldloc.s 30
 			IL_00ff: stloc.s 6
 			IL_0101: ldc.i4.1
 			IL_0102: newarr [System.Runtime]System.Object
@@ -2229,15 +2228,15 @@
 			IL_0108: ldc.i4.0
 			IL_0109: ldarg.0
 			IL_010a: stelem.ref
-			IL_010b: stloc.s 32
+			IL_010b: stloc.s 31
 			IL_010d: ldarg.0
 			IL_010e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0113: ldloc.s 32
+			IL_0113: ldloc.s 31
 			IL_0115: ldarg.0
 			IL_0116: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
 			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0120: stloc.s 31
-			IL_0122: ldloc.s 31
+			IL_0120: stloc.s 30
+			IL_0122: ldloc.s 30
 			IL_0124: stloc.s 7
 			IL_0126: ldc.i4.1
 			IL_0127: newarr [System.Runtime]System.Object
@@ -2245,15 +2244,15 @@
 			IL_012d: ldc.i4.0
 			IL_012e: ldarg.0
 			IL_012f: stelem.ref
-			IL_0130: stloc.s 32
+			IL_0130: stloc.s 31
 			IL_0132: ldarg.0
 			IL_0133: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0138: ldloc.s 32
+			IL_0138: ldloc.s 31
 			IL_013a: ldarg.0
 			IL_013b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
 			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0145: stloc.s 31
-			IL_0147: ldloc.s 31
+			IL_0145: stloc.s 30
+			IL_0147: ldloc.s 30
 			IL_0149: stloc.s 8
 			IL_014b: ldarg.0
 			IL_014c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
@@ -2265,8 +2264,8 @@
 			IL_015a: stelem.ref
 			IL_015b: ldloc.3
 			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0161: stloc.s 31
-			IL_0163: ldloc.s 31
+			IL_0161: stloc.s 30
+			IL_0163: ldloc.s 30
 			IL_0165: stloc.s 9
 			IL_0167: ldarg.0
 			IL_0168: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
@@ -2279,47 +2278,47 @@
 			IL_0177: ldloc.1
 			IL_0178: ldloc.s 9
 			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_017f: stloc.s 31
-			IL_0181: ldloc.s 31
+			IL_017f: stloc.s 30
+			IL_0181: ldloc.s 30
 			IL_0183: stloc.s 10
 			IL_0185: ldloc.s 9
-			IL_0187: stloc.s 31
-			IL_0189: ldloc.s 31
+			IL_0187: stloc.s 30
+			IL_0189: ldloc.s 30
 			IL_018b: ldloc.s 10
 			IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0192: stloc.s 33
-			IL_0194: ldloc.s 33
+			IL_0192: stloc.s 32
+			IL_0194: ldloc.s 32
 			IL_0196: brfalse IL_0214
 
 			IL_019b: ldstr "console"
 			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a5: stloc.s 31
-			IL_01a7: ldloc.s 31
+			IL_01a5: stloc.s 30
+			IL_01a7: ldloc.s 30
 			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ae: stloc.s 31
+			IL_01ae: stloc.s 30
 			IL_01b0: ldloc.s 9
 			IL_01b2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b7: stloc.s 34
+			IL_01b7: stloc.s 33
 			IL_01b9: ldstr "Version unchanged ("
-			IL_01be: ldloc.s 34
+			IL_01be: ldloc.s 33
 			IL_01c0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c5: stloc.s 34
-			IL_01c7: ldloc.s 34
+			IL_01c5: stloc.s 33
+			IL_01c7: ldloc.s 33
 			IL_01c9: ldstr "); aborting."
 			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d3: stloc.s 34
-			IL_01d5: ldloc.s 31
+			IL_01d3: stloc.s 33
+			IL_01d5: ldloc.s 30
 			IL_01d7: ldstr "error"
-			IL_01dc: ldloc.s 34
+			IL_01dc: ldloc.s 33
 			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_01e3: pop
 			IL_01e4: ldstr "process"
 			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ee: stloc.s 31
-			IL_01f0: ldloc.s 31
+			IL_01ee: stloc.s 30
+			IL_01f0: ldloc.s 30
 			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f7: stloc.s 31
-			IL_01f9: ldloc.s 31
+			IL_01f7: stloc.s 30
+			IL_01f9: ldloc.s 30
 			IL_01fb: ldstr "exit"
 			IL_0200: ldc.r8 1
 			IL_0209: box [System.Runtime]System.Double
@@ -2336,46 +2335,46 @@
 			IL_0223: stelem.ref
 			IL_0224: ldloc.s 8
 			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_022b: stloc.s 31
-			IL_022d: ldloc.s 31
+			IL_022b: stloc.s 30
+			IL_022d: ldloc.s 30
 			IL_022f: brfalse IL_0240
 
-			IL_0234: ldloc.s 31
+			IL_0234: ldloc.s 30
 			IL_0236: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_023b: brfalse IL_0251
 
-			IL_0240: ldloc.s 31
+			IL_0240: ldloc.s 30
 			IL_0242: ldstr ""
 			IL_0247: ldstr "body"
 			IL_024c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0251: ldloc.s 31
+			IL_0251: ldloc.s 30
 			IL_0253: ldstr "body"
 			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_025d: stloc.s 11
-			IL_025f: ldloc.s 31
+			IL_025f: ldloc.s 30
 			IL_0261: ldstr "start"
 			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_026b: stloc.s 12
-			IL_026d: ldloc.s 31
+			IL_026d: ldloc.s 30
 			IL_026f: ldstr "end"
 			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0279: stloc.s 13
 			IL_027b: ldloc.s 11
 			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0282: stloc.s 31
+			IL_0282: stloc.s 30
 			IL_0284: ldstr "\\r?\\n"
 			IL_0289: ldstr ""
 			IL_028e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0293: stloc.s 35
-			IL_0295: ldloc.s 31
+			IL_0293: stloc.s 34
+			IL_0295: ldloc.s 30
 			IL_0297: ldstr "split"
-			IL_029c: ldloc.s 35
+			IL_029c: ldloc.s 34
 			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02a3: stloc.s 31
-			IL_02a5: ldloc.s 31
+			IL_02a3: stloc.s 30
+			IL_02a5: ldloc.s 30
 			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ac: stloc.s 31
+			IL_02ac: stloc.s 30
 			IL_02ae: ldnull
 			IL_02af: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
 			IL_02b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
@@ -2398,546 +2397,544 @@
 			IL_02da: ldc.i4.0
 			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_02e5: stloc.s 36
-			IL_02e7: ldloc.s 31
+			IL_02e5: stloc.s 35
+			IL_02e7: ldloc.s 30
 			IL_02e9: ldstr "some"
-			IL_02ee: ldloc.s 36
+			IL_02ee: ldloc.s 35
 			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02f5: stloc.s 36
-			IL_02f7: ldloc.s 36
+			IL_02f5: stloc.s 35
+			IL_02f7: ldloc.s 35
 			IL_02f9: stloc.s 14
 			IL_02fb: ldloc.s 14
 			IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_0302: ldc.i4.0
 			IL_0303: ceq
-			IL_0305: stloc.s 33
-			IL_0307: ldloc.s 33
+			IL_0305: stloc.s 32
+			IL_0307: ldloc.s 32
 			IL_0309: box [System.Runtime]System.Boolean
-			IL_030e: stloc.s 37
-			IL_0310: ldloc.s 37
+			IL_030e: stloc.s 36
+			IL_0310: ldloc.s 36
 			IL_0312: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0317: stloc.s 33
-			IL_0319: ldloc.s 33
+			IL_0317: stloc.s 32
+			IL_0319: ldloc.s 32
 			IL_031b: brfalse IL_0328
 
 			IL_0320: ldloc.2
-			IL_0321: stloc.s 39
+			IL_0321: stloc.s 38
 			IL_0323: br IL_032c
 
-			IL_0328: ldloc.s 37
-			IL_032a: stloc.s 39
+			IL_0328: ldloc.s 36
+			IL_032a: stloc.s 38
 
-			IL_032c: ldloc.s 39
+			IL_032c: ldloc.s 38
 			IL_032e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0333: stloc.s 33
-			IL_0335: ldloc.s 33
-			IL_0337: brfalse IL_04b0
+			IL_0333: stloc.s 32
+			IL_0335: ldloc.s 32
+			IL_0337: brfalse IL_04a9
 
-			IL_033c: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
-			IL_0341: stloc.s 15
-			IL_0343: ldstr "console"
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_034d: stloc.s 36
-			IL_034f: ldloc.s 36
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0356: stloc.s 36
-			IL_0358: ldloc.s 36
-			IL_035a: ldstr "log"
-			IL_035f: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0369: pop
-			IL_036a: ldarg.0
-			IL_036b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0370: ldc.i4.1
-			IL_0371: newarr [System.Runtime]System.Object
-			IL_0376: dup
-			IL_0377: ldc.i4.0
-			IL_0378: ldarg.0
-			IL_0379: stelem.ref
-			IL_037a: ldloc.3
-			IL_037b: ldloc.s 10
-			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0382: stloc.s 36
-			IL_0384: ldloc.s 36
-			IL_0386: stloc.s 16
-			IL_0388: ldarg.0
-			IL_0389: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_038e: ldc.i4.1
-			IL_038f: newarr [System.Runtime]System.Object
-			IL_0394: dup
-			IL_0395: ldc.i4.0
-			IL_0396: ldarg.0
-			IL_0397: stelem.ref
-			IL_0398: ldloc.s 4
-			IL_039a: ldloc.s 10
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03a1: stloc.s 36
-			IL_03a3: ldloc.s 36
-			IL_03a5: stloc.s 17
-			IL_03a7: ldarg.0
-			IL_03a8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_03ad: ldc.i4.1
-			IL_03ae: newarr [System.Runtime]System.Object
-			IL_03b3: dup
-			IL_03b4: ldc.i4.0
-			IL_03b5: ldarg.0
-			IL_03b6: stelem.ref
-			IL_03b7: ldloc.s 5
-			IL_03b9: ldloc.s 10
-			IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03c0: stloc.s 36
-			IL_03c2: ldloc.s 36
-			IL_03c4: stloc.s 18
-			IL_03c6: ldarg.0
-			IL_03c7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_03cc: ldc.i4.1
-			IL_03cd: newarr [System.Runtime]System.Object
-			IL_03d2: dup
-			IL_03d3: ldc.i4.0
-			IL_03d4: ldarg.0
-			IL_03d5: stelem.ref
-			IL_03d6: ldloc.s 6
-			IL_03d8: ldloc.s 10
-			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03df: stloc.s 36
-			IL_03e1: ldloc.s 36
-			IL_03e3: stloc.s 19
-			IL_03e5: ldarg.0
-			IL_03e6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_03eb: ldc.i4.1
-			IL_03ec: newarr [System.Runtime]System.Object
-			IL_03f1: dup
-			IL_03f2: ldc.i4.0
-			IL_03f3: ldarg.0
-			IL_03f4: stelem.ref
-			IL_03f5: ldloc.s 7
-			IL_03f7: ldloc.s 10
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03fe: stloc.s 36
-			IL_0400: ldloc.s 36
-			IL_0402: stloc.s 20
-			IL_0404: ldc.i4.1
-			IL_0405: newarr [System.Runtime]System.Object
-			IL_040a: dup
-			IL_040b: ldc.i4.0
-			IL_040c: ldarg.0
-			IL_040d: stelem.ref
-			IL_040e: stloc.s 32
-			IL_0410: ldarg.0
-			IL_0411: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0416: ldloc.s 32
-			IL_0418: ldarg.0
-			IL_0419: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_041e: ldloc.s 16
-			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0425: pop
-			IL_0426: ldc.i4.1
-			IL_0427: newarr [System.Runtime]System.Object
-			IL_042c: dup
-			IL_042d: ldc.i4.0
-			IL_042e: ldarg.0
-			IL_042f: stelem.ref
-			IL_0430: stloc.s 32
-			IL_0432: ldarg.0
-			IL_0433: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0438: ldloc.s 32
-			IL_043a: ldarg.0
-			IL_043b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0440: ldloc.s 17
-			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0447: pop
-			IL_0448: ldc.i4.1
-			IL_0449: newarr [System.Runtime]System.Object
-			IL_044e: dup
-			IL_044f: ldc.i4.0
-			IL_0450: ldarg.0
-			IL_0451: stelem.ref
-			IL_0452: stloc.s 32
-			IL_0454: ldarg.0
-			IL_0455: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_045a: ldloc.s 32
-			IL_045c: ldarg.0
-			IL_045d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0462: ldloc.s 18
-			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0469: pop
-			IL_046a: ldc.i4.1
-			IL_046b: newarr [System.Runtime]System.Object
-			IL_0470: dup
-			IL_0471: ldc.i4.0
-			IL_0472: ldarg.0
-			IL_0473: stelem.ref
-			IL_0474: stloc.s 32
-			IL_0476: ldarg.0
-			IL_0477: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_047c: ldloc.s 32
-			IL_047e: ldarg.0
-			IL_047f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0484: ldloc.s 19
-			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_048b: pop
-			IL_048c: ldc.i4.1
-			IL_048d: newarr [System.Runtime]System.Object
-			IL_0492: dup
-			IL_0493: ldc.i4.0
-			IL_0494: ldarg.0
-			IL_0495: stelem.ref
-			IL_0496: stloc.s 32
-			IL_0498: ldarg.0
-			IL_0499: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_049e: ldloc.s 32
-			IL_04a0: ldarg.0
-			IL_04a1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_04a6: ldloc.s 20
-			IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04ad: pop
-			IL_04ae: ldnull
-			IL_04af: ret
+			IL_033c: ldstr "console"
+			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0346: stloc.s 35
+			IL_0348: ldloc.s 35
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_034f: stloc.s 35
+			IL_0351: ldloc.s 35
+			IL_0353: ldstr "log"
+			IL_0358: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0362: pop
+			IL_0363: ldarg.0
+			IL_0364: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0369: ldc.i4.1
+			IL_036a: newarr [System.Runtime]System.Object
+			IL_036f: dup
+			IL_0370: ldc.i4.0
+			IL_0371: ldarg.0
+			IL_0372: stelem.ref
+			IL_0373: ldloc.3
+			IL_0374: ldloc.s 10
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_037b: stloc.s 35
+			IL_037d: ldloc.s 35
+			IL_037f: stloc.s 15
+			IL_0381: ldarg.0
+			IL_0382: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0387: ldc.i4.1
+			IL_0388: newarr [System.Runtime]System.Object
+			IL_038d: dup
+			IL_038e: ldc.i4.0
+			IL_038f: ldarg.0
+			IL_0390: stelem.ref
+			IL_0391: ldloc.s 4
+			IL_0393: ldloc.s 10
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_039a: stloc.s 35
+			IL_039c: ldloc.s 35
+			IL_039e: stloc.s 16
+			IL_03a0: ldarg.0
+			IL_03a1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_03a6: ldc.i4.1
+			IL_03a7: newarr [System.Runtime]System.Object
+			IL_03ac: dup
+			IL_03ad: ldc.i4.0
+			IL_03ae: ldarg.0
+			IL_03af: stelem.ref
+			IL_03b0: ldloc.s 5
+			IL_03b2: ldloc.s 10
+			IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03b9: stloc.s 35
+			IL_03bb: ldloc.s 35
+			IL_03bd: stloc.s 17
+			IL_03bf: ldarg.0
+			IL_03c0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_03c5: ldc.i4.1
+			IL_03c6: newarr [System.Runtime]System.Object
+			IL_03cb: dup
+			IL_03cc: ldc.i4.0
+			IL_03cd: ldarg.0
+			IL_03ce: stelem.ref
+			IL_03cf: ldloc.s 6
+			IL_03d1: ldloc.s 10
+			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03d8: stloc.s 35
+			IL_03da: ldloc.s 35
+			IL_03dc: stloc.s 18
+			IL_03de: ldarg.0
+			IL_03df: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_03e4: ldc.i4.1
+			IL_03e5: newarr [System.Runtime]System.Object
+			IL_03ea: dup
+			IL_03eb: ldc.i4.0
+			IL_03ec: ldarg.0
+			IL_03ed: stelem.ref
+			IL_03ee: ldloc.s 7
+			IL_03f0: ldloc.s 10
+			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03f7: stloc.s 35
+			IL_03f9: ldloc.s 35
+			IL_03fb: stloc.s 19
+			IL_03fd: ldc.i4.1
+			IL_03fe: newarr [System.Runtime]System.Object
+			IL_0403: dup
+			IL_0404: ldc.i4.0
+			IL_0405: ldarg.0
+			IL_0406: stelem.ref
+			IL_0407: stloc.s 31
+			IL_0409: ldarg.0
+			IL_040a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_040f: ldloc.s 31
+			IL_0411: ldarg.0
+			IL_0412: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0417: ldloc.s 15
+			IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_041e: pop
+			IL_041f: ldc.i4.1
+			IL_0420: newarr [System.Runtime]System.Object
+			IL_0425: dup
+			IL_0426: ldc.i4.0
+			IL_0427: ldarg.0
+			IL_0428: stelem.ref
+			IL_0429: stloc.s 31
+			IL_042b: ldarg.0
+			IL_042c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0431: ldloc.s 31
+			IL_0433: ldarg.0
+			IL_0434: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0439: ldloc.s 16
+			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0440: pop
+			IL_0441: ldc.i4.1
+			IL_0442: newarr [System.Runtime]System.Object
+			IL_0447: dup
+			IL_0448: ldc.i4.0
+			IL_0449: ldarg.0
+			IL_044a: stelem.ref
+			IL_044b: stloc.s 31
+			IL_044d: ldarg.0
+			IL_044e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0453: ldloc.s 31
+			IL_0455: ldarg.0
+			IL_0456: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_045b: ldloc.s 17
+			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0462: pop
+			IL_0463: ldc.i4.1
+			IL_0464: newarr [System.Runtime]System.Object
+			IL_0469: dup
+			IL_046a: ldc.i4.0
+			IL_046b: ldarg.0
+			IL_046c: stelem.ref
+			IL_046d: stloc.s 31
+			IL_046f: ldarg.0
+			IL_0470: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0475: ldloc.s 31
+			IL_0477: ldarg.0
+			IL_0478: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_047d: ldloc.s 18
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0484: pop
+			IL_0485: ldc.i4.1
+			IL_0486: newarr [System.Runtime]System.Object
+			IL_048b: dup
+			IL_048c: ldc.i4.0
+			IL_048d: ldarg.0
+			IL_048e: stelem.ref
+			IL_048f: stloc.s 31
+			IL_0491: ldarg.0
+			IL_0492: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0497: ldloc.s 31
+			IL_0499: ldarg.0
+			IL_049a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_049f: ldloc.s 19
+			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04a6: pop
+			IL_04a7: ldnull
+			IL_04a8: ret
 
-			IL_04b0: ldarg.0
-			IL_04b1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
-			IL_04b6: ldc.i4.1
-			IL_04b7: newarr [System.Runtime]System.Object
-			IL_04bc: dup
-			IL_04bd: ldc.i4.0
-			IL_04be: ldarg.0
-			IL_04bf: stelem.ref
-			IL_04c0: ldloc.s 10
-			IL_04c2: ldloc.s 11
-			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04c9: stloc.s 36
-			IL_04cb: ldloc.s 36
-			IL_04cd: stloc.s 21
-			IL_04cf: ldloc.s 8
-			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04d6: stloc.s 36
-			IL_04d8: ldloc.s 36
-			IL_04da: ldstr "slice"
-			IL_04df: ldc.r8 0.0
-			IL_04e8: box [System.Runtime]System.Double
-			IL_04ed: ldloc.s 12
-			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04f4: stloc.s 36
-			IL_04f6: ldloc.s 36
-			IL_04f8: stloc.s 22
-			IL_04fa: ldloc.s 8
-			IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0501: stloc.s 36
-			IL_0503: ldloc.s 36
-			IL_0505: ldstr "slice"
-			IL_050a: ldloc.s 13
-			IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0511: stloc.s 36
-			IL_0513: ldloc.s 36
+			IL_04a9: ldarg.0
+			IL_04aa: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
+			IL_04af: ldc.i4.1
+			IL_04b0: newarr [System.Runtime]System.Object
+			IL_04b5: dup
+			IL_04b6: ldc.i4.0
+			IL_04b7: ldarg.0
+			IL_04b8: stelem.ref
+			IL_04b9: ldloc.s 10
+			IL_04bb: ldloc.s 11
+			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04c2: stloc.s 35
+			IL_04c4: ldloc.s 35
+			IL_04c6: stloc.s 20
+			IL_04c8: ldloc.s 8
+			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04cf: stloc.s 35
+			IL_04d1: ldloc.s 35
+			IL_04d3: ldstr "slice"
+			IL_04d8: ldc.r8 0.0
+			IL_04e1: box [System.Runtime]System.Double
+			IL_04e6: ldloc.s 12
+			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04ed: stloc.s 35
+			IL_04ef: ldloc.s 35
+			IL_04f1: stloc.s 21
+			IL_04f3: ldloc.s 8
+			IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04fa: stloc.s 35
+			IL_04fc: ldloc.s 35
+			IL_04fe: ldstr "slice"
+			IL_0503: ldloc.s 13
+			IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_050a: stloc.s 35
+			IL_050c: ldloc.s 35
+			IL_050e: stloc.s 22
+			IL_0510: ldstr "\n_Nothing yet._\n\n"
 			IL_0515: stloc.s 23
-			IL_0517: ldstr "\n_Nothing yet._\n\n"
-			IL_051c: stloc.s 24
-			IL_051e: ldloc.s 22
-			IL_0520: stloc.s 36
-			IL_0522: ldloc.s 36
-			IL_0524: ldloc.s 24
-			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_052b: stloc.s 39
-			IL_052d: ldloc.s 39
-			IL_052f: ldloc.s 21
-			IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0536: stloc.s 39
-			IL_0538: ldloc.s 39
-			IL_053a: ldloc.s 23
-			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0541: stloc.s 39
-			IL_0543: ldloc.s 39
-			IL_0545: stloc.s 25
-			IL_0547: ldarg.0
-			IL_0548: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_054d: ldc.i4.1
-			IL_054e: newarr [System.Runtime]System.Object
-			IL_0553: dup
-			IL_0554: ldc.i4.0
-			IL_0555: ldarg.0
-			IL_0556: stelem.ref
-			IL_0557: ldloc.3
-			IL_0558: ldloc.s 10
-			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_055f: stloc.s 36
-			IL_0561: ldloc.s 36
-			IL_0563: stloc.s 26
-			IL_0565: ldarg.0
-			IL_0566: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_056b: ldc.i4.1
-			IL_056c: newarr [System.Runtime]System.Object
-			IL_0571: dup
-			IL_0572: ldc.i4.0
-			IL_0573: ldarg.0
-			IL_0574: stelem.ref
-			IL_0575: ldloc.s 4
-			IL_0577: ldloc.s 10
-			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_057e: stloc.s 36
-			IL_0580: ldloc.s 36
-			IL_0582: stloc.s 27
-			IL_0584: ldarg.0
-			IL_0585: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_058a: ldc.i4.1
-			IL_058b: newarr [System.Runtime]System.Object
-			IL_0590: dup
-			IL_0591: ldc.i4.0
-			IL_0592: ldarg.0
-			IL_0593: stelem.ref
-			IL_0594: ldloc.s 5
-			IL_0596: ldloc.s 10
-			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_059d: stloc.s 36
-			IL_059f: ldloc.s 36
-			IL_05a1: stloc.s 28
-			IL_05a3: ldarg.0
-			IL_05a4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_05a9: ldc.i4.1
-			IL_05aa: newarr [System.Runtime]System.Object
-			IL_05af: dup
-			IL_05b0: ldc.i4.0
-			IL_05b1: ldarg.0
-			IL_05b2: stelem.ref
-			IL_05b3: ldloc.s 6
-			IL_05b5: ldloc.s 10
-			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05bc: stloc.s 36
-			IL_05be: ldloc.s 36
-			IL_05c0: stloc.s 29
-			IL_05c2: ldarg.0
-			IL_05c3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_05c8: ldc.i4.1
-			IL_05c9: newarr [System.Runtime]System.Object
-			IL_05ce: dup
-			IL_05cf: ldc.i4.0
-			IL_05d0: ldarg.0
-			IL_05d1: stelem.ref
-			IL_05d2: ldloc.s 7
-			IL_05d4: ldloc.s 10
-			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05db: stloc.s 36
-			IL_05dd: ldloc.s 36
-			IL_05df: stloc.s 30
-			IL_05e1: ldc.i4.1
-			IL_05e2: newarr [System.Runtime]System.Object
-			IL_05e7: dup
-			IL_05e8: ldc.i4.0
-			IL_05e9: ldarg.0
-			IL_05ea: stelem.ref
-			IL_05eb: stloc.s 32
-			IL_05ed: ldarg.0
-			IL_05ee: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05f3: ldloc.s 32
-			IL_05f5: ldarg.0
-			IL_05f6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_05fb: ldloc.s 25
-			IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0602: pop
-			IL_0603: ldc.i4.1
-			IL_0604: newarr [System.Runtime]System.Object
-			IL_0609: dup
-			IL_060a: ldc.i4.0
-			IL_060b: ldarg.0
-			IL_060c: stelem.ref
-			IL_060d: stloc.s 32
-			IL_060f: ldarg.0
-			IL_0610: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0615: ldloc.s 32
-			IL_0617: ldarg.0
-			IL_0618: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_061d: ldloc.s 26
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0624: pop
-			IL_0625: ldc.i4.1
-			IL_0626: newarr [System.Runtime]System.Object
-			IL_062b: dup
-			IL_062c: ldc.i4.0
-			IL_062d: ldarg.0
-			IL_062e: stelem.ref
-			IL_062f: stloc.s 32
-			IL_0631: ldarg.0
-			IL_0632: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0637: ldloc.s 32
-			IL_0639: ldarg.0
-			IL_063a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_063f: ldloc.s 27
-			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0646: pop
-			IL_0647: ldc.i4.1
-			IL_0648: newarr [System.Runtime]System.Object
-			IL_064d: dup
-			IL_064e: ldc.i4.0
-			IL_064f: ldarg.0
-			IL_0650: stelem.ref
-			IL_0651: stloc.s 32
-			IL_0653: ldarg.0
-			IL_0654: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0659: ldloc.s 32
-			IL_065b: ldarg.0
-			IL_065c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0661: ldloc.s 28
-			IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0668: pop
-			IL_0669: ldc.i4.1
-			IL_066a: newarr [System.Runtime]System.Object
-			IL_066f: dup
-			IL_0670: ldc.i4.0
-			IL_0671: ldarg.0
-			IL_0672: stelem.ref
-			IL_0673: stloc.s 32
-			IL_0675: ldarg.0
-			IL_0676: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_067b: ldloc.s 32
-			IL_067d: ldarg.0
-			IL_067e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0683: ldloc.s 29
-			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_068a: pop
-			IL_068b: ldc.i4.1
-			IL_068c: newarr [System.Runtime]System.Object
-			IL_0691: dup
-			IL_0692: ldc.i4.0
-			IL_0693: ldarg.0
-			IL_0694: stelem.ref
-			IL_0695: stloc.s 32
-			IL_0697: ldarg.0
-			IL_0698: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_069d: ldloc.s 32
-			IL_069f: ldarg.0
-			IL_06a0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_06a5: ldloc.s 30
-			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06ac: pop
-			IL_06ad: ldstr "console"
-			IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06b7: stloc.s 36
-			IL_06b9: ldloc.s 36
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06c0: stloc.s 36
-			IL_06c2: ldloc.s 9
-			IL_06c4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06c9: stloc.s 34
-			IL_06cb: ldstr "Bumped version: "
-			IL_06d0: ldloc.s 34
-			IL_06d2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06d7: stloc.s 34
-			IL_06d9: ldloc.s 34
-			IL_06db: ldstr " -> "
-			IL_06e0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06e5: stloc.s 34
-			IL_06e7: ldloc.s 10
-			IL_06e9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06ee: stloc.s 40
-			IL_06f0: ldloc.s 34
-			IL_06f2: ldloc.s 40
-			IL_06f4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06f9: stloc.s 40
-			IL_06fb: ldloc.s 36
-			IL_06fd: ldstr "log"
-			IL_0702: ldloc.s 40
-			IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0709: pop
-			IL_070a: ldstr "console"
-			IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0714: stloc.s 36
-			IL_0716: ldloc.s 36
-			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_071d: stloc.s 36
-			IL_071f: ldloc.s 36
-			IL_0721: ldstr "log"
-			IL_0726: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0730: pop
-			IL_0731: ldstr "console"
-			IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_073b: stloc.s 36
-			IL_073d: ldloc.s 36
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0744: stloc.s 36
-			IL_0746: ldloc.s 36
-			IL_0748: ldstr "log"
-			IL_074d: ldstr "\nNext steps:"
-			IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0757: pop
-			IL_0758: ldstr "console"
-			IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0762: stloc.s 36
-			IL_0764: ldloc.s 36
-			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_076b: stloc.s 36
-			IL_076d: ldloc.s 36
-			IL_076f: ldstr "log"
-			IL_0774: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_077e: pop
-			IL_077f: ldstr "console"
-			IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0789: stloc.s 36
-			IL_078b: ldloc.s 36
-			IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0792: stloc.s 36
-			IL_0794: ldloc.s 10
-			IL_0796: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_079b: stloc.s 40
-			IL_079d: ldstr "  git commit -m \"chore(release): cut "
-			IL_07a2: ldloc.s 40
-			IL_07a4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07a9: stloc.s 40
-			IL_07ab: ldloc.s 40
-			IL_07ad: ldstr "\""
-			IL_07b2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07b7: stloc.s 40
-			IL_07b9: ldloc.s 36
-			IL_07bb: ldstr "log"
-			IL_07c0: ldloc.s 40
-			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07c7: pop
-			IL_07c8: ldstr "console"
-			IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07d2: stloc.s 36
-			IL_07d4: ldloc.s 36
-			IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07db: stloc.s 36
-			IL_07dd: ldloc.s 10
-			IL_07df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07e4: stloc.s 40
-			IL_07e6: ldstr "  git tag -a v"
-			IL_07eb: ldloc.s 40
-			IL_07ed: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07f2: stloc.s 40
-			IL_07f4: ldloc.s 40
-			IL_07f6: ldstr " -m \"Release "
-			IL_07fb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0800: stloc.s 40
-			IL_0802: ldloc.s 10
-			IL_0804: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0809: stloc.s 34
-			IL_080b: ldloc.s 40
-			IL_080d: ldloc.s 34
-			IL_080f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0814: stloc.s 34
-			IL_0816: ldloc.s 34
-			IL_0818: ldstr "\""
-			IL_081d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0822: stloc.s 34
-			IL_0824: ldloc.s 36
-			IL_0826: ldstr "log"
-			IL_082b: ldloc.s 34
-			IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0832: pop
-			IL_0833: ldstr "console"
-			IL_0838: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_083d: stloc.s 36
-			IL_083f: ldloc.s 36
-			IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0846: stloc.s 36
-			IL_0848: ldloc.s 36
-			IL_084a: ldstr "log"
-			IL_084f: ldstr "  git push && git push --tags"
-			IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0859: pop
-			IL_085a: ldnull
-			IL_085b: ret
+			IL_0517: ldloc.s 21
+			IL_0519: stloc.s 35
+			IL_051b: ldloc.s 35
+			IL_051d: ldloc.s 23
+			IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0524: stloc.s 38
+			IL_0526: ldloc.s 38
+			IL_0528: ldloc.s 20
+			IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_052f: stloc.s 38
+			IL_0531: ldloc.s 38
+			IL_0533: ldloc.s 22
+			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_053a: stloc.s 38
+			IL_053c: ldloc.s 38
+			IL_053e: stloc.s 24
+			IL_0540: ldarg.0
+			IL_0541: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0546: ldc.i4.1
+			IL_0547: newarr [System.Runtime]System.Object
+			IL_054c: dup
+			IL_054d: ldc.i4.0
+			IL_054e: ldarg.0
+			IL_054f: stelem.ref
+			IL_0550: ldloc.3
+			IL_0551: ldloc.s 10
+			IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0558: stloc.s 35
+			IL_055a: ldloc.s 35
+			IL_055c: stloc.s 25
+			IL_055e: ldarg.0
+			IL_055f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0564: ldc.i4.1
+			IL_0565: newarr [System.Runtime]System.Object
+			IL_056a: dup
+			IL_056b: ldc.i4.0
+			IL_056c: ldarg.0
+			IL_056d: stelem.ref
+			IL_056e: ldloc.s 4
+			IL_0570: ldloc.s 10
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0577: stloc.s 35
+			IL_0579: ldloc.s 35
+			IL_057b: stloc.s 26
+			IL_057d: ldarg.0
+			IL_057e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0583: ldc.i4.1
+			IL_0584: newarr [System.Runtime]System.Object
+			IL_0589: dup
+			IL_058a: ldc.i4.0
+			IL_058b: ldarg.0
+			IL_058c: stelem.ref
+			IL_058d: ldloc.s 5
+			IL_058f: ldloc.s 10
+			IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0596: stloc.s 35
+			IL_0598: ldloc.s 35
+			IL_059a: stloc.s 27
+			IL_059c: ldarg.0
+			IL_059d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05a2: ldc.i4.1
+			IL_05a3: newarr [System.Runtime]System.Object
+			IL_05a8: dup
+			IL_05a9: ldc.i4.0
+			IL_05aa: ldarg.0
+			IL_05ab: stelem.ref
+			IL_05ac: ldloc.s 6
+			IL_05ae: ldloc.s 10
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05b5: stloc.s 35
+			IL_05b7: ldloc.s 35
+			IL_05b9: stloc.s 28
+			IL_05bb: ldarg.0
+			IL_05bc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_05c1: ldc.i4.1
+			IL_05c2: newarr [System.Runtime]System.Object
+			IL_05c7: dup
+			IL_05c8: ldc.i4.0
+			IL_05c9: ldarg.0
+			IL_05ca: stelem.ref
+			IL_05cb: ldloc.s 7
+			IL_05cd: ldloc.s 10
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05d4: stloc.s 35
+			IL_05d6: ldloc.s 35
+			IL_05d8: stloc.s 29
+			IL_05da: ldc.i4.1
+			IL_05db: newarr [System.Runtime]System.Object
+			IL_05e0: dup
+			IL_05e1: ldc.i4.0
+			IL_05e2: ldarg.0
+			IL_05e3: stelem.ref
+			IL_05e4: stloc.s 31
+			IL_05e6: ldarg.0
+			IL_05e7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05ec: ldloc.s 31
+			IL_05ee: ldarg.0
+			IL_05ef: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_05f4: ldloc.s 24
+			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05fb: pop
+			IL_05fc: ldc.i4.1
+			IL_05fd: newarr [System.Runtime]System.Object
+			IL_0602: dup
+			IL_0603: ldc.i4.0
+			IL_0604: ldarg.0
+			IL_0605: stelem.ref
+			IL_0606: stloc.s 31
+			IL_0608: ldarg.0
+			IL_0609: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_060e: ldloc.s 31
+			IL_0610: ldarg.0
+			IL_0611: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0616: ldloc.s 25
+			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_061d: pop
+			IL_061e: ldc.i4.1
+			IL_061f: newarr [System.Runtime]System.Object
+			IL_0624: dup
+			IL_0625: ldc.i4.0
+			IL_0626: ldarg.0
+			IL_0627: stelem.ref
+			IL_0628: stloc.s 31
+			IL_062a: ldarg.0
+			IL_062b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0630: ldloc.s 31
+			IL_0632: ldarg.0
+			IL_0633: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0638: ldloc.s 26
+			IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_063f: pop
+			IL_0640: ldc.i4.1
+			IL_0641: newarr [System.Runtime]System.Object
+			IL_0646: dup
+			IL_0647: ldc.i4.0
+			IL_0648: ldarg.0
+			IL_0649: stelem.ref
+			IL_064a: stloc.s 31
+			IL_064c: ldarg.0
+			IL_064d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0652: ldloc.s 31
+			IL_0654: ldarg.0
+			IL_0655: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_065a: ldloc.s 27
+			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0661: pop
+			IL_0662: ldc.i4.1
+			IL_0663: newarr [System.Runtime]System.Object
+			IL_0668: dup
+			IL_0669: ldc.i4.0
+			IL_066a: ldarg.0
+			IL_066b: stelem.ref
+			IL_066c: stloc.s 31
+			IL_066e: ldarg.0
+			IL_066f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0674: ldloc.s 31
+			IL_0676: ldarg.0
+			IL_0677: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_067c: ldloc.s 28
+			IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0683: pop
+			IL_0684: ldc.i4.1
+			IL_0685: newarr [System.Runtime]System.Object
+			IL_068a: dup
+			IL_068b: ldc.i4.0
+			IL_068c: ldarg.0
+			IL_068d: stelem.ref
+			IL_068e: stloc.s 31
+			IL_0690: ldarg.0
+			IL_0691: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0696: ldloc.s 31
+			IL_0698: ldarg.0
+			IL_0699: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_069e: ldloc.s 29
+			IL_06a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06a5: pop
+			IL_06a6: ldstr "console"
+			IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06b0: stloc.s 35
+			IL_06b2: ldloc.s 35
+			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06b9: stloc.s 35
+			IL_06bb: ldloc.s 9
+			IL_06bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06c2: stloc.s 33
+			IL_06c4: ldstr "Bumped version: "
+			IL_06c9: ldloc.s 33
+			IL_06cb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06d0: stloc.s 33
+			IL_06d2: ldloc.s 33
+			IL_06d4: ldstr " -> "
+			IL_06d9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06de: stloc.s 33
+			IL_06e0: ldloc.s 10
+			IL_06e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06e7: stloc.s 39
+			IL_06e9: ldloc.s 33
+			IL_06eb: ldloc.s 39
+			IL_06ed: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06f2: stloc.s 39
+			IL_06f4: ldloc.s 35
+			IL_06f6: ldstr "log"
+			IL_06fb: ldloc.s 39
+			IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0702: pop
+			IL_0703: ldstr "console"
+			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_070d: stloc.s 35
+			IL_070f: ldloc.s 35
+			IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0716: stloc.s 35
+			IL_0718: ldloc.s 35
+			IL_071a: ldstr "log"
+			IL_071f: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0729: pop
+			IL_072a: ldstr "console"
+			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0734: stloc.s 35
+			IL_0736: ldloc.s 35
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_073d: stloc.s 35
+			IL_073f: ldloc.s 35
+			IL_0741: ldstr "log"
+			IL_0746: ldstr "\nNext steps:"
+			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0750: pop
+			IL_0751: ldstr "console"
+			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_075b: stloc.s 35
+			IL_075d: ldloc.s 35
+			IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0764: stloc.s 35
+			IL_0766: ldloc.s 35
+			IL_0768: ldstr "log"
+			IL_076d: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0777: pop
+			IL_0778: ldstr "console"
+			IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0782: stloc.s 35
+			IL_0784: ldloc.s 35
+			IL_0786: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_078b: stloc.s 35
+			IL_078d: ldloc.s 10
+			IL_078f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0794: stloc.s 39
+			IL_0796: ldstr "  git commit -m \"chore(release): cut "
+			IL_079b: ldloc.s 39
+			IL_079d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07a2: stloc.s 39
+			IL_07a4: ldloc.s 39
+			IL_07a6: ldstr "\""
+			IL_07ab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07b0: stloc.s 39
+			IL_07b2: ldloc.s 35
+			IL_07b4: ldstr "log"
+			IL_07b9: ldloc.s 39
+			IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07c0: pop
+			IL_07c1: ldstr "console"
+			IL_07c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07cb: stloc.s 35
+			IL_07cd: ldloc.s 35
+			IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07d4: stloc.s 35
+			IL_07d6: ldloc.s 10
+			IL_07d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07dd: stloc.s 39
+			IL_07df: ldstr "  git tag -a v"
+			IL_07e4: ldloc.s 39
+			IL_07e6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07eb: stloc.s 39
+			IL_07ed: ldloc.s 39
+			IL_07ef: ldstr " -m \"Release "
+			IL_07f4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07f9: stloc.s 39
+			IL_07fb: ldloc.s 10
+			IL_07fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0802: stloc.s 33
+			IL_0804: ldloc.s 39
+			IL_0806: ldloc.s 33
+			IL_0808: call string [System.Runtime]System.String::Concat(string, string)
+			IL_080d: stloc.s 33
+			IL_080f: ldloc.s 33
+			IL_0811: ldstr "\""
+			IL_0816: call string [System.Runtime]System.String::Concat(string, string)
+			IL_081b: stloc.s 33
+			IL_081d: ldloc.s 35
+			IL_081f: ldstr "log"
+			IL_0824: ldloc.s 33
+			IL_0826: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_082b: pop
+			IL_082c: ldstr "console"
+			IL_0831: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0836: stloc.s 35
+			IL_0838: ldloc.s 35
+			IL_083a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_083f: stloc.s 35
+			IL_0841: ldloc.s 35
+			IL_0843: ldstr "log"
+			IL_0848: ldstr "  git push && git push --tags"
+			IL_084d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0852: pop
+			IL_0853: ldnull
+			IL_0854: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -2972,7 +2969,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a5d
+				// Method begins at RVA 0x3a51
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2992,7 +2989,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3a66
+				// Method begins at RVA 0x3a5a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3030,7 +3027,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3997
+			// Method begins at RVA 0x398b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3056,7 +3053,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1110 (0x456)
+		// Code size: 1103 (0x44f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
@@ -3066,10 +3063,9 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C29,
+			[7] object,
 			[8] object,
-			[9] object,
-			[10] object[]
+			[9] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope::.ctor()
@@ -3091,9 +3087,9 @@
 		IL_0029: ldc.i4.0
 		IL_002a: ldc.i4.1
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0030: stloc.s 9
+		IL_0030: stloc.s 8
 		IL_0032: ldloc.0
-		IL_0033: ldloc.s 9
+		IL_0033: ldloc.s 8
 		IL_0035: stfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
 		IL_003a: ldc.i4.1
 		IL_003b: newarr [System.Runtime]System.Object
@@ -3112,9 +3108,9 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldc.i4.1
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0064: stloc.s 9
+		IL_0064: stloc.s 8
 		IL_0066: ldloc.0
-		IL_0067: ldloc.s 9
+		IL_0067: ldloc.s 8
 		IL_0069: stfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
 		IL_006e: ldnull
 		IL_006f: ldftn object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
@@ -3125,9 +3121,9 @@
 		IL_0081: ldc.i4.0
 		IL_0082: ldc.i4.1
 		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0088: stloc.s 9
+		IL_0088: stloc.s 8
 		IL_008a: ldloc.0
-		IL_008b: ldloc.s 9
+		IL_008b: ldloc.s 8
 		IL_008d: stfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
 		IL_0092: ldnull
 		IL_0093: ldftn object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
@@ -3138,9 +3134,9 @@
 		IL_00a5: ldc.i4.0
 		IL_00a6: ldc.i4.1
 		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00ac: stloc.s 9
+		IL_00ac: stloc.s 8
 		IL_00ae: ldloc.0
-		IL_00af: ldloc.s 9
+		IL_00af: ldloc.s 8
 		IL_00b1: stfld object Modules.Compile_Scripts_BumpVersion/Scope::incVersion
 		IL_00b6: ldc.i4.1
 		IL_00b7: newarr [System.Runtime]System.Object
@@ -3159,9 +3155,9 @@
 		IL_00d9: ldc.i4.0
 		IL_00da: ldc.i4.1
 		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00e0: stloc.s 9
+		IL_00e0: stloc.s 8
 		IL_00e2: ldloc.0
-		IL_00e3: ldloc.s 9
+		IL_00e3: ldloc.s 8
 		IL_00e5: stfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
 		IL_00ea: ldnull
 		IL_00eb: ldftn object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
@@ -3172,9 +3168,9 @@
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
 		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0104: stloc.s 9
+		IL_0104: stloc.s 8
 		IL_0106: ldloc.0
-		IL_0107: ldloc.s 9
+		IL_0107: ldloc.s 8
 		IL_0109: stfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
 		IL_010e: ldnull
 		IL_010f: ldftn object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
@@ -3185,9 +3181,9 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldc.i4.1
 		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0128: stloc.s 9
+		IL_0128: stloc.s 8
 		IL_012a: ldloc.0
-		IL_012b: ldloc.s 9
+		IL_012b: ldloc.s 8
 		IL_012d: stfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
 		IL_0132: ldc.i4.1
 		IL_0133: newarr [System.Runtime]System.Object
@@ -3206,9 +3202,9 @@
 		IL_0155: ldc.i4.0
 		IL_0156: ldc.i4.1
 		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_015c: stloc.s 9
+		IL_015c: stloc.s 8
 		IL_015e: ldloc.0
-		IL_015f: ldloc.s 9
+		IL_015f: ldloc.s 8
 		IL_0161: stfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
 		IL_0166: ldnull
 		IL_0167: ldftn object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
@@ -3219,9 +3215,9 @@
 		IL_0179: ldc.i4.0
 		IL_017a: ldc.i4.1
 		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0180: stloc.s 9
+		IL_0180: stloc.s 8
 		IL_0182: ldloc.0
-		IL_0183: ldloc.s 9
+		IL_0183: ldloc.s 8
 		IL_0185: stfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
 		IL_018a: ldc.i4.1
 		IL_018b: newarr [System.Runtime]System.Object
@@ -3240,9 +3236,9 @@
 		IL_01ad: ldc.i4.0
 		IL_01ae: ldc.i4.1
 		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01b4: stloc.s 9
+		IL_01b4: stloc.s 8
 		IL_01b6: ldloc.0
-		IL_01b7: ldloc.s 9
+		IL_01b7: ldloc.s 8
 		IL_01b9: stfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
 		IL_01be: ldc.i4.1
 		IL_01bf: newarr [System.Runtime]System.Object
@@ -3261,37 +3257,37 @@
 		IL_01e1: ldc.i4.0
 		IL_01e2: ldc.i4.1
 		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01e8: stloc.s 9
-		IL_01ea: ldloc.s 9
+		IL_01e8: stloc.s 8
+		IL_01ea: ldloc.s 8
 		IL_01ec: stloc.1
 		IL_01ed: nop
 		IL_01ee: ldarg.1
 		IL_01ef: ldstr "fs"
 		IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_01f9: stloc.s 9
+		IL_01f9: stloc.s 8
 		IL_01fb: ldloc.0
-		IL_01fc: ldloc.s 9
+		IL_01fc: ldloc.s 8
 		IL_01fe: stfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
 		IL_0203: ldarg.1
 		IL_0204: ldstr "path"
 		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_020e: stloc.s 9
-		IL_0210: ldloc.s 9
+		IL_020e: stloc.s 8
+		IL_0210: ldloc.s 8
 		IL_0212: stloc.2
 		IL_0213: ldloc.2
 		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0219: stloc.s 9
-		IL_021b: ldloc.s 9
+		IL_0219: stloc.s 8
+		IL_021b: ldloc.s 8
 		IL_021d: ldstr "resolve"
 		IL_0222: ldarg.s __dirname
 		IL_0224: ldstr ".."
 		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_022e: stloc.s 9
-		IL_0230: ldloc.s 9
+		IL_022e: stloc.s 8
+		IL_0230: ldloc.s 8
 		IL_0232: stloc.3
 		IL_0233: ldloc.2
 		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0239: stloc.s 9
+		IL_0239: stloc.s 8
 		IL_023b: ldc.i4.4
 		IL_023c: newarr [System.Runtime]System.Object
 		IL_0241: dup
@@ -3310,18 +3306,18 @@
 		IL_0256: ldc.i4.3
 		IL_0257: ldstr "Jroc.csproj"
 		IL_025c: stelem.ref
-		IL_025d: stloc.s 10
-		IL_025f: ldloc.s 9
+		IL_025d: stloc.s 9
+		IL_025f: ldloc.s 8
 		IL_0261: ldstr "join"
-		IL_0266: ldloc.s 10
+		IL_0266: ldloc.s 9
 		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_026d: stloc.s 9
+		IL_026d: stloc.s 8
 		IL_026f: ldloc.0
-		IL_0270: ldloc.s 9
+		IL_0270: ldloc.s 8
 		IL_0272: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
 		IL_0277: ldloc.2
 		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027d: stloc.s 9
+		IL_027d: stloc.s 8
 		IL_027f: ldc.i4.4
 		IL_0280: newarr [System.Runtime]System.Object
 		IL_0285: dup
@@ -3340,18 +3336,18 @@
 		IL_029a: ldc.i4.3
 		IL_029b: ldstr "Jroc.Core.csproj"
 		IL_02a0: stelem.ref
-		IL_02a1: stloc.s 10
-		IL_02a3: ldloc.s 9
+		IL_02a1: stloc.s 9
+		IL_02a3: ldloc.s 8
 		IL_02a5: ldstr "join"
-		IL_02aa: ldloc.s 10
+		IL_02aa: ldloc.s 9
 		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_02b1: stloc.s 9
+		IL_02b1: stloc.s 8
 		IL_02b3: ldloc.0
-		IL_02b4: ldloc.s 9
+		IL_02b4: ldloc.s 8
 		IL_02b6: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
 		IL_02bb: ldloc.2
 		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c1: stloc.s 9
+		IL_02c1: stloc.s 8
 		IL_02c3: ldc.i4.4
 		IL_02c4: newarr [System.Runtime]System.Object
 		IL_02c9: dup
@@ -3370,18 +3366,18 @@
 		IL_02de: ldc.i4.3
 		IL_02df: ldstr "Jroc.SDK.csproj"
 		IL_02e4: stelem.ref
-		IL_02e5: stloc.s 10
-		IL_02e7: ldloc.s 9
+		IL_02e5: stloc.s 9
+		IL_02e7: ldloc.s 8
 		IL_02e9: ldstr "join"
-		IL_02ee: ldloc.s 10
+		IL_02ee: ldloc.s 9
 		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_02f5: stloc.s 9
+		IL_02f5: stloc.s 8
 		IL_02f7: ldloc.0
-		IL_02f8: ldloc.s 9
+		IL_02f8: ldloc.s 8
 		IL_02fa: stfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
 		IL_02ff: ldloc.2
 		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0305: stloc.s 9
+		IL_0305: stloc.s 8
 		IL_0307: ldc.i4.4
 		IL_0308: newarr [System.Runtime]System.Object
 		IL_030d: dup
@@ -3400,39 +3396,39 @@
 		IL_0322: ldc.i4.3
 		IL_0323: ldstr "JavaScriptRuntime.csproj"
 		IL_0328: stelem.ref
-		IL_0329: stloc.s 10
-		IL_032b: ldloc.s 9
+		IL_0329: stloc.s 9
+		IL_032b: ldloc.s 8
 		IL_032d: ldstr "join"
-		IL_0332: ldloc.s 10
+		IL_0332: ldloc.s 9
 		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-		IL_0339: stloc.s 9
+		IL_0339: stloc.s 8
 		IL_033b: ldloc.0
-		IL_033c: ldloc.s 9
+		IL_033c: ldloc.s 8
 		IL_033e: stfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
 		IL_0343: ldloc.2
 		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0349: stloc.s 9
-		IL_034b: ldloc.s 9
+		IL_0349: stloc.s 8
+		IL_034b: ldloc.s 8
 		IL_034d: ldstr "join"
 		IL_0352: ldloc.3
 		IL_0353: ldstr "samples"
 		IL_0358: ldstr "Directory.Build.props"
 		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_0362: stloc.s 9
+		IL_0362: stloc.s 8
 		IL_0364: ldloc.0
-		IL_0365: ldloc.s 9
+		IL_0365: ldloc.s 8
 		IL_0367: stfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
 		IL_036c: ldloc.2
 		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0372: stloc.s 9
-		IL_0374: ldloc.s 9
+		IL_0372: stloc.s 8
+		IL_0374: ldloc.s 8
 		IL_0376: ldstr "join"
 		IL_037b: ldloc.3
 		IL_037c: ldstr "CHANGELOG.md"
 		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0386: stloc.s 9
+		IL_0386: stloc.s 8
 		IL_0388: ldloc.0
-		IL_0389: ldloc.s 9
+		IL_0389: ldloc.s 8
 		IL_038b: stfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
 		IL_0390: nop
 		IL_0391: nop
@@ -3452,7 +3448,7 @@
 			IL_039d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_03a7: pop
-			IL_03a8: leave IL_0452
+			IL_03a8: leave IL_044b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -3478,43 +3474,41 @@
 			IL_03d9: stloc.s 5
 
 			IL_03db: ldloc.s 5
-			IL_03dd: stloc.s 9
-			IL_03df: ldloc.s 9
+			IL_03dd: stloc.s 8
+			IL_03df: ldloc.s 8
 			IL_03e1: stloc.s 6
-			IL_03e3: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C29::.ctor()
-			IL_03e8: stloc.s 7
-			IL_03ea: ldstr "console"
-			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f4: stloc.s 9
-			IL_03f6: ldloc.s 9
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03fd: stloc.s 9
-			IL_03ff: ldloc.s 9
-			IL_0401: ldstr "error"
-			IL_0406: ldstr "ERROR:"
-			IL_040b: ldloc.s 6
-			IL_040d: ldstr "message"
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_041c: pop
-			IL_041d: ldstr "process"
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0427: stloc.s 9
-			IL_0429: ldloc.s 9
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0430: stloc.s 9
-			IL_0432: ldloc.s 9
-			IL_0434: ldstr "exit"
-			IL_0439: ldc.r8 1
-			IL_0442: box [System.Runtime]System.Double
-			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_044c: pop
-			IL_044d: leave IL_0452
+			IL_03e3: ldstr "console"
+			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03ed: stloc.s 8
+			IL_03ef: ldloc.s 8
+			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f6: stloc.s 8
+			IL_03f8: ldloc.s 8
+			IL_03fa: ldstr "error"
+			IL_03ff: ldstr "ERROR:"
+			IL_0404: ldloc.s 6
+			IL_0406: ldstr "message"
+			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0415: pop
+			IL_0416: ldstr "process"
+			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0420: stloc.s 8
+			IL_0422: ldloc.s 8
+			IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0429: stloc.s 8
+			IL_042b: ldloc.s 8
+			IL_042d: ldstr "exit"
+			IL_0432: ldc.r8 1
+			IL_043b: box [System.Runtime]System.Double
+			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0445: pop
+			IL_0446: leave IL_044b
 		} // end handler
 
-		IL_0452: ldnull
-		IL_0453: stloc.s 8
-		IL_0455: ret
+		IL_044b: ldnull
+		IL_044c: stloc.s 7
+		IL_044e: ret
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion
@@ -3526,7 +3520,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3a6f
+		// Method begins at RVA 0x3a63
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3135
+				// Method begins at RVA 0x3115
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3150
+						// Method begins at RVA 0x3130
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3159
+						// Method begins at RVA 0x3139
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3162
+						// Method begins at RVA 0x3142
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x316b
+						// Method begins at RVA 0x314b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3147
+					// Method begins at RVA 0x3127
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x313e
+				// Method begins at RVA 0x311e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -169,25 +169,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22f0
 			// Header size: 12
-			// Code size: 682 (0x2aa)
+			// Code size: 666 (0x29a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[1] float64,
-				[2] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/Scope_For_L21C7/Block_L21C40,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] bool,
+				[2] object,
+				[3] float64,
+				[4] object,
+				[5] bool,
+				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
 				[11] object,
-				[12] object,
-				[13] object
+				[12] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -204,239 +203,237 @@
 			IL_002f: stloc.1
 			// loop start (head: IL_0030)
 				IL_0030: ldloc.1
-				IL_0031: stloc.s 4
-				IL_0033: ldloc.s 4
-				IL_0035: ldarg.2
-				IL_0036: ldstr "length"
-				IL_003b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0040: clt
-				IL_0042: brfalse IL_02a8
+				IL_0031: stloc.3
+				IL_0032: ldloc.3
+				IL_0033: ldarg.2
+				IL_0034: ldstr "length"
+				IL_0039: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_003e: clt
+				IL_0040: brfalse IL_0298
 
-				IL_0047: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/Scope_For_L21C7/Block_L21C40::.ctor()
+				IL_0045: ldarg.2
+				IL_0046: ldloc.1
+				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_004c: stloc.2
-				IL_004d: ldarg.2
-				IL_004e: ldloc.1
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0054: stloc.3
-				IL_0055: ldloc.3
-				IL_0056: stloc.s 5
-				IL_0058: ldloc.s 5
-				IL_005a: ldstr "--in"
-				IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0064: stloc.s 6
-				IL_0066: ldloc.s 6
-				IL_0068: box [System.Runtime]System.Boolean
-				IL_006d: stloc.s 7
-				IL_006f: ldloc.s 7
-				IL_0071: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0076: stloc.s 6
-				IL_0078: ldloc.s 6
-				IL_007a: brtrue IL_00a2
+				IL_004d: ldloc.2
+				IL_004e: stloc.s 4
+				IL_0050: ldloc.s 4
+				IL_0052: ldstr "--in"
+				IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_005c: stloc.s 5
+				IL_005e: ldloc.s 5
+				IL_0060: box [System.Runtime]System.Boolean
+				IL_0065: stloc.s 6
+				IL_0067: ldloc.s 6
+				IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_006e: stloc.s 5
+				IL_0070: ldloc.s 5
+				IL_0072: brtrue IL_009a
 
-				IL_007f: ldloc.3
-				IL_0080: stloc.s 5
-				IL_0082: ldloc.s 5
-				IL_0084: ldstr "-i"
-				IL_0089: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_008e: stloc.s 6
-				IL_0090: ldloc.s 6
-				IL_0092: box [System.Runtime]System.Boolean
-				IL_0097: stloc.s 8
-				IL_0099: ldloc.s 8
-				IL_009b: stloc.s 10
-				IL_009d: br IL_00a6
+				IL_0077: ldloc.2
+				IL_0078: stloc.s 4
+				IL_007a: ldloc.s 4
+				IL_007c: ldstr "-i"
+				IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0086: stloc.s 5
+				IL_0088: ldloc.s 5
+				IL_008a: box [System.Runtime]System.Boolean
+				IL_008f: stloc.s 7
+				IL_0091: ldloc.s 7
+				IL_0093: stloc.s 9
+				IL_0095: br IL_009e
 
-				IL_00a2: ldloc.s 7
-				IL_00a4: stloc.s 10
+				IL_009a: ldloc.s 6
+				IL_009c: stloc.s 9
 
-				IL_00a6: ldloc.s 10
-				IL_00a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00ad: stloc.s 6
-				IL_00af: ldloc.s 6
-				IL_00b1: brfalse IL_0111
+				IL_009e: ldloc.s 9
+				IL_00a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00a5: stloc.s 5
+				IL_00a7: ldloc.s 5
+				IL_00a9: brfalse IL_0105
 
-				IL_00b6: ldloc.1
-				IL_00b7: stloc.s 4
-				IL_00b9: ldloc.s 4
-				IL_00bb: ldc.r8 1
-				IL_00c4: add
-				IL_00c5: stloc.s 4
-				IL_00c7: ldarg.2
-				IL_00c8: ldloc.s 4
-				IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00cf: stloc.s 5
-				IL_00d1: ldloc.s 5
-				IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00d8: stloc.s 6
-				IL_00da: ldloc.s 6
-				IL_00dc: brtrue IL_00ed
+				IL_00ae: ldloc.1
+				IL_00af: stloc.3
+				IL_00b0: ldloc.3
+				IL_00b1: ldc.r8 1
+				IL_00ba: add
+				IL_00bb: stloc.3
+				IL_00bc: ldarg.2
+				IL_00bd: ldloc.3
+				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00c3: stloc.s 4
+				IL_00c5: ldloc.s 4
+				IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00cc: stloc.s 5
+				IL_00ce: ldloc.s 5
+				IL_00d0: brtrue IL_00e1
 
-				IL_00e1: ldstr ""
-				IL_00e6: stloc.s 11
-				IL_00e8: br IL_00f1
+				IL_00d5: ldstr ""
+				IL_00da: stloc.s 10
+				IL_00dc: br IL_00e5
 
-				IL_00ed: ldloc.s 5
-				IL_00ef: stloc.s 11
+				IL_00e1: ldloc.s 4
+				IL_00e3: stloc.s 10
 
-				IL_00f1: ldloc.0
-				IL_00f2: ldstr "inFile"
-				IL_00f7: ldloc.s 11
-				IL_00f9: ldc.i4.1
-				IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_00ff: pop
-				IL_0100: ldloc.1
-				IL_0101: ldc.r8 1
-				IL_010a: add
-				IL_010b: stloc.1
-				IL_010c: br IL_0297
+				IL_00e5: ldloc.0
+				IL_00e6: ldstr "inFile"
+				IL_00eb: ldloc.s 10
+				IL_00ed: ldc.i4.1
+				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_00f3: pop
+				IL_00f4: ldloc.1
+				IL_00f5: ldc.r8 1
+				IL_00fe: add
+				IL_00ff: stloc.1
+				IL_0100: br IL_0287
 
-				IL_0111: ldloc.3
-				IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0117: stloc.s 5
-				IL_0119: ldloc.s 5
-				IL_011b: ldstr "startsWith"
-				IL_0120: ldstr "--in="
-				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_012a: stloc.s 5
-				IL_012c: ldloc.s 5
-				IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0133: stloc.s 6
-				IL_0135: ldloc.s 6
-				IL_0137: brfalse IL_0176
+				IL_0105: ldloc.2
+				IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_010b: stloc.s 4
+				IL_010d: ldloc.s 4
+				IL_010f: ldstr "startsWith"
+				IL_0114: ldstr "--in="
+				IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_011e: stloc.s 4
+				IL_0120: ldloc.s 4
+				IL_0122: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0127: stloc.s 5
+				IL_0129: ldloc.s 5
+				IL_012b: brfalse IL_016a
 
-				IL_013c: ldloc.3
-				IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0142: stloc.s 5
-				IL_0144: ldloc.s 5
-				IL_0146: ldstr "substring"
-				IL_014b: ldstr "--in="
-				IL_0150: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0155: conv.r8
-				IL_0156: box [System.Runtime]System.Double
-				IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0160: stloc.s 5
-				IL_0162: ldloc.0
-				IL_0163: ldstr "inFile"
-				IL_0168: ldloc.s 5
-				IL_016a: ldc.i4.1
-				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0170: pop
-				IL_0171: br IL_0297
+				IL_0130: ldloc.2
+				IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0136: stloc.s 4
+				IL_0138: ldloc.s 4
+				IL_013a: ldstr "substring"
+				IL_013f: ldstr "--in="
+				IL_0144: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0149: conv.r8
+				IL_014a: box [System.Runtime]System.Double
+				IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0154: stloc.s 4
+				IL_0156: ldloc.0
+				IL_0157: ldstr "inFile"
+				IL_015c: ldloc.s 4
+				IL_015e: ldc.i4.1
+				IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0164: pop
+				IL_0165: br IL_0287
 
-				IL_0176: ldloc.3
-				IL_0177: stloc.s 5
-				IL_0179: ldloc.s 5
-				IL_017b: ldstr "--out"
-				IL_0180: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0185: stloc.s 6
-				IL_0187: ldloc.s 6
-				IL_0189: box [System.Runtime]System.Boolean
-				IL_018e: stloc.s 7
-				IL_0190: ldloc.s 7
-				IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0197: stloc.s 6
-				IL_0199: ldloc.s 6
-				IL_019b: brtrue IL_01c3
+				IL_016a: ldloc.2
+				IL_016b: stloc.s 4
+				IL_016d: ldloc.s 4
+				IL_016f: ldstr "--out"
+				IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0179: stloc.s 5
+				IL_017b: ldloc.s 5
+				IL_017d: box [System.Runtime]System.Boolean
+				IL_0182: stloc.s 6
+				IL_0184: ldloc.s 6
+				IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_018b: stloc.s 5
+				IL_018d: ldloc.s 5
+				IL_018f: brtrue IL_01b7
 
-				IL_01a0: ldloc.3
-				IL_01a1: stloc.s 5
-				IL_01a3: ldloc.s 5
-				IL_01a5: ldstr "-o"
-				IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01af: stloc.s 6
-				IL_01b1: ldloc.s 6
-				IL_01b3: box [System.Runtime]System.Boolean
-				IL_01b8: stloc.s 8
-				IL_01ba: ldloc.s 8
-				IL_01bc: stloc.s 12
-				IL_01be: br IL_01c7
+				IL_0194: ldloc.2
+				IL_0195: stloc.s 4
+				IL_0197: ldloc.s 4
+				IL_0199: ldstr "-o"
+				IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01a3: stloc.s 5
+				IL_01a5: ldloc.s 5
+				IL_01a7: box [System.Runtime]System.Boolean
+				IL_01ac: stloc.s 7
+				IL_01ae: ldloc.s 7
+				IL_01b0: stloc.s 11
+				IL_01b2: br IL_01bb
 
-				IL_01c3: ldloc.s 7
-				IL_01c5: stloc.s 12
+				IL_01b7: ldloc.s 6
+				IL_01b9: stloc.s 11
 
-				IL_01c7: ldloc.s 12
-				IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01ce: stloc.s 6
-				IL_01d0: ldloc.s 6
-				IL_01d2: brfalse IL_0232
+				IL_01bb: ldloc.s 11
+				IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01c2: stloc.s 5
+				IL_01c4: ldloc.s 5
+				IL_01c6: brfalse IL_0222
 
-				IL_01d7: ldloc.1
-				IL_01d8: stloc.s 4
-				IL_01da: ldloc.s 4
-				IL_01dc: ldc.r8 1
-				IL_01e5: add
-				IL_01e6: stloc.s 4
-				IL_01e8: ldarg.2
-				IL_01e9: ldloc.s 4
-				IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01f0: stloc.s 5
-				IL_01f2: ldloc.s 5
-				IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01f9: stloc.s 6
-				IL_01fb: ldloc.s 6
-				IL_01fd: brtrue IL_020e
+				IL_01cb: ldloc.1
+				IL_01cc: stloc.3
+				IL_01cd: ldloc.3
+				IL_01ce: ldc.r8 1
+				IL_01d7: add
+				IL_01d8: stloc.3
+				IL_01d9: ldarg.2
+				IL_01da: ldloc.3
+				IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01e0: stloc.s 4
+				IL_01e2: ldloc.s 4
+				IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01e9: stloc.s 5
+				IL_01eb: ldloc.s 5
+				IL_01ed: brtrue IL_01fe
 
-				IL_0202: ldstr ""
-				IL_0207: stloc.s 13
-				IL_0209: br IL_0212
+				IL_01f2: ldstr ""
+				IL_01f7: stloc.s 12
+				IL_01f9: br IL_0202
 
-				IL_020e: ldloc.s 5
-				IL_0210: stloc.s 13
+				IL_01fe: ldloc.s 4
+				IL_0200: stloc.s 12
 
-				IL_0212: ldloc.0
-				IL_0213: ldstr "outFile"
-				IL_0218: ldloc.s 13
-				IL_021a: ldc.i4.1
-				IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0220: pop
-				IL_0221: ldloc.1
-				IL_0222: ldc.r8 1
-				IL_022b: add
-				IL_022c: stloc.1
-				IL_022d: br IL_0297
+				IL_0202: ldloc.0
+				IL_0203: ldstr "outFile"
+				IL_0208: ldloc.s 12
+				IL_020a: ldc.i4.1
+				IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0210: pop
+				IL_0211: ldloc.1
+				IL_0212: ldc.r8 1
+				IL_021b: add
+				IL_021c: stloc.1
+				IL_021d: br IL_0287
 
-				IL_0232: ldloc.3
-				IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0238: stloc.s 5
-				IL_023a: ldloc.s 5
-				IL_023c: ldstr "startsWith"
-				IL_0241: ldstr "--out="
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_024b: stloc.s 5
-				IL_024d: ldloc.s 5
-				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0254: stloc.s 6
-				IL_0256: ldloc.s 6
-				IL_0258: brfalse IL_0297
+				IL_0222: ldloc.2
+				IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0228: stloc.s 4
+				IL_022a: ldloc.s 4
+				IL_022c: ldstr "startsWith"
+				IL_0231: ldstr "--out="
+				IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_023b: stloc.s 4
+				IL_023d: ldloc.s 4
+				IL_023f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0244: stloc.s 5
+				IL_0246: ldloc.s 5
+				IL_0248: brfalse IL_0287
 
-				IL_025d: ldloc.3
-				IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0263: stloc.s 5
-				IL_0265: ldloc.s 5
-				IL_0267: ldstr "substring"
-				IL_026c: ldstr "--out="
-				IL_0271: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0276: conv.r8
-				IL_0277: box [System.Runtime]System.Double
-				IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0281: stloc.s 5
-				IL_0283: ldloc.0
-				IL_0284: ldstr "outFile"
-				IL_0289: ldloc.s 5
-				IL_028b: ldc.i4.1
-				IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0291: pop
-				IL_0292: br IL_0297
+				IL_024d: ldloc.2
+				IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0253: stloc.s 4
+				IL_0255: ldloc.s 4
+				IL_0257: ldstr "substring"
+				IL_025c: ldstr "--out="
+				IL_0261: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0266: conv.r8
+				IL_0267: box [System.Runtime]System.Double
+				IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0271: stloc.s 4
+				IL_0273: ldloc.0
+				IL_0274: ldstr "outFile"
+				IL_0279: ldloc.s 4
+				IL_027b: ldc.i4.1
+				IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0281: pop
+				IL_0282: br IL_0287
 
-				IL_0297: ldloc.1
-				IL_0298: ldc.r8 1
-				IL_02a1: add
-				IL_02a2: stloc.1
-				IL_02a3: br IL_0030
+				IL_0287: ldloc.1
+				IL_0288: ldc.r8 1
+				IL_0291: add
+				IL_0292: stloc.1
+				IL_0293: br IL_0030
 			// end loop
 
-			IL_02a8: ldloc.0
-			IL_02a9: ret
+			IL_0298: ldloc.0
+			IL_0299: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
@@ -456,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x317d
+					// Method begins at RVA 0x315d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -481,7 +478,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b24
+				// Method begins at RVA 0x2b0c
 				// Header size: 12
 				// Code size: 453 (0x1c5)
 				.maxstack 8
@@ -674,7 +671,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3186
+					// Method begins at RVA 0x3166
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -698,7 +695,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cf8
+				// Method begins at RVA 0x2ce0
 				// Header size: 12
 				// Code size: 156 (0x9c)
 				.maxstack 8
@@ -784,7 +781,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318f
+					// Method begins at RVA 0x316f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -808,7 +805,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2da0
+				// Method begins at RVA 0x2d88
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -854,7 +851,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a1
+						// Method begins at RVA 0x3181
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -878,7 +875,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fec
+					// Method begins at RVA 0x2fcc
 					// Header size: 12
 					// Code size: 221 (0xdd)
 					.maxstack 8
@@ -1001,7 +998,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31aa
+						// Method begins at RVA 0x318a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1019,7 +1016,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3198
+					// Method begins at RVA 0x3178
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1045,29 +1042,28 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dcc
+				// Method begins at RVA 0x2db4
 				// Header size: 12
-				// Code size: 530 (0x212)
+				// Code size: 523 (0x20b)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope,
 					[1] object,
 					[2] object,
 					[3] object,
-					[4] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope/Block_L97C39,
+					[4] object,
 					[5] object,
-					[6] object,
-					[7] string,
+					[6] string,
+					[7] object,
 					[8] object,
-					[9] object,
-					[10] bool,
+					[9] bool,
+					[10] object,
 					[11] object,
-					[12] object,
-					[13] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+					[12] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+					[13] object,
 					[14] object,
-					[15] object,
-					[16] string,
-					[17] string
+					[15] string,
+					[16] string
 				)
 
 				IL_0000: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope::.ctor()
@@ -1075,34 +1071,34 @@
 				IL_0006: ldarg.3
 				IL_0007: ldstr "textContent"
 				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0011: stloc.s 9
-				IL_0013: ldloc.s 9
+				IL_0011: stloc.s 8
+				IL_0013: ldloc.s 8
 				IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_001a: stloc.s 10
-				IL_001c: ldloc.s 10
+				IL_001a: stloc.s 9
+				IL_001c: ldloc.s 9
 				IL_001e: brtrue IL_002f
 
 				IL_0023: ldstr ""
-				IL_0028: stloc.s 12
+				IL_0028: stloc.s 11
 				IL_002a: br IL_0033
 
-				IL_002f: ldloc.s 9
-				IL_0031: stloc.s 12
+				IL_002f: ldloc.s 8
+				IL_0031: stloc.s 11
 
-				IL_0033: ldloc.s 12
+				IL_0033: ldloc.s 11
 				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003a: stloc.s 9
+				IL_003a: stloc.s 8
 				IL_003c: ldstr "\\r\\n"
 				IL_0041: ldstr "g"
 				IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_004b: stloc.s 13
-				IL_004d: ldloc.s 9
+				IL_004b: stloc.s 12
+				IL_004d: ldloc.s 8
 				IL_004f: ldstr "replace"
-				IL_0054: ldloc.s 13
+				IL_0054: ldloc.s 12
 				IL_0056: ldstr "\n"
 				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0060: stloc.s 9
-				IL_0062: ldloc.s 9
+				IL_0060: stloc.s 8
+				IL_0062: ldloc.s 8
 				IL_0064: stloc.1
 				IL_0065: ldnull
 				IL_0066: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
@@ -1124,141 +1120,139 @@
 				IL_008f: ldc.i4.0
 				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-				IL_009a: stloc.s 9
-				IL_009c: ldloc.s 9
+				IL_009a: stloc.s 8
+				IL_009c: ldloc.s 8
 				IL_009e: ldstr "langFromClass"
 				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-				IL_00a8: stloc.s 9
-				IL_00aa: ldloc.s 9
+				IL_00a8: stloc.s 8
+				IL_00aa: ldloc.s 8
 				IL_00ac: stloc.2
 				IL_00ad: ldnull
 				IL_00ae: ldarg.3
 				IL_00af: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
-				IL_00b4: stloc.s 9
-				IL_00b6: ldloc.s 9
+				IL_00b4: stloc.s 8
+				IL_00b6: ldloc.s 8
 				IL_00b8: stloc.3
 				IL_00b9: ldloc.3
 				IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_00bf: ldc.i4.0
 				IL_00c0: ceq
-				IL_00c2: stloc.s 10
-				IL_00c4: ldloc.s 10
+				IL_00c2: stloc.s 9
+				IL_00c4: ldloc.s 9
 				IL_00c6: box [System.Runtime]System.Boolean
-				IL_00cb: stloc.s 14
-				IL_00cd: ldloc.s 14
+				IL_00cb: stloc.s 13
+				IL_00cd: ldloc.s 13
 				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00d4: stloc.s 10
-				IL_00d6: ldloc.s 10
+				IL_00d4: stloc.s 9
+				IL_00d6: ldloc.s 9
 				IL_00d8: brfalse IL_00ef
 
 				IL_00dd: ldarg.3
 				IL_00de: ldstr "querySelector"
 				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00e8: stloc.s 15
+				IL_00e8: stloc.s 14
 				IL_00ea: br IL_00f3
 
-				IL_00ef: ldloc.s 14
-				IL_00f1: stloc.s 15
+				IL_00ef: ldloc.s 13
+				IL_00f1: stloc.s 14
 
-				IL_00f3: ldloc.s 15
+				IL_00f3: ldloc.s 14
 				IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00fa: stloc.s 10
-				IL_00fc: ldloc.s 10
-				IL_00fe: brfalse IL_0146
+				IL_00fa: stloc.s 9
+				IL_00fc: ldloc.s 9
+				IL_00fe: brfalse IL_013f
 
-				IL_0103: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope/Block_L97C39::.ctor()
-				IL_0108: stloc.s 4
-				IL_010a: ldarg.3
-				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0110: stloc.s 9
-				IL_0112: ldloc.s 9
-				IL_0114: ldstr "querySelector"
-				IL_0119: ldstr "code"
-				IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0123: stloc.s 9
-				IL_0125: ldloc.s 9
-				IL_0127: stloc.s 5
-				IL_0129: ldloc.s 5
-				IL_012b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0130: stloc.s 10
-				IL_0132: ldloc.s 10
-				IL_0134: brfalse IL_0146
+				IL_0103: ldarg.3
+				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0109: stloc.s 8
+				IL_010b: ldloc.s 8
+				IL_010d: ldstr "querySelector"
+				IL_0112: ldstr "code"
+				IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_011c: stloc.s 8
+				IL_011e: ldloc.s 8
+				IL_0120: stloc.s 4
+				IL_0122: ldloc.s 4
+				IL_0124: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0129: stloc.s 9
+				IL_012b: ldloc.s 9
+				IL_012d: brfalse IL_013f
 
-				IL_0139: ldnull
-				IL_013a: ldloc.s 5
-				IL_013c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
-				IL_0141: stloc.s 9
-				IL_0143: ldloc.s 9
-				IL_0145: stloc.3
+				IL_0132: ldnull
+				IL_0133: ldloc.s 4
+				IL_0135: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
+				IL_013a: stloc.s 8
+				IL_013c: ldloc.s 8
+				IL_013e: stloc.3
 
-				IL_0146: ldloc.3
-				IL_0147: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_014c: stloc.s 10
-				IL_014e: ldloc.s 10
-				IL_0150: brfalse IL_0174
+				IL_013f: ldloc.3
+				IL_0140: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0145: stloc.s 9
+				IL_0147: ldloc.s 9
+				IL_0149: brfalse IL_016d
 
-				IL_0155: ldloc.3
-				IL_0156: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_015b: stloc.s 16
-				IL_015d: ldstr " "
-				IL_0162: ldloc.s 16
-				IL_0164: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0169: stloc.s 16
-				IL_016b: ldloc.s 16
-				IL_016d: stloc.s 6
-				IL_016f: br IL_017b
+				IL_014e: ldloc.3
+				IL_014f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0154: stloc.s 15
+				IL_0156: ldstr " "
+				IL_015b: ldloc.s 15
+				IL_015d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0162: stloc.s 15
+				IL_0164: ldloc.s 15
+				IL_0166: stloc.s 5
+				IL_0168: br IL_0174
 
-				IL_0174: ldstr ""
-				IL_0179: stloc.s 6
+				IL_016d: ldstr ""
+				IL_0172: stloc.s 5
 
-				IL_017b: ldloc.s 6
-				IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0182: stloc.s 16
-				IL_0184: ldstr "\n\n```"
-				IL_0189: ldloc.s 16
-				IL_018b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0190: stloc.s 16
-				IL_0192: ldloc.s 16
-				IL_0194: ldstr "\n"
-				IL_0199: call string [System.Runtime]System.String::Concat(string, string)
-				IL_019e: stloc.s 16
-				IL_01a0: ldloc.s 16
-				IL_01a2: stloc.s 7
-				IL_01a4: ldloc.1
-				IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01aa: stloc.s 9
-				IL_01ac: ldstr "\\n$"
-				IL_01b1: ldstr ""
-				IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01bb: stloc.s 13
-				IL_01bd: ldloc.s 9
-				IL_01bf: ldstr "replace"
-				IL_01c4: ldloc.s 13
-				IL_01c6: ldstr ""
-				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01d0: stloc.s 9
-				IL_01d2: ldloc.s 9
-				IL_01d4: stloc.s 8
-				IL_01d6: ldloc.s 7
-				IL_01d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01dd: stloc.s 16
-				IL_01df: ldstr ""
-				IL_01e4: ldloc.s 16
-				IL_01e6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01eb: stloc.s 16
-				IL_01ed: ldloc.s 8
-				IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01f4: stloc.s 17
-				IL_01f6: ldloc.s 16
-				IL_01f8: ldloc.s 17
-				IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01ff: stloc.s 17
-				IL_0201: ldloc.s 17
-				IL_0203: ldstr "\n```\n\n"
-				IL_0208: call string [System.Runtime]System.String::Concat(string, string)
-				IL_020d: stloc.s 17
-				IL_020f: ldloc.s 17
-				IL_0211: ret
+				IL_0174: ldloc.s 5
+				IL_0176: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_017b: stloc.s 15
+				IL_017d: ldstr "\n\n```"
+				IL_0182: ldloc.s 15
+				IL_0184: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0189: stloc.s 15
+				IL_018b: ldloc.s 15
+				IL_018d: ldstr "\n"
+				IL_0192: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0197: stloc.s 15
+				IL_0199: ldloc.s 15
+				IL_019b: stloc.s 6
+				IL_019d: ldloc.1
+				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a3: stloc.s 8
+				IL_01a5: ldstr "\\n$"
+				IL_01aa: ldstr ""
+				IL_01af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_01b4: stloc.s 12
+				IL_01b6: ldloc.s 8
+				IL_01b8: ldstr "replace"
+				IL_01bd: ldloc.s 12
+				IL_01bf: ldstr ""
+				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01c9: stloc.s 8
+				IL_01cb: ldloc.s 8
+				IL_01cd: stloc.s 7
+				IL_01cf: ldloc.s 6
+				IL_01d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01d6: stloc.s 15
+				IL_01d8: ldstr ""
+				IL_01dd: ldloc.s 15
+				IL_01df: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01e4: stloc.s 15
+				IL_01e6: ldloc.s 7
+				IL_01e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01ed: stloc.s 16
+				IL_01ef: ldloc.s 15
+				IL_01f1: ldloc.s 16
+				IL_01f3: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01f8: stloc.s 16
+				IL_01fa: ldloc.s 16
+				IL_01fc: ldstr "\n```\n\n"
+				IL_0201: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0206: stloc.s 16
+				IL_0208: ldloc.s 16
+				IL_020a: ret
 			} // end of method FunctionExpression_L85C15::__js_call__
 
 		} // end of class FunctionExpression_L85C15
@@ -1270,7 +1264,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3174
+				// Method begins at RVA 0x3154
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1297,7 +1291,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x25b0
+			// Method begins at RVA 0x2598
 			// Header size: 12
 			// Code size: 620 (0x26c)
 			.maxstack 8
@@ -1539,7 +1533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b3
+				// Method begins at RVA 0x3193
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1565,7 +1559,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2828
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 749 (0x2ed)
 			.maxstack 8
@@ -1870,7 +1864,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c5
+					// Method begins at RVA 0x31a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1890,7 +1884,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31ce
+					// Method begins at RVA 0x31ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1908,7 +1902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31bc
+				// Method begins at RVA 0x319c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1934,7 +1928,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x312c
+			// Method begins at RVA 0x310c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1960,7 +1954,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 481 (0x1e1)
+		// Code size: 474 (0x1da)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
@@ -1968,13 +1962,12 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L134C16,
+			[5] object,
 			[6] object,
 			[7] object,
-			[8] object,
-			[9] bool,
-			[10] object,
-			[11] object
+			[8] bool,
+			[9] object,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::.ctor()
@@ -1996,9 +1989,9 @@
 		IL_0029: ldc.i4.0
 		IL_002a: ldc.i4.1
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0030: stloc.s 8
+		IL_0030: stloc.s 7
 		IL_0032: ldloc.0
-		IL_0033: ldloc.s 8
+		IL_0033: ldloc.s 7
 		IL_0035: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::parseArgs
 		IL_003a: ldc.i4.1
 		IL_003b: newarr [System.Runtime]System.Object
@@ -2017,9 +2010,9 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldc.i4.1
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0064: stloc.s 8
+		IL_0064: stloc.s 7
 		IL_0066: ldloc.0
-		IL_0067: ldloc.s 8
+		IL_0067: ldloc.s 7
 		IL_0069: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
 		IL_006e: ldc.i4.1
 		IL_006f: newarr [System.Runtime]System.Object
@@ -2038,30 +2031,30 @@
 		IL_0091: ldc.i4.0
 		IL_0092: ldc.i4.1
 		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0098: stloc.s 8
-		IL_009a: ldloc.s 8
+		IL_0098: stloc.s 7
+		IL_009a: ldloc.s 7
 		IL_009c: stloc.1
 		IL_009d: nop
 		IL_009e: ldarg.1
 		IL_009f: ldstr "fs"
 		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00a9: stloc.s 8
+		IL_00a9: stloc.s 7
 		IL_00ab: ldloc.0
-		IL_00ac: ldloc.s 8
+		IL_00ac: ldloc.s 7
 		IL_00ae: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
 		IL_00b3: ldarg.1
 		IL_00b4: ldstr "path"
 		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00be: stloc.s 8
+		IL_00be: stloc.s 7
 		IL_00c0: ldloc.0
-		IL_00c1: ldloc.s 8
+		IL_00c1: ldloc.s 7
 		IL_00c3: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
 		IL_00c8: ldarg.1
 		IL_00c9: ldstr "turndown"
 		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00d3: stloc.s 8
+		IL_00d3: stloc.s 7
 		IL_00d5: ldloc.0
-		IL_00d6: ldloc.s 8
+		IL_00d6: ldloc.s 7
 		IL_00d8: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::TurndownService
 		IL_00dd: nop
 		IL_00de: nop
@@ -2071,9 +2064,9 @@
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00eb: ldarg.2
 		IL_00ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f1: stloc.s 9
-		IL_00f3: ldloc.s 9
-		IL_00f5: brfalse IL_01dd
+		IL_00f1: stloc.s 8
+		IL_00f3: ldloc.s 8
+		IL_00f5: brfalse IL_01d6
 		.try
 		{
 			IL_00fa: nop
@@ -2081,7 +2074,7 @@
 			IL_00fc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_0106: pop
-			IL_0107: leave IL_01dd
+			IL_0107: leave IL_01d6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -2107,67 +2100,65 @@
 			IL_0134: stloc.3
 
 			IL_0135: ldloc.3
-			IL_0136: stloc.s 8
-			IL_0138: ldloc.s 8
+			IL_0136: stloc.s 7
+			IL_0138: ldloc.s 7
 			IL_013a: stloc.s 4
-			IL_013c: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L134C16::.ctor()
-			IL_0141: stloc.s 5
-			IL_0143: ldstr "console"
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_014d: stloc.s 8
-			IL_014f: ldloc.s 8
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0156: stloc.s 8
-			IL_0158: ldloc.s 4
-			IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_015f: stloc.s 9
-			IL_0161: ldloc.s 9
-			IL_0163: brfalse IL_017b
+			IL_013c: ldstr "console"
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0146: stloc.s 7
+			IL_0148: ldloc.s 7
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014f: stloc.s 7
+			IL_0151: ldloc.s 4
+			IL_0153: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0158: stloc.s 8
+			IL_015a: ldloc.s 8
+			IL_015c: brfalse IL_0174
 
-			IL_0168: ldloc.s 4
-			IL_016a: ldstr "message"
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0174: stloc.s 11
-			IL_0176: br IL_017f
+			IL_0161: ldloc.s 4
+			IL_0163: ldstr "message"
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016d: stloc.s 10
+			IL_016f: br IL_0178
 
-			IL_017b: ldloc.s 4
-			IL_017d: stloc.s 11
+			IL_0174: ldloc.s 4
+			IL_0176: stloc.s 10
 
-			IL_017f: ldloc.s 11
-			IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0186: stloc.s 9
-			IL_0188: ldloc.s 9
-			IL_018a: brfalse IL_01a2
+			IL_0178: ldloc.s 10
+			IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_017f: stloc.s 8
+			IL_0181: ldloc.s 8
+			IL_0183: brfalse IL_019b
 
-			IL_018f: ldloc.s 4
-			IL_0191: ldstr "message"
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_019b: stloc.s 6
-			IL_019d: br IL_01a6
+			IL_0188: ldloc.s 4
+			IL_018a: ldstr "message"
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0194: stloc.s 5
+			IL_0196: br IL_019f
 
-			IL_01a2: ldloc.s 4
-			IL_01a4: stloc.s 6
+			IL_019b: ldloc.s 4
+			IL_019d: stloc.s 5
 
-			IL_01a6: ldloc.s 8
-			IL_01a8: ldstr "error"
-			IL_01ad: ldloc.s 6
-			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b4: pop
-			IL_01b5: ldstr "process"
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01bf: stloc.s 8
-			IL_01c1: ldloc.s 8
-			IL_01c3: ldstr "exitCode"
-			IL_01c8: ldc.r8 1
-			IL_01d1: ldc.i4.1
-			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_01d7: pop
-			IL_01d8: leave IL_01dd
+			IL_019f: ldloc.s 7
+			IL_01a1: ldstr "error"
+			IL_01a6: ldloc.s 5
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ad: pop
+			IL_01ae: ldstr "process"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b8: stloc.s 7
+			IL_01ba: ldloc.s 7
+			IL_01bc: ldstr "exitCode"
+			IL_01c1: ldc.r8 1
+			IL_01ca: ldc.i4.1
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_01d0: pop
+			IL_01d1: leave IL_01d6
 		} // end handler
 
-		IL_01dd: ldnull
-		IL_01de: stloc.s 7
-		IL_01e0: ret
+		IL_01d6: ldnull
+		IL_01d7: stloc.s 6
+		IL_01d9: ret
 	} // end of method Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
@@ -2187,7 +2178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e0
+				// Method begins at RVA 0x31c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2210,7 +2201,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30d5
+			// Method begins at RVA 0x30b5
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2239,7 +2230,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e9
+				// Method begins at RVA 0x31c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2264,7 +2255,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30d8
+			// Method begins at RVA 0x30b8
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2301,7 +2292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f2
+				// Method begins at RVA 0x31d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2325,7 +2316,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30f0
+			// Method begins at RVA 0x30d0
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2379,7 +2370,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x31d7
+			// Method begins at RVA 0x31b7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2403,7 +2394,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2250
+		// Method begins at RVA 0x2248
 		// Header size: 12
 		// Code size: 154 (0x9a)
 		.maxstack 8
@@ -2483,7 +2474,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31fb
+		// Method begins at RVA 0x31db
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3214
+				// Method begins at RVA 0x31ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321d
+				// Method begins at RVA 0x31f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -261,7 +261,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3238
+					// Method begins at RVA 0x3210
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -285,7 +285,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x31a0
+				// Method begins at RVA 0x3178
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -323,7 +323,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3241
+					// Method begins at RVA 0x3219
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -348,7 +348,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x31c4
+				// Method begins at RVA 0x319c
 				// Header size: 12
 				// Code size: 59 (0x3b)
 				.maxstack 8
@@ -400,7 +400,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x322f
+					// Method begins at RVA 0x3207
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -421,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3226
+				// Method begins at RVA 0x31fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -449,7 +449,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x325c
+						// Method begins at RVA 0x3234
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -467,7 +467,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3253
+					// Method begins at RVA 0x322b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -485,7 +485,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x324a
+				// Method begins at RVA 0x3222
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -515,7 +515,7 @@
 			)
 			// Method begins at RVA 0x23a4
 			// Header size: 12
-			// Code size: 600 (0x258)
+			// Code size: 593 (0x251)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope,
@@ -526,14 +526,13 @@
 				[5] bool,
 				[6] bool,
 				[7] object,
-				[8] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32,
+				[8] object,
 				[9] object,
 				[10] object,
-				[11] object,
-				[12] bool,
-				[13] object,
-				[14] float64,
-				[15] float64
+				[11] bool,
+				[12] object,
+				[13] float64,
+				[14] float64
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::.ctor()
@@ -544,19 +543,19 @@
 			IL_000d: ldarg.0
 			IL_000e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
 			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0018: stloc.s 11
-			IL_001a: ldloc.s 11
+			IL_0018: stloc.s 10
+			IL_001a: ldloc.s 10
 			IL_001c: ldstr "existsSync"
 			IL_0021: ldloc.0
 			IL_0022: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_002c: stloc.s 11
-			IL_002e: ldloc.s 11
+			IL_002c: stloc.s 10
+			IL_002e: ldloc.s 10
 			IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_0035: ldc.i4.0
 			IL_0036: ceq
-			IL_0038: stloc.s 12
-			IL_003a: ldloc.s 12
+			IL_0038: stloc.s 11
+			IL_003a: ldloc.s 11
 			IL_003c: brfalse IL_0048
 
 			IL_0041: ldc.i4.0
@@ -566,23 +565,23 @@
 			IL_0048: ldarg.0
 			IL_0049: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
 			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0053: stloc.s 11
+			IL_0053: stloc.s 10
 			IL_0055: ldloc.0
 			IL_0056: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_005b: stloc.s 13
-			IL_005d: ldloc.s 11
+			IL_005b: stloc.s 12
+			IL_005d: ldloc.s 10
 			IL_005f: ldstr "readdirSync"
-			IL_0064: ldloc.s 13
+			IL_0064: ldloc.s 12
 			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_006b: dup
 			IL_006c: ldstr "withFileTypes"
 			IL_0071: ldc.i4.1
 			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_007c: stloc.s 13
-			IL_007e: ldloc.s 13
+			IL_007c: stloc.s 12
+			IL_007e: ldloc.s 12
 			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0085: stloc.s 13
+			IL_0085: stloc.s 12
 			IL_0087: ldnull
 			IL_0088: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L47C13::__js_call__(object, object)
 			IL_008e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -601,15 +600,15 @@
 			IL_00af: ldc.i4.0
 			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00ba: stloc.s 11
-			IL_00bc: ldloc.s 13
+			IL_00ba: stloc.s 10
+			IL_00bc: ldloc.s 12
 			IL_00be: ldstr "filter"
-			IL_00c3: ldloc.s 11
+			IL_00c3: ldloc.s 10
 			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ca: stloc.s 11
-			IL_00cc: ldloc.s 11
+			IL_00ca: stloc.s 10
+			IL_00cc: ldloc.s 10
 			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d3: stloc.s 11
+			IL_00d3: stloc.s 10
 			IL_00d5: ldnull
 			IL_00d6: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L48C10::__js_call__(object[], object, object)
 			IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
@@ -632,13 +631,13 @@
 			IL_0101: ldc.i4.0
 			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_010c: stloc.s 13
-			IL_010e: ldloc.s 11
+			IL_010c: stloc.s 12
+			IL_010e: ldloc.s 10
 			IL_0110: ldstr "map"
-			IL_0115: ldloc.s 13
+			IL_0115: ldloc.s 12
 			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_011c: stloc.s 13
-			IL_011e: ldloc.s 13
+			IL_011c: stloc.s 12
+			IL_011e: ldloc.s 12
 			IL_0120: stloc.1
 			IL_0121: ldc.i4.0
 			IL_0122: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
@@ -659,113 +658,111 @@
 				// loop start (head: IL_0146)
 					IL_0146: ldloc.s 4
 					IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_014d: stloc.s 13
-					IL_014f: ldloc.s 13
+					IL_014d: stloc.s 12
+					IL_014f: ldloc.s 12
 					IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0156: stloc.s 12
-					IL_0158: ldloc.s 12
-					IL_015a: brtrue IL_0238
+					IL_0156: stloc.s 11
+					IL_0158: ldloc.s 11
+					IL_015a: brtrue IL_0231
 
-					IL_015f: ldloc.s 13
+					IL_015f: ldloc.s 12
 					IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0166: stloc.s 13
-					IL_0168: ldloc.s 13
+					IL_0166: stloc.s 12
+					IL_0168: ldloc.s 12
 					IL_016a: stloc.s 7
-					IL_016c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope_ForOf_L53C7/Block_L53C32::.ctor()
-					IL_0171: stloc.s 8
-					IL_0173: ldarg.0
-					IL_0174: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-					IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_017e: stloc.s 13
-					IL_0180: ldloc.s 13
-					IL_0182: ldstr "join"
-					IL_0187: ldloc.s 7
-					IL_0189: ldarg.3
-					IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_018f: stloc.s 13
-					IL_0191: ldloc.s 13
-					IL_0193: stloc.s 9
-					IL_0195: ldarg.0
-					IL_0196: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01a0: stloc.s 13
-					IL_01a2: ldloc.s 13
-					IL_01a4: ldstr "existsSync"
-					IL_01a9: ldloc.s 9
-					IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_01b0: stloc.s 13
-					IL_01b2: ldloc.s 13
-					IL_01b4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_01b9: ldc.i4.0
-					IL_01ba: ceq
-					IL_01bc: stloc.s 12
-					IL_01be: ldloc.s 12
-					IL_01c0: brfalse IL_01ca
+					IL_016c: ldarg.0
+					IL_016d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0177: stloc.s 12
+					IL_0179: ldloc.s 12
+					IL_017b: ldstr "join"
+					IL_0180: ldloc.s 7
+					IL_0182: ldarg.3
+					IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0188: stloc.s 12
+					IL_018a: ldloc.s 12
+					IL_018c: stloc.s 8
+					IL_018e: ldarg.0
+					IL_018f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0199: stloc.s 12
+					IL_019b: ldloc.s 12
+					IL_019d: ldstr "existsSync"
+					IL_01a2: ldloc.s 8
+					IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_01a9: stloc.s 12
+					IL_01ab: ldloc.s 12
+					IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_01b2: ldc.i4.0
+					IL_01b3: ceq
+					IL_01b5: stloc.s 11
+					IL_01b7: ldloc.s 11
+					IL_01b9: brfalse IL_01c3
 
-					IL_01c5: br IL_0224
+					IL_01be: br IL_021d
 
-					IL_01ca: ldarg.0
-					IL_01cb: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01d5: stloc.s 13
-					IL_01d7: ldloc.s 13
-					IL_01d9: ldstr "statSync"
-					IL_01de: ldloc.s 9
-					IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_01e5: stloc.s 13
-					IL_01e7: ldloc.s 13
-					IL_01e9: stloc.s 10
-					IL_01eb: ldloc.s 10
-					IL_01ed: ldstr "mtimeMs"
-					IL_01f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_01f7: stloc.s 14
-					IL_01f9: ldloc.3
-					IL_01fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01ff: stloc.s 15
-					IL_0201: ldloc.s 14
-					IL_0203: ldloc.s 15
-					IL_0205: cgt
-					IL_0207: brfalse IL_0224
+					IL_01c3: ldarg.0
+					IL_01c4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01ce: stloc.s 12
+					IL_01d0: ldloc.s 12
+					IL_01d2: ldstr "statSync"
+					IL_01d7: ldloc.s 8
+					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_01de: stloc.s 12
+					IL_01e0: ldloc.s 12
+					IL_01e2: stloc.s 9
+					IL_01e4: ldloc.s 9
+					IL_01e6: ldstr "mtimeMs"
+					IL_01eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+					IL_01f0: stloc.s 13
+					IL_01f2: ldloc.3
+					IL_01f3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01f8: stloc.s 14
+					IL_01fa: ldloc.s 13
+					IL_01fc: ldloc.s 14
+					IL_01fe: cgt
+					IL_0200: brfalse IL_021d
 
-					IL_020c: ldloc.s 10
-					IL_020e: ldstr "mtimeMs"
-					IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0218: stloc.s 13
-					IL_021a: ldloc.s 13
-					IL_021c: stloc.3
-					IL_021d: ldloc.s 9
-					IL_021f: stloc.s 13
-					IL_0221: ldloc.s 13
-					IL_0223: stloc.2
+					IL_0205: ldloc.s 9
+					IL_0207: ldstr "mtimeMs"
+					IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0211: stloc.s 12
+					IL_0213: ldloc.s 12
+					IL_0215: stloc.3
+					IL_0216: ldloc.s 8
+					IL_0218: stloc.s 12
+					IL_021a: ldloc.s 12
+					IL_021c: stloc.2
 
-					IL_0224: br IL_0146
+					IL_021d: br IL_0146
 				// end loop
-				IL_0229: ldloc.s 4
-				IL_022b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0230: ldc.i4.1
-				IL_0231: stloc.s 6
-				IL_0233: leave IL_0256
+				IL_0222: ldloc.s 4
+				IL_0224: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0229: ldc.i4.1
+				IL_022a: stloc.s 6
+				IL_022c: leave IL_024f
 
-				IL_0238: ldc.i4.1
-				IL_0239: stloc.s 5
-				IL_023b: leave IL_0256
+				IL_0231: ldc.i4.1
+				IL_0232: stloc.s 5
+				IL_0234: leave IL_024f
 			} // end .try
 			finally
 			{
-				IL_0240: ldloc.s 5
-				IL_0242: brtrue IL_0255
+				IL_0239: ldloc.s 5
+				IL_023b: brtrue IL_024e
 
-				IL_0247: ldloc.s 6
-				IL_0249: brtrue IL_0255
+				IL_0240: ldloc.s 6
+				IL_0242: brtrue IL_024e
 
-				IL_024e: ldloc.s 4
-				IL_0250: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0247: ldloc.s 4
+				IL_0249: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0255: endfinally
+				IL_024e: endfinally
 			} // end handler
 
-			IL_0256: ldloc.2
-			IL_0257: ret
+			IL_024f: ldloc.2
+			IL_0250: ret
 		} // end of method tryFindLatestGeneratedAssemblyInRoot::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssemblyInRoot
@@ -785,7 +782,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x326e
+					// Method begins at RVA 0x3246
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -803,7 +800,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3265
+				// Method begins at RVA 0x323d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -831,7 +828,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2618
+			// Method begins at RVA 0x2614
 			// Header size: 12
 			// Code size: 312 (0x138)
 			.maxstack 8
@@ -1023,7 +1020,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3289
+						// Method begins at RVA 0x3261
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1041,7 +1038,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3280
+					// Method begins at RVA 0x3258
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1059,7 +1056,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3277
+				// Method begins at RVA 0x324f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1086,184 +1083,181 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x276c
+			// Method begins at RVA 0x2768
 			// Header size: 12
-			// Code size: 397 (0x18d)
+			// Code size: 387 (0x183)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15,
+				[1] object,
 				[2] object,
 				[3] object,
 				[4] object,
 				[5] object,
-				[6] object,
-				[7] bool,
+				[6] bool,
+				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
-				[13] object,
-				[14] string
+				[13] string
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: stloc.0
 			// loop start (head: IL_0002)
 				IL_0002: ldc.i4.1
-				IL_0003: brfalse IL_014c
+				IL_0003: brfalse IL_0142
 
-				IL_0008: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/Scope/Block_L80C15::.ctor()
-				IL_000d: stloc.1
-				IL_000e: ldarg.0
-				IL_000f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0019: stloc.s 6
-				IL_001b: ldloc.s 6
-				IL_001d: ldstr "join"
-				IL_0022: ldloc.0
-				IL_0023: ldstr "jroc.sln"
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_002d: stloc.s 6
-				IL_002f: ldloc.s 6
-				IL_0031: stloc.2
-				IL_0032: ldarg.0
-				IL_0033: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003d: stloc.s 6
-				IL_003f: ldloc.s 6
-				IL_0041: ldstr "join"
-				IL_0046: ldloc.0
-				IL_0047: ldstr "tests"
-				IL_004c: ldstr "Jroc.Tests"
-				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0056: stloc.s 6
-				IL_0058: ldloc.s 6
-				IL_005a: stloc.3
-				IL_005b: ldarg.0
-				IL_005c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0066: stloc.s 6
-				IL_0068: ldloc.s 6
-				IL_006a: ldstr "existsSync"
-				IL_006f: ldloc.2
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0075: stloc.s 6
-				IL_0077: ldloc.s 6
-				IL_0079: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_007e: stloc.s 7
-				IL_0080: ldloc.s 7
-				IL_0082: brfalse IL_00ac
+				IL_0008: ldarg.0
+				IL_0009: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0013: stloc.s 5
+				IL_0015: ldloc.s 5
+				IL_0017: ldstr "join"
+				IL_001c: ldloc.0
+				IL_001d: ldstr "jroc.sln"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0027: stloc.s 5
+				IL_0029: ldloc.s 5
+				IL_002b: stloc.1
+				IL_002c: ldarg.0
+				IL_002d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0037: stloc.s 5
+				IL_0039: ldloc.s 5
+				IL_003b: ldstr "join"
+				IL_0040: ldloc.0
+				IL_0041: ldstr "tests"
+				IL_0046: ldstr "Jroc.Tests"
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0050: stloc.s 5
+				IL_0052: ldloc.s 5
+				IL_0054: stloc.2
+				IL_0055: ldarg.0
+				IL_0056: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0060: stloc.s 5
+				IL_0062: ldloc.s 5
+				IL_0064: ldstr "existsSync"
+				IL_0069: ldloc.1
+				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_006f: stloc.s 5
+				IL_0071: ldloc.s 5
+				IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0078: stloc.s 6
+				IL_007a: ldloc.s 6
+				IL_007c: brfalse IL_00a6
 
-				IL_0087: ldarg.0
-				IL_0088: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0092: stloc.s 8
-				IL_0094: ldloc.s 8
-				IL_0096: ldstr "existsSync"
-				IL_009b: ldloc.3
-				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00a1: stloc.s 8
-				IL_00a3: ldloc.s 8
-				IL_00a5: stloc.s 10
-				IL_00a7: br IL_00b0
+				IL_0081: ldarg.0
+				IL_0082: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008c: stloc.s 7
+				IL_008e: ldloc.s 7
+				IL_0090: ldstr "existsSync"
+				IL_0095: ldloc.2
+				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_009b: stloc.s 7
+				IL_009d: ldloc.s 7
+				IL_009f: stloc.s 9
+				IL_00a1: br IL_00aa
 
-				IL_00ac: ldloc.s 6
-				IL_00ae: stloc.s 10
+				IL_00a6: ldloc.s 5
+				IL_00a8: stloc.s 9
 
-				IL_00b0: ldloc.s 10
-				IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00b7: stloc.s 7
-				IL_00b9: ldloc.s 7
-				IL_00bb: brfalse IL_00c2
+				IL_00aa: ldloc.s 9
+				IL_00ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00b1: stloc.s 6
+				IL_00b3: ldloc.s 6
+				IL_00b5: brfalse IL_00bc
 
-				IL_00c0: ldloc.0
-				IL_00c1: ret
+				IL_00ba: ldloc.0
+				IL_00bb: ret
 
-				IL_00c2: ldarg.0
-				IL_00c3: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00cd: stloc.s 6
-				IL_00cf: ldloc.s 6
-				IL_00d1: ldstr "dirname"
-				IL_00d6: ldloc.0
-				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00dc: stloc.s 6
-				IL_00de: ldloc.s 6
-				IL_00e0: stloc.s 4
-				IL_00e2: ldloc.s 4
-				IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_00e9: ldc.i4.0
-				IL_00ea: ceq
-				IL_00ec: stloc.s 7
-				IL_00ee: ldloc.s 7
-				IL_00f0: box [System.Runtime]System.Boolean
-				IL_00f5: stloc.s 11
-				IL_00f7: ldloc.s 11
-				IL_00f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00fe: stloc.s 7
-				IL_0100: ldloc.s 7
-				IL_0102: brtrue IL_0127
+				IL_00bc: ldarg.0
+				IL_00bd: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c7: stloc.s 5
+				IL_00c9: ldloc.s 5
+				IL_00cb: ldstr "dirname"
+				IL_00d0: ldloc.0
+				IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00d6: stloc.s 5
+				IL_00d8: ldloc.s 5
+				IL_00da: stloc.3
+				IL_00db: ldloc.3
+				IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00e1: ldc.i4.0
+				IL_00e2: ceq
+				IL_00e4: stloc.s 6
+				IL_00e6: ldloc.s 6
+				IL_00e8: box [System.Runtime]System.Boolean
+				IL_00ed: stloc.s 10
+				IL_00ef: ldloc.s 10
+				IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00f6: stloc.s 6
+				IL_00f8: ldloc.s 6
+				IL_00fa: brtrue IL_011e
 
-				IL_0107: ldloc.s 4
-				IL_0109: stloc.s 6
-				IL_010b: ldloc.s 6
-				IL_010d: ldloc.0
-				IL_010e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0113: stloc.s 7
-				IL_0115: ldloc.s 7
-				IL_0117: box [System.Runtime]System.Boolean
-				IL_011c: stloc.s 12
-				IL_011e: ldloc.s 12
-				IL_0120: stloc.s 13
-				IL_0122: br IL_012b
+				IL_00ff: ldloc.3
+				IL_0100: stloc.s 5
+				IL_0102: ldloc.s 5
+				IL_0104: ldloc.0
+				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_010a: stloc.s 6
+				IL_010c: ldloc.s 6
+				IL_010e: box [System.Runtime]System.Boolean
+				IL_0113: stloc.s 11
+				IL_0115: ldloc.s 11
+				IL_0117: stloc.s 12
+				IL_0119: br IL_0122
 
-				IL_0127: ldloc.s 11
-				IL_0129: stloc.s 13
+				IL_011e: ldloc.s 10
+				IL_0120: stloc.s 12
 
-				IL_012b: ldloc.s 13
-				IL_012d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0132: stloc.s 7
-				IL_0134: ldloc.s 7
-				IL_0136: brfalse IL_0140
+				IL_0122: ldloc.s 12
+				IL_0124: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0129: stloc.s 6
+				IL_012b: ldloc.s 6
+				IL_012d: brfalse IL_0137
 
-				IL_013b: br IL_014c
+				IL_0132: br IL_0142
 
-				IL_0140: ldloc.s 4
-				IL_0142: stloc.s 6
-				IL_0144: ldloc.s 6
-				IL_0146: stloc.0
-				IL_0147: br IL_0002
+				IL_0137: ldloc.3
+				IL_0138: stloc.s 5
+				IL_013a: ldloc.s 5
+				IL_013c: stloc.0
+				IL_013d: br IL_0002
 			// end loop
 
-			IL_014c: ldarg.2
-			IL_014d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0152: stloc.s 14
-			IL_0154: ldstr "Could not locate jroc repo root starting from: "
-			IL_0159: ldloc.s 14
-			IL_015b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0160: stloc.s 14
-			IL_0162: ldloc.s 14
-			IL_0164: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_016e: stloc.s 6
-			IL_0170: ldloc.s 6
-			IL_0172: stloc.s 5
-			IL_0174: ldloc.s 5
-			IL_0176: isinst [System.Runtime]System.Exception
-			IL_017b: dup
-			IL_017c: brtrue IL_018a
+			IL_0142: ldarg.2
+			IL_0143: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0148: stloc.s 13
+			IL_014a: ldstr "Could not locate jroc repo root starting from: "
+			IL_014f: ldloc.s 13
+			IL_0151: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0156: stloc.s 13
+			IL_0158: ldloc.s 13
+			IL_015a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_015f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0164: stloc.s 5
+			IL_0166: ldloc.s 5
+			IL_0168: stloc.s 4
+			IL_016a: ldloc.s 4
+			IL_016c: isinst [System.Runtime]System.Exception
+			IL_0171: dup
+			IL_0172: brtrue IL_0180
 
-			IL_0181: pop
-			IL_0182: ldloc.s 5
-			IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0189: throw
+			IL_0177: pop
+			IL_0178: ldloc.s 4
+			IL_017a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_017f: throw
 
-			IL_018a: throw
+			IL_0180: throw
 
-			IL_018b: ldnull
-			IL_018c: ret
+			IL_0181: ldnull
+			IL_0182: ret
 		} // end of method findProjectRoot::__js_call__
 
 	} // end of class findProjectRoot
@@ -1279,7 +1273,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3292
+				// Method begins at RVA 0x326a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1306,7 +1300,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2908
+			// Method begins at RVA 0x28f8
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -1393,7 +1387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32a4
+					// Method begins at RVA 0x327c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1417,7 +1411,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32b6
+						// Method begins at RVA 0x328e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1435,7 +1429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32ad
+					// Method begins at RVA 0x3285
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1455,7 +1449,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32bf
+					// Method begins at RVA 0x3297
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1479,7 +1473,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32d1
+						// Method begins at RVA 0x32a9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1497,7 +1491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32c8
+					// Method begins at RVA 0x32a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1517,7 +1511,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32da
+					// Method begins at RVA 0x32b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1537,7 +1531,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32e3
+					// Method begins at RVA 0x32bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1555,7 +1549,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x329b
+				// Method begins at RVA 0x3273
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1581,9 +1575,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x29b4
+			// Method begins at RVA 0x29a4
 			// Header size: 12
-			// Code size: 1997 (0x7cd)
+			// Code size: 1976 (0x7b8)
 			.maxstack 9
 			.locals init (
 				[0] object,
@@ -1592,45 +1586,42 @@
 				[3] string,
 				[4] object,
 				[5] object,
-				[6] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31,
+				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21,
-				[11] object,
-				[12] float64,
-				[13] class [System.Runtime]System.Exception,
+				[10] float64,
+				[11] class [System.Runtime]System.Exception,
+				[12] object,
+				[13] object,
 				[14] object,
 				[15] object,
-				[16] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16,
-				[17] object,
-				[18] object,
-				[19] string,
-				[20] string,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[22] bool,
-				[23] object,
-				[24] object,
-				[25] float64
+				[16] string,
+				[17] string,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[19] bool,
+				[20] object,
+				[21] object,
+				[22] float64
 			)
 
 			IL_0000: ldstr "process"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_000a: stloc.s 18
-			IL_000c: ldloc.s 18
+			IL_000a: stloc.s 15
+			IL_000c: ldloc.s 15
 			IL_000e: ldstr "argv"
 			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0018: stloc.s 18
-			IL_001a: ldloc.s 18
+			IL_0018: stloc.s 15
+			IL_001a: ldloc.s 15
 			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0021: stloc.s 18
-			IL_0023: ldloc.s 18
+			IL_0021: stloc.s 15
+			IL_0023: ldloc.s 15
 			IL_0025: ldstr "slice"
 			IL_002a: ldc.r8 2
 			IL_0033: box [System.Runtime]System.Double
 			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_003d: stloc.s 18
-			IL_003f: ldloc.s 18
+			IL_003d: stloc.s 15
+			IL_003f: ldloc.s 15
 			IL_0041: stloc.0
 			IL_0042: ldloc.0
 			IL_0043: ldstr "length"
@@ -1642,66 +1633,66 @@
 
 			IL_0062: ldstr "console"
 			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006c: stloc.s 18
-			IL_006e: ldloc.s 18
+			IL_006c: stloc.s 15
+			IL_006e: ldloc.s 15
 			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0075: stloc.s 18
-			IL_0077: ldloc.s 18
+			IL_0075: stloc.s 15
+			IL_0077: ldloc.s 15
 			IL_0079: ldstr "error"
 			IL_007e: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
 			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0088: pop
 			IL_0089: ldstr "console"
 			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0093: stloc.s 18
-			IL_0095: ldloc.s 18
+			IL_0093: stloc.s 15
+			IL_0095: ldloc.s 15
 			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009c: stloc.s 18
-			IL_009e: ldloc.s 18
+			IL_009c: stloc.s 15
+			IL_009e: ldloc.s 15
 			IL_00a0: ldstr "error"
 			IL_00a5: ldstr ""
 			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00af: pop
 			IL_00b0: ldstr "console"
 			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ba: stloc.s 18
-			IL_00bc: ldloc.s 18
+			IL_00ba: stloc.s 15
+			IL_00bc: ldloc.s 15
 			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c3: stloc.s 18
-			IL_00c5: ldloc.s 18
+			IL_00c3: stloc.s 15
+			IL_00c5: ldloc.s 15
 			IL_00c7: ldstr "error"
 			IL_00cc: ldstr "Examples:"
 			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00d6: pop
 			IL_00d7: ldstr "console"
 			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e1: stloc.s 18
-			IL_00e3: ldloc.s 18
+			IL_00e1: stloc.s 15
+			IL_00e3: ldloc.s 15
 			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ea: stloc.s 18
-			IL_00ec: ldloc.s 18
+			IL_00ea: stloc.s 15
+			IL_00ec: ldloc.s 15
 			IL_00ee: ldstr "error"
 			IL_00f3: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
 			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00fd: pop
 			IL_00fe: ldstr "console"
 			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0108: stloc.s 18
-			IL_010a: ldloc.s 18
+			IL_0108: stloc.s 15
+			IL_010a: ldloc.s 15
 			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0111: stloc.s 18
-			IL_0113: ldloc.s 18
+			IL_0111: stloc.s 15
+			IL_0113: ldloc.s 15
 			IL_0115: ldstr "error"
 			IL_011a: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
 			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0124: pop
 			IL_0125: ldstr "process"
 			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_012f: stloc.s 18
-			IL_0131: ldloc.s 18
+			IL_012f: stloc.s 15
+			IL_0131: ldloc.s 15
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0138: stloc.s 18
-			IL_013a: ldloc.s 18
+			IL_0138: stloc.s 15
+			IL_013a: ldloc.s 15
 			IL_013c: ldstr "exit"
 			IL_0141: ldc.r8 1
 			IL_014a: box [System.Runtime]System.Double
@@ -1718,29 +1709,29 @@
 			IL_0174: stloc.2
 			IL_0175: ldloc.1
 			IL_0176: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_017b: stloc.s 19
+			IL_017b: stloc.s 16
 			IL_017d: ldstr "Jroc.Tests."
-			IL_0182: ldloc.s 19
+			IL_0182: ldloc.s 16
 			IL_0184: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0189: stloc.s 19
-			IL_018b: ldloc.s 19
+			IL_0189: stloc.s 16
+			IL_018b: ldloc.s 16
 			IL_018d: ldstr ".GeneratorTests."
 			IL_0192: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0197: stloc.s 19
+			IL_0197: stloc.s 16
 			IL_0199: ldloc.2
 			IL_019a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_019f: stloc.s 20
-			IL_01a1: ldloc.s 19
-			IL_01a3: ldloc.s 20
+			IL_019f: stloc.s 17
+			IL_01a1: ldloc.s 16
+			IL_01a3: ldloc.s 17
 			IL_01a5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01aa: stloc.s 20
-			IL_01ac: ldloc.s 20
+			IL_01aa: stloc.s 17
+			IL_01ac: ldloc.s 17
 			IL_01ae: stloc.3
 			IL_01af: ldarg.0
 			IL_01b0: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
 			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ba: stloc.s 18
-			IL_01bc: ldloc.s 18
+			IL_01ba: stloc.s 15
+			IL_01bc: ldloc.s 15
 			IL_01be: ldstr "join"
 			IL_01c3: ldc.i4.4
 			IL_01c4: newarr [System.Runtime]System.Object
@@ -1762,38 +1753,38 @@
 			IL_01e4: ldstr "Jroc.Tests.csproj"
 			IL_01e9: stelem.ref
 			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_01ef: stloc.s 18
-			IL_01f1: ldloc.s 18
+			IL_01ef: stloc.s 15
+			IL_01f1: ldloc.s 15
 			IL_01f3: stloc.s 4
 			IL_01f5: ldstr "console"
 			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ff: stloc.s 18
-			IL_0201: ldloc.s 18
+			IL_01ff: stloc.s 15
+			IL_0201: ldloc.s 15
 			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0208: stloc.s 18
+			IL_0208: stloc.s 15
 			IL_020a: ldloc.3
 			IL_020b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0210: stloc.s 20
+			IL_0210: stloc.s 17
 			IL_0212: ldstr "Running test: "
-			IL_0217: ldloc.s 20
+			IL_0217: ldloc.s 17
 			IL_0219: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021e: stloc.s 20
-			IL_0220: ldloc.s 18
+			IL_021e: stloc.s 17
+			IL_0220: ldloc.s 15
 			IL_0222: ldstr "log"
-			IL_0227: ldloc.s 20
+			IL_0227: ldloc.s 17
 			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_022e: pop
 			IL_022f: ldarg.0
 			IL_0230: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
 			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023a: stloc.s 18
+			IL_023a: stloc.s 15
 			IL_023c: ldloc.3
 			IL_023d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0242: stloc.s 20
+			IL_0242: stloc.s 17
 			IL_0244: ldstr "FullyQualifiedName="
-			IL_0249: ldloc.s 20
+			IL_0249: ldloc.s 17
 			IL_024b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0250: stloc.s 20
+			IL_0250: stloc.s 17
 			IL_0252: ldc.i4.5
 			IL_0253: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0258: dup
@@ -1806,16 +1797,16 @@
 			IL_026c: ldstr "--filter"
 			IL_0271: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0276: dup
-			IL_0277: ldloc.s 20
+			IL_0277: ldloc.s 17
 			IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_027e: dup
 			IL_027f: ldstr "--no-build"
 			IL_0284: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0289: stloc.s 21
-			IL_028b: ldloc.s 18
+			IL_0289: stloc.s 18
+			IL_028b: ldloc.s 15
 			IL_028d: ldstr "spawnSync"
 			IL_0292: ldstr "dotnet"
-			IL_0297: ldloc.s 21
+			IL_0297: ldloc.s 18
 			IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_029e: dup
 			IL_029f: ldstr "stdio"
@@ -1831,428 +1822,422 @@
 			IL_02c1: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
 			IL_02c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_02d0: stloc.s 18
-			IL_02d2: ldloc.s 18
+			IL_02d0: stloc.s 15
+			IL_02d2: ldloc.s 15
 			IL_02d4: stloc.s 5
 			IL_02d6: ldloc.s 5
 			IL_02d8: ldstr "status"
 			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e2: stloc.s 18
-			IL_02e4: ldloc.s 18
+			IL_02e2: stloc.s 15
+			IL_02e4: ldloc.s 15
 			IL_02e6: ldc.r8 0.0
 			IL_02ef: box [System.Runtime]System.Double
 			IL_02f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02f9: stloc.s 22
-			IL_02fb: ldloc.s 22
-			IL_02fd: brfalse IL_0470
+			IL_02f9: stloc.s 19
+			IL_02fb: ldloc.s 19
+			IL_02fd: brfalse IL_0469
 
-			IL_0302: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L137C31::.ctor()
-			IL_0307: stloc.s 6
-			IL_0309: ldstr "console"
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0313: stloc.s 18
-			IL_0315: ldloc.s 18
-			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031c: stloc.s 18
-			IL_031e: ldloc.s 18
-			IL_0320: ldstr "log"
-			IL_0325: ldstr "Test failed or not found, retrying with build..."
-			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_032f: pop
-			IL_0330: ldarg.0
-			IL_0331: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_033b: stloc.s 18
-			IL_033d: ldloc.3
-			IL_033e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0343: stloc.s 20
-			IL_0345: ldstr "FullyQualifiedName="
-			IL_034a: ldloc.s 20
-			IL_034c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0351: stloc.s 20
-			IL_0353: ldc.i4.4
-			IL_0354: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0359: dup
-			IL_035a: ldstr "test"
-			IL_035f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0364: dup
-			IL_0365: ldloc.s 4
-			IL_0367: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_036c: dup
-			IL_036d: ldstr "--filter"
-			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0377: dup
-			IL_0378: ldloc.s 20
-			IL_037a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_037f: stloc.s 21
-			IL_0381: ldloc.s 18
-			IL_0383: ldstr "spawnSync"
-			IL_0388: ldstr "dotnet"
-			IL_038d: ldloc.s 21
-			IL_038f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0394: dup
-			IL_0395: ldstr "stdio"
-			IL_039a: ldstr "inherit"
-			IL_039f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03a4: dup
-			IL_03a5: ldstr "shell"
-			IL_03aa: ldc.i4.1
-			IL_03ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03b0: dup
-			IL_03b1: ldstr "cwd"
-			IL_03b6: ldarg.0
-			IL_03b7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_03bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_03c6: stloc.s 18
-			IL_03c8: ldloc.s 18
-			IL_03ca: stloc.s 7
-			IL_03cc: ldloc.s 7
-			IL_03ce: ldstr "status"
-			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d8: stloc.s 18
-			IL_03da: ldloc.s 18
-			IL_03dc: ldc.r8 0.0
-			IL_03e5: box [System.Runtime]System.Double
-			IL_03ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03ef: stloc.s 22
-			IL_03f1: ldloc.s 22
-			IL_03f3: brfalse IL_0470
+			IL_0302: ldstr "console"
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_030c: stloc.s 15
+			IL_030e: ldloc.s 15
+			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0315: stloc.s 15
+			IL_0317: ldloc.s 15
+			IL_0319: ldstr "log"
+			IL_031e: ldstr "Test failed or not found, retrying with build..."
+			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0328: pop
+			IL_0329: ldarg.0
+			IL_032a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0334: stloc.s 15
+			IL_0336: ldloc.3
+			IL_0337: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_033c: stloc.s 17
+			IL_033e: ldstr "FullyQualifiedName="
+			IL_0343: ldloc.s 17
+			IL_0345: call string [System.Runtime]System.String::Concat(string, string)
+			IL_034a: stloc.s 17
+			IL_034c: ldc.i4.4
+			IL_034d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0352: dup
+			IL_0353: ldstr "test"
+			IL_0358: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_035d: dup
+			IL_035e: ldloc.s 4
+			IL_0360: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0365: dup
+			IL_0366: ldstr "--filter"
+			IL_036b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0370: dup
+			IL_0371: ldloc.s 17
+			IL_0373: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0378: stloc.s 18
+			IL_037a: ldloc.s 15
+			IL_037c: ldstr "spawnSync"
+			IL_0381: ldstr "dotnet"
+			IL_0386: ldloc.s 18
+			IL_0388: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_038d: dup
+			IL_038e: ldstr "stdio"
+			IL_0393: ldstr "inherit"
+			IL_0398: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_039d: dup
+			IL_039e: ldstr "shell"
+			IL_03a3: ldc.i4.1
+			IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03a9: dup
+			IL_03aa: ldstr "cwd"
+			IL_03af: ldarg.0
+			IL_03b0: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_03b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_03bf: stloc.s 15
+			IL_03c1: ldloc.s 15
+			IL_03c3: stloc.s 6
+			IL_03c5: ldloc.s 6
+			IL_03c7: ldstr "status"
+			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d1: stloc.s 15
+			IL_03d3: ldloc.s 15
+			IL_03d5: ldc.r8 0.0
+			IL_03de: box [System.Runtime]System.Double
+			IL_03e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03e8: stloc.s 19
+			IL_03ea: ldloc.s 19
+			IL_03ec: brfalse IL_0469
 
-			IL_03f8: ldstr "console"
-			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0402: stloc.s 18
-			IL_0404: ldloc.s 18
-			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_040b: stloc.s 18
-			IL_040d: ldloc.3
-			IL_040e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0413: stloc.s 20
-			IL_0415: ldstr "Test "
-			IL_041a: ldloc.s 20
-			IL_041c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0421: stloc.s 20
-			IL_0423: ldloc.s 20
-			IL_0425: ldstr " failed or not found."
-			IL_042a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_042f: stloc.s 20
-			IL_0431: ldloc.s 18
-			IL_0433: ldstr "error"
-			IL_0438: ldloc.s 20
-			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_043f: pop
-			IL_0440: ldstr "process"
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_044a: stloc.s 18
-			IL_044c: ldloc.s 18
-			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0453: stloc.s 18
-			IL_0455: ldloc.s 18
-			IL_0457: ldstr "exit"
-			IL_045c: ldc.r8 1
-			IL_0465: box [System.Runtime]System.Double
-			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_046f: pop
+			IL_03f1: ldstr "console"
+			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03fb: stloc.s 15
+			IL_03fd: ldloc.s 15
+			IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0404: stloc.s 15
+			IL_0406: ldloc.3
+			IL_0407: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040c: stloc.s 17
+			IL_040e: ldstr "Test "
+			IL_0413: ldloc.s 17
+			IL_0415: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041a: stloc.s 17
+			IL_041c: ldloc.s 17
+			IL_041e: ldstr " failed or not found."
+			IL_0423: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0428: stloc.s 17
+			IL_042a: ldloc.s 15
+			IL_042c: ldstr "error"
+			IL_0431: ldloc.s 17
+			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0438: pop
+			IL_0439: ldstr "process"
+			IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0443: stloc.s 15
+			IL_0445: ldloc.s 15
+			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_044c: stloc.s 15
+			IL_044e: ldloc.s 15
+			IL_0450: ldstr "exit"
+			IL_0455: ldc.r8 1
+			IL_045e: box [System.Runtime]System.Double
+			IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0468: pop
 
-			IL_0470: ldarg.0
-			IL_0471: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_0476: ldc.i4.1
-			IL_0477: newarr [System.Runtime]System.Object
-			IL_047c: dup
-			IL_047d: ldc.i4.0
-			IL_047e: ldarg.0
-			IL_047f: stelem.ref
-			IL_0480: ldloc.2
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0486: stloc.s 18
-			IL_0488: ldloc.s 18
-			IL_048a: stloc.s 8
-			IL_048c: ldarg.0
-			IL_048d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_0492: ldc.i4.1
-			IL_0493: newarr [System.Runtime]System.Object
-			IL_0498: dup
-			IL_0499: ldc.i4.0
-			IL_049a: ldarg.0
-			IL_049b: stelem.ref
-			IL_049c: ldloc.1
-			IL_049d: ldloc.s 8
-			IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04a4: stloc.s 18
-			IL_04a6: ldloc.s 18
-			IL_04a8: brfalse IL_04c2
+			IL_0469: ldarg.0
+			IL_046a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_046f: ldc.i4.1
+			IL_0470: newarr [System.Runtime]System.Object
+			IL_0475: dup
+			IL_0476: ldc.i4.0
+			IL_0477: ldarg.0
+			IL_0478: stelem.ref
+			IL_0479: ldloc.2
+			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_047f: stloc.s 15
+			IL_0481: ldloc.s 15
+			IL_0483: stloc.s 7
+			IL_0485: ldarg.0
+			IL_0486: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_048b: ldc.i4.1
+			IL_048c: newarr [System.Runtime]System.Object
+			IL_0491: dup
+			IL_0492: ldc.i4.0
+			IL_0493: ldarg.0
+			IL_0494: stelem.ref
+			IL_0495: ldloc.1
+			IL_0496: ldloc.s 7
+			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_049d: stloc.s 15
+			IL_049f: ldloc.s 15
+			IL_04a1: brfalse IL_04bb
 
-			IL_04ad: ldloc.s 18
-			IL_04af: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04b4: brtrue IL_04c2
+			IL_04a6: ldloc.s 15
+			IL_04a8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04ad: brtrue IL_04bb
 
-			IL_04b9: ldloc.s 18
-			IL_04bb: stloc.s 24
-			IL_04bd: br IL_04ca
+			IL_04b2: ldloc.s 15
+			IL_04b4: stloc.s 21
+			IL_04b6: br IL_04c3
 
-			IL_04c2: ldc.i4.0
-			IL_04c3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04c8: stloc.s 24
+			IL_04bb: ldc.i4.0
+			IL_04bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04c1: stloc.s 21
 
-			IL_04ca: ldloc.s 24
-			IL_04cc: stloc.s 9
-			IL_04ce: ldloc.s 9
-			IL_04d0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04d5: ldc.i4.0
-			IL_04d6: ceq
-			IL_04d8: stloc.s 22
-			IL_04da: ldloc.s 22
-			IL_04dc: brfalse IL_0663
+			IL_04c3: ldloc.s 21
+			IL_04c5: stloc.s 8
+			IL_04c7: ldloc.s 8
+			IL_04c9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04ce: ldc.i4.0
+			IL_04cf: ceq
+			IL_04d1: stloc.s 19
+			IL_04d3: ldloc.s 19
+			IL_04d5: brfalse IL_0655
 
-			IL_04e1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
-			IL_04e6: stloc.s 10
-			IL_04e8: ldstr "console"
-			IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04f2: stloc.s 18
-			IL_04f4: ldloc.s 18
-			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04fb: stloc.s 18
-			IL_04fd: ldloc.1
-			IL_04fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0503: stloc.s 20
-			IL_0505: ldstr "Assembly not found for category '"
-			IL_050a: ldloc.s 20
+			IL_04da: ldstr "console"
+			IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04e4: stloc.s 15
+			IL_04e6: ldloc.s 15
+			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ed: stloc.s 15
+			IL_04ef: ldloc.1
+			IL_04f0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04f5: stloc.s 17
+			IL_04f7: ldstr "Assembly not found for category '"
+			IL_04fc: ldloc.s 17
+			IL_04fe: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0503: stloc.s 17
+			IL_0505: ldloc.s 17
+			IL_0507: ldstr "' and test '"
 			IL_050c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0511: stloc.s 20
-			IL_0513: ldloc.s 20
-			IL_0515: ldstr "' and test '"
-			IL_051a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_051f: stloc.s 20
-			IL_0521: ldloc.2
-			IL_0522: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0527: stloc.s 19
-			IL_0529: ldloc.s 20
-			IL_052b: ldloc.s 19
+			IL_0511: stloc.s 17
+			IL_0513: ldloc.2
+			IL_0514: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0519: stloc.s 16
+			IL_051b: ldloc.s 17
+			IL_051d: ldloc.s 16
+			IL_051f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0524: stloc.s 16
+			IL_0526: ldloc.s 16
+			IL_0528: ldstr "'."
 			IL_052d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0532: stloc.s 19
-			IL_0534: ldloc.s 19
-			IL_0536: ldstr "'."
-			IL_053b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0540: stloc.s 19
-			IL_0542: ldloc.s 18
-			IL_0544: ldstr "error"
-			IL_0549: ldloc.s 19
-			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0550: pop
-			IL_0551: ldstr "console"
-			IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_055b: stloc.s 18
-			IL_055d: ldloc.s 18
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0564: stloc.s 18
-			IL_0566: ldloc.s 18
-			IL_0568: ldstr "error"
-			IL_056d: ldstr "Looked under:"
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0577: pop
+			IL_0532: stloc.s 16
+			IL_0534: ldloc.s 15
+			IL_0536: ldstr "error"
+			IL_053b: ldloc.s 16
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0542: pop
+			IL_0543: ldstr "console"
+			IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_054d: stloc.s 15
+			IL_054f: ldloc.s 15
+			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0556: stloc.s 15
+			IL_0558: ldloc.s 15
+			IL_055a: ldstr "error"
+			IL_055f: ldstr "Looked under:"
+			IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0569: pop
+			IL_056a: ldarg.0
+			IL_056b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_0570: ldc.i4.1
+			IL_0571: newarr [System.Runtime]System.Object
+			IL_0576: dup
+			IL_0577: ldc.i4.0
 			IL_0578: ldarg.0
-			IL_0579: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_057e: ldc.i4.1
-			IL_057f: newarr [System.Runtime]System.Object
-			IL_0584: dup
-			IL_0585: ldc.i4.0
-			IL_0586: ldarg.0
-			IL_0587: stelem.ref
-			IL_0588: ldloc.1
-			IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_058e: stloc.s 18
-			IL_0590: ldloc.s 18
-			IL_0592: stloc.s 11
-			IL_0594: ldc.r8 0.0
-			IL_059d: stloc.s 12
-			// loop start (head: IL_059f)
-				IL_059f: ldloc.s 12
-				IL_05a1: stloc.s 25
-				IL_05a3: ldloc.s 25
-				IL_05a5: ldloc.s 11
-				IL_05a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_05ac: clt
-				IL_05ae: brfalse IL_060c
+			IL_0579: stelem.ref
+			IL_057a: ldloc.1
+			IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0580: stloc.s 15
+			IL_0582: ldloc.s 15
+			IL_0584: stloc.s 9
+			IL_0586: ldc.r8 0.0
+			IL_058f: stloc.s 10
+			// loop start (head: IL_0591)
+				IL_0591: ldloc.s 10
+				IL_0593: stloc.s 22
+				IL_0595: ldloc.s 22
+				IL_0597: ldloc.s 9
+				IL_0599: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_059e: clt
+				IL_05a0: brfalse IL_05fe
 
-				IL_05b3: ldstr "console"
-				IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_05bd: stloc.s 18
-				IL_05bf: ldloc.s 18
-				IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_05c6: stloc.s 18
-				IL_05c8: ldloc.s 11
-				IL_05ca: ldloc.s 12
-				IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_05d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_05d6: stloc.s 19
-				IL_05d8: ldstr "  - "
-				IL_05dd: ldloc.s 19
-				IL_05df: call string [System.Runtime]System.String::Concat(string, string)
-				IL_05e4: stloc.s 19
-				IL_05e6: ldloc.s 18
-				IL_05e8: ldstr "error"
-				IL_05ed: ldloc.s 19
-				IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05f4: pop
-				IL_05f5: ldloc.s 12
-				IL_05f7: ldc.r8 1
-				IL_0600: add
-				IL_0601: stloc.s 25
-				IL_0603: ldloc.s 25
-				IL_0605: stloc.s 12
-				IL_0607: br IL_059f
+				IL_05a5: ldstr "console"
+				IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_05af: stloc.s 15
+				IL_05b1: ldloc.s 15
+				IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_05b8: stloc.s 15
+				IL_05ba: ldloc.s 9
+				IL_05bc: ldloc.s 10
+				IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_05c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_05c8: stloc.s 16
+				IL_05ca: ldstr "  - "
+				IL_05cf: ldloc.s 16
+				IL_05d1: call string [System.Runtime]System.String::Concat(string, string)
+				IL_05d6: stloc.s 16
+				IL_05d8: ldloc.s 15
+				IL_05da: ldstr "error"
+				IL_05df: ldloc.s 16
+				IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05e6: pop
+				IL_05e7: ldloc.s 10
+				IL_05e9: ldc.r8 1
+				IL_05f2: add
+				IL_05f3: stloc.s 22
+				IL_05f5: ldloc.s 22
+				IL_05f7: stloc.s 10
+				IL_05f9: br IL_0591
 			// end loop
 
-			IL_060c: ldstr "console"
-			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0616: stloc.s 18
-			IL_0618: ldloc.s 18
-			IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_061f: stloc.s 18
-			IL_0621: ldloc.s 18
-			IL_0623: ldstr "error"
-			IL_0628: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0632: pop
-			IL_0633: ldstr "process"
-			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_063d: stloc.s 18
-			IL_063f: ldloc.s 18
-			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0646: stloc.s 18
-			IL_0648: ldloc.s 18
-			IL_064a: ldstr "exit"
-			IL_064f: ldc.r8 1
-			IL_0658: box [System.Runtime]System.Double
-			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0662: pop
+			IL_05fe: ldstr "console"
+			IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0608: stloc.s 15
+			IL_060a: ldloc.s 15
+			IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0611: stloc.s 15
+			IL_0613: ldloc.s 15
+			IL_0615: ldstr "error"
+			IL_061a: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0624: pop
+			IL_0625: ldstr "process"
+			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_062f: stloc.s 15
+			IL_0631: ldloc.s 15
+			IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0638: stloc.s 15
+			IL_063a: ldloc.s 15
+			IL_063c: ldstr "exit"
+			IL_0641: ldc.r8 1
+			IL_064a: box [System.Runtime]System.Double
+			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0654: pop
 
-			IL_0663: ldstr "console"
-			IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_066d: stloc.s 18
-			IL_066f: ldloc.s 18
-			IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0676: stloc.s 18
-			IL_0678: ldloc.s 9
-			IL_067a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_067f: stloc.s 19
-			IL_0681: ldstr "Found assembly: "
-			IL_0686: ldloc.s 19
-			IL_0688: call string [System.Runtime]System.String::Concat(string, string)
-			IL_068d: stloc.s 19
-			IL_068f: ldloc.s 18
-			IL_0691: ldstr "log"
-			IL_0696: ldloc.s 19
-			IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_069d: pop
+			IL_0655: ldstr "console"
+			IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_065f: stloc.s 15
+			IL_0661: ldloc.s 15
+			IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0668: stloc.s 15
+			IL_066a: ldloc.s 8
+			IL_066c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0671: stloc.s 16
+			IL_0673: ldstr "Found assembly: "
+			IL_0678: ldloc.s 16
+			IL_067a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_067f: stloc.s 16
+			IL_0681: ldloc.s 15
+			IL_0683: ldstr "log"
+			IL_0688: ldloc.s 16
+			IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_068f: pop
 			.try
 			{
-				IL_069e: nop
-				IL_069f: ldstr "console"
-				IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06a9: stloc.s 18
-				IL_06ab: ldloc.s 18
-				IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06b2: stloc.s 18
-				IL_06b4: ldloc.s 18
-				IL_06b6: ldstr "log"
-				IL_06bb: ldstr "Opening in ILSpy..."
-				IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_06c5: pop
+				IL_0690: nop
+				IL_0691: ldstr "console"
+				IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_069b: stloc.s 15
+				IL_069d: ldloc.s 15
+				IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06a4: stloc.s 15
+				IL_06a6: ldloc.s 15
+				IL_06a8: ldstr "log"
+				IL_06ad: ldstr "Opening in ILSpy..."
+				IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_06b7: pop
+				IL_06b8: ldarg.0
+				IL_06b9: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_06be: ldc.i4.1
+				IL_06bf: newarr [System.Runtime]System.Object
+				IL_06c4: dup
+				IL_06c5: ldc.i4.0
 				IL_06c6: ldarg.0
-				IL_06c7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_06cc: ldc.i4.1
-				IL_06cd: newarr [System.Runtime]System.Object
-				IL_06d2: dup
-				IL_06d3: ldc.i4.0
-				IL_06d4: ldarg.0
-				IL_06d5: stelem.ref
-				IL_06d6: ldloc.s 9
-				IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_06dd: pop
-				IL_06de: leave IL_07a0
+				IL_06c7: stelem.ref
+				IL_06c8: ldloc.s 8
+				IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_06cf: pop
+				IL_06d0: leave IL_078b
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_06e3: stloc.s 13
-				IL_06e5: ldloc.s 13
-				IL_06e7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_06d5: stloc.s 11
+				IL_06d7: ldloc.s 11
+				IL_06d9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_06de: dup
+				IL_06df: brtrue IL_06f5
+
+				IL_06e4: pop
+				IL_06e5: ldloc.s 11
+				IL_06e7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 				IL_06ec: dup
-				IL_06ed: brtrue IL_0703
+				IL_06ed: brtrue IL_0701
 
 				IL_06f2: pop
-				IL_06f3: ldloc.s 13
-				IL_06f5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_06fa: dup
-				IL_06fb: brtrue IL_070f
+				IL_06f3: rethrow
 
-				IL_0700: pop
-				IL_0701: rethrow
+				IL_06f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_06fa: stloc.s 12
+				IL_06fc: br IL_0703
 
-				IL_0703: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0708: stloc.s 14
-				IL_070a: br IL_0711
+				IL_0701: stloc.s 12
 
-				IL_070f: stloc.s 14
-
-				IL_0711: ldloc.s 14
-				IL_0713: stloc.s 18
-				IL_0715: ldloc.s 18
-				IL_0717: stloc.s 15
-				IL_0719: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
-				IL_071e: stloc.s 16
-				IL_0720: ldstr "console"
-				IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_072a: stloc.s 18
-				IL_072c: ldloc.s 18
-				IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0733: stloc.s 18
-				IL_0735: ldloc.s 18
-				IL_0737: ldstr "error"
-				IL_073c: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0746: pop
-				IL_0747: ldstr "console"
-				IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0751: stloc.s 18
-				IL_0753: ldloc.s 18
-				IL_0755: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_075a: stloc.s 18
-				IL_075c: ldloc.s 18
-				IL_075e: ldstr "error"
-				IL_0763: ldloc.s 15
-				IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_076a: pop
-				IL_076b: ldstr "process"
-				IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0775: stloc.s 18
-				IL_0777: ldloc.s 18
-				IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_077e: stloc.s 18
-				IL_0780: ldloc.s 18
-				IL_0782: ldstr "exit"
-				IL_0787: ldc.r8 1
-				IL_0790: box [System.Runtime]System.Double
-				IL_0795: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_079a: pop
-				IL_079b: leave IL_07a0
+				IL_0703: ldloc.s 12
+				IL_0705: stloc.s 15
+				IL_0707: ldloc.s 15
+				IL_0709: stloc.s 13
+				IL_070b: ldstr "console"
+				IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0715: stloc.s 15
+				IL_0717: ldloc.s 15
+				IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_071e: stloc.s 15
+				IL_0720: ldloc.s 15
+				IL_0722: ldstr "error"
+				IL_0727: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0731: pop
+				IL_0732: ldstr "console"
+				IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_073c: stloc.s 15
+				IL_073e: ldloc.s 15
+				IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0745: stloc.s 15
+				IL_0747: ldloc.s 15
+				IL_0749: ldstr "error"
+				IL_074e: ldloc.s 13
+				IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0755: pop
+				IL_0756: ldstr "process"
+				IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0760: stloc.s 15
+				IL_0762: ldloc.s 15
+				IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0769: stloc.s 15
+				IL_076b: ldloc.s 15
+				IL_076d: ldstr "exit"
+				IL_0772: ldc.r8 1
+				IL_077b: box [System.Runtime]System.Double
+				IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0785: pop
+				IL_0786: leave IL_078b
 			} // end handler
 
-			IL_07a0: ldstr "console"
-			IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07aa: stloc.s 18
-			IL_07ac: ldloc.s 18
-			IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07b3: stloc.s 18
-			IL_07b5: ldloc.s 18
-			IL_07b7: ldstr "log"
-			IL_07bc: ldstr "Done!"
-			IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07c6: pop
-			IL_07c7: ldnull
-			IL_07c8: stloc.s 17
-			IL_07ca: ldloc.s 17
-			IL_07cc: ret
+			IL_078b: ldstr "console"
+			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0795: stloc.s 15
+			IL_0797: ldloc.s 15
+			IL_0799: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_079e: stloc.s 15
+			IL_07a0: ldloc.s 15
+			IL_07a2: ldstr "log"
+			IL_07a7: ldstr "Done!"
+			IL_07ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07b1: pop
+			IL_07b2: ldnull
+			IL_07b3: stloc.s 14
+			IL_07b5: ldloc.s 14
+			IL_07b7: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2301,7 +2286,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x320b
+			// Method begins at RVA 0x31e3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2538,7 +2523,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x32ec
+		// Method begins at RVA 0x32c4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46b3
+				// Method begins at RVA 0x462b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46bc
+				// Method begins at RVA 0x4634
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -340,7 +340,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x46aa
+			// Method begins at RVA 0x4622
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -455,7 +455,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d7
+					// Method begins at RVA 0x464f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -473,7 +473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46ce
+				// Method begins at RVA 0x4646
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -622,7 +622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e0
+				// Method begins at RVA 0x4658
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -650,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46fb
+						// Method begins at RVA 0x4673
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -670,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4704
+						// Method begins at RVA 0x467c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -690,7 +690,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x470d
+						// Method begins at RVA 0x4685
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -710,7 +710,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4716
+						// Method begins at RVA 0x468e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -730,7 +730,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x471f
+						// Method begins at RVA 0x4697
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -750,7 +750,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4728
+						// Method begins at RVA 0x46a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -768,7 +768,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f2
+					// Method begins at RVA 0x466a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -786,7 +786,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e9
+				// Method begins at RVA 0x4661
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -815,22 +815,21 @@
 			)
 			// Method begins at RVA 0x2654
 			// Header size: 12
-			// Code size: 782 (0x30e)
+			// Code size: 754 (0x2f2)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[1] float64,
-				[2] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/Scope_For_L30C7/Block_L30C40,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] bool,
+				[2] object,
+				[3] float64,
+				[4] object,
+				[5] bool,
+				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
-				[11] object,
-				[12] object
+				[11] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -863,266 +862,264 @@
 			IL_006b: stloc.1
 			// loop start (head: IL_006c)
 				IL_006c: ldloc.1
-				IL_006d: stloc.s 4
-				IL_006f: ldloc.s 4
-				IL_0071: ldarg.2
-				IL_0072: ldstr "length"
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_007c: clt
-				IL_007e: brfalse IL_030c
+				IL_006d: stloc.3
+				IL_006e: ldloc.3
+				IL_006f: ldarg.2
+				IL_0070: ldstr "length"
+				IL_0075: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_007a: clt
+				IL_007c: brfalse IL_02f0
 
-				IL_0083: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/Scope_For_L30C7/Block_L30C40::.ctor()
+				IL_0081: ldarg.2
+				IL_0082: ldloc.1
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_0088: stloc.2
-				IL_0089: ldarg.2
-				IL_008a: ldloc.1
-				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0090: stloc.3
-				IL_0091: ldloc.3
-				IL_0092: stloc.s 5
-				IL_0094: ldloc.s 5
-				IL_0096: ldstr "--section"
-				IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00a0: stloc.s 6
-				IL_00a2: ldloc.s 6
-				IL_00a4: brfalse IL_0104
+				IL_0089: ldloc.2
+				IL_008a: stloc.s 4
+				IL_008c: ldloc.s 4
+				IL_008e: ldstr "--section"
+				IL_0093: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0098: stloc.s 5
+				IL_009a: ldloc.s 5
+				IL_009c: brfalse IL_00f8
 
-				IL_00a9: ldloc.1
-				IL_00aa: stloc.s 4
-				IL_00ac: ldloc.s 4
-				IL_00ae: ldc.r8 1
-				IL_00b7: add
-				IL_00b8: stloc.s 4
-				IL_00ba: ldarg.2
-				IL_00bb: ldloc.s 4
-				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c2: stloc.s 5
-				IL_00c4: ldloc.s 5
-				IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00cb: stloc.s 6
-				IL_00cd: ldloc.s 6
-				IL_00cf: brtrue IL_00e0
+				IL_00a1: ldloc.1
+				IL_00a2: stloc.3
+				IL_00a3: ldloc.3
+				IL_00a4: ldc.r8 1
+				IL_00ad: add
+				IL_00ae: stloc.3
+				IL_00af: ldarg.2
+				IL_00b0: ldloc.3
+				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00b6: stloc.s 4
+				IL_00b8: ldloc.s 4
+				IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00bf: stloc.s 5
+				IL_00c1: ldloc.s 5
+				IL_00c3: brtrue IL_00d4
 
-				IL_00d4: ldstr ""
-				IL_00d9: stloc.s 8
-				IL_00db: br IL_00e4
+				IL_00c8: ldstr ""
+				IL_00cd: stloc.s 7
+				IL_00cf: br IL_00d8
 
-				IL_00e0: ldloc.s 5
-				IL_00e2: stloc.s 8
+				IL_00d4: ldloc.s 4
+				IL_00d6: stloc.s 7
 
-				IL_00e4: ldloc.0
-				IL_00e5: ldstr "section"
-				IL_00ea: ldloc.s 8
-				IL_00ec: ldc.i4.1
-				IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_00f2: pop
-				IL_00f3: ldloc.1
-				IL_00f4: ldc.r8 1
-				IL_00fd: add
-				IL_00fe: stloc.1
-				IL_00ff: br IL_02fb
+				IL_00d8: ldloc.0
+				IL_00d9: ldstr "section"
+				IL_00de: ldloc.s 7
+				IL_00e0: ldc.i4.1
+				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_00e6: pop
+				IL_00e7: ldloc.1
+				IL_00e8: ldc.r8 1
+				IL_00f1: add
+				IL_00f2: stloc.1
+				IL_00f3: br IL_02df
 
-				IL_0104: ldloc.3
-				IL_0105: stloc.s 5
-				IL_0107: ldloc.s 5
-				IL_0109: ldstr "--url"
-				IL_010e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0113: stloc.s 6
-				IL_0115: ldloc.s 6
-				IL_0117: brfalse IL_0177
+				IL_00f8: ldloc.2
+				IL_00f9: stloc.s 4
+				IL_00fb: ldloc.s 4
+				IL_00fd: ldstr "--url"
+				IL_0102: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0107: stloc.s 5
+				IL_0109: ldloc.s 5
+				IL_010b: brfalse IL_0167
 
-				IL_011c: ldloc.1
-				IL_011d: stloc.s 4
-				IL_011f: ldloc.s 4
-				IL_0121: ldc.r8 1
-				IL_012a: add
-				IL_012b: stloc.s 4
-				IL_012d: ldarg.2
-				IL_012e: ldloc.s 4
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0135: stloc.s 5
-				IL_0137: ldloc.s 5
-				IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013e: stloc.s 6
-				IL_0140: ldloc.s 6
-				IL_0142: brtrue IL_0153
+				IL_0110: ldloc.1
+				IL_0111: stloc.3
+				IL_0112: ldloc.3
+				IL_0113: ldc.r8 1
+				IL_011c: add
+				IL_011d: stloc.3
+				IL_011e: ldarg.2
+				IL_011f: ldloc.3
+				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0125: stloc.s 4
+				IL_0127: ldloc.s 4
+				IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_012e: stloc.s 5
+				IL_0130: ldloc.s 5
+				IL_0132: brtrue IL_0143
 
-				IL_0147: ldstr ""
-				IL_014c: stloc.s 9
-				IL_014e: br IL_0157
+				IL_0137: ldstr ""
+				IL_013c: stloc.s 8
+				IL_013e: br IL_0147
 
-				IL_0153: ldloc.s 5
-				IL_0155: stloc.s 9
+				IL_0143: ldloc.s 4
+				IL_0145: stloc.s 8
 
-				IL_0157: ldloc.0
-				IL_0158: ldstr "url"
-				IL_015d: ldloc.s 9
-				IL_015f: ldc.i4.1
-				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0165: pop
-				IL_0166: ldloc.1
-				IL_0167: ldc.r8 1
-				IL_0170: add
-				IL_0171: stloc.1
-				IL_0172: br IL_02fb
+				IL_0147: ldloc.0
+				IL_0148: ldstr "url"
+				IL_014d: ldloc.s 8
+				IL_014f: ldc.i4.1
+				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0155: pop
+				IL_0156: ldloc.1
+				IL_0157: ldc.r8 1
+				IL_0160: add
+				IL_0161: stloc.1
+				IL_0162: br IL_02df
 
-				IL_0177: ldloc.3
-				IL_0178: stloc.s 5
-				IL_017a: ldloc.s 5
-				IL_017c: ldstr "--auto"
-				IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0186: stloc.s 6
-				IL_0188: ldloc.s 6
-				IL_018a: brfalse IL_01a7
+				IL_0167: ldloc.2
+				IL_0168: stloc.s 4
+				IL_016a: ldloc.s 4
+				IL_016c: ldstr "--auto"
+				IL_0171: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0176: stloc.s 5
+				IL_0178: ldloc.s 5
+				IL_017a: brfalse IL_0197
 
-				IL_018f: ldloc.0
-				IL_0190: ldstr "auto"
-				IL_0195: ldc.i4.1
-				IL_0196: box [System.Runtime]System.Boolean
-				IL_019b: ldc.i4.1
-				IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_01a1: pop
-				IL_01a2: br IL_02fb
+				IL_017f: ldloc.0
+				IL_0180: ldstr "auto"
+				IL_0185: ldc.i4.1
+				IL_0186: box [System.Runtime]System.Boolean
+				IL_018b: ldc.i4.1
+				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0191: pop
+				IL_0192: br IL_02df
 
-				IL_01a7: ldloc.3
-				IL_01a8: stloc.s 5
-				IL_01aa: ldloc.s 5
-				IL_01ac: ldstr "--index-url"
-				IL_01b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01b6: stloc.s 6
-				IL_01b8: ldloc.s 6
-				IL_01ba: brfalse IL_021a
+				IL_0197: ldloc.2
+				IL_0198: stloc.s 4
+				IL_019a: ldloc.s 4
+				IL_019c: ldstr "--index-url"
+				IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01a6: stloc.s 5
+				IL_01a8: ldloc.s 5
+				IL_01aa: brfalse IL_0206
 
-				IL_01bf: ldloc.1
-				IL_01c0: stloc.s 4
-				IL_01c2: ldloc.s 4
-				IL_01c4: ldc.r8 1
-				IL_01cd: add
-				IL_01ce: stloc.s 4
-				IL_01d0: ldarg.2
-				IL_01d1: ldloc.s 4
-				IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01d8: stloc.s 5
-				IL_01da: ldloc.s 5
-				IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01e1: stloc.s 6
-				IL_01e3: ldloc.s 6
-				IL_01e5: brtrue IL_01f6
+				IL_01af: ldloc.1
+				IL_01b0: stloc.3
+				IL_01b1: ldloc.3
+				IL_01b2: ldc.r8 1
+				IL_01bb: add
+				IL_01bc: stloc.3
+				IL_01bd: ldarg.2
+				IL_01be: ldloc.3
+				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01c4: stloc.s 4
+				IL_01c6: ldloc.s 4
+				IL_01c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01cd: stloc.s 5
+				IL_01cf: ldloc.s 5
+				IL_01d1: brtrue IL_01e2
 
-				IL_01ea: ldstr ""
-				IL_01ef: stloc.s 10
-				IL_01f1: br IL_01fa
+				IL_01d6: ldstr ""
+				IL_01db: stloc.s 9
+				IL_01dd: br IL_01e6
 
-				IL_01f6: ldloc.s 5
-				IL_01f8: stloc.s 10
+				IL_01e2: ldloc.s 4
+				IL_01e4: stloc.s 9
 
-				IL_01fa: ldloc.0
-				IL_01fb: ldstr "indexUrl"
-				IL_0200: ldloc.s 10
-				IL_0202: ldc.i4.1
-				IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0208: pop
-				IL_0209: ldloc.1
-				IL_020a: ldc.r8 1
-				IL_0213: add
-				IL_0214: stloc.1
-				IL_0215: br IL_02fb
+				IL_01e6: ldloc.0
+				IL_01e7: ldstr "indexUrl"
+				IL_01ec: ldloc.s 9
+				IL_01ee: ldc.i4.1
+				IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_01f4: pop
+				IL_01f5: ldloc.1
+				IL_01f6: ldc.r8 1
+				IL_01ff: add
+				IL_0200: stloc.1
+				IL_0201: br IL_02df
 
-				IL_021a: ldloc.3
-				IL_021b: stloc.s 5
-				IL_021d: ldloc.s 5
-				IL_021f: ldstr "--out"
-				IL_0224: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0229: stloc.s 6
-				IL_022b: ldloc.s 6
-				IL_022d: brfalse IL_028d
+				IL_0206: ldloc.2
+				IL_0207: stloc.s 4
+				IL_0209: ldloc.s 4
+				IL_020b: ldstr "--out"
+				IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0215: stloc.s 5
+				IL_0217: ldloc.s 5
+				IL_0219: brfalse IL_0275
 
-				IL_0232: ldloc.1
+				IL_021e: ldloc.1
+				IL_021f: stloc.3
+				IL_0220: ldloc.3
+				IL_0221: ldc.r8 1
+				IL_022a: add
+				IL_022b: stloc.3
+				IL_022c: ldarg.2
+				IL_022d: ldloc.3
+				IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_0233: stloc.s 4
 				IL_0235: ldloc.s 4
-				IL_0237: ldc.r8 1
-				IL_0240: add
-				IL_0241: stloc.s 4
-				IL_0243: ldarg.2
-				IL_0244: ldloc.s 4
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_024b: stloc.s 5
-				IL_024d: ldloc.s 5
-				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0254: stloc.s 6
-				IL_0256: ldloc.s 6
-				IL_0258: brtrue IL_0269
+				IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_023c: stloc.s 5
+				IL_023e: ldloc.s 5
+				IL_0240: brtrue IL_0251
 
-				IL_025d: ldstr ""
-				IL_0262: stloc.s 11
-				IL_0264: br IL_026d
+				IL_0245: ldstr ""
+				IL_024a: stloc.s 10
+				IL_024c: br IL_0255
 
-				IL_0269: ldloc.s 5
-				IL_026b: stloc.s 11
+				IL_0251: ldloc.s 4
+				IL_0253: stloc.s 10
 
-				IL_026d: ldloc.0
-				IL_026e: ldstr "outFile"
-				IL_0273: ldloc.s 11
-				IL_0275: ldc.i4.1
-				IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_027b: pop
-				IL_027c: ldloc.1
-				IL_027d: ldc.r8 1
-				IL_0286: add
-				IL_0287: stloc.1
-				IL_0288: br IL_02fb
+				IL_0255: ldloc.0
+				IL_0256: ldstr "outFile"
+				IL_025b: ldloc.s 10
+				IL_025d: ldc.i4.1
+				IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0263: pop
+				IL_0264: ldloc.1
+				IL_0265: ldc.r8 1
+				IL_026e: add
+				IL_026f: stloc.1
+				IL_0270: br IL_02df
 
-				IL_028d: ldloc.3
-				IL_028e: stloc.s 5
-				IL_0290: ldloc.s 5
-				IL_0292: ldstr "--id"
-				IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_029c: stloc.s 6
-				IL_029e: ldloc.s 6
-				IL_02a0: brfalse IL_02fb
+				IL_0275: ldloc.2
+				IL_0276: stloc.s 4
+				IL_0278: ldloc.s 4
+				IL_027a: ldstr "--id"
+				IL_027f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0284: stloc.s 5
+				IL_0286: ldloc.s 5
+				IL_0288: brfalse IL_02df
 
-				IL_02a5: ldloc.1
-				IL_02a6: stloc.s 4
-				IL_02a8: ldloc.s 4
-				IL_02aa: ldc.r8 1
-				IL_02b3: add
-				IL_02b4: stloc.s 4
-				IL_02b6: ldarg.2
-				IL_02b7: ldloc.s 4
-				IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02be: stloc.s 5
-				IL_02c0: ldloc.s 5
-				IL_02c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c7: stloc.s 6
-				IL_02c9: ldloc.s 6
-				IL_02cb: brtrue IL_02dc
+				IL_028d: ldloc.1
+				IL_028e: stloc.3
+				IL_028f: ldloc.3
+				IL_0290: ldc.r8 1
+				IL_0299: add
+				IL_029a: stloc.3
+				IL_029b: ldarg.2
+				IL_029c: ldloc.3
+				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02a2: stloc.s 4
+				IL_02a4: ldloc.s 4
+				IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02ab: stloc.s 5
+				IL_02ad: ldloc.s 5
+				IL_02af: brtrue IL_02c0
 
-				IL_02d0: ldstr ""
-				IL_02d5: stloc.s 12
-				IL_02d7: br IL_02e0
+				IL_02b4: ldstr ""
+				IL_02b9: stloc.s 11
+				IL_02bb: br IL_02c4
 
-				IL_02dc: ldloc.s 5
-				IL_02de: stloc.s 12
+				IL_02c0: ldloc.s 4
+				IL_02c2: stloc.s 11
 
-				IL_02e0: ldloc.0
-				IL_02e1: ldstr "id"
-				IL_02e6: ldloc.s 12
-				IL_02e8: ldc.i4.1
-				IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_02ee: pop
-				IL_02ef: ldloc.1
-				IL_02f0: ldc.r8 1
-				IL_02f9: add
-				IL_02fa: stloc.1
+				IL_02c4: ldloc.0
+				IL_02c5: ldstr "id"
+				IL_02ca: ldloc.s 11
+				IL_02cc: ldc.i4.1
+				IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_02d2: pop
+				IL_02d3: ldloc.1
+				IL_02d4: ldc.r8 1
+				IL_02dd: add
+				IL_02de: stloc.1
 
-				IL_02fb: ldloc.1
-				IL_02fc: ldc.r8 1
-				IL_0305: add
-				IL_0306: stloc.1
-				IL_0307: br IL_006c
+				IL_02df: ldloc.1
+				IL_02e0: ldc.r8 1
+				IL_02e9: add
+				IL_02ea: stloc.1
+				IL_02eb: br IL_006c
 			// end loop
 
-			IL_030c: ldloc.0
-			IL_030d: ret
+			IL_02f0: ldloc.0
+			IL_02f1: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
@@ -1157,7 +1154,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4782
+							// Method begins at RVA 0x46fa
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1182,7 +1179,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x462c
+						// Method begins at RVA 0x45a4
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1221,7 +1218,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x478b
+							// Method begins at RVA 0x4703
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1245,7 +1242,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x465c
+						// Method begins at RVA 0x45d4
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1318,7 +1315,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4770
+								// Method begins at RVA 0x46e8
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1336,7 +1333,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4767
+							// Method begins at RVA 0x46df
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1356,7 +1353,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4779
+							// Method begins at RVA 0x46f1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1378,7 +1375,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x475e
+						// Method begins at RVA 0x46d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1403,30 +1400,29 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x419c
+					// Method begins at RVA 0x411c
 					// Header size: 12
-					// Code size: 1153 (0x481)
+					// Code size: 1145 (0x479)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
 						[1] object,
 						[2] object,
-						[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55,
+						[3] object,
 						[4] object,
-						[5] object,
-						[6] bool,
+						[5] bool,
+						[6] object,
 						[7] object,
-						[8] object,
-						[9] float64,
+						[8] float64,
+						[9] object,
 						[10] object,
 						[11] object,
 						[12] object,
-						[13] object,
-						[14] object[],
-						[15] string,
+						[13] object[],
+						[14] string,
+						[15] object,
 						[16] object,
-						[17] object,
-						[18] string
+						[17] string
 					)
 
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
@@ -1434,22 +1430,22 @@
 					IL_0006: ldarg.2
 					IL_0007: ldstr "statusCode"
 					IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0011: stloc.s 5
-					IL_0013: ldloc.s 5
+					IL_0011: stloc.s 4
+					IL_0013: ldloc.s 4
 					IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_001a: stloc.s 6
-					IL_001c: ldloc.s 6
+					IL_001a: stloc.s 5
+					IL_001c: ldloc.s 5
 					IL_001e: brtrue IL_0038
 
 					IL_0023: ldc.r8 0.0
 					IL_002c: box [System.Runtime]System.Double
-					IL_0031: stloc.s 8
+					IL_0031: stloc.s 7
 					IL_0033: br IL_003c
 
-					IL_0038: ldloc.s 5
-					IL_003a: stloc.s 8
+					IL_0038: ldloc.s 4
+					IL_003a: stloc.s 7
 
-					IL_003c: ldloc.s 8
+					IL_003c: ldloc.s 7
 					IL_003e: stloc.1
 					IL_003f: ldarg.2
 					IL_0040: ldstr "headers"
@@ -1458,453 +1454,451 @@
 					IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0054: stloc.2
 					IL_0055: ldloc.1
-					IL_0056: stloc.s 8
-					IL_0058: ldloc.s 8
+					IL_0056: stloc.s 7
+					IL_0058: ldloc.s 7
 					IL_005a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_005f: stloc.s 9
-					IL_0061: ldloc.s 9
+					IL_005f: stloc.s 8
+					IL_0061: ldloc.s 8
 					IL_0063: ldc.r8 300
 					IL_006c: clt
 					IL_006e: ldc.i4.0
 					IL_006f: ceq
-					IL_0071: stloc.s 6
-					IL_0073: ldloc.s 6
+					IL_0071: stloc.s 5
+					IL_0073: ldloc.s 5
 					IL_0075: box [System.Runtime]System.Boolean
-					IL_007a: stloc.s 10
-					IL_007c: ldloc.s 10
+					IL_007a: stloc.s 9
+					IL_007c: ldloc.s 9
 					IL_007e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0083: stloc.s 6
-					IL_0085: ldloc.s 6
+					IL_0083: stloc.s 5
+					IL_0085: ldloc.s 5
 					IL_0087: brfalse IL_00b9
 
 					IL_008c: ldloc.1
-					IL_008d: stloc.s 8
-					IL_008f: ldloc.s 8
+					IL_008d: stloc.s 7
+					IL_008f: ldloc.s 7
 					IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0096: stloc.s 9
-					IL_0098: ldloc.s 9
+					IL_0096: stloc.s 8
+					IL_0098: ldloc.s 8
 					IL_009a: ldc.r8 400
 					IL_00a3: clt
-					IL_00a5: stloc.s 6
-					IL_00a7: ldloc.s 6
+					IL_00a5: stloc.s 5
+					IL_00a7: ldloc.s 5
 					IL_00a9: box [System.Runtime]System.Boolean
-					IL_00ae: stloc.s 11
-					IL_00b0: ldloc.s 11
-					IL_00b2: stloc.s 12
+					IL_00ae: stloc.s 10
+					IL_00b0: ldloc.s 10
+					IL_00b2: stloc.s 11
 					IL_00b4: br IL_00bd
 
-					IL_00b9: ldloc.s 10
-					IL_00bb: stloc.s 12
+					IL_00b9: ldloc.s 9
+					IL_00bb: stloc.s 11
 
-					IL_00bd: ldloc.s 12
+					IL_00bd: ldloc.s 11
 					IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00c4: stloc.s 6
-					IL_00c6: ldloc.s 6
+					IL_00c4: stloc.s 5
+					IL_00c6: ldloc.s 5
 					IL_00c8: brfalse IL_00d5
 
 					IL_00cd: ldloc.2
-					IL_00ce: stloc.s 12
+					IL_00ce: stloc.s 11
 					IL_00d0: br IL_00d5
 
-					IL_00d5: ldloc.s 12
+					IL_00d5: ldloc.s 11
 					IL_00d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00dc: stloc.s 6
-					IL_00de: ldloc.s 6
-					IL_00e0: brfalse IL_027f
+					IL_00dc: stloc.s 5
+					IL_00de: ldloc.s 5
+					IL_00e0: brfalse IL_0277
 
-					IL_00e5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
-					IL_00ea: stloc.3
-					IL_00eb: ldarg.0
-					IL_00ec: ldc.i4.1
-					IL_00ed: ldelem.ref
-					IL_00ee: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00fd: ldc.r8 0.0
-					IL_0106: cgt
-					IL_0108: ldc.i4.0
-					IL_0109: ceq
-					IL_010b: brfalse IL_018c
+					IL_00e5: ldarg.0
+					IL_00e6: ldc.i4.1
+					IL_00e7: ldelem.ref
+					IL_00e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_00ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_00f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00f7: ldc.r8 0.0
+					IL_0100: cgt
+					IL_0102: ldc.i4.0
+					IL_0103: ceq
+					IL_0105: brfalse IL_0186
 
-					IL_0110: ldarg.2
-					IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0116: stloc.s 5
-					IL_0118: ldloc.s 5
-					IL_011a: ldstr "resume"
-					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0124: pop
-					IL_0125: ldarg.0
-					IL_0126: ldc.i4.2
-					IL_0127: ldelem.ref
-					IL_0128: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_012d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0132: stloc.s 5
-					IL_0134: ldc.i4.3
-					IL_0135: newarr [System.Runtime]System.Object
+					IL_010a: ldarg.2
+					IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0110: stloc.s 4
+					IL_0112: ldloc.s 4
+					IL_0114: ldstr "resume"
+					IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_011e: pop
+					IL_011f: ldarg.0
+					IL_0120: ldc.i4.2
+					IL_0121: ldelem.ref
+					IL_0122: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0127: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_012c: stloc.s 4
+					IL_012e: ldc.i4.3
+					IL_012f: newarr [System.Runtime]System.Object
+					IL_0134: dup
+					IL_0135: ldc.i4.0
+					IL_0136: ldarg.0
+					IL_0137: ldc.i4.0
+					IL_0138: ldelem.ref
+					IL_0139: stelem.ref
 					IL_013a: dup
-					IL_013b: ldc.i4.0
+					IL_013b: ldc.i4.1
 					IL_013c: ldarg.0
-					IL_013d: ldc.i4.0
+					IL_013d: ldc.i4.1
 					IL_013e: ldelem.ref
 					IL_013f: stelem.ref
 					IL_0140: dup
-					IL_0141: ldc.i4.1
+					IL_0141: ldc.i4.2
 					IL_0142: ldarg.0
-					IL_0143: ldc.i4.1
+					IL_0143: ldc.i4.2
 					IL_0144: ldelem.ref
 					IL_0145: stelem.ref
-					IL_0146: dup
-					IL_0147: ldc.i4.2
+					IL_0146: stloc.s 13
 					IL_0148: ldarg.0
-					IL_0149: ldc.i4.2
+					IL_0149: ldc.i4.1
 					IL_014a: ldelem.ref
-					IL_014b: stelem.ref
-					IL_014c: stloc.s 14
-					IL_014e: ldarg.0
-					IL_014f: ldc.i4.1
-					IL_0150: ldelem.ref
-					IL_0151: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0156: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0160: stloc.s 15
-					IL_0162: ldstr "Too many redirects fetching "
-					IL_0167: ldloc.s 15
-					IL_0169: call string [System.Runtime]System.String::Concat(string, string)
-					IL_016e: stloc.s 15
-					IL_0170: ldloc.s 15
-					IL_0172: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_017c: stloc.s 16
-					IL_017e: ldloc.s 5
-					IL_0180: ldloc.s 14
-					IL_0182: ldloc.s 16
-					IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0189: pop
-					IL_018a: ldnull
-					IL_018b: ret
+					IL_014b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0150: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_015a: stloc.s 14
+					IL_015c: ldstr "Too many redirects fetching "
+					IL_0161: ldloc.s 14
+					IL_0163: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0168: stloc.s 14
+					IL_016a: ldloc.s 14
+					IL_016c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0171: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0176: stloc.s 15
+					IL_0178: ldloc.s 4
+					IL_017a: ldloc.s 13
+					IL_017c: ldloc.s 15
+					IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0183: pop
+					IL_0184: ldnull
+					IL_0185: ret
 
-					IL_018c: ldarg.0
-					IL_018d: ldc.i4.0
-					IL_018e: ldelem.ref
-					IL_018f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0194: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_0199: stloc.s 16
-					IL_019b: ldc.i4.2
-					IL_019c: newarr [System.Runtime]System.Object
-					IL_01a1: dup
-					IL_01a2: ldc.i4.0
-					IL_01a3: ldloc.2
-					IL_01a4: stelem.ref
-					IL_01a5: dup
-					IL_01a6: ldc.i4.1
-					IL_01a7: ldarg.0
-					IL_01a8: ldc.i4.2
-					IL_01a9: ldelem.ref
-					IL_01aa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_01af: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_01b4: stelem.ref
-					IL_01b5: stloc.s 14
-					IL_01b7: ldloc.s 16
-					IL_01b9: ldloc.s 14
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_01c0: stloc.s 16
-					IL_01c2: ldloc.s 16
-					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01c9: stloc.s 16
-					IL_01cb: ldloc.s 16
-					IL_01cd: ldstr "toString"
-					IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01d7: stloc.s 16
-					IL_01d9: ldloc.s 16
-					IL_01db: stloc.s 4
-					IL_01dd: ldarg.2
-					IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01e3: stloc.s 16
-					IL_01e5: ldloc.s 16
-					IL_01e7: ldstr "resume"
-					IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01f1: pop
-					IL_01f2: ldarg.0
-					IL_01f3: ldc.i4.0
-					IL_01f4: ldelem.ref
-					IL_01f5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_01fa: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_01ff: stloc.s 16
-					IL_0201: ldc.i4.3
-					IL_0202: newarr [System.Runtime]System.Object
-					IL_0207: dup
-					IL_0208: ldc.i4.0
-					IL_0209: ldarg.0
-					IL_020a: ldc.i4.0
-					IL_020b: ldelem.ref
-					IL_020c: stelem.ref
-					IL_020d: dup
-					IL_020e: ldc.i4.1
-					IL_020f: ldarg.0
-					IL_0210: ldc.i4.1
-					IL_0211: ldelem.ref
-					IL_0212: stelem.ref
-					IL_0213: dup
-					IL_0214: ldc.i4.2
-					IL_0215: ldarg.0
-					IL_0216: ldc.i4.2
-					IL_0217: ldelem.ref
-					IL_0218: stelem.ref
-					IL_0219: stloc.s 14
-					IL_021b: ldloc.s 16
-					IL_021d: ldloc.s 14
-					IL_021f: ldloc.s 4
-					IL_0221: ldarg.0
-					IL_0222: ldc.i4.1
-					IL_0223: ldelem.ref
-					IL_0224: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0229: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_022e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0233: ldc.r8 1
-					IL_023c: sub
-					IL_023d: box [System.Runtime]System.Double
-					IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_0247: stloc.s 16
-					IL_0249: ldloc.s 16
-					IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0250: stloc.s 16
-					IL_0252: ldarg.0
-					IL_0253: ldc.i4.2
-					IL_0254: ldelem.ref
-					IL_0255: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_025a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_025f: stloc.s 5
-					IL_0261: ldloc.s 16
-					IL_0263: ldstr "then"
-					IL_0268: ldloc.s 5
-					IL_026a: ldarg.0
-					IL_026b: ldc.i4.2
-					IL_026c: ldelem.ref
-					IL_026d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0272: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_027c: pop
-					IL_027d: ldnull
-					IL_027e: ret
+					IL_0186: ldarg.0
+					IL_0187: ldc.i4.0
+					IL_0188: ldelem.ref
+					IL_0189: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_018e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0193: stloc.s 15
+					IL_0195: ldc.i4.2
+					IL_0196: newarr [System.Runtime]System.Object
+					IL_019b: dup
+					IL_019c: ldc.i4.0
+					IL_019d: ldloc.2
+					IL_019e: stelem.ref
+					IL_019f: dup
+					IL_01a0: ldc.i4.1
+					IL_01a1: ldarg.0
+					IL_01a2: ldc.i4.2
+					IL_01a3: ldelem.ref
+					IL_01a4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_01a9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_01ae: stelem.ref
+					IL_01af: stloc.s 13
+					IL_01b1: ldloc.s 15
+					IL_01b3: ldloc.s 13
+					IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01ba: stloc.s 15
+					IL_01bc: ldloc.s 15
+					IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01c3: stloc.s 15
+					IL_01c5: ldloc.s 15
+					IL_01c7: ldstr "toString"
+					IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01d1: stloc.s 15
+					IL_01d3: ldloc.s 15
+					IL_01d5: stloc.3
+					IL_01d6: ldarg.2
+					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01dc: stloc.s 15
+					IL_01de: ldloc.s 15
+					IL_01e0: ldstr "resume"
+					IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01ea: pop
+					IL_01eb: ldarg.0
+					IL_01ec: ldc.i4.0
+					IL_01ed: ldelem.ref
+					IL_01ee: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_01f8: stloc.s 15
+					IL_01fa: ldc.i4.3
+					IL_01fb: newarr [System.Runtime]System.Object
+					IL_0200: dup
+					IL_0201: ldc.i4.0
+					IL_0202: ldarg.0
+					IL_0203: ldc.i4.0
+					IL_0204: ldelem.ref
+					IL_0205: stelem.ref
+					IL_0206: dup
+					IL_0207: ldc.i4.1
+					IL_0208: ldarg.0
+					IL_0209: ldc.i4.1
+					IL_020a: ldelem.ref
+					IL_020b: stelem.ref
+					IL_020c: dup
+					IL_020d: ldc.i4.2
+					IL_020e: ldarg.0
+					IL_020f: ldc.i4.2
+					IL_0210: ldelem.ref
+					IL_0211: stelem.ref
+					IL_0212: stloc.s 13
+					IL_0214: ldloc.s 15
+					IL_0216: ldloc.s 13
+					IL_0218: ldloc.3
+					IL_0219: ldarg.0
+					IL_021a: ldc.i4.1
+					IL_021b: ldelem.ref
+					IL_021c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0221: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_0226: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_022b: ldc.r8 1
+					IL_0234: sub
+					IL_0235: box [System.Runtime]System.Double
+					IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_023f: stloc.s 15
+					IL_0241: ldloc.s 15
+					IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0248: stloc.s 15
+					IL_024a: ldarg.0
+					IL_024b: ldc.i4.2
+					IL_024c: ldelem.ref
+					IL_024d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0252: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0257: stloc.s 4
+					IL_0259: ldloc.s 15
+					IL_025b: ldstr "then"
+					IL_0260: ldloc.s 4
+					IL_0262: ldarg.0
+					IL_0263: ldc.i4.2
+					IL_0264: ldelem.ref
+					IL_0265: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_026a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0274: pop
+					IL_0275: ldnull
+					IL_0276: ret
 
-					IL_027f: ldloc.1
-					IL_0280: stloc.s 12
-					IL_0282: ldloc.s 12
-					IL_0284: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0289: stloc.s 9
-					IL_028b: ldloc.s 9
-					IL_028d: ldc.r8 200
-					IL_0296: clt
-					IL_0298: stloc.s 6
-					IL_029a: ldloc.s 6
-					IL_029c: box [System.Runtime]System.Boolean
-					IL_02a1: stloc.s 10
-					IL_02a3: ldloc.s 10
-					IL_02a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02aa: stloc.s 6
-					IL_02ac: ldloc.s 6
-					IL_02ae: brtrue IL_02e3
+					IL_0277: ldloc.1
+					IL_0278: stloc.s 11
+					IL_027a: ldloc.s 11
+					IL_027c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0281: stloc.s 8
+					IL_0283: ldloc.s 8
+					IL_0285: ldc.r8 200
+					IL_028e: clt
+					IL_0290: stloc.s 5
+					IL_0292: ldloc.s 5
+					IL_0294: box [System.Runtime]System.Boolean
+					IL_0299: stloc.s 9
+					IL_029b: ldloc.s 9
+					IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a2: stloc.s 5
+					IL_02a4: ldloc.s 5
+					IL_02a6: brtrue IL_02db
 
-					IL_02b3: ldloc.1
-					IL_02b4: stloc.s 12
-					IL_02b6: ldloc.s 12
-					IL_02b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02bd: stloc.s 9
-					IL_02bf: ldloc.s 9
-					IL_02c1: ldc.r8 300
-					IL_02ca: clt
-					IL_02cc: ldc.i4.0
-					IL_02cd: ceq
-					IL_02cf: stloc.s 6
-					IL_02d1: ldloc.s 6
-					IL_02d3: box [System.Runtime]System.Boolean
-					IL_02d8: stloc.s 11
-					IL_02da: ldloc.s 11
-					IL_02dc: stloc.s 17
-					IL_02de: br IL_02e7
+					IL_02ab: ldloc.1
+					IL_02ac: stloc.s 11
+					IL_02ae: ldloc.s 11
+					IL_02b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02b5: stloc.s 8
+					IL_02b7: ldloc.s 8
+					IL_02b9: ldc.r8 300
+					IL_02c2: clt
+					IL_02c4: ldc.i4.0
+					IL_02c5: ceq
+					IL_02c7: stloc.s 5
+					IL_02c9: ldloc.s 5
+					IL_02cb: box [System.Runtime]System.Boolean
+					IL_02d0: stloc.s 10
+					IL_02d2: ldloc.s 10
+					IL_02d4: stloc.s 16
+					IL_02d6: br IL_02df
 
-					IL_02e3: ldloc.s 10
-					IL_02e5: stloc.s 17
+					IL_02db: ldloc.s 9
+					IL_02dd: stloc.s 16
 
-					IL_02e7: ldloc.s 17
-					IL_02e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02ee: stloc.s 6
-					IL_02f0: ldloc.s 6
-					IL_02f2: brfalse IL_0394
+					IL_02df: ldloc.s 16
+					IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02e6: stloc.s 5
+					IL_02e8: ldloc.s 5
+					IL_02ea: brfalse IL_038c
 
-					IL_02f7: ldarg.2
-					IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02fd: stloc.s 5
-					IL_02ff: ldloc.s 5
-					IL_0301: ldstr "resume"
-					IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_030b: pop
-					IL_030c: ldarg.0
-					IL_030d: ldc.i4.2
-					IL_030e: ldelem.ref
-					IL_030f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0314: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0319: stloc.s 5
-					IL_031b: ldc.i4.3
-					IL_031c: newarr [System.Runtime]System.Object
-					IL_0321: dup
-					IL_0322: ldc.i4.0
-					IL_0323: ldarg.0
-					IL_0324: ldc.i4.0
-					IL_0325: ldelem.ref
-					IL_0326: stelem.ref
-					IL_0327: dup
-					IL_0328: ldc.i4.1
-					IL_0329: ldarg.0
-					IL_032a: ldc.i4.1
-					IL_032b: ldelem.ref
-					IL_032c: stelem.ref
-					IL_032d: dup
-					IL_032e: ldc.i4.2
-					IL_032f: ldarg.0
-					IL_0330: ldc.i4.2
-					IL_0331: ldelem.ref
-					IL_0332: stelem.ref
+					IL_02ef: ldarg.2
+					IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02f5: stloc.s 4
+					IL_02f7: ldloc.s 4
+					IL_02f9: ldstr "resume"
+					IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0303: pop
+					IL_0304: ldarg.0
+					IL_0305: ldc.i4.2
+					IL_0306: ldelem.ref
+					IL_0307: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_030c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0311: stloc.s 4
+					IL_0313: ldc.i4.3
+					IL_0314: newarr [System.Runtime]System.Object
+					IL_0319: dup
+					IL_031a: ldc.i4.0
+					IL_031b: ldarg.0
+					IL_031c: ldc.i4.0
+					IL_031d: ldelem.ref
+					IL_031e: stelem.ref
+					IL_031f: dup
+					IL_0320: ldc.i4.1
+					IL_0321: ldarg.0
+					IL_0322: ldc.i4.1
+					IL_0323: ldelem.ref
+					IL_0324: stelem.ref
+					IL_0325: dup
+					IL_0326: ldc.i4.2
+					IL_0327: ldarg.0
+					IL_0328: ldc.i4.2
+					IL_0329: ldelem.ref
+					IL_032a: stelem.ref
+					IL_032b: stloc.s 13
+					IL_032d: ldloc.1
+					IL_032e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_0333: stloc.s 14
-					IL_0335: ldloc.1
-					IL_0336: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_033b: stloc.s 15
-					IL_033d: ldstr "HTTP "
-					IL_0342: ldloc.s 15
-					IL_0344: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0349: stloc.s 15
-					IL_034b: ldloc.s 15
-					IL_034d: ldstr " fetching "
-					IL_0352: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0357: stloc.s 15
-					IL_0359: ldarg.0
-					IL_035a: ldc.i4.1
-					IL_035b: ldelem.ref
-					IL_035c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0361: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0366: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_036b: stloc.s 18
-					IL_036d: ldloc.s 15
-					IL_036f: ldloc.s 18
-					IL_0371: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0376: stloc.s 18
-					IL_0378: ldloc.s 18
-					IL_037a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_037f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0384: stloc.s 16
-					IL_0386: ldloc.s 5
-					IL_0388: ldloc.s 14
-					IL_038a: ldloc.s 16
-					IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0391: pop
-					IL_0392: ldnull
-					IL_0393: ret
+					IL_0335: ldstr "HTTP "
+					IL_033a: ldloc.s 14
+					IL_033c: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0341: stloc.s 14
+					IL_0343: ldloc.s 14
+					IL_0345: ldstr " fetching "
+					IL_034a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_034f: stloc.s 14
+					IL_0351: ldarg.0
+					IL_0352: ldc.i4.1
+					IL_0353: ldelem.ref
+					IL_0354: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0359: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_035e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0363: stloc.s 17
+					IL_0365: ldloc.s 14
+					IL_0367: ldloc.s 17
+					IL_0369: call string [System.Runtime]System.String::Concat(string, string)
+					IL_036e: stloc.s 17
+					IL_0370: ldloc.s 17
+					IL_0372: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0377: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_037c: stloc.s 15
+					IL_037e: ldloc.s 4
+					IL_0380: ldloc.s 13
+					IL_0382: ldloc.s 15
+					IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0389: pop
+					IL_038a: ldnull
+					IL_038b: ret
 
-					IL_0394: ldarg.2
-					IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_039a: stloc.s 16
-					IL_039c: ldloc.s 16
-					IL_039e: ldstr "setEncoding"
-					IL_03a3: ldstr "utf8"
-					IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_03ad: pop
-					IL_03ae: ldloc.0
-					IL_03af: ldstr ""
-					IL_03b4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_03b9: ldarg.2
-					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03bf: stloc.s 16
-					IL_03c1: ldnull
-					IL_03c2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_03c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_03cd: ldc.i4.4
-					IL_03ce: newarr [System.Runtime]System.Object
-					IL_03d3: dup
-					IL_03d4: ldc.i4.0
-					IL_03d5: ldarg.0
-					IL_03d6: ldc.i4.0
-					IL_03d7: ldelem.ref
-					IL_03d8: stelem.ref
-					IL_03d9: dup
-					IL_03da: ldc.i4.1
-					IL_03db: ldarg.0
-					IL_03dc: ldc.i4.1
-					IL_03dd: ldelem.ref
-					IL_03de: stelem.ref
-					IL_03df: dup
-					IL_03e0: ldc.i4.2
-					IL_03e1: ldarg.0
-					IL_03e2: ldc.i4.2
-					IL_03e3: ldelem.ref
-					IL_03e4: stelem.ref
-					IL_03e5: dup
-					IL_03e6: ldc.i4.3
-					IL_03e7: ldloc.0
-					IL_03e8: stelem.ref
-					IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03f3: ldc.i4.1
-					IL_03f4: conv.r8
-					IL_03f5: ldstr ""
-					IL_03fa: ldc.i4.0
-					IL_03fb: ldc.i4.0
-					IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0406: stloc.s 5
-					IL_0408: ldloc.s 16
-					IL_040a: ldstr "on"
-					IL_040f: ldstr "data"
-					IL_0414: ldloc.s 5
-					IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_041b: pop
-					IL_041c: ldarg.2
-					IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0422: stloc.s 5
-					IL_0424: ldnull
-					IL_0425: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_042b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0430: ldc.i4.4
-					IL_0431: newarr [System.Runtime]System.Object
-					IL_0436: dup
-					IL_0437: ldc.i4.0
-					IL_0438: ldarg.0
-					IL_0439: ldc.i4.0
-					IL_043a: ldelem.ref
-					IL_043b: stelem.ref
-					IL_043c: dup
-					IL_043d: ldc.i4.1
-					IL_043e: ldarg.0
-					IL_043f: ldc.i4.1
-					IL_0440: ldelem.ref
-					IL_0441: stelem.ref
-					IL_0442: dup
-					IL_0443: ldc.i4.2
-					IL_0444: ldarg.0
-					IL_0445: ldc.i4.2
-					IL_0446: ldelem.ref
-					IL_0447: stelem.ref
-					IL_0448: dup
-					IL_0449: ldc.i4.3
-					IL_044a: ldloc.0
-					IL_044b: stelem.ref
-					IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_038c: ldarg.2
+					IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0392: stloc.s 15
+					IL_0394: ldloc.s 15
+					IL_0396: ldstr "setEncoding"
+					IL_039b: ldstr "utf8"
+					IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_03a5: pop
+					IL_03a6: ldloc.0
+					IL_03a7: ldstr ""
+					IL_03ac: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_03b1: ldarg.2
+					IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03b7: stloc.s 15
+					IL_03b9: ldnull
+					IL_03ba: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03c5: ldc.i4.4
+					IL_03c6: newarr [System.Runtime]System.Object
+					IL_03cb: dup
+					IL_03cc: ldc.i4.0
+					IL_03cd: ldarg.0
+					IL_03ce: ldc.i4.0
+					IL_03cf: ldelem.ref
+					IL_03d0: stelem.ref
+					IL_03d1: dup
+					IL_03d2: ldc.i4.1
+					IL_03d3: ldarg.0
+					IL_03d4: ldc.i4.1
+					IL_03d5: ldelem.ref
+					IL_03d6: stelem.ref
+					IL_03d7: dup
+					IL_03d8: ldc.i4.2
+					IL_03d9: ldarg.0
+					IL_03da: ldc.i4.2
+					IL_03db: ldelem.ref
+					IL_03dc: stelem.ref
+					IL_03dd: dup
+					IL_03de: ldc.i4.3
+					IL_03df: ldloc.0
+					IL_03e0: stelem.ref
+					IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03eb: ldc.i4.1
+					IL_03ec: conv.r8
+					IL_03ed: ldstr ""
+					IL_03f2: ldc.i4.0
+					IL_03f3: ldc.i4.0
+					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_03fe: stloc.s 4
+					IL_0400: ldloc.s 15
+					IL_0402: ldstr "on"
+					IL_0407: ldstr "data"
+					IL_040c: ldloc.s 4
+					IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0413: pop
+					IL_0414: ldarg.2
+					IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_041a: stloc.s 4
+					IL_041c: ldnull
+					IL_041d: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0423: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_0428: ldc.i4.4
+					IL_0429: newarr [System.Runtime]System.Object
+					IL_042e: dup
+					IL_042f: ldc.i4.0
+					IL_0430: ldarg.0
+					IL_0431: ldc.i4.0
+					IL_0432: ldelem.ref
+					IL_0433: stelem.ref
+					IL_0434: dup
+					IL_0435: ldc.i4.1
+					IL_0436: ldarg.0
+					IL_0437: ldc.i4.1
+					IL_0438: ldelem.ref
+					IL_0439: stelem.ref
+					IL_043a: dup
+					IL_043b: ldc.i4.2
+					IL_043c: ldarg.0
+					IL_043d: ldc.i4.2
+					IL_043e: ldelem.ref
+					IL_043f: stelem.ref
+					IL_0440: dup
+					IL_0441: ldc.i4.3
+					IL_0442: ldloc.0
+					IL_0443: stelem.ref
+					IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_044e: ldc.i4.0
+					IL_044f: conv.r8
+					IL_0450: ldstr ""
+					IL_0455: ldc.i4.0
 					IL_0456: ldc.i4.0
-					IL_0457: conv.r8
-					IL_0458: ldstr ""
-					IL_045d: ldc.i4.0
-					IL_045e: ldc.i4.0
-					IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0469: stloc.s 16
-					IL_046b: ldloc.s 5
-					IL_046d: ldstr "on"
-					IL_0472: ldstr "end"
-					IL_0477: ldloc.s 16
-					IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_047e: pop
-					IL_047f: ldnull
-					IL_0480: ret
+					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0461: stloc.s 15
+					IL_0463: ldloc.s 4
+					IL_0465: ldstr "on"
+					IL_046a: ldstr "end"
+					IL_046f: ldloc.s 15
+					IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0476: pop
+					IL_0477: ldnull
+					IL_0478: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1926,7 +1920,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x474c
+						// Method begins at RVA 0x46c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1946,7 +1940,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4755
+						// Method begins at RVA 0x46cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1969,7 +1963,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4743
+					// Method begins at RVA 0x46bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1995,7 +1989,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f90
+				// Method begins at RVA 0x3f10
 				// Header size: 12
 				// Code size: 495 (0x1ef)
 				.maxstack 8
@@ -2235,7 +2229,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x473a
+					// Method begins at RVA 0x46b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2257,7 +2251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4731
+				// Method begins at RVA 0x46a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2285,7 +2279,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2970
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -2353,7 +2347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4794
+				// Method begins at RVA 0x470c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2377,7 +2371,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29e8
+			// Method begins at RVA 0x29cc
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -2420,7 +2414,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47a6
+					// Method begins at RVA 0x471e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2438,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x47b8
+						// Method begins at RVA 0x4730
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2462,7 +2456,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47af
+					// Method begins at RVA 0x4727
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2480,7 +2474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x479d
+				// Method begins at RVA 0x4715
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2508,17 +2502,17 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2a20
+			// Method begins at RVA 0x2a04
 			// Header size: 12
-			// Code size: 564 (0x234)
+			// Code size: 544 (0x220)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/Scope/Block_L140C30,
-				[2] object,
-				[3] float64,
-				[4] object,
-				[5] bool,
+				[1] object,
+				[2] float64,
+				[3] object,
+				[4] bool,
+				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
@@ -2527,222 +2521,219 @@
 				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] object
+				[14] object
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.3
-			IL_0007: ldloc.3
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
 			IL_0008: ldc.r8 0.0
 			IL_0011: clt
 			IL_0013: box [System.Runtime]System.Boolean
-			IL_0018: stloc.s 4
-			IL_001a: ldloc.s 4
-			IL_001c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0021: stloc.s 5
-			IL_0023: ldloc.s 5
-			IL_0025: brtrue IL_004f
+			IL_0018: stloc.3
+			IL_0019: ldloc.3
+			IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001f: stloc.s 4
+			IL_0021: ldloc.s 4
+			IL_0023: brtrue IL_004d
 
-			IL_002a: ldarg.2
-			IL_002b: ldloc.3
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0031: ldstr "<"
-			IL_0036: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_003b: stloc.s 5
-			IL_003d: ldloc.s 5
-			IL_003f: box [System.Runtime]System.Boolean
-			IL_0044: stloc.s 6
-			IL_0046: ldloc.s 6
-			IL_0048: stloc.s 8
-			IL_004a: br IL_0053
+			IL_0028: ldarg.2
+			IL_0029: ldloc.2
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_002f: ldstr "<"
+			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: box [System.Runtime]System.Boolean
+			IL_0042: stloc.s 5
+			IL_0044: ldloc.s 5
+			IL_0046: stloc.s 7
+			IL_0048: br IL_0050
 
-			IL_004f: ldloc.s 4
-			IL_0051: stloc.s 8
+			IL_004d: ldloc.3
+			IL_004e: stloc.s 7
 
-			IL_0053: ldloc.s 8
-			IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005a: stloc.s 5
-			IL_005c: ldloc.s 5
-			IL_005e: brfalse IL_0069
+			IL_0050: ldloc.s 7
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.s 4
+			IL_005b: brfalse IL_0066
 
-			IL_0063: ldstr ""
-			IL_0068: ret
+			IL_0060: ldstr ""
+			IL_0065: ret
 
-			IL_0069: ldarg.3
-			IL_006a: ldc.r8 1
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0078: stloc.s 8
-			IL_007a: ldloc.s 8
-			IL_007c: stloc.0
-			// loop start (head: IL_007d)
-				IL_007d: ldloc.0
-				IL_007e: stloc.s 8
-				IL_0080: ldarg.2
-				IL_0081: ldstr "length"
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_008b: stloc.s 9
-				IL_008d: ldloc.s 8
-				IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0094: stloc.3
-				IL_0095: ldloc.3
-				IL_0096: ldloc.s 9
-				IL_0098: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_009d: clt
-				IL_009f: brfalse IL_0207
+			IL_0066: ldarg.3
+			IL_0067: ldc.r8 1
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0075: stloc.s 7
+			IL_0077: ldloc.s 7
+			IL_0079: stloc.0
+			// loop start (head: IL_007a)
+				IL_007a: ldloc.0
+				IL_007b: stloc.s 7
+				IL_007d: ldarg.2
+				IL_007e: ldstr "length"
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0088: stloc.s 8
+				IL_008a: ldloc.s 7
+				IL_008c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0091: stloc.2
+				IL_0092: ldloc.2
+				IL_0093: ldloc.s 8
+				IL_0095: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_009a: clt
+				IL_009c: brfalse IL_01f3
 
-				IL_00a4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/Scope/Block_L140C30::.ctor()
-				IL_00a9: stloc.1
-				IL_00aa: ldarg.2
-				IL_00ab: ldloc.0
-				IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00b1: stloc.2
-				IL_00b2: ldloc.2
-				IL_00b3: stloc.s 9
-				IL_00b5: ldloc.s 9
-				IL_00b7: ldstr " "
-				IL_00bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00c1: stloc.s 5
-				IL_00c3: ldloc.s 5
-				IL_00c5: box [System.Runtime]System.Boolean
-				IL_00ca: stloc.s 4
-				IL_00cc: ldloc.s 4
-				IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00d3: stloc.s 5
-				IL_00d5: ldloc.s 5
-				IL_00d7: brtrue IL_00ff
+				IL_00a1: ldarg.2
+				IL_00a2: ldloc.0
+				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00a8: stloc.1
+				IL_00a9: ldloc.1
+				IL_00aa: stloc.s 8
+				IL_00ac: ldloc.s 8
+				IL_00ae: ldstr " "
+				IL_00b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00b8: stloc.s 4
+				IL_00ba: ldloc.s 4
+				IL_00bc: box [System.Runtime]System.Boolean
+				IL_00c1: stloc.3
+				IL_00c2: ldloc.3
+				IL_00c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00c8: stloc.s 4
+				IL_00ca: ldloc.s 4
+				IL_00cc: brtrue IL_00f4
 
-				IL_00dc: ldloc.2
-				IL_00dd: stloc.s 9
-				IL_00df: ldloc.s 9
-				IL_00e1: ldstr "\t"
-				IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00eb: stloc.s 5
-				IL_00ed: ldloc.s 5
-				IL_00ef: box [System.Runtime]System.Boolean
-				IL_00f4: stloc.s 6
-				IL_00f6: ldloc.s 6
-				IL_00f8: stloc.s 10
-				IL_00fa: br IL_0103
+				IL_00d1: ldloc.1
+				IL_00d2: stloc.s 8
+				IL_00d4: ldloc.s 8
+				IL_00d6: ldstr "\t"
+				IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e0: stloc.s 4
+				IL_00e2: ldloc.s 4
+				IL_00e4: box [System.Runtime]System.Boolean
+				IL_00e9: stloc.s 5
+				IL_00eb: ldloc.s 5
+				IL_00ed: stloc.s 9
+				IL_00ef: br IL_00f7
 
-				IL_00ff: ldloc.s 4
-				IL_0101: stloc.s 10
+				IL_00f4: ldloc.3
+				IL_00f5: stloc.s 9
 
-				IL_0103: ldloc.s 10
-				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_010a: stloc.s 5
-				IL_010c: ldloc.s 5
-				IL_010e: brtrue IL_0136
+				IL_00f7: ldloc.s 9
+				IL_00f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00fe: stloc.s 4
+				IL_0100: ldloc.s 4
+				IL_0102: brtrue IL_0128
 
-				IL_0113: ldloc.2
-				IL_0114: stloc.s 9
-				IL_0116: ldloc.s 9
-				IL_0118: ldstr "\r"
-				IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0122: stloc.s 5
-				IL_0124: ldloc.s 5
-				IL_0126: box [System.Runtime]System.Boolean
-				IL_012b: stloc.s 4
-				IL_012d: ldloc.s 4
-				IL_012f: stloc.s 10
-				IL_0131: br IL_0136
+				IL_0107: ldloc.1
+				IL_0108: stloc.s 8
+				IL_010a: ldloc.s 8
+				IL_010c: ldstr "\r"
+				IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0116: stloc.s 4
+				IL_0118: ldloc.s 4
+				IL_011a: box [System.Runtime]System.Boolean
+				IL_011f: stloc.3
+				IL_0120: ldloc.3
+				IL_0121: stloc.s 9
+				IL_0123: br IL_0128
 
-				IL_0136: ldloc.s 10
-				IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013d: stloc.s 5
-				IL_013f: ldloc.s 5
-				IL_0141: brtrue IL_0169
+				IL_0128: ldloc.s 9
+				IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_012f: stloc.s 4
+				IL_0131: ldloc.s 4
+				IL_0133: brtrue IL_0159
 
-				IL_0146: ldloc.2
-				IL_0147: stloc.s 9
-				IL_0149: ldloc.s 9
-				IL_014b: ldstr "\n"
-				IL_0150: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0155: stloc.s 5
-				IL_0157: ldloc.s 5
-				IL_0159: box [System.Runtime]System.Boolean
-				IL_015e: stloc.s 4
-				IL_0160: ldloc.s 4
-				IL_0162: stloc.s 10
-				IL_0164: br IL_0169
+				IL_0138: ldloc.1
+				IL_0139: stloc.s 8
+				IL_013b: ldloc.s 8
+				IL_013d: ldstr "\n"
+				IL_0142: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0147: stloc.s 4
+				IL_0149: ldloc.s 4
+				IL_014b: box [System.Runtime]System.Boolean
+				IL_0150: stloc.3
+				IL_0151: ldloc.3
+				IL_0152: stloc.s 9
+				IL_0154: br IL_0159
 
-				IL_0169: ldloc.s 10
-				IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0170: stloc.s 5
-				IL_0172: ldloc.s 5
-				IL_0174: brtrue IL_019c
+				IL_0159: ldloc.s 9
+				IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0160: stloc.s 4
+				IL_0162: ldloc.s 4
+				IL_0164: brtrue IL_018a
 
-				IL_0179: ldloc.2
-				IL_017a: stloc.s 9
-				IL_017c: ldloc.s 9
-				IL_017e: ldstr ">"
-				IL_0183: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0188: stloc.s 5
-				IL_018a: ldloc.s 5
-				IL_018c: box [System.Runtime]System.Boolean
+				IL_0169: ldloc.1
+				IL_016a: stloc.s 8
+				IL_016c: ldloc.s 8
+				IL_016e: ldstr ">"
+				IL_0173: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0178: stloc.s 4
+				IL_017a: ldloc.s 4
+				IL_017c: box [System.Runtime]System.Boolean
+				IL_0181: stloc.3
+				IL_0182: ldloc.3
+				IL_0183: stloc.s 9
+				IL_0185: br IL_018a
+
+				IL_018a: ldloc.s 9
+				IL_018c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0191: stloc.s 4
 				IL_0193: ldloc.s 4
-				IL_0195: stloc.s 10
-				IL_0197: br IL_019c
+				IL_0195: brtrue IL_01bb
 
-				IL_019c: ldloc.s 10
-				IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01a3: stloc.s 5
-				IL_01a5: ldloc.s 5
-				IL_01a7: brtrue IL_01cf
+				IL_019a: ldloc.1
+				IL_019b: stloc.s 8
+				IL_019d: ldloc.s 8
+				IL_019f: ldstr "/"
+				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01a9: stloc.s 4
+				IL_01ab: ldloc.s 4
+				IL_01ad: box [System.Runtime]System.Boolean
+				IL_01b2: stloc.3
+				IL_01b3: ldloc.3
+				IL_01b4: stloc.s 9
+				IL_01b6: br IL_01bb
 
-				IL_01ac: ldloc.2
-				IL_01ad: stloc.s 9
-				IL_01af: ldloc.s 9
-				IL_01b1: ldstr "/"
-				IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01bb: stloc.s 5
-				IL_01bd: ldloc.s 5
-				IL_01bf: box [System.Runtime]System.Boolean
-				IL_01c4: stloc.s 4
-				IL_01c6: ldloc.s 4
-				IL_01c8: stloc.s 10
-				IL_01ca: br IL_01cf
+				IL_01bb: ldloc.s 9
+				IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01c2: stloc.s 4
+				IL_01c4: ldloc.s 4
+				IL_01c6: brfalse IL_01d0
 
-				IL_01cf: ldloc.s 10
-				IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01d6: stloc.s 5
-				IL_01d8: ldloc.s 5
-				IL_01da: brfalse IL_01e4
+				IL_01cb: br IL_01f3
 
-				IL_01df: br IL_0207
-
-				IL_01e4: ldloc.0
-				IL_01e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01ea: stloc.3
-				IL_01eb: ldloc.3
-				IL_01ec: ldc.r8 1
-				IL_01f5: add
-				IL_01f6: stloc.3
-				IL_01f7: ldloc.3
-				IL_01f8: box [System.Runtime]System.Double
-				IL_01fd: stloc.s 15
-				IL_01ff: ldloc.s 15
-				IL_0201: stloc.0
-				IL_0202: br IL_007d
+				IL_01d0: ldloc.0
+				IL_01d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01d6: stloc.2
+				IL_01d7: ldloc.2
+				IL_01d8: ldc.r8 1
+				IL_01e1: add
+				IL_01e2: stloc.2
+				IL_01e3: ldloc.2
+				IL_01e4: box [System.Runtime]System.Double
+				IL_01e9: stloc.s 14
+				IL_01eb: ldloc.s 14
+				IL_01ed: stloc.0
+				IL_01ee: br IL_007a
 			// end loop
 
-			IL_0207: ldarg.2
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_020d: stloc.s 9
-			IL_020f: ldarg.3
-			IL_0210: ldc.r8 1
-			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_021e: stloc.s 10
-			IL_0220: ldloc.s 9
-			IL_0222: ldstr "substring"
-			IL_0227: ldloc.s 10
-			IL_0229: ldloc.0
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_022f: stloc.s 9
-			IL_0231: ldloc.s 9
-			IL_0233: ret
+			IL_01f3: ldarg.2
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f9: stloc.s 8
+			IL_01fb: ldarg.3
+			IL_01fc: ldc.r8 1
+			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_020a: stloc.s 9
+			IL_020c: ldloc.s 8
+			IL_020e: ldstr "substring"
+			IL_0213: ldloc.s 9
+			IL_0215: ldloc.0
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_021b: stloc.s 8
+			IL_021d: ldloc.s 8
+			IL_021f: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -2762,7 +2753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47ca
+					// Method begins at RVA 0x4742
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2782,7 +2773,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47d3
+					// Method begins at RVA 0x474b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2802,7 +2793,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47dc
+					// Method begins at RVA 0x4754
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2822,7 +2813,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47e5
+					// Method begins at RVA 0x475d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2846,7 +2837,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x47f7
+						// Method begins at RVA 0x476f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2866,7 +2857,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4800
+						// Method begins at RVA 0x4778
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2890,7 +2881,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4812
+							// Method begins at RVA 0x478a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2908,7 +2899,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4809
+						// Method begins at RVA 0x4781
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2928,7 +2919,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x481b
+						// Method begins at RVA 0x4793
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2946,7 +2937,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47ee
+					// Method begins at RVA 0x4766
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2964,7 +2955,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x47c1
+				// Method begins at RVA 0x4739
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2992,9 +2983,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2c60
+			// Method begins at RVA 0x2c30
 			// Header size: 12
-			// Code size: 1079 (0x437)
+			// Code size: 1072 (0x430)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3008,104 +2999,103 @@
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[9] float64,
 				[10] object,
-				[11] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15,
+				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] string,
-				[16] object,
-				[17] float64,
-				[18] object[],
-				[19] bool,
-				[20] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[21] object,
-				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[23] string
+				[14] string,
+				[15] object,
+				[16] float64,
+				[17] object[],
+				[18] bool,
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[20] object,
+				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[22] string
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0006: stloc.s 15
+			IL_0006: stloc.s 14
 			IL_0008: ldstr "id=\""
-			IL_000d: ldloc.s 15
+			IL_000d: ldloc.s 14
 			IL_000f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0014: stloc.s 15
-			IL_0016: ldloc.s 15
+			IL_0014: stloc.s 14
+			IL_0016: ldloc.s 14
 			IL_0018: ldstr "\""
 			IL_001d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0022: stloc.s 15
-			IL_0024: ldloc.s 15
+			IL_0022: stloc.s 14
+			IL_0024: ldloc.s 14
 			IL_0026: stloc.0
 			IL_0027: ldarg.3
 			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002d: stloc.s 15
+			IL_002d: stloc.s 14
 			IL_002f: ldstr "id='"
-			IL_0034: ldloc.s 15
+			IL_0034: ldloc.s 14
 			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.s 15
-			IL_003d: ldloc.s 15
+			IL_003b: stloc.s 14
+			IL_003d: ldloc.s 14
 			IL_003f: ldstr "'"
 			IL_0044: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0049: stloc.s 15
-			IL_004b: ldloc.s 15
+			IL_0049: stloc.s 14
+			IL_004b: ldloc.s 14
 			IL_004d: stloc.1
 			IL_004e: ldarg.2
 			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0054: stloc.s 16
-			IL_0056: ldloc.s 16
+			IL_0054: stloc.s 15
+			IL_0056: ldloc.s 15
 			IL_0058: ldstr "indexOf"
 			IL_005d: ldloc.0
 			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0063: stloc.s 16
-			IL_0065: ldloc.s 16
+			IL_0063: stloc.s 15
+			IL_0065: ldloc.s 15
 			IL_0067: stloc.2
 			IL_0068: ldloc.2
-			IL_0069: stloc.s 16
-			IL_006b: ldloc.s 16
+			IL_0069: stloc.s 15
+			IL_006b: ldloc.s 15
 			IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0072: stloc.s 17
-			IL_0074: ldloc.s 17
+			IL_0072: stloc.s 16
+			IL_0074: ldloc.s 16
 			IL_0076: ldc.r8 0.0
 			IL_007f: clt
 			IL_0081: brfalse IL_00a0
 
 			IL_0086: ldarg.2
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008c: stloc.s 16
-			IL_008e: ldloc.s 16
+			IL_008c: stloc.s 15
+			IL_008e: ldloc.s 15
 			IL_0090: ldstr "indexOf"
 			IL_0095: ldloc.1
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009b: stloc.s 16
-			IL_009d: ldloc.s 16
+			IL_009b: stloc.s 15
+			IL_009d: ldloc.s 15
 			IL_009f: stloc.2
 
 			IL_00a0: ldloc.2
-			IL_00a1: stloc.s 16
-			IL_00a3: ldloc.s 16
+			IL_00a1: stloc.s 15
+			IL_00a3: ldloc.s 15
 			IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00aa: stloc.s 17
-			IL_00ac: ldloc.s 17
+			IL_00aa: stloc.s 16
+			IL_00ac: ldloc.s 16
 			IL_00ae: ldc.r8 0.0
 			IL_00b7: clt
 			IL_00b9: brfalse IL_0108
 
 			IL_00be: ldarg.3
 			IL_00bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c4: stloc.s 15
+			IL_00c4: stloc.s 14
 			IL_00c6: ldstr "Could not find id '"
-			IL_00cb: ldloc.s 15
+			IL_00cb: ldloc.s 14
 			IL_00cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d2: stloc.s 15
-			IL_00d4: ldloc.s 15
+			IL_00d2: stloc.s 14
+			IL_00d4: ldloc.s 14
 			IL_00d6: ldstr "' in input HTML."
 			IL_00db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e0: stloc.s 15
-			IL_00e2: ldloc.s 15
+			IL_00e0: stloc.s 14
+			IL_00e2: ldloc.s 14
 			IL_00e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ee: stloc.s 16
-			IL_00f0: ldloc.s 16
+			IL_00ee: stloc.s 15
+			IL_00f0: ldloc.s 15
 			IL_00f2: stloc.3
 			IL_00f3: ldloc.3
 			IL_00f4: isinst [System.Runtime]System.Exception
@@ -3121,41 +3111,41 @@
 
 			IL_0108: ldarg.2
 			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010e: stloc.s 16
-			IL_0110: ldloc.s 16
+			IL_010e: stloc.s 15
+			IL_0110: ldloc.s 15
 			IL_0112: ldstr "lastIndexOf"
 			IL_0117: ldstr "<"
 			IL_011c: ldloc.2
 			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0122: stloc.s 16
-			IL_0124: ldloc.s 16
+			IL_0122: stloc.s 15
+			IL_0124: ldloc.s 15
 			IL_0126: stloc.s 4
 			IL_0128: ldloc.s 4
-			IL_012a: stloc.s 16
-			IL_012c: ldloc.s 16
+			IL_012a: stloc.s 15
+			IL_012c: ldloc.s 15
 			IL_012e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0133: stloc.s 17
-			IL_0135: ldloc.s 17
+			IL_0133: stloc.s 16
+			IL_0135: ldloc.s 16
 			IL_0137: ldc.r8 0.0
 			IL_0140: clt
 			IL_0142: brfalse IL_0194
 
 			IL_0147: ldarg.3
 			IL_0148: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_014d: stloc.s 15
+			IL_014d: stloc.s 14
 			IL_014f: ldstr "Could not locate tag start for id '"
-			IL_0154: ldloc.s 15
+			IL_0154: ldloc.s 14
 			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015b: stloc.s 15
-			IL_015d: ldloc.s 15
+			IL_015b: stloc.s 14
+			IL_015d: ldloc.s 14
 			IL_015f: ldstr "'."
 			IL_0164: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0169: stloc.s 15
-			IL_016b: ldloc.s 15
+			IL_0169: stloc.s 14
+			IL_016b: ldloc.s 14
 			IL_016d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0177: stloc.s 16
-			IL_0179: ldloc.s 16
+			IL_0177: stloc.s 15
+			IL_0179: ldloc.s 15
 			IL_017b: stloc.s 5
 			IL_017d: ldloc.s 5
 			IL_017f: isinst [System.Runtime]System.Exception
@@ -3175,40 +3165,40 @@
 			IL_019b: ldc.i4.0
 			IL_019c: ldarg.0
 			IL_019d: stelem.ref
-			IL_019e: stloc.s 18
+			IL_019e: stloc.s 17
 			IL_01a0: ldarg.0
 			IL_01a1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_01a6: ldloc.s 18
+			IL_01a6: ldloc.s 17
 			IL_01a8: ldarg.2
 			IL_01a9: ldloc.s 4
 			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01b0: stloc.s 16
-			IL_01b2: ldloc.s 16
+			IL_01b0: stloc.s 15
+			IL_01b2: ldloc.s 15
 			IL_01b4: stloc.s 6
 			IL_01b6: ldloc.s 6
 			IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_01bd: ldc.i4.0
 			IL_01be: ceq
-			IL_01c0: stloc.s 19
-			IL_01c2: ldloc.s 19
+			IL_01c0: stloc.s 18
+			IL_01c2: ldloc.s 18
 			IL_01c4: brfalse IL_0216
 
 			IL_01c9: ldarg.3
 			IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cf: stloc.s 15
+			IL_01cf: stloc.s 14
 			IL_01d1: ldstr "Could not determine tag name for id '"
-			IL_01d6: ldloc.s 15
+			IL_01d6: ldloc.s 14
 			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01dd: stloc.s 15
-			IL_01df: ldloc.s 15
+			IL_01dd: stloc.s 14
+			IL_01df: ldloc.s 14
 			IL_01e1: ldstr "'."
 			IL_01e6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01eb: stloc.s 15
-			IL_01ed: ldloc.s 15
+			IL_01eb: stloc.s 14
+			IL_01ed: ldloc.s 14
 			IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_01f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01f9: stloc.s 16
-			IL_01fb: ldloc.s 16
+			IL_01f9: stloc.s 15
+			IL_01fb: ldloc.s 15
 			IL_01fd: stloc.s 7
 			IL_01ff: ldloc.s 7
 			IL_0201: isinst [System.Runtime]System.Exception
@@ -3232,23 +3222,23 @@
 			IL_0225: stelem.ref
 			IL_0226: ldloc.s 6
 			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_022d: stloc.s 16
-			IL_022f: ldloc.s 16
+			IL_022d: stloc.s 15
+			IL_022f: ldloc.s 15
 			IL_0231: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0236: stloc.s 15
+			IL_0236: stloc.s 14
 			IL_0238: ldstr "<\\/?"
-			IL_023d: ldloc.s 15
+			IL_023d: ldloc.s 14
 			IL_023f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0244: stloc.s 15
-			IL_0246: ldloc.s 15
+			IL_0244: stloc.s 14
+			IL_0246: ldloc.s 14
 			IL_0248: ldstr "\\b[^>]*>"
 			IL_024d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0252: stloc.s 15
-			IL_0254: ldloc.s 15
+			IL_0252: stloc.s 14
+			IL_0254: ldloc.s 14
 			IL_0256: ldstr "gi"
 			IL_025b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0260: stloc.s 20
-			IL_0262: ldloc.s 20
+			IL_0260: stloc.s 19
+			IL_0262: ldloc.s 19
 			IL_0264: stloc.s 8
 			IL_0266: ldloc.s 8
 			IL_0268: ldstr "lastIndex"
@@ -3264,152 +3254,150 @@
 			IL_0290: stloc.s 10
 			// loop start (head: IL_0292)
 				IL_0292: ldc.i4.1
-				IL_0293: brfalse IL_03c6
+				IL_0293: brfalse IL_03bf
 
-				IL_0298: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_029d: stloc.s 11
-				IL_029f: ldloc.s 8
-				IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02a6: stloc.s 16
-				IL_02a8: ldloc.s 16
-				IL_02aa: ldstr "exec"
-				IL_02af: ldarg.2
-				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02b5: stloc.s 16
-				IL_02b7: ldloc.s 16
-				IL_02b9: stloc.s 12
-				IL_02bb: ldloc.s 12
-				IL_02bd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02c2: ldc.i4.0
-				IL_02c3: ceq
-				IL_02c5: stloc.s 19
-				IL_02c7: ldloc.s 19
-				IL_02c9: brfalse IL_02d3
+				IL_0298: ldloc.s 8
+				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_029f: stloc.s 15
+				IL_02a1: ldloc.s 15
+				IL_02a3: ldstr "exec"
+				IL_02a8: ldarg.2
+				IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02ae: stloc.s 15
+				IL_02b0: ldloc.s 15
+				IL_02b2: stloc.s 11
+				IL_02b4: ldloc.s 11
+				IL_02b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02bb: ldc.i4.0
+				IL_02bc: ceq
+				IL_02be: stloc.s 18
+				IL_02c0: ldloc.s 18
+				IL_02c2: brfalse IL_02cc
 
-				IL_02ce: br IL_03c6
+				IL_02c7: br IL_03bf
 
-				IL_02d3: ldloc.s 12
-				IL_02d5: ldc.r8 0.0
-				IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02e3: stloc.s 13
-				IL_02e5: ldloc.s 10
-				IL_02e7: stloc.s 21
-				IL_02e9: ldloc.s 21
-				IL_02eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_02f0: stloc.s 17
-				IL_02f2: ldloc.s 17
-				IL_02f4: ldc.r8 0.0
-				IL_02fd: clt
-				IL_02ff: brfalse IL_0316
+				IL_02cc: ldloc.s 11
+				IL_02ce: ldc.r8 0.0
+				IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02dc: stloc.s 12
+				IL_02de: ldloc.s 10
+				IL_02e0: stloc.s 20
+				IL_02e2: ldloc.s 20
+				IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
+				IL_02ed: ldc.r8 0.0
+				IL_02f6: clt
+				IL_02f8: brfalse IL_030f
 
-				IL_0304: ldloc.s 12
-				IL_0306: ldstr "index"
-				IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0310: stloc.s 16
-				IL_0312: ldloc.s 16
-				IL_0314: stloc.s 10
+				IL_02fd: ldloc.s 11
+				IL_02ff: ldstr "index"
+				IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0309: stloc.s 15
+				IL_030b: ldloc.s 15
+				IL_030d: stloc.s 10
 
-				IL_0316: ldloc.s 13
-				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_031d: stloc.s 16
-				IL_031f: ldloc.s 16
-				IL_0321: ldstr "startsWith"
-				IL_0326: ldstr "</"
-				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0330: stloc.s 16
-				IL_0332: ldloc.s 16
-				IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0339: stloc.s 19
-				IL_033b: ldloc.s 19
-				IL_033d: brfalse IL_03b3
+				IL_030f: ldloc.s 12
+				IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0316: stloc.s 15
+				IL_0318: ldloc.s 15
+				IL_031a: ldstr "startsWith"
+				IL_031f: ldstr "</"
+				IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0329: stloc.s 15
+				IL_032b: ldloc.s 15
+				IL_032d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0332: stloc.s 18
+				IL_0334: ldloc.s 18
+				IL_0336: brfalse IL_03ac
 
-				IL_0342: ldloc.s 9
-				IL_0344: ldc.r8 1
-				IL_034d: sub
-				IL_034e: stloc.s 9
-				IL_0350: ldloc.s 9
-				IL_0352: stloc.s 17
-				IL_0354: ldloc.s 17
-				IL_0356: ldc.r8 0.0
-				IL_035f: ceq
-				IL_0361: brfalse IL_03ae
+				IL_033b: ldloc.s 9
+				IL_033d: ldc.r8 1
+				IL_0346: sub
+				IL_0347: stloc.s 9
+				IL_0349: ldloc.s 9
+				IL_034b: stloc.s 16
+				IL_034d: ldloc.s 16
+				IL_034f: ldc.r8 0.0
+				IL_0358: ceq
+				IL_035a: brfalse IL_03a7
 
-				IL_0366: ldarg.2
-				IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_036c: stloc.s 16
-				IL_036e: ldloc.s 16
-				IL_0370: ldstr "substring"
-				IL_0375: ldloc.s 10
-				IL_0377: ldloc.s 8
-				IL_0379: ldstr "lastIndex"
-				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0388: stloc.s 16
-				IL_038a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_038f: dup
-				IL_0390: ldstr "tagName"
-				IL_0395: ldloc.s 6
-				IL_0397: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_039c: dup
-				IL_039d: ldstr "html"
-				IL_03a2: ldloc.s 16
-				IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03a9: stloc.s 22
-				IL_03ab: ldloc.s 22
-				IL_03ad: ret
+				IL_035f: ldarg.2
+				IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0365: stloc.s 15
+				IL_0367: ldloc.s 15
+				IL_0369: ldstr "substring"
+				IL_036e: ldloc.s 10
+				IL_0370: ldloc.s 8
+				IL_0372: ldstr "lastIndex"
+				IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0381: stloc.s 15
+				IL_0383: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0388: dup
+				IL_0389: ldstr "tagName"
+				IL_038e: ldloc.s 6
+				IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0395: dup
+				IL_0396: ldstr "html"
+				IL_039b: ldloc.s 15
+				IL_039d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03a2: stloc.s 21
+				IL_03a4: ldloc.s 21
+				IL_03a6: ret
 
-				IL_03ae: br IL_03c1
+				IL_03a7: br IL_03ba
 
-				IL_03b3: ldloc.s 9
-				IL_03b5: ldc.r8 1
-				IL_03be: add
-				IL_03bf: stloc.s 9
+				IL_03ac: ldloc.s 9
+				IL_03ae: ldc.r8 1
+				IL_03b7: add
+				IL_03b8: stloc.s 9
 
-				IL_03c1: br IL_0292
+				IL_03ba: br IL_0292
 			// end loop
 
-			IL_03c6: ldloc.s 6
-			IL_03c8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03cd: stloc.s 15
-			IL_03cf: ldstr "Could not find a matching closing </"
-			IL_03d4: ldloc.s 15
-			IL_03d6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03db: stloc.s 15
-			IL_03dd: ldloc.s 15
-			IL_03df: ldstr "> for id '"
-			IL_03e4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03e9: stloc.s 15
-			IL_03eb: ldarg.3
-			IL_03ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03f1: stloc.s 23
-			IL_03f3: ldloc.s 15
-			IL_03f5: ldloc.s 23
-			IL_03f7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03fc: stloc.s 23
-			IL_03fe: ldloc.s 23
-			IL_0400: ldstr "'."
-			IL_0405: call string [System.Runtime]System.String::Concat(string, string)
-			IL_040a: stloc.s 23
-			IL_040c: ldloc.s 23
-			IL_040e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0413: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0418: stloc.s 16
-			IL_041a: ldloc.s 16
-			IL_041c: stloc.s 14
-			IL_041e: ldloc.s 14
-			IL_0420: isinst [System.Runtime]System.Exception
-			IL_0425: dup
-			IL_0426: brtrue IL_0434
+			IL_03bf: ldloc.s 6
+			IL_03c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03c6: stloc.s 14
+			IL_03c8: ldstr "Could not find a matching closing </"
+			IL_03cd: ldloc.s 14
+			IL_03cf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03d4: stloc.s 14
+			IL_03d6: ldloc.s 14
+			IL_03d8: ldstr "> for id '"
+			IL_03dd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03e2: stloc.s 14
+			IL_03e4: ldarg.3
+			IL_03e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03ea: stloc.s 22
+			IL_03ec: ldloc.s 14
+			IL_03ee: ldloc.s 22
+			IL_03f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f5: stloc.s 22
+			IL_03f7: ldloc.s 22
+			IL_03f9: ldstr "'."
+			IL_03fe: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0403: stloc.s 22
+			IL_0405: ldloc.s 22
+			IL_0407: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0411: stloc.s 15
+			IL_0413: ldloc.s 15
+			IL_0415: stloc.s 13
+			IL_0417: ldloc.s 13
+			IL_0419: isinst [System.Runtime]System.Exception
+			IL_041e: dup
+			IL_041f: brtrue IL_042d
 
-			IL_042b: pop
-			IL_042c: ldloc.s 14
-			IL_042e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0433: throw
+			IL_0424: pop
+			IL_0425: ldloc.s 13
+			IL_0427: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_042c: throw
 
-			IL_0434: throw
+			IL_042d: throw
 
-			IL_0435: ldnull
-			IL_0436: ret
+			IL_042e: ldnull
+			IL_042f: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3429,7 +3417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x482d
+					// Method begins at RVA 0x47a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3447,7 +3435,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4824
+				// Method begins at RVA 0x479c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3475,7 +3463,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x30a4
+			// Method begins at RVA 0x306c
 			// Header size: 12
 			// Code size: 516 (0x204)
 			.maxstack 8
@@ -3703,7 +3691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4836
+				// Method begins at RVA 0x47ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3729,7 +3717,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32b4
+			// Method begins at RVA 0x327c
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -3836,7 +3824,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4848
+					// Method begins at RVA 0x47c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3856,7 +3844,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4851
+					// Method begins at RVA 0x47c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3876,7 +3864,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x485a
+					// Method begins at RVA 0x47d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3900,7 +3888,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x486c
+						// Method begins at RVA 0x47e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3920,7 +3908,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4875
+						// Method begins at RVA 0x47ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3938,7 +3926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4863
+					// Method begins at RVA 0x47db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3958,7 +3946,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x487e
+					// Method begins at RVA 0x47f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3978,7 +3966,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4887
+					// Method begins at RVA 0x47ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4018,7 +4006,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x483f
+				// Method begins at RVA 0x47b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4042,9 +4030,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3358
+			// Method begins at RVA 0x3320
 			// Header size: 12
-			// Code size: 3116 (0xc2c)
+			// Code size: 3044 (0xbe4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4058,29 +4046,27 @@
 				[8] object,
 				[9] object,
 				[10] string,
-				[11] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17,
+				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9,
+				[17] object,
 				[18] object,
 				[19] object,
 				[20] object,
 				[21] object,
-				[22] object,
+				[22] object[],
 				[23] object,
-				[24] object[],
+				[24] bool,
 				[25] object,
-				[26] bool,
-				[27] object,
-				[28] object,
-				[29] string,
-				[30] string,
-				[31] object,
-				[32] object,
-				[33] object
+				[26] object,
+				[27] string,
+				[28] string,
+				[29] object,
+				[30] object,
+				[31] object
 			)
 
 			IL_0000: ldarg.0
@@ -4113,14 +4099,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 33
+			IL_0048: ldc.i4.s 31
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0144
+			IL_005b: ble IL_012e
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -4168,1320 +4154,1282 @@
 			IL_009b: dup
 			IL_009c: ldc.i4.s 10
 			IL_009e: ldelem.ref
-			IL_009f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17
-			IL_00a4: stloc.s 11
-			IL_00a6: dup
-			IL_00a7: ldc.i4.s 11
-			IL_00a9: ldelem.ref
-			IL_00aa: stloc.s 12
-			IL_00ac: dup
-			IL_00ad: ldc.i4.s 12
-			IL_00af: ldelem.ref
-			IL_00b0: stloc.s 13
-			IL_00b2: dup
-			IL_00b3: ldc.i4.s 13
-			IL_00b5: ldelem.ref
-			IL_00b6: stloc.s 14
-			IL_00b8: dup
-			IL_00b9: ldc.i4.s 14
-			IL_00bb: ldelem.ref
-			IL_00bc: stloc.s 15
-			IL_00be: dup
-			IL_00bf: ldc.i4.s 15
-			IL_00c1: ldelem.ref
-			IL_00c2: stloc.s 16
-			IL_00c4: dup
-			IL_00c5: ldc.i4.s 16
-			IL_00c7: ldelem.ref
-			IL_00c8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9
-			IL_00cd: stloc.s 17
-			IL_00cf: dup
-			IL_00d0: ldc.i4.s 17
-			IL_00d2: ldelem.ref
-			IL_00d3: stloc.s 18
-			IL_00d5: dup
-			IL_00d6: ldc.i4.s 18
-			IL_00d8: ldelem.ref
-			IL_00d9: stloc.s 19
-			IL_00db: dup
-			IL_00dc: ldc.i4.s 19
-			IL_00de: ldelem.ref
-			IL_00df: stloc.s 20
-			IL_00e1: dup
-			IL_00e2: ldc.i4.s 20
-			IL_00e4: ldelem.ref
-			IL_00e5: stloc.s 21
-			IL_00e7: dup
-			IL_00e8: ldc.i4.s 21
-			IL_00ea: ldelem.ref
-			IL_00eb: stloc.s 22
-			IL_00ed: dup
-			IL_00ee: ldc.i4.s 22
-			IL_00f0: ldelem.ref
-			IL_00f1: stloc.s 23
-			IL_00f3: dup
-			IL_00f4: ldc.i4.s 23
-			IL_00f6: ldelem.ref
-			IL_00f7: castclass object[]
-			IL_00fc: stloc.s 24
-			IL_00fe: dup
-			IL_00ff: ldc.i4.s 24
-			IL_0101: ldelem.ref
-			IL_0102: stloc.s 25
-			IL_0104: dup
-			IL_0105: ldc.i4.s 25
-			IL_0107: ldelem.ref
-			IL_0108: unbox.any [System.Runtime]System.Boolean
-			IL_010d: stloc.s 26
-			IL_010f: dup
-			IL_0110: ldc.i4.s 26
-			IL_0112: ldelem.ref
-			IL_0113: stloc.s 27
-			IL_0115: dup
-			IL_0116: ldc.i4.s 27
-			IL_0118: ldelem.ref
+			IL_009f: stloc.s 11
+			IL_00a1: dup
+			IL_00a2: ldc.i4.s 11
+			IL_00a4: ldelem.ref
+			IL_00a5: stloc.s 12
+			IL_00a7: dup
+			IL_00a8: ldc.i4.s 12
+			IL_00aa: ldelem.ref
+			IL_00ab: stloc.s 13
+			IL_00ad: dup
+			IL_00ae: ldc.i4.s 13
+			IL_00b0: ldelem.ref
+			IL_00b1: stloc.s 14
+			IL_00b3: dup
+			IL_00b4: ldc.i4.s 14
+			IL_00b6: ldelem.ref
+			IL_00b7: stloc.s 15
+			IL_00b9: dup
+			IL_00ba: ldc.i4.s 15
+			IL_00bc: ldelem.ref
+			IL_00bd: stloc.s 16
+			IL_00bf: dup
+			IL_00c0: ldc.i4.s 16
+			IL_00c2: ldelem.ref
+			IL_00c3: stloc.s 17
+			IL_00c5: dup
+			IL_00c6: ldc.i4.s 17
+			IL_00c8: ldelem.ref
+			IL_00c9: stloc.s 18
+			IL_00cb: dup
+			IL_00cc: ldc.i4.s 18
+			IL_00ce: ldelem.ref
+			IL_00cf: stloc.s 19
+			IL_00d1: dup
+			IL_00d2: ldc.i4.s 19
+			IL_00d4: ldelem.ref
+			IL_00d5: stloc.s 20
+			IL_00d7: dup
+			IL_00d8: ldc.i4.s 20
+			IL_00da: ldelem.ref
+			IL_00db: stloc.s 21
+			IL_00dd: dup
+			IL_00de: ldc.i4.s 21
+			IL_00e0: ldelem.ref
+			IL_00e1: castclass object[]
+			IL_00e6: stloc.s 22
+			IL_00e8: dup
+			IL_00e9: ldc.i4.s 22
+			IL_00eb: ldelem.ref
+			IL_00ec: stloc.s 23
+			IL_00ee: dup
+			IL_00ef: ldc.i4.s 23
+			IL_00f1: ldelem.ref
+			IL_00f2: unbox.any [System.Runtime]System.Boolean
+			IL_00f7: stloc.s 24
+			IL_00f9: dup
+			IL_00fa: ldc.i4.s 24
+			IL_00fc: ldelem.ref
+			IL_00fd: stloc.s 25
+			IL_00ff: dup
+			IL_0100: ldc.i4.s 25
+			IL_0102: ldelem.ref
+			IL_0103: stloc.s 26
+			IL_0105: dup
+			IL_0106: ldc.i4.s 26
+			IL_0108: ldelem.ref
+			IL_0109: castclass [System.Runtime]System.String
+			IL_010e: stloc.s 27
+			IL_0110: dup
+			IL_0111: ldc.i4.s 27
+			IL_0113: ldelem.ref
+			IL_0114: castclass [System.Runtime]System.String
 			IL_0119: stloc.s 28
 			IL_011b: dup
 			IL_011c: ldc.i4.s 28
 			IL_011e: ldelem.ref
-			IL_011f: castclass [System.Runtime]System.String
-			IL_0124: stloc.s 29
-			IL_0126: dup
-			IL_0127: ldc.i4.s 29
-			IL_0129: ldelem.ref
-			IL_012a: castclass [System.Runtime]System.String
-			IL_012f: stloc.s 30
-			IL_0131: dup
-			IL_0132: ldc.i4.s 30
-			IL_0134: ldelem.ref
-			IL_0135: stloc.s 31
-			IL_0137: dup
-			IL_0138: ldc.i4.s 31
-			IL_013a: ldelem.ref
-			IL_013b: stloc.s 32
-			IL_013d: dup
-			IL_013e: ldc.i4.s 32
-			IL_0140: ldelem.ref
-			IL_0141: stloc.s 33
-			IL_0143: pop
+			IL_011f: stloc.s 29
+			IL_0121: dup
+			IL_0122: ldc.i4.s 29
+			IL_0124: ldelem.ref
+			IL_0125: stloc.s 30
+			IL_0127: dup
+			IL_0128: ldc.i4.s 30
+			IL_012a: ldelem.ref
+			IL_012b: stloc.s 31
+			IL_012d: pop
 
-			IL_0144: ldloc.0
-			IL_0145: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_014a: switch (IL_015f, IL_04fb, IL_0775, IL_0909)
+			IL_012e: ldloc.0
+			IL_012f: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0134: switch (IL_0149, IL_04d2, IL_0740, IL_08c1)
 
-			IL_015f: ldarg.0
-			IL_0160: ldc.i4.1
-			IL_0161: ldelem.ref
-			IL_0162: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0167: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
-			IL_016c: stloc.s 23
-			IL_016e: ldc.i4.1
-			IL_016f: newarr [System.Runtime]System.Object
-			IL_0174: dup
-			IL_0175: ldc.i4.0
-			IL_0176: ldarg.0
-			IL_0177: ldc.i4.1
-			IL_0178: ldelem.ref
-			IL_0179: stelem.ref
-			IL_017a: stloc.s 24
-			IL_017c: ldstr "process"
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0186: stloc.s 25
-			IL_0188: ldloc.s 25
-			IL_018a: ldstr "argv"
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0194: stloc.s 25
-			IL_0196: ldloc.s 23
-			IL_0198: ldloc.s 24
-			IL_019a: ldloc.s 25
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01a1: stloc.s 25
-			IL_01a3: ldloc.s 25
-			IL_01a5: stloc.1
-			IL_01a6: ldloc.1
-			IL_01a7: ldstr "section"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01b6: ldc.i4.0
-			IL_01b7: ceq
-			IL_01b9: stloc.s 26
-			IL_01bb: ldloc.s 26
-			IL_01bd: brfalse IL_0205
+			IL_0149: ldarg.0
+			IL_014a: ldc.i4.1
+			IL_014b: ldelem.ref
+			IL_014c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0151: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
+			IL_0156: stloc.s 21
+			IL_0158: ldc.i4.1
+			IL_0159: newarr [System.Runtime]System.Object
+			IL_015e: dup
+			IL_015f: ldc.i4.0
+			IL_0160: ldarg.0
+			IL_0161: ldc.i4.1
+			IL_0162: ldelem.ref
+			IL_0163: stelem.ref
+			IL_0164: stloc.s 22
+			IL_0166: ldstr "process"
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0170: stloc.s 23
+			IL_0172: ldloc.s 23
+			IL_0174: ldstr "argv"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017e: stloc.s 23
+			IL_0180: ldloc.s 21
+			IL_0182: ldloc.s 22
+			IL_0184: ldloc.s 23
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_018b: stloc.s 23
+			IL_018d: ldloc.s 23
+			IL_018f: stloc.1
+			IL_0190: ldloc.1
+			IL_0191: ldstr "section"
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01a0: ldc.i4.0
+			IL_01a1: ceq
+			IL_01a3: stloc.s 24
+			IL_01a5: ldloc.s 24
+			IL_01a7: brfalse IL_01ef
 
-			IL_01c2: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01d1: stloc.s 25
-			IL_01d3: ldloc.s 25
-			IL_01d5: stloc.2
-			IL_01d6: ldloc.0
-			IL_01d7: ldc.i4.m1
-			IL_01d8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01dd: ldloc.0
-			IL_01de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01e8: ldarg.0
-			IL_01e9: ldc.i4.1
-			IL_01ea: newarr [System.Runtime]System.Object
-			IL_01ef: dup
-			IL_01f0: ldc.i4.0
-			IL_01f1: ldloc.2
-			IL_01f2: stelem.ref
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01f8: pop
-			IL_01f9: ldloc.0
-			IL_01fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0204: ret
+			IL_01ac: ldstr "Missing required --section (e.g. 27.3)."
+			IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01bb: stloc.s 23
+			IL_01bd: ldloc.s 23
+			IL_01bf: stloc.2
+			IL_01c0: ldloc.0
+			IL_01c1: ldc.i4.m1
+			IL_01c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c7: ldloc.0
+			IL_01c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01d2: ldarg.0
+			IL_01d3: ldc.i4.1
+			IL_01d4: newarr [System.Runtime]System.Object
+			IL_01d9: dup
+			IL_01da: ldc.i4.0
+			IL_01db: ldloc.2
+			IL_01dc: stelem.ref
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01e2: pop
+			IL_01e3: ldloc.0
+			IL_01e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ee: ret
 
-			IL_0205: ldloc.1
-			IL_0206: ldstr "outFile"
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0215: ldc.i4.0
-			IL_0216: ceq
-			IL_0218: stloc.s 26
-			IL_021a: ldloc.s 26
-			IL_021c: brfalse IL_0264
+			IL_01ef: ldloc.1
+			IL_01f0: ldstr "outFile"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fa: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01ff: ldc.i4.0
+			IL_0200: ceq
+			IL_0202: stloc.s 24
+			IL_0204: ldloc.s 24
+			IL_0206: brfalse IL_024e
 
-			IL_0221: ldstr "Missing required --out <output.html>."
-			IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0230: stloc.s 25
-			IL_0232: ldloc.s 25
-			IL_0234: stloc.3
-			IL_0235: ldloc.0
-			IL_0236: ldc.i4.m1
-			IL_0237: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_023c: ldloc.0
-			IL_023d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0242: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0247: ldarg.0
-			IL_0248: ldc.i4.1
-			IL_0249: newarr [System.Runtime]System.Object
-			IL_024e: dup
-			IL_024f: ldc.i4.0
-			IL_0250: ldloc.3
-			IL_0251: stelem.ref
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0257: pop
-			IL_0258: ldloc.0
-			IL_0259: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_025e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0263: ret
+			IL_020b: ldstr "Missing required --out <output.html>."
+			IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_021a: stloc.s 23
+			IL_021c: ldloc.s 23
+			IL_021e: stloc.3
+			IL_021f: ldloc.0
+			IL_0220: ldc.i4.m1
+			IL_0221: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0226: ldloc.0
+			IL_0227: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0231: ldarg.0
+			IL_0232: ldc.i4.1
+			IL_0233: newarr [System.Runtime]System.Object
+			IL_0238: dup
+			IL_0239: ldc.i4.0
+			IL_023a: ldloc.3
+			IL_023b: stelem.ref
+			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0241: pop
+			IL_0242: ldloc.0
+			IL_0243: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0248: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_024d: ret
 
-			IL_0264: ldloc.1
-			IL_0265: ldstr "url"
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0274: stloc.s 26
-			IL_0276: ldloc.s 26
-			IL_0278: brfalse IL_0292
+			IL_024e: ldloc.1
+			IL_024f: ldstr "url"
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_025e: stloc.s 24
+			IL_0260: ldloc.s 24
+			IL_0262: brfalse IL_027c
 
-			IL_027d: ldc.r8 1
-			IL_0286: box [System.Runtime]System.Double
-			IL_028b: stloc.s 4
-			IL_028d: br IL_02a2
+			IL_0267: ldc.r8 1
+			IL_0270: box [System.Runtime]System.Double
+			IL_0275: stloc.s 4
+			IL_0277: br IL_028c
 
-			IL_0292: ldc.r8 0.0
-			IL_029b: box [System.Runtime]System.Double
-			IL_02a0: stloc.s 4
+			IL_027c: ldc.r8 0.0
+			IL_0285: box [System.Runtime]System.Double
+			IL_028a: stloc.s 4
 
-			IL_02a2: ldloc.s 4
-			IL_02a4: stloc.s 27
-			IL_02a6: ldloc.1
-			IL_02a7: ldstr "auto"
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02b6: stloc.s 26
-			IL_02b8: ldloc.s 26
-			IL_02ba: brfalse IL_02d4
+			IL_028c: ldloc.s 4
+			IL_028e: stloc.s 25
+			IL_0290: ldloc.1
+			IL_0291: ldstr "auto"
+			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a0: stloc.s 24
+			IL_02a2: ldloc.s 24
+			IL_02a4: brfalse IL_02be
 
-			IL_02bf: ldc.r8 1
-			IL_02c8: box [System.Runtime]System.Double
-			IL_02cd: stloc.s 5
-			IL_02cf: br IL_02e4
+			IL_02a9: ldc.r8 1
+			IL_02b2: box [System.Runtime]System.Double
+			IL_02b7: stloc.s 5
+			IL_02b9: br IL_02ce
 
-			IL_02d4: ldc.r8 0.0
-			IL_02dd: box [System.Runtime]System.Double
-			IL_02e2: stloc.s 5
+			IL_02be: ldc.r8 0.0
+			IL_02c7: box [System.Runtime]System.Double
+			IL_02cc: stloc.s 5
 
-			IL_02e4: ldloc.s 27
-			IL_02e6: ldloc.s 5
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ed: stloc.s 27
-			IL_02ef: ldloc.s 27
-			IL_02f1: stloc.s 6
-			IL_02f3: ldloc.s 6
-			IL_02f5: stloc.s 27
-			IL_02f7: ldloc.s 27
-			IL_02f9: ldc.r8 1
-			IL_0302: box [System.Runtime]System.Double
-			IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_030c: stloc.s 26
-			IL_030e: ldloc.s 26
-			IL_0310: brfalse IL_035a
+			IL_02ce: ldloc.s 25
+			IL_02d0: ldloc.s 5
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d7: stloc.s 25
+			IL_02d9: ldloc.s 25
+			IL_02db: stloc.s 6
+			IL_02dd: ldloc.s 6
+			IL_02df: stloc.s 25
+			IL_02e1: ldloc.s 25
+			IL_02e3: ldc.r8 1
+			IL_02ec: box [System.Runtime]System.Double
+			IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02f6: stloc.s 24
+			IL_02f8: ldloc.s 24
+			IL_02fa: brfalse IL_0344
 
-			IL_0315: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_031a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_031f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0324: stloc.s 25
-			IL_0326: ldloc.s 25
-			IL_0328: stloc.s 7
-			IL_032a: ldloc.0
-			IL_032b: ldc.i4.m1
-			IL_032c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0331: ldloc.0
-			IL_0332: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_033c: ldarg.0
-			IL_033d: ldc.i4.1
-			IL_033e: newarr [System.Runtime]System.Object
-			IL_0343: dup
-			IL_0344: ldc.i4.0
-			IL_0345: ldloc.s 7
-			IL_0347: stelem.ref
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_034d: pop
-			IL_034e: ldloc.0
-			IL_034f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0354: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0359: ret
+			IL_02ff: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0304: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0309: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_030e: stloc.s 23
+			IL_0310: ldloc.s 23
+			IL_0312: stloc.s 7
+			IL_0314: ldloc.0
+			IL_0315: ldc.i4.m1
+			IL_0316: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_031b: ldloc.0
+			IL_031c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0321: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0326: ldarg.0
+			IL_0327: ldc.i4.1
+			IL_0328: newarr [System.Runtime]System.Object
+			IL_032d: dup
+			IL_032e: ldc.i4.0
+			IL_032f: ldloc.s 7
+			IL_0331: stelem.ref
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0337: pop
+			IL_0338: ldloc.0
+			IL_0339: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_033e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0343: ret
 
-			IL_035a: ldnull
-			IL_035b: stloc.s 8
-			IL_035d: ldloc.1
-			IL_035e: ldstr "id"
-			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0368: stloc.s 25
-			IL_036a: ldloc.s 25
-			IL_036c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0371: stloc.s 26
-			IL_0373: ldloc.s 26
-			IL_0375: brtrue IL_0386
+			IL_0344: ldnull
+			IL_0345: stloc.s 8
+			IL_0347: ldloc.1
+			IL_0348: ldstr "id"
+			IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0352: stloc.s 23
+			IL_0354: ldloc.s 23
+			IL_0356: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_035b: stloc.s 24
+			IL_035d: ldloc.s 24
+			IL_035f: brtrue IL_0370
 
-			IL_037a: ldstr ""
-			IL_037f: stloc.s 28
-			IL_0381: br IL_038a
+			IL_0364: ldstr ""
+			IL_0369: stloc.s 26
+			IL_036b: br IL_0374
 
-			IL_0386: ldloc.s 25
-			IL_0388: stloc.s 28
+			IL_0370: ldloc.s 23
+			IL_0372: stloc.s 26
 
-			IL_038a: ldloc.s 28
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0391: stloc.s 25
-			IL_0393: ldloc.s 25
-			IL_0395: castclass [System.Runtime]System.String
-			IL_039a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_039f: stloc.s 29
-			IL_03a1: ldloc.s 29
-			IL_03a3: stloc.s 9
-			IL_03a5: ldstr ""
-			IL_03aa: stloc.s 10
-			IL_03ac: ldloc.1
-			IL_03ad: ldstr "auto"
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03bc: stloc.s 26
-			IL_03be: ldloc.s 26
-			IL_03c0: brfalse IL_07d3
+			IL_0374: ldloc.s 26
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037b: stloc.s 23
+			IL_037d: ldloc.s 23
+			IL_037f: castclass [System.Runtime]System.String
+			IL_0384: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0389: stloc.s 27
+			IL_038b: ldloc.s 27
+			IL_038d: stloc.s 9
+			IL_038f: ldstr ""
+			IL_0394: stloc.s 10
+			IL_0396: ldloc.1
+			IL_0397: ldstr "auto"
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a6: stloc.s 24
+			IL_03a8: ldloc.s 24
+			IL_03aa: brfalse IL_079e
 
-			IL_03c5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_03ca: stloc.s 11
-			IL_03cc: ldloc.1
-			IL_03cd: ldstr "indexUrl"
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03dc: stloc.s 25
-			IL_03de: ldloc.s 25
-			IL_03e0: ldstr "trim"
-			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03ea: stloc.s 25
-			IL_03ec: ldloc.s 25
-			IL_03ee: stloc.s 12
-			IL_03f0: ldarg.0
-			IL_03f1: ldc.i4.1
-			IL_03f2: ldelem.ref
-			IL_03f3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03f8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_03fd: ldc.i4.1
-			IL_03fe: newarr [System.Runtime]System.Object
-			IL_0403: dup
-			IL_0404: ldc.i4.0
-			IL_0405: ldarg.0
-			IL_0406: ldc.i4.1
-			IL_0407: ldelem.ref
-			IL_0408: stelem.ref
-			IL_0409: ldloc.s 12
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0410: stloc.s 25
-			IL_0412: ldloc.0
-			IL_0413: ldc.i4.1
-			IL_0414: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0419: ldloc.0
-			IL_041a: ldloc.s 25
-			IL_041c: ldarg.0
-			IL_041d: ldc.i4.1
-			IL_041e: ldloc.0
-			IL_041f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0424: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0429: ldloc.0
-			IL_042a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_042f: dup
-			IL_0430: ldc.i4.0
-			IL_0431: ldloc.1
-			IL_0432: stelem.ref
-			IL_0433: dup
-			IL_0434: ldc.i4.1
-			IL_0435: ldloc.2
+			IL_03af: ldloc.1
+			IL_03b0: ldstr "indexUrl"
+			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03bf: stloc.s 23
+			IL_03c1: ldloc.s 23
+			IL_03c3: ldstr "trim"
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03cd: stloc.s 23
+			IL_03cf: ldloc.s 23
+			IL_03d1: stloc.s 11
+			IL_03d3: ldarg.0
+			IL_03d4: ldc.i4.1
+			IL_03d5: ldelem.ref
+			IL_03d6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03db: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_03e0: ldc.i4.1
+			IL_03e1: newarr [System.Runtime]System.Object
+			IL_03e6: dup
+			IL_03e7: ldc.i4.0
+			IL_03e8: ldarg.0
+			IL_03e9: ldc.i4.1
+			IL_03ea: ldelem.ref
+			IL_03eb: stelem.ref
+			IL_03ec: ldloc.s 11
+			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03f3: stloc.s 23
+			IL_03f5: ldloc.0
+			IL_03f6: ldc.i4.1
+			IL_03f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03fc: ldloc.0
+			IL_03fd: ldloc.s 23
+			IL_03ff: ldarg.0
+			IL_0400: ldc.i4.1
+			IL_0401: ldloc.0
+			IL_0402: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0407: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_040c: ldloc.0
+			IL_040d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0412: dup
+			IL_0413: ldc.i4.0
+			IL_0414: ldloc.1
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.1
+			IL_0418: ldloc.2
+			IL_0419: stelem.ref
+			IL_041a: dup
+			IL_041b: ldc.i4.2
+			IL_041c: ldloc.3
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.3
+			IL_0420: ldloc.s 4
+			IL_0422: stelem.ref
+			IL_0423: dup
+			IL_0424: ldc.i4.4
+			IL_0425: ldloc.s 5
+			IL_0427: stelem.ref
+			IL_0428: dup
+			IL_0429: ldc.i4.5
+			IL_042a: ldloc.s 6
+			IL_042c: stelem.ref
+			IL_042d: dup
+			IL_042e: ldc.i4.6
+			IL_042f: ldloc.s 7
+			IL_0431: stelem.ref
+			IL_0432: dup
+			IL_0433: ldc.i4.7
+			IL_0434: ldloc.s 8
 			IL_0436: stelem.ref
 			IL_0437: dup
-			IL_0438: ldc.i4.2
-			IL_0439: ldloc.3
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.3
-			IL_043d: ldloc.s 4
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.4
-			IL_0442: ldloc.s 5
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.5
-			IL_0447: ldloc.s 6
-			IL_0449: stelem.ref
-			IL_044a: dup
-			IL_044b: ldc.i4.6
-			IL_044c: ldloc.s 7
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.7
-			IL_0451: ldloc.s 8
+			IL_0438: ldc.i4.8
+			IL_0439: ldloc.s 9
+			IL_043b: stelem.ref
+			IL_043c: dup
+			IL_043d: ldc.i4.s 9
+			IL_043f: ldloc.s 10
+			IL_0441: stelem.ref
+			IL_0442: dup
+			IL_0443: ldc.i4.s 10
+			IL_0445: ldloc.s 11
+			IL_0447: stelem.ref
+			IL_0448: dup
+			IL_0449: ldc.i4.s 11
+			IL_044b: ldloc.s 12
+			IL_044d: stelem.ref
+			IL_044e: dup
+			IL_044f: ldc.i4.s 12
+			IL_0451: ldloc.s 13
 			IL_0453: stelem.ref
 			IL_0454: dup
-			IL_0455: ldc.i4.8
-			IL_0456: ldloc.s 9
-			IL_0458: stelem.ref
-			IL_0459: dup
-			IL_045a: ldc.i4.s 9
-			IL_045c: ldloc.s 10
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.s 10
-			IL_0462: ldloc.s 11
-			IL_0464: stelem.ref
-			IL_0465: dup
-			IL_0466: ldc.i4.s 11
-			IL_0468: ldloc.s 12
-			IL_046a: stelem.ref
-			IL_046b: dup
-			IL_046c: ldc.i4.s 12
-			IL_046e: ldloc.s 13
-			IL_0470: stelem.ref
-			IL_0471: dup
-			IL_0472: ldc.i4.s 13
-			IL_0474: ldloc.s 14
-			IL_0476: stelem.ref
-			IL_0477: dup
-			IL_0478: ldc.i4.s 14
-			IL_047a: ldloc.s 15
-			IL_047c: stelem.ref
-			IL_047d: dup
-			IL_047e: ldc.i4.s 15
-			IL_0480: ldloc.s 16
-			IL_0482: stelem.ref
-			IL_0483: dup
-			IL_0484: ldc.i4.s 16
-			IL_0486: ldloc.s 17
-			IL_0488: stelem.ref
-			IL_0489: dup
-			IL_048a: ldc.i4.s 17
-			IL_048c: ldloc.s 18
-			IL_048e: stelem.ref
-			IL_048f: dup
-			IL_0490: ldc.i4.s 18
-			IL_0492: ldloc.s 19
-			IL_0494: stelem.ref
-			IL_0495: dup
-			IL_0496: ldc.i4.s 19
-			IL_0498: ldloc.s 20
+			IL_0455: ldc.i4.s 13
+			IL_0457: ldloc.s 14
+			IL_0459: stelem.ref
+			IL_045a: dup
+			IL_045b: ldc.i4.s 14
+			IL_045d: ldloc.s 15
+			IL_045f: stelem.ref
+			IL_0460: dup
+			IL_0461: ldc.i4.s 15
+			IL_0463: ldloc.s 16
+			IL_0465: stelem.ref
+			IL_0466: dup
+			IL_0467: ldc.i4.s 16
+			IL_0469: ldloc.s 17
+			IL_046b: stelem.ref
+			IL_046c: dup
+			IL_046d: ldc.i4.s 17
+			IL_046f: ldloc.s 18
+			IL_0471: stelem.ref
+			IL_0472: dup
+			IL_0473: ldc.i4.s 18
+			IL_0475: ldloc.s 19
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.s 19
+			IL_047b: ldloc.s 20
+			IL_047d: stelem.ref
+			IL_047e: dup
+			IL_047f: ldc.i4.s 20
+			IL_0481: ldloc.s 21
+			IL_0483: stelem.ref
+			IL_0484: dup
+			IL_0485: ldc.i4.s 21
+			IL_0487: ldloc.s 22
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.s 22
+			IL_048d: ldloc.s 23
+			IL_048f: stelem.ref
+			IL_0490: dup
+			IL_0491: ldc.i4.s 23
+			IL_0493: ldloc.s 24
+			IL_0495: box [System.Runtime]System.Boolean
 			IL_049a: stelem.ref
 			IL_049b: dup
-			IL_049c: ldc.i4.s 20
-			IL_049e: ldloc.s 21
+			IL_049c: ldc.i4.s 24
+			IL_049e: ldloc.s 25
 			IL_04a0: stelem.ref
 			IL_04a1: dup
-			IL_04a2: ldc.i4.s 21
-			IL_04a4: ldloc.s 22
+			IL_04a2: ldc.i4.s 25
+			IL_04a4: ldloc.s 26
 			IL_04a6: stelem.ref
 			IL_04a7: dup
-			IL_04a8: ldc.i4.s 22
-			IL_04aa: ldloc.s 23
+			IL_04a8: ldc.i4.s 26
+			IL_04aa: ldloc.s 27
 			IL_04ac: stelem.ref
 			IL_04ad: dup
-			IL_04ae: ldc.i4.s 23
-			IL_04b0: ldloc.s 24
+			IL_04ae: ldc.i4.s 27
+			IL_04b0: ldloc.s 28
 			IL_04b2: stelem.ref
 			IL_04b3: dup
-			IL_04b4: ldc.i4.s 24
-			IL_04b6: ldloc.s 25
+			IL_04b4: ldc.i4.s 28
+			IL_04b6: ldloc.s 29
 			IL_04b8: stelem.ref
 			IL_04b9: dup
-			IL_04ba: ldc.i4.s 25
-			IL_04bc: ldloc.s 26
-			IL_04be: box [System.Runtime]System.Boolean
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 26
-			IL_04c7: ldloc.s 27
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 27
-			IL_04cd: ldloc.s 28
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.s 28
-			IL_04d3: ldloc.s 29
-			IL_04d5: stelem.ref
-			IL_04d6: dup
-			IL_04d7: ldc.i4.s 29
-			IL_04d9: ldloc.s 30
-			IL_04db: stelem.ref
-			IL_04dc: dup
-			IL_04dd: ldc.i4.s 30
-			IL_04df: ldloc.s 31
-			IL_04e1: stelem.ref
-			IL_04e2: dup
-			IL_04e3: ldc.i4.s 31
-			IL_04e5: ldloc.s 32
-			IL_04e7: stelem.ref
-			IL_04e8: dup
-			IL_04e9: ldc.i4.s 32
-			IL_04eb: ldloc.s 33
-			IL_04ed: stelem.ref
-			IL_04ee: pop
-			IL_04ef: ldloc.0
-			IL_04f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04fa: ret
+			IL_04ba: ldc.i4.s 29
+			IL_04bc: ldloc.s 30
+			IL_04be: stelem.ref
+			IL_04bf: dup
+			IL_04c0: ldc.i4.s 30
+			IL_04c2: ldloc.s 31
+			IL_04c4: stelem.ref
+			IL_04c5: pop
+			IL_04c6: ldloc.0
+			IL_04c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04d1: ret
 
-			IL_04fb: ldloc.0
-			IL_04fc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0501: stloc.s 25
-			IL_0503: ldloc.s 25
-			IL_0505: stloc.s 13
-			IL_0507: ldarg.0
-			IL_0508: ldc.i4.1
-			IL_0509: ldelem.ref
-			IL_050a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_050f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_0514: stloc.s 25
-			IL_0516: ldc.i4.1
-			IL_0517: newarr [System.Runtime]System.Object
-			IL_051c: dup
-			IL_051d: ldc.i4.0
-			IL_051e: ldarg.0
-			IL_051f: ldc.i4.1
-			IL_0520: ldelem.ref
-			IL_0521: stelem.ref
-			IL_0522: stloc.s 24
-			IL_0524: ldloc.1
-			IL_0525: ldstr "section"
-			IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0534: stloc.s 23
-			IL_0536: ldloc.s 23
-			IL_0538: ldstr "trim"
-			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0542: stloc.s 23
-			IL_0544: ldloc.s 25
-			IL_0546: ldloc.s 24
-			IL_0548: ldloc.s 13
-			IL_054a: ldloc.s 23
-			IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0551: stloc.s 23
-			IL_0553: ldloc.s 23
-			IL_0555: stloc.s 14
-			IL_0557: ldloc.s 14
-			IL_0559: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_055e: ldc.i4.0
-			IL_055f: ceq
-			IL_0561: stloc.s 26
-			IL_0563: ldloc.s 26
-			IL_0565: brfalse IL_05ee
+			IL_04d2: ldloc.0
+			IL_04d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04d8: stloc.s 23
+			IL_04da: ldloc.s 23
+			IL_04dc: stloc.s 12
+			IL_04de: ldarg.0
+			IL_04df: ldc.i4.1
+			IL_04e0: ldelem.ref
+			IL_04e1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04e6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_04eb: stloc.s 23
+			IL_04ed: ldc.i4.1
+			IL_04ee: newarr [System.Runtime]System.Object
+			IL_04f3: dup
+			IL_04f4: ldc.i4.0
+			IL_04f5: ldarg.0
+			IL_04f6: ldc.i4.1
+			IL_04f7: ldelem.ref
+			IL_04f8: stelem.ref
+			IL_04f9: stloc.s 22
+			IL_04fb: ldloc.1
+			IL_04fc: ldstr "section"
+			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_050b: stloc.s 21
+			IL_050d: ldloc.s 21
+			IL_050f: ldstr "trim"
+			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0519: stloc.s 21
+			IL_051b: ldloc.s 23
+			IL_051d: ldloc.s 22
+			IL_051f: ldloc.s 12
+			IL_0521: ldloc.s 21
+			IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0528: stloc.s 21
+			IL_052a: ldloc.s 21
+			IL_052c: stloc.s 13
+			IL_052e: ldloc.s 13
+			IL_0530: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0535: ldc.i4.0
+			IL_0536: ceq
+			IL_0538: stloc.s 24
+			IL_053a: ldloc.s 24
+			IL_053c: brfalse IL_05c5
 
-			IL_056a: ldloc.1
-			IL_056b: ldstr "section"
-			IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0575: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_057a: stloc.s 29
-			IL_057c: ldstr "Could not find section '"
-			IL_0581: ldloc.s 29
-			IL_0583: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0588: stloc.s 29
-			IL_058a: ldloc.s 29
-			IL_058c: ldstr "' in multipage index: "
-			IL_0591: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0596: stloc.s 29
-			IL_0598: ldloc.s 12
-			IL_059a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_059f: stloc.s 30
-			IL_05a1: ldloc.s 29
-			IL_05a3: ldloc.s 30
-			IL_05a5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05aa: stloc.s 30
-			IL_05ac: ldloc.s 30
-			IL_05ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_05b8: stloc.s 23
-			IL_05ba: ldloc.s 23
-			IL_05bc: stloc.s 15
-			IL_05be: ldloc.0
-			IL_05bf: ldc.i4.m1
-			IL_05c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c5: ldloc.0
-			IL_05c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05d0: ldarg.0
-			IL_05d1: ldc.i4.1
-			IL_05d2: newarr [System.Runtime]System.Object
-			IL_05d7: dup
-			IL_05d8: ldc.i4.0
-			IL_05d9: ldloc.s 15
-			IL_05db: stelem.ref
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05e1: pop
-			IL_05e2: ldloc.0
-			IL_05e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ed: ret
+			IL_0541: ldloc.1
+			IL_0542: ldstr "section"
+			IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_054c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0551: stloc.s 27
+			IL_0553: ldstr "Could not find section '"
+			IL_0558: ldloc.s 27
+			IL_055a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_055f: stloc.s 27
+			IL_0561: ldloc.s 27
+			IL_0563: ldstr "' in multipage index: "
+			IL_0568: call string [System.Runtime]System.String::Concat(string, string)
+			IL_056d: stloc.s 27
+			IL_056f: ldloc.s 11
+			IL_0571: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0576: stloc.s 28
+			IL_0578: ldloc.s 27
+			IL_057a: ldloc.s 28
+			IL_057c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0581: stloc.s 28
+			IL_0583: ldloc.s 28
+			IL_0585: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_058a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_058f: stloc.s 21
+			IL_0591: ldloc.s 21
+			IL_0593: stloc.s 14
+			IL_0595: ldloc.0
+			IL_0596: ldc.i4.m1
+			IL_0597: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_059c: ldloc.0
+			IL_059d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_05a7: ldarg.0
+			IL_05a8: ldc.i4.1
+			IL_05a9: newarr [System.Runtime]System.Object
+			IL_05ae: dup
+			IL_05af: ldc.i4.0
+			IL_05b0: ldloc.s 14
+			IL_05b2: stelem.ref
+			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05b8: pop
+			IL_05b9: ldloc.0
+			IL_05ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05c4: ret
 
-			IL_05ee: ldarg.0
-			IL_05ef: ldc.i4.1
-			IL_05f0: ldelem.ref
-			IL_05f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05f6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05fb: stloc.s 23
-			IL_05fd: ldloc.s 14
-			IL_05ff: ldstr "filePart"
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0609: stloc.s 25
-			IL_060b: ldloc.s 25
-			IL_060d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0612: stloc.s 26
-			IL_0614: ldloc.s 26
-			IL_0616: brtrue IL_062e
+			IL_05c5: ldarg.0
+			IL_05c6: ldc.i4.1
+			IL_05c7: ldelem.ref
+			IL_05c8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05cd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_05d2: stloc.s 21
+			IL_05d4: ldloc.s 13
+			IL_05d6: ldstr "filePart"
+			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e0: stloc.s 23
+			IL_05e2: ldloc.s 23
+			IL_05e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05e9: stloc.s 24
+			IL_05eb: ldloc.s 24
+			IL_05ed: brtrue IL_0605
 
-			IL_061b: ldloc.s 14
-			IL_061d: ldstr "href"
-			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0627: stloc.s 31
-			IL_0629: br IL_0632
+			IL_05f2: ldloc.s 13
+			IL_05f4: ldstr "href"
+			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05fe: stloc.s 29
+			IL_0600: br IL_0609
 
-			IL_062e: ldloc.s 25
-			IL_0630: stloc.s 31
+			IL_0605: ldloc.s 23
+			IL_0607: stloc.s 29
 
-			IL_0632: ldc.i4.2
-			IL_0633: newarr [System.Runtime]System.Object
-			IL_0638: dup
-			IL_0639: ldc.i4.0
-			IL_063a: ldloc.s 31
-			IL_063c: stelem.ref
-			IL_063d: dup
-			IL_063e: ldc.i4.1
-			IL_063f: ldloc.s 12
-			IL_0641: stelem.ref
-			IL_0642: stloc.s 24
-			IL_0644: ldloc.s 23
-			IL_0646: ldloc.s 24
-			IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_064d: stloc.s 23
-			IL_064f: ldloc.s 23
-			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0656: stloc.s 23
-			IL_0658: ldloc.s 23
-			IL_065a: ldstr "toString"
-			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0664: stloc.s 23
-			IL_0666: ldloc.s 23
-			IL_0668: stloc.s 16
-			IL_066a: ldarg.0
-			IL_066b: ldc.i4.1
-			IL_066c: ldelem.ref
-			IL_066d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0672: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0677: ldc.i4.1
-			IL_0678: newarr [System.Runtime]System.Object
-			IL_067d: dup
-			IL_067e: ldc.i4.0
-			IL_067f: ldarg.0
-			IL_0680: ldc.i4.1
-			IL_0681: ldelem.ref
-			IL_0682: stelem.ref
-			IL_0683: ldloc.s 16
-			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_068a: stloc.s 23
-			IL_068c: ldloc.0
-			IL_068d: ldc.i4.2
-			IL_068e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0693: ldloc.0
-			IL_0694: ldloc.s 23
-			IL_0696: ldarg.0
-			IL_0697: ldc.i4.2
-			IL_0698: ldloc.0
-			IL_0699: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_069e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_06a3: ldloc.0
-			IL_06a4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06a9: dup
-			IL_06aa: ldc.i4.0
-			IL_06ab: ldloc.1
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.1
-			IL_06af: ldloc.2
-			IL_06b0: stelem.ref
-			IL_06b1: dup
-			IL_06b2: ldc.i4.2
-			IL_06b3: ldloc.3
-			IL_06b4: stelem.ref
-			IL_06b5: dup
-			IL_06b6: ldc.i4.3
-			IL_06b7: ldloc.s 4
-			IL_06b9: stelem.ref
-			IL_06ba: dup
-			IL_06bb: ldc.i4.4
-			IL_06bc: ldloc.s 5
-			IL_06be: stelem.ref
-			IL_06bf: dup
-			IL_06c0: ldc.i4.5
-			IL_06c1: ldloc.s 6
-			IL_06c3: stelem.ref
-			IL_06c4: dup
-			IL_06c5: ldc.i4.6
-			IL_06c6: ldloc.s 7
-			IL_06c8: stelem.ref
-			IL_06c9: dup
-			IL_06ca: ldc.i4.7
-			IL_06cb: ldloc.s 8
+			IL_0609: ldc.i4.2
+			IL_060a: newarr [System.Runtime]System.Object
+			IL_060f: dup
+			IL_0610: ldc.i4.0
+			IL_0611: ldloc.s 29
+			IL_0613: stelem.ref
+			IL_0614: dup
+			IL_0615: ldc.i4.1
+			IL_0616: ldloc.s 11
+			IL_0618: stelem.ref
+			IL_0619: stloc.s 22
+			IL_061b: ldloc.s 21
+			IL_061d: ldloc.s 22
+			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0624: stloc.s 21
+			IL_0626: ldloc.s 21
+			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_062d: stloc.s 21
+			IL_062f: ldloc.s 21
+			IL_0631: ldstr "toString"
+			IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_063b: stloc.s 21
+			IL_063d: ldloc.s 21
+			IL_063f: stloc.s 15
+			IL_0641: ldarg.0
+			IL_0642: ldc.i4.1
+			IL_0643: ldelem.ref
+			IL_0644: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0649: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_064e: ldc.i4.1
+			IL_064f: newarr [System.Runtime]System.Object
+			IL_0654: dup
+			IL_0655: ldc.i4.0
+			IL_0656: ldarg.0
+			IL_0657: ldc.i4.1
+			IL_0658: ldelem.ref
+			IL_0659: stelem.ref
+			IL_065a: ldloc.s 15
+			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0661: stloc.s 21
+			IL_0663: ldloc.0
+			IL_0664: ldc.i4.2
+			IL_0665: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_066a: ldloc.0
+			IL_066b: ldloc.s 21
+			IL_066d: ldarg.0
+			IL_066e: ldc.i4.2
+			IL_066f: ldloc.0
+			IL_0670: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0675: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_067a: ldloc.0
+			IL_067b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0680: dup
+			IL_0681: ldc.i4.0
+			IL_0682: ldloc.1
+			IL_0683: stelem.ref
+			IL_0684: dup
+			IL_0685: ldc.i4.1
+			IL_0686: ldloc.2
+			IL_0687: stelem.ref
+			IL_0688: dup
+			IL_0689: ldc.i4.2
+			IL_068a: ldloc.3
+			IL_068b: stelem.ref
+			IL_068c: dup
+			IL_068d: ldc.i4.3
+			IL_068e: ldloc.s 4
+			IL_0690: stelem.ref
+			IL_0691: dup
+			IL_0692: ldc.i4.4
+			IL_0693: ldloc.s 5
+			IL_0695: stelem.ref
+			IL_0696: dup
+			IL_0697: ldc.i4.5
+			IL_0698: ldloc.s 6
+			IL_069a: stelem.ref
+			IL_069b: dup
+			IL_069c: ldc.i4.6
+			IL_069d: ldloc.s 7
+			IL_069f: stelem.ref
+			IL_06a0: dup
+			IL_06a1: ldc.i4.7
+			IL_06a2: ldloc.s 8
+			IL_06a4: stelem.ref
+			IL_06a5: dup
+			IL_06a6: ldc.i4.8
+			IL_06a7: ldloc.s 9
+			IL_06a9: stelem.ref
+			IL_06aa: dup
+			IL_06ab: ldc.i4.s 9
+			IL_06ad: ldloc.s 10
+			IL_06af: stelem.ref
+			IL_06b0: dup
+			IL_06b1: ldc.i4.s 10
+			IL_06b3: ldloc.s 11
+			IL_06b5: stelem.ref
+			IL_06b6: dup
+			IL_06b7: ldc.i4.s 11
+			IL_06b9: ldloc.s 12
+			IL_06bb: stelem.ref
+			IL_06bc: dup
+			IL_06bd: ldc.i4.s 12
+			IL_06bf: ldloc.s 13
+			IL_06c1: stelem.ref
+			IL_06c2: dup
+			IL_06c3: ldc.i4.s 13
+			IL_06c5: ldloc.s 14
+			IL_06c7: stelem.ref
+			IL_06c8: dup
+			IL_06c9: ldc.i4.s 14
+			IL_06cb: ldloc.s 15
 			IL_06cd: stelem.ref
 			IL_06ce: dup
-			IL_06cf: ldc.i4.8
-			IL_06d0: ldloc.s 9
-			IL_06d2: stelem.ref
-			IL_06d3: dup
-			IL_06d4: ldc.i4.s 9
-			IL_06d6: ldloc.s 10
-			IL_06d8: stelem.ref
-			IL_06d9: dup
-			IL_06da: ldc.i4.s 10
-			IL_06dc: ldloc.s 11
-			IL_06de: stelem.ref
-			IL_06df: dup
-			IL_06e0: ldc.i4.s 11
-			IL_06e2: ldloc.s 12
-			IL_06e4: stelem.ref
-			IL_06e5: dup
-			IL_06e6: ldc.i4.s 12
-			IL_06e8: ldloc.s 13
-			IL_06ea: stelem.ref
-			IL_06eb: dup
-			IL_06ec: ldc.i4.s 13
-			IL_06ee: ldloc.s 14
-			IL_06f0: stelem.ref
-			IL_06f1: dup
-			IL_06f2: ldc.i4.s 14
-			IL_06f4: ldloc.s 15
-			IL_06f6: stelem.ref
-			IL_06f7: dup
-			IL_06f8: ldc.i4.s 15
-			IL_06fa: ldloc.s 16
-			IL_06fc: stelem.ref
-			IL_06fd: dup
-			IL_06fe: ldc.i4.s 16
-			IL_0700: ldloc.s 17
-			IL_0702: stelem.ref
-			IL_0703: dup
-			IL_0704: ldc.i4.s 17
-			IL_0706: ldloc.s 18
+			IL_06cf: ldc.i4.s 15
+			IL_06d1: ldloc.s 16
+			IL_06d3: stelem.ref
+			IL_06d4: dup
+			IL_06d5: ldc.i4.s 16
+			IL_06d7: ldloc.s 17
+			IL_06d9: stelem.ref
+			IL_06da: dup
+			IL_06db: ldc.i4.s 17
+			IL_06dd: ldloc.s 18
+			IL_06df: stelem.ref
+			IL_06e0: dup
+			IL_06e1: ldc.i4.s 18
+			IL_06e3: ldloc.s 19
+			IL_06e5: stelem.ref
+			IL_06e6: dup
+			IL_06e7: ldc.i4.s 19
+			IL_06e9: ldloc.s 20
+			IL_06eb: stelem.ref
+			IL_06ec: dup
+			IL_06ed: ldc.i4.s 20
+			IL_06ef: ldloc.s 21
+			IL_06f1: stelem.ref
+			IL_06f2: dup
+			IL_06f3: ldc.i4.s 21
+			IL_06f5: ldloc.s 22
+			IL_06f7: stelem.ref
+			IL_06f8: dup
+			IL_06f9: ldc.i4.s 22
+			IL_06fb: ldloc.s 23
+			IL_06fd: stelem.ref
+			IL_06fe: dup
+			IL_06ff: ldc.i4.s 23
+			IL_0701: ldloc.s 24
+			IL_0703: box [System.Runtime]System.Boolean
 			IL_0708: stelem.ref
 			IL_0709: dup
-			IL_070a: ldc.i4.s 18
-			IL_070c: ldloc.s 19
+			IL_070a: ldc.i4.s 24
+			IL_070c: ldloc.s 25
 			IL_070e: stelem.ref
 			IL_070f: dup
-			IL_0710: ldc.i4.s 19
-			IL_0712: ldloc.s 20
+			IL_0710: ldc.i4.s 25
+			IL_0712: ldloc.s 26
 			IL_0714: stelem.ref
 			IL_0715: dup
-			IL_0716: ldc.i4.s 20
-			IL_0718: ldloc.s 21
+			IL_0716: ldc.i4.s 26
+			IL_0718: ldloc.s 27
 			IL_071a: stelem.ref
 			IL_071b: dup
-			IL_071c: ldc.i4.s 21
-			IL_071e: ldloc.s 22
+			IL_071c: ldc.i4.s 27
+			IL_071e: ldloc.s 28
 			IL_0720: stelem.ref
 			IL_0721: dup
-			IL_0722: ldc.i4.s 22
-			IL_0724: ldloc.s 23
+			IL_0722: ldc.i4.s 28
+			IL_0724: ldloc.s 29
 			IL_0726: stelem.ref
 			IL_0727: dup
-			IL_0728: ldc.i4.s 23
-			IL_072a: ldloc.s 24
+			IL_0728: ldc.i4.s 29
+			IL_072a: ldloc.s 30
 			IL_072c: stelem.ref
 			IL_072d: dup
-			IL_072e: ldc.i4.s 24
-			IL_0730: ldloc.s 25
+			IL_072e: ldc.i4.s 30
+			IL_0730: ldloc.s 31
 			IL_0732: stelem.ref
-			IL_0733: dup
-			IL_0734: ldc.i4.s 25
-			IL_0736: ldloc.s 26
-			IL_0738: box [System.Runtime]System.Boolean
-			IL_073d: stelem.ref
-			IL_073e: dup
-			IL_073f: ldc.i4.s 26
-			IL_0741: ldloc.s 27
-			IL_0743: stelem.ref
-			IL_0744: dup
-			IL_0745: ldc.i4.s 27
-			IL_0747: ldloc.s 28
-			IL_0749: stelem.ref
-			IL_074a: dup
-			IL_074b: ldc.i4.s 28
-			IL_074d: ldloc.s 29
-			IL_074f: stelem.ref
-			IL_0750: dup
-			IL_0751: ldc.i4.s 29
-			IL_0753: ldloc.s 30
-			IL_0755: stelem.ref
-			IL_0756: dup
-			IL_0757: ldc.i4.s 30
-			IL_0759: ldloc.s 31
-			IL_075b: stelem.ref
-			IL_075c: dup
-			IL_075d: ldc.i4.s 31
-			IL_075f: ldloc.s 32
-			IL_0761: stelem.ref
-			IL_0762: dup
-			IL_0763: ldc.i4.s 32
-			IL_0765: ldloc.s 33
-			IL_0767: stelem.ref
-			IL_0768: pop
-			IL_0769: ldloc.0
-			IL_076a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_076f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0774: ret
+			IL_0733: pop
+			IL_0734: ldloc.0
+			IL_0735: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_073a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_073f: ret
 
-			IL_0775: ldloc.0
-			IL_0776: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_077b: stloc.s 23
-			IL_077d: ldloc.s 23
-			IL_077f: stloc.s 8
-			IL_0781: ldloc.s 16
-			IL_0783: stloc.s 23
-			IL_0785: ldloc.s 23
-			IL_0787: stloc.s 10
-			IL_0789: ldloc.s 9
-			IL_078b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0790: ldc.i4.0
-			IL_0791: ceq
-			IL_0793: stloc.s 26
-			IL_0795: ldloc.s 26
-			IL_0797: brfalse IL_07ce
+			IL_0740: ldloc.0
+			IL_0741: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0746: stloc.s 21
+			IL_0748: ldloc.s 21
+			IL_074a: stloc.s 8
+			IL_074c: ldloc.s 15
+			IL_074e: stloc.s 21
+			IL_0750: ldloc.s 21
+			IL_0752: stloc.s 10
+			IL_0754: ldloc.s 9
+			IL_0756: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_075b: ldc.i4.0
+			IL_075c: ceq
+			IL_075e: stloc.s 24
+			IL_0760: ldloc.s 24
+			IL_0762: brfalse IL_0799
 
-			IL_079c: ldloc.s 14
-			IL_079e: ldstr "fragment"
-			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a8: stloc.s 23
-			IL_07aa: ldloc.s 23
-			IL_07ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07b1: stloc.s 26
-			IL_07b3: ldloc.s 26
-			IL_07b5: brtrue IL_07c6
+			IL_0767: ldloc.s 13
+			IL_0769: ldstr "fragment"
+			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0773: stloc.s 21
+			IL_0775: ldloc.s 21
+			IL_0777: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_077c: stloc.s 24
+			IL_077e: ldloc.s 24
+			IL_0780: brtrue IL_0791
 
-			IL_07ba: ldstr ""
-			IL_07bf: stloc.s 32
-			IL_07c1: br IL_07ca
+			IL_0785: ldstr ""
+			IL_078a: stloc.s 30
+			IL_078c: br IL_0795
 
-			IL_07c6: ldloc.s 23
-			IL_07c8: stloc.s 32
+			IL_0791: ldloc.s 21
+			IL_0793: stloc.s 30
 
-			IL_07ca: ldloc.s 32
-			IL_07cc: stloc.s 9
+			IL_0795: ldloc.s 30
+			IL_0797: stloc.s 9
 
-			IL_07ce: br IL_091d
+			IL_0799: br IL_08d5
 
-			IL_07d3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_07d8: stloc.s 17
-			IL_07da: ldloc.1
-			IL_07db: ldstr "url"
-			IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ea: stloc.s 23
-			IL_07ec: ldloc.s 23
-			IL_07ee: ldstr "trim"
-			IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_07f8: stloc.s 23
-			IL_07fa: ldloc.s 23
-			IL_07fc: stloc.s 18
-			IL_07fe: ldarg.0
-			IL_07ff: ldc.i4.1
-			IL_0800: ldelem.ref
-			IL_0801: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0806: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_080b: ldc.i4.1
-			IL_080c: newarr [System.Runtime]System.Object
-			IL_0811: dup
-			IL_0812: ldc.i4.0
-			IL_0813: ldarg.0
-			IL_0814: ldc.i4.1
-			IL_0815: ldelem.ref
+			IL_079e: ldloc.1
+			IL_079f: ldstr "url"
+			IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07ae: stloc.s 21
+			IL_07b0: ldloc.s 21
+			IL_07b2: ldstr "trim"
+			IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07bc: stloc.s 21
+			IL_07be: ldloc.s 21
+			IL_07c0: stloc.s 16
+			IL_07c2: ldarg.0
+			IL_07c3: ldc.i4.1
+			IL_07c4: ldelem.ref
+			IL_07c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_07cf: ldc.i4.1
+			IL_07d0: newarr [System.Runtime]System.Object
+			IL_07d5: dup
+			IL_07d6: ldc.i4.0
+			IL_07d7: ldarg.0
+			IL_07d8: ldc.i4.1
+			IL_07d9: ldelem.ref
+			IL_07da: stelem.ref
+			IL_07db: ldloc.s 16
+			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07e2: stloc.s 21
+			IL_07e4: ldloc.0
+			IL_07e5: ldc.i4.3
+			IL_07e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07eb: ldloc.0
+			IL_07ec: ldloc.s 21
+			IL_07ee: ldarg.0
+			IL_07ef: ldc.i4.3
+			IL_07f0: ldloc.0
+			IL_07f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07fb: ldloc.0
+			IL_07fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0801: dup
+			IL_0802: ldc.i4.0
+			IL_0803: ldloc.1
+			IL_0804: stelem.ref
+			IL_0805: dup
+			IL_0806: ldc.i4.1
+			IL_0807: ldloc.2
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.2
+			IL_080b: ldloc.3
+			IL_080c: stelem.ref
+			IL_080d: dup
+			IL_080e: ldc.i4.3
+			IL_080f: ldloc.s 4
+			IL_0811: stelem.ref
+			IL_0812: dup
+			IL_0813: ldc.i4.4
+			IL_0814: ldloc.s 5
 			IL_0816: stelem.ref
-			IL_0817: ldloc.s 18
-			IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_081e: stloc.s 23
-			IL_0820: ldloc.0
-			IL_0821: ldc.i4.3
-			IL_0822: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0827: ldloc.0
-			IL_0828: ldloc.s 23
-			IL_082a: ldarg.0
-			IL_082b: ldc.i4.3
-			IL_082c: ldloc.0
-			IL_082d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0832: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0837: ldloc.0
-			IL_0838: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0817: dup
+			IL_0818: ldc.i4.5
+			IL_0819: ldloc.s 6
+			IL_081b: stelem.ref
+			IL_081c: dup
+			IL_081d: ldc.i4.6
+			IL_081e: ldloc.s 7
+			IL_0820: stelem.ref
+			IL_0821: dup
+			IL_0822: ldc.i4.7
+			IL_0823: ldloc.s 8
+			IL_0825: stelem.ref
+			IL_0826: dup
+			IL_0827: ldc.i4.8
+			IL_0828: ldloc.s 9
+			IL_082a: stelem.ref
+			IL_082b: dup
+			IL_082c: ldc.i4.s 9
+			IL_082e: ldloc.s 10
+			IL_0830: stelem.ref
+			IL_0831: dup
+			IL_0832: ldc.i4.s 10
+			IL_0834: ldloc.s 11
+			IL_0836: stelem.ref
+			IL_0837: dup
+			IL_0838: ldc.i4.s 11
+			IL_083a: ldloc.s 12
+			IL_083c: stelem.ref
 			IL_083d: dup
-			IL_083e: ldc.i4.0
-			IL_083f: ldloc.1
-			IL_0840: stelem.ref
-			IL_0841: dup
-			IL_0842: ldc.i4.1
-			IL_0843: ldloc.2
-			IL_0844: stelem.ref
-			IL_0845: dup
-			IL_0846: ldc.i4.2
-			IL_0847: ldloc.3
+			IL_083e: ldc.i4.s 12
+			IL_0840: ldloc.s 13
+			IL_0842: stelem.ref
+			IL_0843: dup
+			IL_0844: ldc.i4.s 13
+			IL_0846: ldloc.s 14
 			IL_0848: stelem.ref
 			IL_0849: dup
-			IL_084a: ldc.i4.3
-			IL_084b: ldloc.s 4
-			IL_084d: stelem.ref
-			IL_084e: dup
-			IL_084f: ldc.i4.4
-			IL_0850: ldloc.s 5
-			IL_0852: stelem.ref
-			IL_0853: dup
-			IL_0854: ldc.i4.5
-			IL_0855: ldloc.s 6
-			IL_0857: stelem.ref
-			IL_0858: dup
-			IL_0859: ldc.i4.6
-			IL_085a: ldloc.s 7
-			IL_085c: stelem.ref
-			IL_085d: dup
-			IL_085e: ldc.i4.7
-			IL_085f: ldloc.s 8
-			IL_0861: stelem.ref
-			IL_0862: dup
-			IL_0863: ldc.i4.8
-			IL_0864: ldloc.s 9
+			IL_084a: ldc.i4.s 14
+			IL_084c: ldloc.s 15
+			IL_084e: stelem.ref
+			IL_084f: dup
+			IL_0850: ldc.i4.s 15
+			IL_0852: ldloc.s 16
+			IL_0854: stelem.ref
+			IL_0855: dup
+			IL_0856: ldc.i4.s 16
+			IL_0858: ldloc.s 17
+			IL_085a: stelem.ref
+			IL_085b: dup
+			IL_085c: ldc.i4.s 17
+			IL_085e: ldloc.s 18
+			IL_0860: stelem.ref
+			IL_0861: dup
+			IL_0862: ldc.i4.s 18
+			IL_0864: ldloc.s 19
 			IL_0866: stelem.ref
 			IL_0867: dup
-			IL_0868: ldc.i4.s 9
-			IL_086a: ldloc.s 10
+			IL_0868: ldc.i4.s 19
+			IL_086a: ldloc.s 20
 			IL_086c: stelem.ref
 			IL_086d: dup
-			IL_086e: ldc.i4.s 10
-			IL_0870: ldloc.s 11
+			IL_086e: ldc.i4.s 20
+			IL_0870: ldloc.s 21
 			IL_0872: stelem.ref
 			IL_0873: dup
-			IL_0874: ldc.i4.s 11
-			IL_0876: ldloc.s 12
+			IL_0874: ldc.i4.s 21
+			IL_0876: ldloc.s 22
 			IL_0878: stelem.ref
 			IL_0879: dup
-			IL_087a: ldc.i4.s 12
-			IL_087c: ldloc.s 13
+			IL_087a: ldc.i4.s 22
+			IL_087c: ldloc.s 23
 			IL_087e: stelem.ref
 			IL_087f: dup
-			IL_0880: ldc.i4.s 13
-			IL_0882: ldloc.s 14
-			IL_0884: stelem.ref
-			IL_0885: dup
-			IL_0886: ldc.i4.s 14
-			IL_0888: ldloc.s 15
-			IL_088a: stelem.ref
-			IL_088b: dup
-			IL_088c: ldc.i4.s 15
-			IL_088e: ldloc.s 16
-			IL_0890: stelem.ref
-			IL_0891: dup
-			IL_0892: ldc.i4.s 16
-			IL_0894: ldloc.s 17
-			IL_0896: stelem.ref
-			IL_0897: dup
-			IL_0898: ldc.i4.s 17
-			IL_089a: ldloc.s 18
-			IL_089c: stelem.ref
-			IL_089d: dup
-			IL_089e: ldc.i4.s 18
-			IL_08a0: ldloc.s 19
-			IL_08a2: stelem.ref
-			IL_08a3: dup
-			IL_08a4: ldc.i4.s 19
-			IL_08a6: ldloc.s 20
-			IL_08a8: stelem.ref
-			IL_08a9: dup
-			IL_08aa: ldc.i4.s 20
-			IL_08ac: ldloc.s 21
-			IL_08ae: stelem.ref
-			IL_08af: dup
-			IL_08b0: ldc.i4.s 21
-			IL_08b2: ldloc.s 22
-			IL_08b4: stelem.ref
-			IL_08b5: dup
-			IL_08b6: ldc.i4.s 22
-			IL_08b8: ldloc.s 23
-			IL_08ba: stelem.ref
-			IL_08bb: dup
-			IL_08bc: ldc.i4.s 23
-			IL_08be: ldloc.s 24
-			IL_08c0: stelem.ref
-			IL_08c1: dup
-			IL_08c2: ldc.i4.s 24
-			IL_08c4: ldloc.s 25
-			IL_08c6: stelem.ref
-			IL_08c7: dup
-			IL_08c8: ldc.i4.s 25
-			IL_08ca: ldloc.s 26
-			IL_08cc: box [System.Runtime]System.Boolean
-			IL_08d1: stelem.ref
-			IL_08d2: dup
-			IL_08d3: ldc.i4.s 26
-			IL_08d5: ldloc.s 27
-			IL_08d7: stelem.ref
-			IL_08d8: dup
-			IL_08d9: ldc.i4.s 27
-			IL_08db: ldloc.s 28
-			IL_08dd: stelem.ref
-			IL_08de: dup
-			IL_08df: ldc.i4.s 28
-			IL_08e1: ldloc.s 29
-			IL_08e3: stelem.ref
-			IL_08e4: dup
-			IL_08e5: ldc.i4.s 29
-			IL_08e7: ldloc.s 30
-			IL_08e9: stelem.ref
-			IL_08ea: dup
-			IL_08eb: ldc.i4.s 30
-			IL_08ed: ldloc.s 31
-			IL_08ef: stelem.ref
-			IL_08f0: dup
-			IL_08f1: ldc.i4.s 31
-			IL_08f3: ldloc.s 32
-			IL_08f5: stelem.ref
-			IL_08f6: dup
-			IL_08f7: ldc.i4.s 32
-			IL_08f9: ldloc.s 33
-			IL_08fb: stelem.ref
-			IL_08fc: pop
-			IL_08fd: ldloc.0
-			IL_08fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0903: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0908: ret
+			IL_0880: ldc.i4.s 23
+			IL_0882: ldloc.s 24
+			IL_0884: box [System.Runtime]System.Boolean
+			IL_0889: stelem.ref
+			IL_088a: dup
+			IL_088b: ldc.i4.s 24
+			IL_088d: ldloc.s 25
+			IL_088f: stelem.ref
+			IL_0890: dup
+			IL_0891: ldc.i4.s 25
+			IL_0893: ldloc.s 26
+			IL_0895: stelem.ref
+			IL_0896: dup
+			IL_0897: ldc.i4.s 26
+			IL_0899: ldloc.s 27
+			IL_089b: stelem.ref
+			IL_089c: dup
+			IL_089d: ldc.i4.s 27
+			IL_089f: ldloc.s 28
+			IL_08a1: stelem.ref
+			IL_08a2: dup
+			IL_08a3: ldc.i4.s 28
+			IL_08a5: ldloc.s 29
+			IL_08a7: stelem.ref
+			IL_08a8: dup
+			IL_08a9: ldc.i4.s 29
+			IL_08ab: ldloc.s 30
+			IL_08ad: stelem.ref
+			IL_08ae: dup
+			IL_08af: ldc.i4.s 30
+			IL_08b1: ldloc.s 31
+			IL_08b3: stelem.ref
+			IL_08b4: pop
+			IL_08b5: ldloc.0
+			IL_08b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08c0: ret
 
-			IL_0909: ldloc.0
-			IL_090a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_090f: stloc.s 23
-			IL_0911: ldloc.s 23
-			IL_0913: stloc.s 8
-			IL_0915: ldloc.s 18
-			IL_0917: stloc.s 23
-			IL_0919: ldloc.s 23
-			IL_091b: stloc.s 10
+			IL_08c1: ldloc.0
+			IL_08c2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_08c7: stloc.s 21
+			IL_08c9: ldloc.s 21
+			IL_08cb: stloc.s 8
+			IL_08cd: ldloc.s 16
+			IL_08cf: stloc.s 21
+			IL_08d1: ldloc.s 21
+			IL_08d3: stloc.s 10
 
-			IL_091d: ldloc.s 9
-			IL_091f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0924: ldc.i4.0
-			IL_0925: ceq
-			IL_0927: stloc.s 26
-			IL_0929: ldloc.s 26
-			IL_092b: brfalse IL_09a0
+			IL_08d5: ldloc.s 9
+			IL_08d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08dc: ldc.i4.0
+			IL_08dd: ceq
+			IL_08df: stloc.s 24
+			IL_08e1: ldloc.s 24
+			IL_08e3: brfalse IL_0958
 
-			IL_0930: ldloc.1
-			IL_0931: ldstr "section"
-			IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_093b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0940: stloc.s 30
-			IL_0942: ldstr "Could not infer an element id for section '"
-			IL_0947: ldloc.s 30
-			IL_0949: call string [System.Runtime]System.String::Concat(string, string)
-			IL_094e: stloc.s 30
-			IL_0950: ldloc.s 30
-			IL_0952: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0957: call string [System.Runtime]System.String::Concat(string, string)
-			IL_095c: stloc.s 30
-			IL_095e: ldloc.s 30
-			IL_0960: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0965: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_096a: stloc.s 23
-			IL_096c: ldloc.s 23
-			IL_096e: stloc.s 19
-			IL_0970: ldloc.0
-			IL_0971: ldc.i4.m1
-			IL_0972: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0977: ldloc.0
-			IL_0978: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_097d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0982: ldarg.0
-			IL_0983: ldc.i4.1
-			IL_0984: newarr [System.Runtime]System.Object
-			IL_0989: dup
-			IL_098a: ldc.i4.0
-			IL_098b: ldloc.s 19
-			IL_098d: stelem.ref
-			IL_098e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0993: pop
-			IL_0994: ldloc.0
-			IL_0995: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_099a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_099f: ret
+			IL_08e8: ldloc.1
+			IL_08e9: ldstr "section"
+			IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08f8: stloc.s 28
+			IL_08fa: ldstr "Could not infer an element id for section '"
+			IL_08ff: ldloc.s 28
+			IL_0901: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0906: stloc.s 28
+			IL_0908: ldloc.s 28
+			IL_090a: ldstr "'. Try passing --id sec-... explicitly."
+			IL_090f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0914: stloc.s 28
+			IL_0916: ldloc.s 28
+			IL_0918: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_091d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0922: stloc.s 21
+			IL_0924: ldloc.s 21
+			IL_0926: stloc.s 17
+			IL_0928: ldloc.0
+			IL_0929: ldc.i4.m1
+			IL_092a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_092f: ldloc.0
+			IL_0930: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0935: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_093a: ldarg.0
+			IL_093b: ldc.i4.1
+			IL_093c: newarr [System.Runtime]System.Object
+			IL_0941: dup
+			IL_0942: ldc.i4.0
+			IL_0943: ldloc.s 17
+			IL_0945: stelem.ref
+			IL_0946: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_094b: pop
+			IL_094c: ldloc.0
+			IL_094d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0952: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0957: ret
 
-			IL_09a0: ldarg.0
-			IL_09a1: ldc.i4.1
-			IL_09a2: ldelem.ref
-			IL_09a3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09a8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_09ad: ldc.i4.1
-			IL_09ae: newarr [System.Runtime]System.Object
-			IL_09b3: dup
-			IL_09b4: ldc.i4.0
-			IL_09b5: ldarg.0
-			IL_09b6: ldc.i4.1
-			IL_09b7: ldelem.ref
-			IL_09b8: stelem.ref
-			IL_09b9: ldloc.s 8
-			IL_09bb: ldloc.s 9
-			IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_09c2: stloc.s 23
-			IL_09c4: ldloc.s 23
-			IL_09c6: stloc.s 20
-			IL_09c8: ldarg.0
-			IL_09c9: ldc.i4.1
-			IL_09ca: ldelem.ref
-			IL_09cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_09d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09da: stloc.s 23
-			IL_09dc: ldstr "process"
-			IL_09e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09e6: stloc.s 25
-			IL_09e8: ldloc.s 25
-			IL_09ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ef: stloc.s 25
-			IL_09f1: ldloc.s 25
-			IL_09f3: ldstr "cwd"
-			IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_09fd: stloc.s 25
-			IL_09ff: ldloc.s 23
-			IL_0a01: ldstr "join"
-			IL_0a06: ldloc.s 25
-			IL_0a08: ldloc.1
-			IL_0a09: ldstr "outFile"
-			IL_0a0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a13: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a18: stloc.s 25
-			IL_0a1a: ldloc.s 25
-			IL_0a1c: stloc.s 21
-			IL_0a1e: ldarg.0
-			IL_0a1f: ldc.i4.1
-			IL_0a20: ldelem.ref
-			IL_0a21: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a26: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0a2b: stloc.s 25
-			IL_0a2d: ldc.i4.1
-			IL_0a2e: newarr [System.Runtime]System.Object
-			IL_0a33: dup
-			IL_0a34: ldc.i4.0
-			IL_0a35: ldarg.0
-			IL_0a36: ldc.i4.1
-			IL_0a37: ldelem.ref
-			IL_0a38: stelem.ref
-			IL_0a39: stloc.s 24
-			IL_0a3b: ldloc.s 20
-			IL_0a3d: ldstr "html"
-			IL_0a42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a47: stloc.s 23
-			IL_0a49: ldloc.1
-			IL_0a4a: ldstr "section"
-			IL_0a4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a54: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a59: stloc.s 30
-			IL_0a5b: ldstr "ECMA-262 "
-			IL_0a60: ldloc.s 30
-			IL_0a62: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a67: stloc.s 30
-			IL_0a69: ldloc.s 25
-			IL_0a6b: ldloc.s 24
-			IL_0a6d: ldloc.s 23
-			IL_0a6f: ldloc.s 30
-			IL_0a71: ldloc.s 10
-			IL_0a73: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a78: stloc.s 23
-			IL_0a7a: ldloc.s 23
-			IL_0a7c: stloc.s 22
-			IL_0a7e: ldarg.0
-			IL_0a7f: ldc.i4.1
-			IL_0a80: ldelem.ref
-			IL_0a81: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a86: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a90: stloc.s 23
-			IL_0a92: ldloc.s 23
-			IL_0a94: ldstr "writeFileSync"
-			IL_0a99: ldloc.s 21
-			IL_0a9b: ldloc.s 22
-			IL_0a9d: ldstr "utf8"
-			IL_0aa2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0aa7: pop
-			IL_0aa8: ldstr "console"
-			IL_0aad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ab2: stloc.s 23
-			IL_0ab4: ldloc.s 23
-			IL_0ab6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0abb: stloc.s 23
-			IL_0abd: ldarg.0
-			IL_0abe: ldc.i4.1
-			IL_0abf: ldelem.ref
-			IL_0ac0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ac5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0aca: stloc.s 25
-			IL_0acc: ldc.i4.1
-			IL_0acd: newarr [System.Runtime]System.Object
-			IL_0ad2: dup
-			IL_0ad3: ldc.i4.0
-			IL_0ad4: ldarg.0
-			IL_0ad5: ldc.i4.1
-			IL_0ad6: ldelem.ref
-			IL_0ad7: stelem.ref
-			IL_0ad8: stloc.s 24
-			IL_0ada: ldloc.1
-			IL_0adb: ldstr "section"
-			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ae5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aea: stloc.s 30
-			IL_0aec: ldstr "Extracted section "
-			IL_0af1: ldloc.s 30
-			IL_0af3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0af8: stloc.s 30
-			IL_0afa: ldloc.s 30
-			IL_0afc: ldstr " (id="
-			IL_0b01: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b06: stloc.s 30
-			IL_0b08: ldloc.s 9
-			IL_0b0a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b0f: stloc.s 29
-			IL_0b11: ldloc.s 30
-			IL_0b13: ldloc.s 29
-			IL_0b15: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b1a: stloc.s 29
-			IL_0b1c: ldloc.s 29
-			IL_0b1e: ldstr ", tag="
-			IL_0b23: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b28: stloc.s 29
-			IL_0b2a: ldloc.s 20
-			IL_0b2c: ldstr "tagName"
-			IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b36: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b3b: stloc.s 30
-			IL_0b3d: ldloc.s 29
-			IL_0b3f: ldloc.s 30
-			IL_0b41: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b46: stloc.s 30
-			IL_0b48: ldloc.s 30
-			IL_0b4a: ldstr ") -> "
-			IL_0b4f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b54: stloc.s 30
-			IL_0b56: ldloc.s 21
-			IL_0b58: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b5d: stloc.s 29
-			IL_0b5f: ldloc.s 30
-			IL_0b61: ldloc.s 29
-			IL_0b63: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b68: stloc.s 29
-			IL_0b6a: ldloc.s 25
-			IL_0b6c: ldloc.s 24
-			IL_0b6e: ldloc.s 29
-			IL_0b70: ldloc.s 21
-			IL_0b72: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b77: stloc.s 25
-			IL_0b79: ldloc.s 23
-			IL_0b7b: ldstr "log"
-			IL_0b80: ldloc.s 25
-			IL_0b82: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0b87: pop
-			IL_0b88: ldstr "console"
-			IL_0b8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b92: stloc.s 25
-			IL_0b94: ldloc.s 25
-			IL_0b96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b9b: stloc.s 25
-			IL_0b9d: ldarg.0
-			IL_0b9e: ldc.i4.1
-			IL_0b9f: ldelem.ref
-			IL_0ba0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ba5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0baa: stloc.s 23
-			IL_0bac: ldc.i4.1
-			IL_0bad: newarr [System.Runtime]System.Object
-			IL_0bb2: dup
-			IL_0bb3: ldc.i4.0
-			IL_0bb4: ldarg.0
-			IL_0bb5: ldc.i4.1
-			IL_0bb6: ldelem.ref
-			IL_0bb7: stelem.ref
-			IL_0bb8: stloc.s 24
-			IL_0bba: ldarg.0
-			IL_0bbb: ldc.i4.1
-			IL_0bbc: ldelem.ref
-			IL_0bbd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bc2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0bc7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0bcc: stloc.s 33
-			IL_0bce: ldloc.s 33
-			IL_0bd0: ldstr "readFileSync"
-			IL_0bd5: ldloc.s 21
-			IL_0bd7: ldstr "utf8"
-			IL_0bdc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0be1: stloc.s 33
-			IL_0be3: ldloc.s 23
-			IL_0be5: ldloc.s 24
-			IL_0be7: ldloc.s 33
-			IL_0be9: ldloc.s 21
-			IL_0beb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0bf0: stloc.s 33
-			IL_0bf2: ldloc.s 25
-			IL_0bf4: ldstr "log"
-			IL_0bf9: ldloc.s 33
-			IL_0bfb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0c00: pop
-			IL_0c01: ldloc.0
-			IL_0c02: ldc.i4.m1
-			IL_0c03: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c08: ldloc.0
-			IL_0c09: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c13: ldarg.0
-			IL_0c14: ldc.i4.1
-			IL_0c15: newarr [System.Runtime]System.Object
-			IL_0c1a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c1f: pop
-			IL_0c20: ldloc.0
-			IL_0c21: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c26: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c2b: ret
+			IL_0958: ldarg.0
+			IL_0959: ldc.i4.1
+			IL_095a: ldelem.ref
+			IL_095b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0960: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0965: ldc.i4.1
+			IL_0966: newarr [System.Runtime]System.Object
+			IL_096b: dup
+			IL_096c: ldc.i4.0
+			IL_096d: ldarg.0
+			IL_096e: ldc.i4.1
+			IL_096f: ldelem.ref
+			IL_0970: stelem.ref
+			IL_0971: ldloc.s 8
+			IL_0973: ldloc.s 9
+			IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_097a: stloc.s 21
+			IL_097c: ldloc.s 21
+			IL_097e: stloc.s 18
+			IL_0980: ldarg.0
+			IL_0981: ldc.i4.1
+			IL_0982: ldelem.ref
+			IL_0983: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0988: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_098d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0992: stloc.s 21
+			IL_0994: ldstr "process"
+			IL_0999: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_099e: stloc.s 23
+			IL_09a0: ldloc.s 23
+			IL_09a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09a7: stloc.s 23
+			IL_09a9: ldloc.s 23
+			IL_09ab: ldstr "cwd"
+			IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_09b5: stloc.s 23
+			IL_09b7: ldloc.s 21
+			IL_09b9: ldstr "join"
+			IL_09be: ldloc.s 23
+			IL_09c0: ldloc.1
+			IL_09c1: ldstr "outFile"
+			IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_09d0: stloc.s 23
+			IL_09d2: ldloc.s 23
+			IL_09d4: stloc.s 19
+			IL_09d6: ldarg.0
+			IL_09d7: ldc.i4.1
+			IL_09d8: ldelem.ref
+			IL_09d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09de: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09e3: stloc.s 23
+			IL_09e5: ldc.i4.1
+			IL_09e6: newarr [System.Runtime]System.Object
+			IL_09eb: dup
+			IL_09ec: ldc.i4.0
+			IL_09ed: ldarg.0
+			IL_09ee: ldc.i4.1
+			IL_09ef: ldelem.ref
+			IL_09f0: stelem.ref
+			IL_09f1: stloc.s 22
+			IL_09f3: ldloc.s 18
+			IL_09f5: ldstr "html"
+			IL_09fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ff: stloc.s 21
+			IL_0a01: ldloc.1
+			IL_0a02: ldstr "section"
+			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a11: stloc.s 28
+			IL_0a13: ldstr "ECMA-262 "
+			IL_0a18: ldloc.s 28
+			IL_0a1a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a1f: stloc.s 28
+			IL_0a21: ldloc.s 23
+			IL_0a23: ldloc.s 22
+			IL_0a25: ldloc.s 21
+			IL_0a27: ldloc.s 28
+			IL_0a29: ldloc.s 10
+			IL_0a2b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a30: stloc.s 21
+			IL_0a32: ldloc.s 21
+			IL_0a34: stloc.s 20
+			IL_0a36: ldarg.0
+			IL_0a37: ldc.i4.1
+			IL_0a38: ldelem.ref
+			IL_0a39: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a3e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a48: stloc.s 21
+			IL_0a4a: ldloc.s 21
+			IL_0a4c: ldstr "writeFileSync"
+			IL_0a51: ldloc.s 19
+			IL_0a53: ldloc.s 20
+			IL_0a55: ldstr "utf8"
+			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0a5f: pop
+			IL_0a60: ldstr "console"
+			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a6a: stloc.s 21
+			IL_0a6c: ldloc.s 21
+			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a73: stloc.s 21
+			IL_0a75: ldarg.0
+			IL_0a76: ldc.i4.1
+			IL_0a77: ldelem.ref
+			IL_0a78: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a7d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a82: stloc.s 23
+			IL_0a84: ldc.i4.1
+			IL_0a85: newarr [System.Runtime]System.Object
+			IL_0a8a: dup
+			IL_0a8b: ldc.i4.0
+			IL_0a8c: ldarg.0
+			IL_0a8d: ldc.i4.1
+			IL_0a8e: ldelem.ref
+			IL_0a8f: stelem.ref
+			IL_0a90: stloc.s 22
+			IL_0a92: ldloc.1
+			IL_0a93: ldstr "section"
+			IL_0a98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a9d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aa2: stloc.s 28
+			IL_0aa4: ldstr "Extracted section "
+			IL_0aa9: ldloc.s 28
+			IL_0aab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ab0: stloc.s 28
+			IL_0ab2: ldloc.s 28
+			IL_0ab4: ldstr " (id="
+			IL_0ab9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0abe: stloc.s 28
+			IL_0ac0: ldloc.s 9
+			IL_0ac2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ac7: stloc.s 27
+			IL_0ac9: ldloc.s 28
+			IL_0acb: ldloc.s 27
+			IL_0acd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ad2: stloc.s 27
+			IL_0ad4: ldloc.s 27
+			IL_0ad6: ldstr ", tag="
+			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae0: stloc.s 27
+			IL_0ae2: ldloc.s 18
+			IL_0ae4: ldstr "tagName"
+			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aee: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0af3: stloc.s 28
+			IL_0af5: ldloc.s 27
+			IL_0af7: ldloc.s 28
+			IL_0af9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0afe: stloc.s 28
+			IL_0b00: ldloc.s 28
+			IL_0b02: ldstr ") -> "
+			IL_0b07: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b0c: stloc.s 28
+			IL_0b0e: ldloc.s 19
+			IL_0b10: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b15: stloc.s 27
+			IL_0b17: ldloc.s 28
+			IL_0b19: ldloc.s 27
+			IL_0b1b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b20: stloc.s 27
+			IL_0b22: ldloc.s 23
+			IL_0b24: ldloc.s 22
+			IL_0b26: ldloc.s 27
+			IL_0b28: ldloc.s 19
+			IL_0b2a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b2f: stloc.s 23
+			IL_0b31: ldloc.s 21
+			IL_0b33: ldstr "log"
+			IL_0b38: ldloc.s 23
+			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0b3f: pop
+			IL_0b40: ldstr "console"
+			IL_0b45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b4a: stloc.s 23
+			IL_0b4c: ldloc.s 23
+			IL_0b4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b53: stloc.s 23
+			IL_0b55: ldarg.0
+			IL_0b56: ldc.i4.1
+			IL_0b57: ldelem.ref
+			IL_0b58: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b5d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b62: stloc.s 21
+			IL_0b64: ldc.i4.1
+			IL_0b65: newarr [System.Runtime]System.Object
+			IL_0b6a: dup
+			IL_0b6b: ldc.i4.0
+			IL_0b6c: ldarg.0
+			IL_0b6d: ldc.i4.1
+			IL_0b6e: ldelem.ref
+			IL_0b6f: stelem.ref
+			IL_0b70: stloc.s 22
+			IL_0b72: ldarg.0
+			IL_0b73: ldc.i4.1
+			IL_0b74: ldelem.ref
+			IL_0b75: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b7a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b84: stloc.s 31
+			IL_0b86: ldloc.s 31
+			IL_0b88: ldstr "readFileSync"
+			IL_0b8d: ldloc.s 19
+			IL_0b8f: ldstr "utf8"
+			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b99: stloc.s 31
+			IL_0b9b: ldloc.s 21
+			IL_0b9d: ldloc.s 22
+			IL_0b9f: ldloc.s 31
+			IL_0ba1: ldloc.s 19
+			IL_0ba3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0ba8: stloc.s 31
+			IL_0baa: ldloc.s 23
+			IL_0bac: ldstr "log"
+			IL_0bb1: ldloc.s 31
+			IL_0bb3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0bb8: pop
+			IL_0bb9: ldloc.0
+			IL_0bba: ldc.i4.m1
+			IL_0bbb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0bc0: ldloc.0
+			IL_0bc1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bc6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bcb: ldarg.0
+			IL_0bcc: ldc.i4.1
+			IL_0bcd: newarr [System.Runtime]System.Object
+			IL_0bd2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bd7: pop
+			IL_0bd8: ldloc.0
+			IL_0bd9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bde: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0be3: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5521,7 +5469,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x46c5
+			// Method begins at RVA 0x463d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5797,7 +5745,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4890
+		// Method begins at RVA 0x4808
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46b3
+				// Method begins at RVA 0x462b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46bc
+				// Method begins at RVA 0x4634
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -340,7 +340,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x46aa
+			// Method begins at RVA 0x4622
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -455,7 +455,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d7
+					// Method begins at RVA 0x464f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -473,7 +473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46ce
+				// Method begins at RVA 0x4646
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -622,7 +622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e0
+				// Method begins at RVA 0x4658
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -650,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46fb
+						// Method begins at RVA 0x4673
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -670,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4704
+						// Method begins at RVA 0x467c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -690,7 +690,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x470d
+						// Method begins at RVA 0x4685
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -710,7 +710,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4716
+						// Method begins at RVA 0x468e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -730,7 +730,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x471f
+						// Method begins at RVA 0x4697
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -750,7 +750,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4728
+						// Method begins at RVA 0x46a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -768,7 +768,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46f2
+					// Method begins at RVA 0x466a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -786,7 +786,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e9
+				// Method begins at RVA 0x4661
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -815,22 +815,21 @@
 			)
 			// Method begins at RVA 0x2654
 			// Header size: 12
-			// Code size: 782 (0x30e)
+			// Code size: 754 (0x2f2)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[1] float64,
-				[2] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/Scope_For_L30C7/Block_L30C40,
-				[3] object,
-				[4] float64,
-				[5] object,
-				[6] bool,
+				[2] object,
+				[3] float64,
+				[4] object,
+				[5] bool,
+				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
-				[11] object,
-				[12] object
+				[11] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -863,266 +862,264 @@
 			IL_006b: stloc.1
 			// loop start (head: IL_006c)
 				IL_006c: ldloc.1
-				IL_006d: stloc.s 4
-				IL_006f: ldloc.s 4
-				IL_0071: ldarg.2
-				IL_0072: ldstr "length"
-				IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_007c: clt
-				IL_007e: brfalse IL_030c
+				IL_006d: stloc.3
+				IL_006e: ldloc.3
+				IL_006f: ldarg.2
+				IL_0070: ldstr "length"
+				IL_0075: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_007a: clt
+				IL_007c: brfalse IL_02f0
 
-				IL_0083: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/Scope_For_L30C7/Block_L30C40::.ctor()
+				IL_0081: ldarg.2
+				IL_0082: ldloc.1
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_0088: stloc.2
-				IL_0089: ldarg.2
-				IL_008a: ldloc.1
-				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0090: stloc.3
-				IL_0091: ldloc.3
-				IL_0092: stloc.s 5
-				IL_0094: ldloc.s 5
-				IL_0096: ldstr "--section"
-				IL_009b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00a0: stloc.s 6
-				IL_00a2: ldloc.s 6
-				IL_00a4: brfalse IL_0104
+				IL_0089: ldloc.2
+				IL_008a: stloc.s 4
+				IL_008c: ldloc.s 4
+				IL_008e: ldstr "--section"
+				IL_0093: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0098: stloc.s 5
+				IL_009a: ldloc.s 5
+				IL_009c: brfalse IL_00f8
 
-				IL_00a9: ldloc.1
-				IL_00aa: stloc.s 4
-				IL_00ac: ldloc.s 4
-				IL_00ae: ldc.r8 1
-				IL_00b7: add
-				IL_00b8: stloc.s 4
-				IL_00ba: ldarg.2
-				IL_00bb: ldloc.s 4
-				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c2: stloc.s 5
-				IL_00c4: ldloc.s 5
-				IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00cb: stloc.s 6
-				IL_00cd: ldloc.s 6
-				IL_00cf: brtrue IL_00e0
+				IL_00a1: ldloc.1
+				IL_00a2: stloc.3
+				IL_00a3: ldloc.3
+				IL_00a4: ldc.r8 1
+				IL_00ad: add
+				IL_00ae: stloc.3
+				IL_00af: ldarg.2
+				IL_00b0: ldloc.3
+				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00b6: stloc.s 4
+				IL_00b8: ldloc.s 4
+				IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00bf: stloc.s 5
+				IL_00c1: ldloc.s 5
+				IL_00c3: brtrue IL_00d4
 
-				IL_00d4: ldstr ""
-				IL_00d9: stloc.s 8
-				IL_00db: br IL_00e4
+				IL_00c8: ldstr ""
+				IL_00cd: stloc.s 7
+				IL_00cf: br IL_00d8
 
-				IL_00e0: ldloc.s 5
-				IL_00e2: stloc.s 8
+				IL_00d4: ldloc.s 4
+				IL_00d6: stloc.s 7
 
-				IL_00e4: ldloc.0
-				IL_00e5: ldstr "section"
-				IL_00ea: ldloc.s 8
-				IL_00ec: ldc.i4.1
-				IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_00f2: pop
-				IL_00f3: ldloc.1
-				IL_00f4: ldc.r8 1
-				IL_00fd: add
-				IL_00fe: stloc.1
-				IL_00ff: br IL_02fb
+				IL_00d8: ldloc.0
+				IL_00d9: ldstr "section"
+				IL_00de: ldloc.s 7
+				IL_00e0: ldc.i4.1
+				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_00e6: pop
+				IL_00e7: ldloc.1
+				IL_00e8: ldc.r8 1
+				IL_00f1: add
+				IL_00f2: stloc.1
+				IL_00f3: br IL_02df
 
-				IL_0104: ldloc.3
-				IL_0105: stloc.s 5
-				IL_0107: ldloc.s 5
-				IL_0109: ldstr "--url"
-				IL_010e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0113: stloc.s 6
-				IL_0115: ldloc.s 6
-				IL_0117: brfalse IL_0177
+				IL_00f8: ldloc.2
+				IL_00f9: stloc.s 4
+				IL_00fb: ldloc.s 4
+				IL_00fd: ldstr "--url"
+				IL_0102: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0107: stloc.s 5
+				IL_0109: ldloc.s 5
+				IL_010b: brfalse IL_0167
 
-				IL_011c: ldloc.1
-				IL_011d: stloc.s 4
-				IL_011f: ldloc.s 4
-				IL_0121: ldc.r8 1
-				IL_012a: add
-				IL_012b: stloc.s 4
-				IL_012d: ldarg.2
-				IL_012e: ldloc.s 4
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0135: stloc.s 5
-				IL_0137: ldloc.s 5
-				IL_0139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013e: stloc.s 6
-				IL_0140: ldloc.s 6
-				IL_0142: brtrue IL_0153
+				IL_0110: ldloc.1
+				IL_0111: stloc.3
+				IL_0112: ldloc.3
+				IL_0113: ldc.r8 1
+				IL_011c: add
+				IL_011d: stloc.3
+				IL_011e: ldarg.2
+				IL_011f: ldloc.3
+				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0125: stloc.s 4
+				IL_0127: ldloc.s 4
+				IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_012e: stloc.s 5
+				IL_0130: ldloc.s 5
+				IL_0132: brtrue IL_0143
 
-				IL_0147: ldstr ""
-				IL_014c: stloc.s 9
-				IL_014e: br IL_0157
+				IL_0137: ldstr ""
+				IL_013c: stloc.s 8
+				IL_013e: br IL_0147
 
-				IL_0153: ldloc.s 5
-				IL_0155: stloc.s 9
+				IL_0143: ldloc.s 4
+				IL_0145: stloc.s 8
 
-				IL_0157: ldloc.0
-				IL_0158: ldstr "url"
-				IL_015d: ldloc.s 9
-				IL_015f: ldc.i4.1
-				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0165: pop
-				IL_0166: ldloc.1
-				IL_0167: ldc.r8 1
-				IL_0170: add
-				IL_0171: stloc.1
-				IL_0172: br IL_02fb
+				IL_0147: ldloc.0
+				IL_0148: ldstr "url"
+				IL_014d: ldloc.s 8
+				IL_014f: ldc.i4.1
+				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0155: pop
+				IL_0156: ldloc.1
+				IL_0157: ldc.r8 1
+				IL_0160: add
+				IL_0161: stloc.1
+				IL_0162: br IL_02df
 
-				IL_0177: ldloc.3
-				IL_0178: stloc.s 5
-				IL_017a: ldloc.s 5
-				IL_017c: ldstr "--auto"
-				IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0186: stloc.s 6
-				IL_0188: ldloc.s 6
-				IL_018a: brfalse IL_01a7
+				IL_0167: ldloc.2
+				IL_0168: stloc.s 4
+				IL_016a: ldloc.s 4
+				IL_016c: ldstr "--auto"
+				IL_0171: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0176: stloc.s 5
+				IL_0178: ldloc.s 5
+				IL_017a: brfalse IL_0197
 
-				IL_018f: ldloc.0
-				IL_0190: ldstr "auto"
-				IL_0195: ldc.i4.1
-				IL_0196: box [System.Runtime]System.Boolean
-				IL_019b: ldc.i4.1
-				IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_01a1: pop
-				IL_01a2: br IL_02fb
+				IL_017f: ldloc.0
+				IL_0180: ldstr "auto"
+				IL_0185: ldc.i4.1
+				IL_0186: box [System.Runtime]System.Boolean
+				IL_018b: ldc.i4.1
+				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0191: pop
+				IL_0192: br IL_02df
 
-				IL_01a7: ldloc.3
-				IL_01a8: stloc.s 5
-				IL_01aa: ldloc.s 5
-				IL_01ac: ldstr "--index-url"
-				IL_01b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01b6: stloc.s 6
-				IL_01b8: ldloc.s 6
-				IL_01ba: brfalse IL_021a
+				IL_0197: ldloc.2
+				IL_0198: stloc.s 4
+				IL_019a: ldloc.s 4
+				IL_019c: ldstr "--index-url"
+				IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01a6: stloc.s 5
+				IL_01a8: ldloc.s 5
+				IL_01aa: brfalse IL_0206
 
-				IL_01bf: ldloc.1
-				IL_01c0: stloc.s 4
-				IL_01c2: ldloc.s 4
-				IL_01c4: ldc.r8 1
-				IL_01cd: add
-				IL_01ce: stloc.s 4
-				IL_01d0: ldarg.2
-				IL_01d1: ldloc.s 4
-				IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01d8: stloc.s 5
-				IL_01da: ldloc.s 5
-				IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01e1: stloc.s 6
-				IL_01e3: ldloc.s 6
-				IL_01e5: brtrue IL_01f6
+				IL_01af: ldloc.1
+				IL_01b0: stloc.3
+				IL_01b1: ldloc.3
+				IL_01b2: ldc.r8 1
+				IL_01bb: add
+				IL_01bc: stloc.3
+				IL_01bd: ldarg.2
+				IL_01be: ldloc.3
+				IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01c4: stloc.s 4
+				IL_01c6: ldloc.s 4
+				IL_01c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01cd: stloc.s 5
+				IL_01cf: ldloc.s 5
+				IL_01d1: brtrue IL_01e2
 
-				IL_01ea: ldstr ""
-				IL_01ef: stloc.s 10
-				IL_01f1: br IL_01fa
+				IL_01d6: ldstr ""
+				IL_01db: stloc.s 9
+				IL_01dd: br IL_01e6
 
-				IL_01f6: ldloc.s 5
-				IL_01f8: stloc.s 10
+				IL_01e2: ldloc.s 4
+				IL_01e4: stloc.s 9
 
-				IL_01fa: ldloc.0
-				IL_01fb: ldstr "indexUrl"
-				IL_0200: ldloc.s 10
-				IL_0202: ldc.i4.1
-				IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0208: pop
-				IL_0209: ldloc.1
-				IL_020a: ldc.r8 1
-				IL_0213: add
-				IL_0214: stloc.1
-				IL_0215: br IL_02fb
+				IL_01e6: ldloc.0
+				IL_01e7: ldstr "indexUrl"
+				IL_01ec: ldloc.s 9
+				IL_01ee: ldc.i4.1
+				IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_01f4: pop
+				IL_01f5: ldloc.1
+				IL_01f6: ldc.r8 1
+				IL_01ff: add
+				IL_0200: stloc.1
+				IL_0201: br IL_02df
 
-				IL_021a: ldloc.3
-				IL_021b: stloc.s 5
-				IL_021d: ldloc.s 5
-				IL_021f: ldstr "--out"
-				IL_0224: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0229: stloc.s 6
-				IL_022b: ldloc.s 6
-				IL_022d: brfalse IL_028d
+				IL_0206: ldloc.2
+				IL_0207: stloc.s 4
+				IL_0209: ldloc.s 4
+				IL_020b: ldstr "--out"
+				IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0215: stloc.s 5
+				IL_0217: ldloc.s 5
+				IL_0219: brfalse IL_0275
 
-				IL_0232: ldloc.1
+				IL_021e: ldloc.1
+				IL_021f: stloc.3
+				IL_0220: ldloc.3
+				IL_0221: ldc.r8 1
+				IL_022a: add
+				IL_022b: stloc.3
+				IL_022c: ldarg.2
+				IL_022d: ldloc.3
+				IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_0233: stloc.s 4
 				IL_0235: ldloc.s 4
-				IL_0237: ldc.r8 1
-				IL_0240: add
-				IL_0241: stloc.s 4
-				IL_0243: ldarg.2
-				IL_0244: ldloc.s 4
-				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_024b: stloc.s 5
-				IL_024d: ldloc.s 5
-				IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0254: stloc.s 6
-				IL_0256: ldloc.s 6
-				IL_0258: brtrue IL_0269
+				IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_023c: stloc.s 5
+				IL_023e: ldloc.s 5
+				IL_0240: brtrue IL_0251
 
-				IL_025d: ldstr ""
-				IL_0262: stloc.s 11
-				IL_0264: br IL_026d
+				IL_0245: ldstr ""
+				IL_024a: stloc.s 10
+				IL_024c: br IL_0255
 
-				IL_0269: ldloc.s 5
-				IL_026b: stloc.s 11
+				IL_0251: ldloc.s 4
+				IL_0253: stloc.s 10
 
-				IL_026d: ldloc.0
-				IL_026e: ldstr "outFile"
-				IL_0273: ldloc.s 11
-				IL_0275: ldc.i4.1
-				IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_027b: pop
-				IL_027c: ldloc.1
-				IL_027d: ldc.r8 1
-				IL_0286: add
-				IL_0287: stloc.1
-				IL_0288: br IL_02fb
+				IL_0255: ldloc.0
+				IL_0256: ldstr "outFile"
+				IL_025b: ldloc.s 10
+				IL_025d: ldc.i4.1
+				IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0263: pop
+				IL_0264: ldloc.1
+				IL_0265: ldc.r8 1
+				IL_026e: add
+				IL_026f: stloc.1
+				IL_0270: br IL_02df
 
-				IL_028d: ldloc.3
-				IL_028e: stloc.s 5
-				IL_0290: ldloc.s 5
-				IL_0292: ldstr "--id"
-				IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_029c: stloc.s 6
-				IL_029e: ldloc.s 6
-				IL_02a0: brfalse IL_02fb
+				IL_0275: ldloc.2
+				IL_0276: stloc.s 4
+				IL_0278: ldloc.s 4
+				IL_027a: ldstr "--id"
+				IL_027f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0284: stloc.s 5
+				IL_0286: ldloc.s 5
+				IL_0288: brfalse IL_02df
 
-				IL_02a5: ldloc.1
-				IL_02a6: stloc.s 4
-				IL_02a8: ldloc.s 4
-				IL_02aa: ldc.r8 1
-				IL_02b3: add
-				IL_02b4: stloc.s 4
-				IL_02b6: ldarg.2
-				IL_02b7: ldloc.s 4
-				IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02be: stloc.s 5
-				IL_02c0: ldloc.s 5
-				IL_02c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c7: stloc.s 6
-				IL_02c9: ldloc.s 6
-				IL_02cb: brtrue IL_02dc
+				IL_028d: ldloc.1
+				IL_028e: stloc.3
+				IL_028f: ldloc.3
+				IL_0290: ldc.r8 1
+				IL_0299: add
+				IL_029a: stloc.3
+				IL_029b: ldarg.2
+				IL_029c: ldloc.3
+				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02a2: stloc.s 4
+				IL_02a4: ldloc.s 4
+				IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02ab: stloc.s 5
+				IL_02ad: ldloc.s 5
+				IL_02af: brtrue IL_02c0
 
-				IL_02d0: ldstr ""
-				IL_02d5: stloc.s 12
-				IL_02d7: br IL_02e0
+				IL_02b4: ldstr ""
+				IL_02b9: stloc.s 11
+				IL_02bb: br IL_02c4
 
-				IL_02dc: ldloc.s 5
-				IL_02de: stloc.s 12
+				IL_02c0: ldloc.s 4
+				IL_02c2: stloc.s 11
 
-				IL_02e0: ldloc.0
-				IL_02e1: ldstr "id"
-				IL_02e6: ldloc.s 12
-				IL_02e8: ldc.i4.1
-				IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_02ee: pop
-				IL_02ef: ldloc.1
-				IL_02f0: ldc.r8 1
-				IL_02f9: add
-				IL_02fa: stloc.1
+				IL_02c4: ldloc.0
+				IL_02c5: ldstr "id"
+				IL_02ca: ldloc.s 11
+				IL_02cc: ldc.i4.1
+				IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_02d2: pop
+				IL_02d3: ldloc.1
+				IL_02d4: ldc.r8 1
+				IL_02dd: add
+				IL_02de: stloc.1
 
-				IL_02fb: ldloc.1
-				IL_02fc: ldc.r8 1
-				IL_0305: add
-				IL_0306: stloc.1
-				IL_0307: br IL_006c
+				IL_02df: ldloc.1
+				IL_02e0: ldc.r8 1
+				IL_02e9: add
+				IL_02ea: stloc.1
+				IL_02eb: br IL_006c
 			// end loop
 
-			IL_030c: ldloc.0
-			IL_030d: ret
+			IL_02f0: ldloc.0
+			IL_02f1: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
@@ -1157,7 +1154,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4782
+							// Method begins at RVA 0x46fa
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1182,7 +1179,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x462c
+						// Method begins at RVA 0x45a4
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1221,7 +1218,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x478b
+							// Method begins at RVA 0x4703
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1245,7 +1242,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x465c
+						// Method begins at RVA 0x45d4
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1318,7 +1315,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x4770
+								// Method begins at RVA 0x46e8
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1336,7 +1333,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4767
+							// Method begins at RVA 0x46df
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1356,7 +1353,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4779
+							// Method begins at RVA 0x46f1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1378,7 +1375,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x475e
+						// Method begins at RVA 0x46d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1403,30 +1400,29 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x419c
+					// Method begins at RVA 0x411c
 					// Header size: 12
-					// Code size: 1153 (0x481)
+					// Code size: 1145 (0x479)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
 						[1] object,
 						[2] object,
-						[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55,
+						[3] object,
 						[4] object,
-						[5] object,
-						[6] bool,
+						[5] bool,
+						[6] object,
 						[7] object,
-						[8] object,
-						[9] float64,
+						[8] float64,
+						[9] object,
 						[10] object,
 						[11] object,
 						[12] object,
-						[13] object,
-						[14] object[],
-						[15] string,
+						[13] object[],
+						[14] string,
+						[15] object,
 						[16] object,
-						[17] object,
-						[18] string
+						[17] string
 					)
 
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
@@ -1434,22 +1430,22 @@
 					IL_0006: ldarg.2
 					IL_0007: ldstr "statusCode"
 					IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0011: stloc.s 5
-					IL_0013: ldloc.s 5
+					IL_0011: stloc.s 4
+					IL_0013: ldloc.s 4
 					IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_001a: stloc.s 6
-					IL_001c: ldloc.s 6
+					IL_001a: stloc.s 5
+					IL_001c: ldloc.s 5
 					IL_001e: brtrue IL_0038
 
 					IL_0023: ldc.r8 0.0
 					IL_002c: box [System.Runtime]System.Double
-					IL_0031: stloc.s 8
+					IL_0031: stloc.s 7
 					IL_0033: br IL_003c
 
-					IL_0038: ldloc.s 5
-					IL_003a: stloc.s 8
+					IL_0038: ldloc.s 4
+					IL_003a: stloc.s 7
 
-					IL_003c: ldloc.s 8
+					IL_003c: ldloc.s 7
 					IL_003e: stloc.1
 					IL_003f: ldarg.2
 					IL_0040: ldstr "headers"
@@ -1458,453 +1454,451 @@
 					IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0054: stloc.2
 					IL_0055: ldloc.1
-					IL_0056: stloc.s 8
-					IL_0058: ldloc.s 8
+					IL_0056: stloc.s 7
+					IL_0058: ldloc.s 7
 					IL_005a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_005f: stloc.s 9
-					IL_0061: ldloc.s 9
+					IL_005f: stloc.s 8
+					IL_0061: ldloc.s 8
 					IL_0063: ldc.r8 300
 					IL_006c: clt
 					IL_006e: ldc.i4.0
 					IL_006f: ceq
-					IL_0071: stloc.s 6
-					IL_0073: ldloc.s 6
+					IL_0071: stloc.s 5
+					IL_0073: ldloc.s 5
 					IL_0075: box [System.Runtime]System.Boolean
-					IL_007a: stloc.s 10
-					IL_007c: ldloc.s 10
+					IL_007a: stloc.s 9
+					IL_007c: ldloc.s 9
 					IL_007e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0083: stloc.s 6
-					IL_0085: ldloc.s 6
+					IL_0083: stloc.s 5
+					IL_0085: ldloc.s 5
 					IL_0087: brfalse IL_00b9
 
 					IL_008c: ldloc.1
-					IL_008d: stloc.s 8
-					IL_008f: ldloc.s 8
+					IL_008d: stloc.s 7
+					IL_008f: ldloc.s 7
 					IL_0091: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0096: stloc.s 9
-					IL_0098: ldloc.s 9
+					IL_0096: stloc.s 8
+					IL_0098: ldloc.s 8
 					IL_009a: ldc.r8 400
 					IL_00a3: clt
-					IL_00a5: stloc.s 6
-					IL_00a7: ldloc.s 6
+					IL_00a5: stloc.s 5
+					IL_00a7: ldloc.s 5
 					IL_00a9: box [System.Runtime]System.Boolean
-					IL_00ae: stloc.s 11
-					IL_00b0: ldloc.s 11
-					IL_00b2: stloc.s 12
+					IL_00ae: stloc.s 10
+					IL_00b0: ldloc.s 10
+					IL_00b2: stloc.s 11
 					IL_00b4: br IL_00bd
 
-					IL_00b9: ldloc.s 10
-					IL_00bb: stloc.s 12
+					IL_00b9: ldloc.s 9
+					IL_00bb: stloc.s 11
 
-					IL_00bd: ldloc.s 12
+					IL_00bd: ldloc.s 11
 					IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00c4: stloc.s 6
-					IL_00c6: ldloc.s 6
+					IL_00c4: stloc.s 5
+					IL_00c6: ldloc.s 5
 					IL_00c8: brfalse IL_00d5
 
 					IL_00cd: ldloc.2
-					IL_00ce: stloc.s 12
+					IL_00ce: stloc.s 11
 					IL_00d0: br IL_00d5
 
-					IL_00d5: ldloc.s 12
+					IL_00d5: ldloc.s 11
 					IL_00d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00dc: stloc.s 6
-					IL_00de: ldloc.s 6
-					IL_00e0: brfalse IL_027f
+					IL_00dc: stloc.s 5
+					IL_00de: ldloc.s 5
+					IL_00e0: brfalse IL_0277
 
-					IL_00e5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
-					IL_00ea: stloc.3
-					IL_00eb: ldarg.0
-					IL_00ec: ldc.i4.1
-					IL_00ed: ldelem.ref
-					IL_00ee: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_00f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_00f8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00fd: ldc.r8 0.0
-					IL_0106: cgt
-					IL_0108: ldc.i4.0
-					IL_0109: ceq
-					IL_010b: brfalse IL_018c
+					IL_00e5: ldarg.0
+					IL_00e6: ldc.i4.1
+					IL_00e7: ldelem.ref
+					IL_00e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_00ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_00f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00f7: ldc.r8 0.0
+					IL_0100: cgt
+					IL_0102: ldc.i4.0
+					IL_0103: ceq
+					IL_0105: brfalse IL_0186
 
-					IL_0110: ldarg.2
-					IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0116: stloc.s 5
-					IL_0118: ldloc.s 5
-					IL_011a: ldstr "resume"
-					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0124: pop
-					IL_0125: ldarg.0
-					IL_0126: ldc.i4.2
-					IL_0127: ldelem.ref
-					IL_0128: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_012d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0132: stloc.s 5
-					IL_0134: ldc.i4.3
-					IL_0135: newarr [System.Runtime]System.Object
+					IL_010a: ldarg.2
+					IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0110: stloc.s 4
+					IL_0112: ldloc.s 4
+					IL_0114: ldstr "resume"
+					IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_011e: pop
+					IL_011f: ldarg.0
+					IL_0120: ldc.i4.2
+					IL_0121: ldelem.ref
+					IL_0122: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0127: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_012c: stloc.s 4
+					IL_012e: ldc.i4.3
+					IL_012f: newarr [System.Runtime]System.Object
+					IL_0134: dup
+					IL_0135: ldc.i4.0
+					IL_0136: ldarg.0
+					IL_0137: ldc.i4.0
+					IL_0138: ldelem.ref
+					IL_0139: stelem.ref
 					IL_013a: dup
-					IL_013b: ldc.i4.0
+					IL_013b: ldc.i4.1
 					IL_013c: ldarg.0
-					IL_013d: ldc.i4.0
+					IL_013d: ldc.i4.1
 					IL_013e: ldelem.ref
 					IL_013f: stelem.ref
 					IL_0140: dup
-					IL_0141: ldc.i4.1
+					IL_0141: ldc.i4.2
 					IL_0142: ldarg.0
-					IL_0143: ldc.i4.1
+					IL_0143: ldc.i4.2
 					IL_0144: ldelem.ref
 					IL_0145: stelem.ref
-					IL_0146: dup
-					IL_0147: ldc.i4.2
+					IL_0146: stloc.s 13
 					IL_0148: ldarg.0
-					IL_0149: ldc.i4.2
+					IL_0149: ldc.i4.1
 					IL_014a: ldelem.ref
-					IL_014b: stelem.ref
-					IL_014c: stloc.s 14
-					IL_014e: ldarg.0
-					IL_014f: ldc.i4.1
-					IL_0150: ldelem.ref
-					IL_0151: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0156: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0160: stloc.s 15
-					IL_0162: ldstr "Too many redirects fetching "
-					IL_0167: ldloc.s 15
-					IL_0169: call string [System.Runtime]System.String::Concat(string, string)
-					IL_016e: stloc.s 15
-					IL_0170: ldloc.s 15
-					IL_0172: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_017c: stloc.s 16
-					IL_017e: ldloc.s 5
-					IL_0180: ldloc.s 14
-					IL_0182: ldloc.s 16
-					IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0189: pop
-					IL_018a: ldnull
-					IL_018b: ret
+					IL_014b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0150: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_015a: stloc.s 14
+					IL_015c: ldstr "Too many redirects fetching "
+					IL_0161: ldloc.s 14
+					IL_0163: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0168: stloc.s 14
+					IL_016a: ldloc.s 14
+					IL_016c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0171: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0176: stloc.s 15
+					IL_0178: ldloc.s 4
+					IL_017a: ldloc.s 13
+					IL_017c: ldloc.s 15
+					IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0183: pop
+					IL_0184: ldnull
+					IL_0185: ret
 
-					IL_018c: ldarg.0
-					IL_018d: ldc.i4.0
-					IL_018e: ldelem.ref
-					IL_018f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0194: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-					IL_0199: stloc.s 16
-					IL_019b: ldc.i4.2
-					IL_019c: newarr [System.Runtime]System.Object
-					IL_01a1: dup
-					IL_01a2: ldc.i4.0
-					IL_01a3: ldloc.2
-					IL_01a4: stelem.ref
-					IL_01a5: dup
-					IL_01a6: ldc.i4.1
-					IL_01a7: ldarg.0
-					IL_01a8: ldc.i4.2
-					IL_01a9: ldelem.ref
-					IL_01aa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_01af: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-					IL_01b4: stelem.ref
-					IL_01b5: stloc.s 14
-					IL_01b7: ldloc.s 16
-					IL_01b9: ldloc.s 14
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-					IL_01c0: stloc.s 16
-					IL_01c2: ldloc.s 16
-					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01c9: stloc.s 16
-					IL_01cb: ldloc.s 16
-					IL_01cd: ldstr "toString"
-					IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01d7: stloc.s 16
-					IL_01d9: ldloc.s 16
-					IL_01db: stloc.s 4
-					IL_01dd: ldarg.2
-					IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01e3: stloc.s 16
-					IL_01e5: ldloc.s 16
-					IL_01e7: ldstr "resume"
-					IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_01f1: pop
-					IL_01f2: ldarg.0
-					IL_01f3: ldc.i4.0
-					IL_01f4: ldelem.ref
-					IL_01f5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_01fa: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_01ff: stloc.s 16
-					IL_0201: ldc.i4.3
-					IL_0202: newarr [System.Runtime]System.Object
-					IL_0207: dup
-					IL_0208: ldc.i4.0
-					IL_0209: ldarg.0
-					IL_020a: ldc.i4.0
-					IL_020b: ldelem.ref
-					IL_020c: stelem.ref
-					IL_020d: dup
-					IL_020e: ldc.i4.1
-					IL_020f: ldarg.0
-					IL_0210: ldc.i4.1
-					IL_0211: ldelem.ref
-					IL_0212: stelem.ref
-					IL_0213: dup
-					IL_0214: ldc.i4.2
-					IL_0215: ldarg.0
-					IL_0216: ldc.i4.2
-					IL_0217: ldelem.ref
-					IL_0218: stelem.ref
-					IL_0219: stloc.s 14
-					IL_021b: ldloc.s 16
-					IL_021d: ldloc.s 14
-					IL_021f: ldloc.s 4
-					IL_0221: ldarg.0
-					IL_0222: ldc.i4.1
-					IL_0223: ldelem.ref
-					IL_0224: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0229: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_022e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0233: ldc.r8 1
-					IL_023c: sub
-					IL_023d: box [System.Runtime]System.Double
-					IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_0247: stloc.s 16
-					IL_0249: ldloc.s 16
-					IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0250: stloc.s 16
-					IL_0252: ldarg.0
-					IL_0253: ldc.i4.2
-					IL_0254: ldelem.ref
-					IL_0255: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_025a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_025f: stloc.s 5
-					IL_0261: ldloc.s 16
-					IL_0263: ldstr "then"
-					IL_0268: ldloc.s 5
-					IL_026a: ldarg.0
-					IL_026b: ldc.i4.2
-					IL_026c: ldelem.ref
-					IL_026d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0272: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_027c: pop
-					IL_027d: ldnull
-					IL_027e: ret
+					IL_0186: ldarg.0
+					IL_0187: ldc.i4.0
+					IL_0188: ldelem.ref
+					IL_0189: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_018e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+					IL_0193: stloc.s 15
+					IL_0195: ldc.i4.2
+					IL_0196: newarr [System.Runtime]System.Object
+					IL_019b: dup
+					IL_019c: ldc.i4.0
+					IL_019d: ldloc.2
+					IL_019e: stelem.ref
+					IL_019f: dup
+					IL_01a0: ldc.i4.1
+					IL_01a1: ldarg.0
+					IL_01a2: ldc.i4.2
+					IL_01a3: ldelem.ref
+					IL_01a4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_01a9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+					IL_01ae: stelem.ref
+					IL_01af: stloc.s 13
+					IL_01b1: ldloc.s 15
+					IL_01b3: ldloc.s 13
+					IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+					IL_01ba: stloc.s 15
+					IL_01bc: ldloc.s 15
+					IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01c3: stloc.s 15
+					IL_01c5: ldloc.s 15
+					IL_01c7: ldstr "toString"
+					IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01d1: stloc.s 15
+					IL_01d3: ldloc.s 15
+					IL_01d5: stloc.3
+					IL_01d6: ldarg.2
+					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01dc: stloc.s 15
+					IL_01de: ldloc.s 15
+					IL_01e0: ldstr "resume"
+					IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_01ea: pop
+					IL_01eb: ldarg.0
+					IL_01ec: ldc.i4.0
+					IL_01ed: ldelem.ref
+					IL_01ee: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01f3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_01f8: stloc.s 15
+					IL_01fa: ldc.i4.3
+					IL_01fb: newarr [System.Runtime]System.Object
+					IL_0200: dup
+					IL_0201: ldc.i4.0
+					IL_0202: ldarg.0
+					IL_0203: ldc.i4.0
+					IL_0204: ldelem.ref
+					IL_0205: stelem.ref
+					IL_0206: dup
+					IL_0207: ldc.i4.1
+					IL_0208: ldarg.0
+					IL_0209: ldc.i4.1
+					IL_020a: ldelem.ref
+					IL_020b: stelem.ref
+					IL_020c: dup
+					IL_020d: ldc.i4.2
+					IL_020e: ldarg.0
+					IL_020f: ldc.i4.2
+					IL_0210: ldelem.ref
+					IL_0211: stelem.ref
+					IL_0212: stloc.s 13
+					IL_0214: ldloc.s 15
+					IL_0216: ldloc.s 13
+					IL_0218: ldloc.3
+					IL_0219: ldarg.0
+					IL_021a: ldc.i4.1
+					IL_021b: ldelem.ref
+					IL_021c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0221: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_0226: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_022b: ldc.r8 1
+					IL_0234: sub
+					IL_0235: box [System.Runtime]System.Double
+					IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_023f: stloc.s 15
+					IL_0241: ldloc.s 15
+					IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0248: stloc.s 15
+					IL_024a: ldarg.0
+					IL_024b: ldc.i4.2
+					IL_024c: ldelem.ref
+					IL_024d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0252: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0257: stloc.s 4
+					IL_0259: ldloc.s 15
+					IL_025b: ldstr "then"
+					IL_0260: ldloc.s 4
+					IL_0262: ldarg.0
+					IL_0263: ldc.i4.2
+					IL_0264: ldelem.ref
+					IL_0265: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_026a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0274: pop
+					IL_0275: ldnull
+					IL_0276: ret
 
-					IL_027f: ldloc.1
-					IL_0280: stloc.s 12
-					IL_0282: ldloc.s 12
-					IL_0284: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0289: stloc.s 9
-					IL_028b: ldloc.s 9
-					IL_028d: ldc.r8 200
-					IL_0296: clt
-					IL_0298: stloc.s 6
-					IL_029a: ldloc.s 6
-					IL_029c: box [System.Runtime]System.Boolean
-					IL_02a1: stloc.s 10
-					IL_02a3: ldloc.s 10
-					IL_02a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02aa: stloc.s 6
-					IL_02ac: ldloc.s 6
-					IL_02ae: brtrue IL_02e3
+					IL_0277: ldloc.1
+					IL_0278: stloc.s 11
+					IL_027a: ldloc.s 11
+					IL_027c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0281: stloc.s 8
+					IL_0283: ldloc.s 8
+					IL_0285: ldc.r8 200
+					IL_028e: clt
+					IL_0290: stloc.s 5
+					IL_0292: ldloc.s 5
+					IL_0294: box [System.Runtime]System.Boolean
+					IL_0299: stloc.s 9
+					IL_029b: ldloc.s 9
+					IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a2: stloc.s 5
+					IL_02a4: ldloc.s 5
+					IL_02a6: brtrue IL_02db
 
-					IL_02b3: ldloc.1
-					IL_02b4: stloc.s 12
-					IL_02b6: ldloc.s 12
-					IL_02b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02bd: stloc.s 9
-					IL_02bf: ldloc.s 9
-					IL_02c1: ldc.r8 300
-					IL_02ca: clt
-					IL_02cc: ldc.i4.0
-					IL_02cd: ceq
-					IL_02cf: stloc.s 6
-					IL_02d1: ldloc.s 6
-					IL_02d3: box [System.Runtime]System.Boolean
-					IL_02d8: stloc.s 11
-					IL_02da: ldloc.s 11
-					IL_02dc: stloc.s 17
-					IL_02de: br IL_02e7
+					IL_02ab: ldloc.1
+					IL_02ac: stloc.s 11
+					IL_02ae: ldloc.s 11
+					IL_02b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02b5: stloc.s 8
+					IL_02b7: ldloc.s 8
+					IL_02b9: ldc.r8 300
+					IL_02c2: clt
+					IL_02c4: ldc.i4.0
+					IL_02c5: ceq
+					IL_02c7: stloc.s 5
+					IL_02c9: ldloc.s 5
+					IL_02cb: box [System.Runtime]System.Boolean
+					IL_02d0: stloc.s 10
+					IL_02d2: ldloc.s 10
+					IL_02d4: stloc.s 16
+					IL_02d6: br IL_02df
 
-					IL_02e3: ldloc.s 10
-					IL_02e5: stloc.s 17
+					IL_02db: ldloc.s 9
+					IL_02dd: stloc.s 16
 
-					IL_02e7: ldloc.s 17
-					IL_02e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02ee: stloc.s 6
-					IL_02f0: ldloc.s 6
-					IL_02f2: brfalse IL_0394
+					IL_02df: ldloc.s 16
+					IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02e6: stloc.s 5
+					IL_02e8: ldloc.s 5
+					IL_02ea: brfalse IL_038c
 
-					IL_02f7: ldarg.2
-					IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02fd: stloc.s 5
-					IL_02ff: ldloc.s 5
-					IL_0301: ldstr "resume"
-					IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_030b: pop
-					IL_030c: ldarg.0
-					IL_030d: ldc.i4.2
-					IL_030e: ldelem.ref
-					IL_030f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0314: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0319: stloc.s 5
-					IL_031b: ldc.i4.3
-					IL_031c: newarr [System.Runtime]System.Object
-					IL_0321: dup
-					IL_0322: ldc.i4.0
-					IL_0323: ldarg.0
-					IL_0324: ldc.i4.0
-					IL_0325: ldelem.ref
-					IL_0326: stelem.ref
-					IL_0327: dup
-					IL_0328: ldc.i4.1
-					IL_0329: ldarg.0
-					IL_032a: ldc.i4.1
-					IL_032b: ldelem.ref
-					IL_032c: stelem.ref
-					IL_032d: dup
-					IL_032e: ldc.i4.2
-					IL_032f: ldarg.0
-					IL_0330: ldc.i4.2
-					IL_0331: ldelem.ref
-					IL_0332: stelem.ref
+					IL_02ef: ldarg.2
+					IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02f5: stloc.s 4
+					IL_02f7: ldloc.s 4
+					IL_02f9: ldstr "resume"
+					IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0303: pop
+					IL_0304: ldarg.0
+					IL_0305: ldc.i4.2
+					IL_0306: ldelem.ref
+					IL_0307: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_030c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0311: stloc.s 4
+					IL_0313: ldc.i4.3
+					IL_0314: newarr [System.Runtime]System.Object
+					IL_0319: dup
+					IL_031a: ldc.i4.0
+					IL_031b: ldarg.0
+					IL_031c: ldc.i4.0
+					IL_031d: ldelem.ref
+					IL_031e: stelem.ref
+					IL_031f: dup
+					IL_0320: ldc.i4.1
+					IL_0321: ldarg.0
+					IL_0322: ldc.i4.1
+					IL_0323: ldelem.ref
+					IL_0324: stelem.ref
+					IL_0325: dup
+					IL_0326: ldc.i4.2
+					IL_0327: ldarg.0
+					IL_0328: ldc.i4.2
+					IL_0329: ldelem.ref
+					IL_032a: stelem.ref
+					IL_032b: stloc.s 13
+					IL_032d: ldloc.1
+					IL_032e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_0333: stloc.s 14
-					IL_0335: ldloc.1
-					IL_0336: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_033b: stloc.s 15
-					IL_033d: ldstr "HTTP "
-					IL_0342: ldloc.s 15
-					IL_0344: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0349: stloc.s 15
-					IL_034b: ldloc.s 15
-					IL_034d: ldstr " fetching "
-					IL_0352: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0357: stloc.s 15
-					IL_0359: ldarg.0
-					IL_035a: ldc.i4.1
-					IL_035b: ldelem.ref
-					IL_035c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0361: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0366: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_036b: stloc.s 18
-					IL_036d: ldloc.s 15
-					IL_036f: ldloc.s 18
-					IL_0371: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0376: stloc.s 18
-					IL_0378: ldloc.s 18
-					IL_037a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_037f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0384: stloc.s 16
-					IL_0386: ldloc.s 5
-					IL_0388: ldloc.s 14
-					IL_038a: ldloc.s 16
-					IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0391: pop
-					IL_0392: ldnull
-					IL_0393: ret
+					IL_0335: ldstr "HTTP "
+					IL_033a: ldloc.s 14
+					IL_033c: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0341: stloc.s 14
+					IL_0343: ldloc.s 14
+					IL_0345: ldstr " fetching "
+					IL_034a: call string [System.Runtime]System.String::Concat(string, string)
+					IL_034f: stloc.s 14
+					IL_0351: ldarg.0
+					IL_0352: ldc.i4.1
+					IL_0353: ldelem.ref
+					IL_0354: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0359: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_035e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0363: stloc.s 17
+					IL_0365: ldloc.s 14
+					IL_0367: ldloc.s 17
+					IL_0369: call string [System.Runtime]System.String::Concat(string, string)
+					IL_036e: stloc.s 17
+					IL_0370: ldloc.s 17
+					IL_0372: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0377: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_037c: stloc.s 15
+					IL_037e: ldloc.s 4
+					IL_0380: ldloc.s 13
+					IL_0382: ldloc.s 15
+					IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0389: pop
+					IL_038a: ldnull
+					IL_038b: ret
 
-					IL_0394: ldarg.2
-					IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_039a: stloc.s 16
-					IL_039c: ldloc.s 16
-					IL_039e: ldstr "setEncoding"
-					IL_03a3: ldstr "utf8"
-					IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_03ad: pop
-					IL_03ae: ldloc.0
-					IL_03af: ldstr ""
-					IL_03b4: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_03b9: ldarg.2
-					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03bf: stloc.s 16
-					IL_03c1: ldnull
-					IL_03c2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_03c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_03cd: ldc.i4.4
-					IL_03ce: newarr [System.Runtime]System.Object
-					IL_03d3: dup
-					IL_03d4: ldc.i4.0
-					IL_03d5: ldarg.0
-					IL_03d6: ldc.i4.0
-					IL_03d7: ldelem.ref
-					IL_03d8: stelem.ref
-					IL_03d9: dup
-					IL_03da: ldc.i4.1
-					IL_03db: ldarg.0
-					IL_03dc: ldc.i4.1
-					IL_03dd: ldelem.ref
-					IL_03de: stelem.ref
-					IL_03df: dup
-					IL_03e0: ldc.i4.2
-					IL_03e1: ldarg.0
-					IL_03e2: ldc.i4.2
-					IL_03e3: ldelem.ref
-					IL_03e4: stelem.ref
-					IL_03e5: dup
-					IL_03e6: ldc.i4.3
-					IL_03e7: ldloc.0
-					IL_03e8: stelem.ref
-					IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03f3: ldc.i4.1
-					IL_03f4: conv.r8
-					IL_03f5: ldstr ""
-					IL_03fa: ldc.i4.0
-					IL_03fb: ldc.i4.0
-					IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0406: stloc.s 5
-					IL_0408: ldloc.s 16
-					IL_040a: ldstr "on"
-					IL_040f: ldstr "data"
-					IL_0414: ldloc.s 5
-					IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_041b: pop
-					IL_041c: ldarg.2
-					IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0422: stloc.s 5
-					IL_0424: ldnull
-					IL_0425: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_042b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0430: ldc.i4.4
-					IL_0431: newarr [System.Runtime]System.Object
-					IL_0436: dup
-					IL_0437: ldc.i4.0
-					IL_0438: ldarg.0
-					IL_0439: ldc.i4.0
-					IL_043a: ldelem.ref
-					IL_043b: stelem.ref
-					IL_043c: dup
-					IL_043d: ldc.i4.1
-					IL_043e: ldarg.0
-					IL_043f: ldc.i4.1
-					IL_0440: ldelem.ref
-					IL_0441: stelem.ref
-					IL_0442: dup
-					IL_0443: ldc.i4.2
-					IL_0444: ldarg.0
-					IL_0445: ldc.i4.2
-					IL_0446: ldelem.ref
-					IL_0447: stelem.ref
-					IL_0448: dup
-					IL_0449: ldc.i4.3
-					IL_044a: ldloc.0
-					IL_044b: stelem.ref
-					IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_038c: ldarg.2
+					IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0392: stloc.s 15
+					IL_0394: ldloc.s 15
+					IL_0396: ldstr "setEncoding"
+					IL_039b: ldstr "utf8"
+					IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_03a5: pop
+					IL_03a6: ldloc.0
+					IL_03a7: ldstr ""
+					IL_03ac: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_03b1: ldarg.2
+					IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03b7: stloc.s 15
+					IL_03b9: ldnull
+					IL_03ba: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03c5: ldc.i4.4
+					IL_03c6: newarr [System.Runtime]System.Object
+					IL_03cb: dup
+					IL_03cc: ldc.i4.0
+					IL_03cd: ldarg.0
+					IL_03ce: ldc.i4.0
+					IL_03cf: ldelem.ref
+					IL_03d0: stelem.ref
+					IL_03d1: dup
+					IL_03d2: ldc.i4.1
+					IL_03d3: ldarg.0
+					IL_03d4: ldc.i4.1
+					IL_03d5: ldelem.ref
+					IL_03d6: stelem.ref
+					IL_03d7: dup
+					IL_03d8: ldc.i4.2
+					IL_03d9: ldarg.0
+					IL_03da: ldc.i4.2
+					IL_03db: ldelem.ref
+					IL_03dc: stelem.ref
+					IL_03dd: dup
+					IL_03de: ldc.i4.3
+					IL_03df: ldloc.0
+					IL_03e0: stelem.ref
+					IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03eb: ldc.i4.1
+					IL_03ec: conv.r8
+					IL_03ed: ldstr ""
+					IL_03f2: ldc.i4.0
+					IL_03f3: ldc.i4.0
+					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_03fe: stloc.s 4
+					IL_0400: ldloc.s 15
+					IL_0402: ldstr "on"
+					IL_0407: ldstr "data"
+					IL_040c: ldloc.s 4
+					IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0413: pop
+					IL_0414: ldarg.2
+					IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_041a: stloc.s 4
+					IL_041c: ldnull
+					IL_041d: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0423: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_0428: ldc.i4.4
+					IL_0429: newarr [System.Runtime]System.Object
+					IL_042e: dup
+					IL_042f: ldc.i4.0
+					IL_0430: ldarg.0
+					IL_0431: ldc.i4.0
+					IL_0432: ldelem.ref
+					IL_0433: stelem.ref
+					IL_0434: dup
+					IL_0435: ldc.i4.1
+					IL_0436: ldarg.0
+					IL_0437: ldc.i4.1
+					IL_0438: ldelem.ref
+					IL_0439: stelem.ref
+					IL_043a: dup
+					IL_043b: ldc.i4.2
+					IL_043c: ldarg.0
+					IL_043d: ldc.i4.2
+					IL_043e: ldelem.ref
+					IL_043f: stelem.ref
+					IL_0440: dup
+					IL_0441: ldc.i4.3
+					IL_0442: ldloc.0
+					IL_0443: stelem.ref
+					IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_044e: ldc.i4.0
+					IL_044f: conv.r8
+					IL_0450: ldstr ""
+					IL_0455: ldc.i4.0
 					IL_0456: ldc.i4.0
-					IL_0457: conv.r8
-					IL_0458: ldstr ""
-					IL_045d: ldc.i4.0
-					IL_045e: ldc.i4.0
-					IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0469: stloc.s 16
-					IL_046b: ldloc.s 5
-					IL_046d: ldstr "on"
-					IL_0472: ldstr "end"
-					IL_0477: ldloc.s 16
-					IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_047e: pop
-					IL_047f: ldnull
-					IL_0480: ret
+					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0461: stloc.s 15
+					IL_0463: ldloc.s 4
+					IL_0465: ldstr "on"
+					IL_046a: ldstr "end"
+					IL_046f: ldloc.s 15
+					IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0476: pop
+					IL_0477: ldnull
+					IL_0478: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1926,7 +1920,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x474c
+						// Method begins at RVA 0x46c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1946,7 +1940,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4755
+						// Method begins at RVA 0x46cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1969,7 +1963,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4743
+					// Method begins at RVA 0x46bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1995,7 +1989,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f90
+				// Method begins at RVA 0x3f10
 				// Header size: 12
 				// Code size: 495 (0x1ef)
 				.maxstack 8
@@ -2235,7 +2229,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x473a
+					// Method begins at RVA 0x46b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2257,7 +2251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4731
+				// Method begins at RVA 0x46a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2285,7 +2279,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2970
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -2353,7 +2347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4794
+				// Method begins at RVA 0x470c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2377,7 +2371,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29e8
+			// Method begins at RVA 0x29cc
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -2420,7 +2414,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47a6
+					// Method begins at RVA 0x471e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2438,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x47b8
+						// Method begins at RVA 0x4730
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2462,7 +2456,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47af
+					// Method begins at RVA 0x4727
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2480,7 +2474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x479d
+				// Method begins at RVA 0x4715
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2508,17 +2502,17 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2a20
+			// Method begins at RVA 0x2a04
 			// Header size: 12
-			// Code size: 564 (0x234)
+			// Code size: 544 (0x220)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/Scope/Block_L140C30,
-				[2] object,
-				[3] float64,
-				[4] object,
-				[5] bool,
+				[1] object,
+				[2] float64,
+				[3] object,
+				[4] bool,
+				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
@@ -2527,222 +2521,219 @@
 				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] object
+				[14] object
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.3
-			IL_0007: ldloc.3
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
 			IL_0008: ldc.r8 0.0
 			IL_0011: clt
 			IL_0013: box [System.Runtime]System.Boolean
-			IL_0018: stloc.s 4
-			IL_001a: ldloc.s 4
-			IL_001c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0021: stloc.s 5
-			IL_0023: ldloc.s 5
-			IL_0025: brtrue IL_004f
+			IL_0018: stloc.3
+			IL_0019: ldloc.3
+			IL_001a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001f: stloc.s 4
+			IL_0021: ldloc.s 4
+			IL_0023: brtrue IL_004d
 
-			IL_002a: ldarg.2
-			IL_002b: ldloc.3
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0031: ldstr "<"
-			IL_0036: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_003b: stloc.s 5
-			IL_003d: ldloc.s 5
-			IL_003f: box [System.Runtime]System.Boolean
-			IL_0044: stloc.s 6
-			IL_0046: ldloc.s 6
-			IL_0048: stloc.s 8
-			IL_004a: br IL_0053
+			IL_0028: ldarg.2
+			IL_0029: ldloc.2
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_002f: ldstr "<"
+			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: box [System.Runtime]System.Boolean
+			IL_0042: stloc.s 5
+			IL_0044: ldloc.s 5
+			IL_0046: stloc.s 7
+			IL_0048: br IL_0050
 
-			IL_004f: ldloc.s 4
-			IL_0051: stloc.s 8
+			IL_004d: ldloc.3
+			IL_004e: stloc.s 7
 
-			IL_0053: ldloc.s 8
-			IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005a: stloc.s 5
-			IL_005c: ldloc.s 5
-			IL_005e: brfalse IL_0069
+			IL_0050: ldloc.s 7
+			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.s 4
+			IL_005b: brfalse IL_0066
 
-			IL_0063: ldstr ""
-			IL_0068: ret
+			IL_0060: ldstr ""
+			IL_0065: ret
 
-			IL_0069: ldarg.3
-			IL_006a: ldc.r8 1
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0078: stloc.s 8
-			IL_007a: ldloc.s 8
-			IL_007c: stloc.0
-			// loop start (head: IL_007d)
-				IL_007d: ldloc.0
-				IL_007e: stloc.s 8
-				IL_0080: ldarg.2
-				IL_0081: ldstr "length"
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_008b: stloc.s 9
-				IL_008d: ldloc.s 8
-				IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0094: stloc.3
-				IL_0095: ldloc.3
-				IL_0096: ldloc.s 9
-				IL_0098: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_009d: clt
-				IL_009f: brfalse IL_0207
+			IL_0066: ldarg.3
+			IL_0067: ldc.r8 1
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0075: stloc.s 7
+			IL_0077: ldloc.s 7
+			IL_0079: stloc.0
+			// loop start (head: IL_007a)
+				IL_007a: ldloc.0
+				IL_007b: stloc.s 7
+				IL_007d: ldarg.2
+				IL_007e: ldstr "length"
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0088: stloc.s 8
+				IL_008a: ldloc.s 7
+				IL_008c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0091: stloc.2
+				IL_0092: ldloc.2
+				IL_0093: ldloc.s 8
+				IL_0095: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_009a: clt
+				IL_009c: brfalse IL_01f3
 
-				IL_00a4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/Scope/Block_L140C30::.ctor()
-				IL_00a9: stloc.1
-				IL_00aa: ldarg.2
-				IL_00ab: ldloc.0
-				IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_00b1: stloc.2
-				IL_00b2: ldloc.2
-				IL_00b3: stloc.s 9
-				IL_00b5: ldloc.s 9
-				IL_00b7: ldstr " "
-				IL_00bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00c1: stloc.s 5
-				IL_00c3: ldloc.s 5
-				IL_00c5: box [System.Runtime]System.Boolean
-				IL_00ca: stloc.s 4
-				IL_00cc: ldloc.s 4
-				IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00d3: stloc.s 5
-				IL_00d5: ldloc.s 5
-				IL_00d7: brtrue IL_00ff
+				IL_00a1: ldarg.2
+				IL_00a2: ldloc.0
+				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_00a8: stloc.1
+				IL_00a9: ldloc.1
+				IL_00aa: stloc.s 8
+				IL_00ac: ldloc.s 8
+				IL_00ae: ldstr " "
+				IL_00b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00b8: stloc.s 4
+				IL_00ba: ldloc.s 4
+				IL_00bc: box [System.Runtime]System.Boolean
+				IL_00c1: stloc.3
+				IL_00c2: ldloc.3
+				IL_00c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00c8: stloc.s 4
+				IL_00ca: ldloc.s 4
+				IL_00cc: brtrue IL_00f4
 
-				IL_00dc: ldloc.2
-				IL_00dd: stloc.s 9
-				IL_00df: ldloc.s 9
-				IL_00e1: ldstr "\t"
-				IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00eb: stloc.s 5
-				IL_00ed: ldloc.s 5
-				IL_00ef: box [System.Runtime]System.Boolean
-				IL_00f4: stloc.s 6
-				IL_00f6: ldloc.s 6
-				IL_00f8: stloc.s 10
-				IL_00fa: br IL_0103
+				IL_00d1: ldloc.1
+				IL_00d2: stloc.s 8
+				IL_00d4: ldloc.s 8
+				IL_00d6: ldstr "\t"
+				IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00e0: stloc.s 4
+				IL_00e2: ldloc.s 4
+				IL_00e4: box [System.Runtime]System.Boolean
+				IL_00e9: stloc.s 5
+				IL_00eb: ldloc.s 5
+				IL_00ed: stloc.s 9
+				IL_00ef: br IL_00f7
 
-				IL_00ff: ldloc.s 4
-				IL_0101: stloc.s 10
+				IL_00f4: ldloc.3
+				IL_00f5: stloc.s 9
 
-				IL_0103: ldloc.s 10
-				IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_010a: stloc.s 5
-				IL_010c: ldloc.s 5
-				IL_010e: brtrue IL_0136
+				IL_00f7: ldloc.s 9
+				IL_00f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00fe: stloc.s 4
+				IL_0100: ldloc.s 4
+				IL_0102: brtrue IL_0128
 
-				IL_0113: ldloc.2
-				IL_0114: stloc.s 9
-				IL_0116: ldloc.s 9
-				IL_0118: ldstr "\r"
-				IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0122: stloc.s 5
-				IL_0124: ldloc.s 5
-				IL_0126: box [System.Runtime]System.Boolean
-				IL_012b: stloc.s 4
-				IL_012d: ldloc.s 4
-				IL_012f: stloc.s 10
-				IL_0131: br IL_0136
+				IL_0107: ldloc.1
+				IL_0108: stloc.s 8
+				IL_010a: ldloc.s 8
+				IL_010c: ldstr "\r"
+				IL_0111: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0116: stloc.s 4
+				IL_0118: ldloc.s 4
+				IL_011a: box [System.Runtime]System.Boolean
+				IL_011f: stloc.3
+				IL_0120: ldloc.3
+				IL_0121: stloc.s 9
+				IL_0123: br IL_0128
 
-				IL_0136: ldloc.s 10
-				IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013d: stloc.s 5
-				IL_013f: ldloc.s 5
-				IL_0141: brtrue IL_0169
+				IL_0128: ldloc.s 9
+				IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_012f: stloc.s 4
+				IL_0131: ldloc.s 4
+				IL_0133: brtrue IL_0159
 
-				IL_0146: ldloc.2
-				IL_0147: stloc.s 9
-				IL_0149: ldloc.s 9
-				IL_014b: ldstr "\n"
-				IL_0150: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0155: stloc.s 5
-				IL_0157: ldloc.s 5
-				IL_0159: box [System.Runtime]System.Boolean
-				IL_015e: stloc.s 4
-				IL_0160: ldloc.s 4
-				IL_0162: stloc.s 10
-				IL_0164: br IL_0169
+				IL_0138: ldloc.1
+				IL_0139: stloc.s 8
+				IL_013b: ldloc.s 8
+				IL_013d: ldstr "\n"
+				IL_0142: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0147: stloc.s 4
+				IL_0149: ldloc.s 4
+				IL_014b: box [System.Runtime]System.Boolean
+				IL_0150: stloc.3
+				IL_0151: ldloc.3
+				IL_0152: stloc.s 9
+				IL_0154: br IL_0159
 
-				IL_0169: ldloc.s 10
-				IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0170: stloc.s 5
-				IL_0172: ldloc.s 5
-				IL_0174: brtrue IL_019c
+				IL_0159: ldloc.s 9
+				IL_015b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0160: stloc.s 4
+				IL_0162: ldloc.s 4
+				IL_0164: brtrue IL_018a
 
-				IL_0179: ldloc.2
-				IL_017a: stloc.s 9
-				IL_017c: ldloc.s 9
-				IL_017e: ldstr ">"
-				IL_0183: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0188: stloc.s 5
-				IL_018a: ldloc.s 5
-				IL_018c: box [System.Runtime]System.Boolean
+				IL_0169: ldloc.1
+				IL_016a: stloc.s 8
+				IL_016c: ldloc.s 8
+				IL_016e: ldstr ">"
+				IL_0173: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0178: stloc.s 4
+				IL_017a: ldloc.s 4
+				IL_017c: box [System.Runtime]System.Boolean
+				IL_0181: stloc.3
+				IL_0182: ldloc.3
+				IL_0183: stloc.s 9
+				IL_0185: br IL_018a
+
+				IL_018a: ldloc.s 9
+				IL_018c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0191: stloc.s 4
 				IL_0193: ldloc.s 4
-				IL_0195: stloc.s 10
-				IL_0197: br IL_019c
+				IL_0195: brtrue IL_01bb
 
-				IL_019c: ldloc.s 10
-				IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01a3: stloc.s 5
-				IL_01a5: ldloc.s 5
-				IL_01a7: brtrue IL_01cf
+				IL_019a: ldloc.1
+				IL_019b: stloc.s 8
+				IL_019d: ldloc.s 8
+				IL_019f: ldstr "/"
+				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01a9: stloc.s 4
+				IL_01ab: ldloc.s 4
+				IL_01ad: box [System.Runtime]System.Boolean
+				IL_01b2: stloc.3
+				IL_01b3: ldloc.3
+				IL_01b4: stloc.s 9
+				IL_01b6: br IL_01bb
 
-				IL_01ac: ldloc.2
-				IL_01ad: stloc.s 9
-				IL_01af: ldloc.s 9
-				IL_01b1: ldstr "/"
-				IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01bb: stloc.s 5
-				IL_01bd: ldloc.s 5
-				IL_01bf: box [System.Runtime]System.Boolean
-				IL_01c4: stloc.s 4
-				IL_01c6: ldloc.s 4
-				IL_01c8: stloc.s 10
-				IL_01ca: br IL_01cf
+				IL_01bb: ldloc.s 9
+				IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01c2: stloc.s 4
+				IL_01c4: ldloc.s 4
+				IL_01c6: brfalse IL_01d0
 
-				IL_01cf: ldloc.s 10
-				IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01d6: stloc.s 5
-				IL_01d8: ldloc.s 5
-				IL_01da: brfalse IL_01e4
+				IL_01cb: br IL_01f3
 
-				IL_01df: br IL_0207
-
-				IL_01e4: ldloc.0
-				IL_01e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01ea: stloc.3
-				IL_01eb: ldloc.3
-				IL_01ec: ldc.r8 1
-				IL_01f5: add
-				IL_01f6: stloc.3
-				IL_01f7: ldloc.3
-				IL_01f8: box [System.Runtime]System.Double
-				IL_01fd: stloc.s 15
-				IL_01ff: ldloc.s 15
-				IL_0201: stloc.0
-				IL_0202: br IL_007d
+				IL_01d0: ldloc.0
+				IL_01d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01d6: stloc.2
+				IL_01d7: ldloc.2
+				IL_01d8: ldc.r8 1
+				IL_01e1: add
+				IL_01e2: stloc.2
+				IL_01e3: ldloc.2
+				IL_01e4: box [System.Runtime]System.Double
+				IL_01e9: stloc.s 14
+				IL_01eb: ldloc.s 14
+				IL_01ed: stloc.0
+				IL_01ee: br IL_007a
 			// end loop
 
-			IL_0207: ldarg.2
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_020d: stloc.s 9
-			IL_020f: ldarg.3
-			IL_0210: ldc.r8 1
-			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_021e: stloc.s 10
-			IL_0220: ldloc.s 9
-			IL_0222: ldstr "substring"
-			IL_0227: ldloc.s 10
-			IL_0229: ldloc.0
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_022f: stloc.s 9
-			IL_0231: ldloc.s 9
-			IL_0233: ret
+			IL_01f3: ldarg.2
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f9: stloc.s 8
+			IL_01fb: ldarg.3
+			IL_01fc: ldc.r8 1
+			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_020a: stloc.s 9
+			IL_020c: ldloc.s 8
+			IL_020e: ldstr "substring"
+			IL_0213: ldloc.s 9
+			IL_0215: ldloc.0
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_021b: stloc.s 8
+			IL_021d: ldloc.s 8
+			IL_021f: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -2762,7 +2753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47ca
+					// Method begins at RVA 0x4742
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2782,7 +2773,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47d3
+					// Method begins at RVA 0x474b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2802,7 +2793,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47dc
+					// Method begins at RVA 0x4754
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2822,7 +2813,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47e5
+					// Method begins at RVA 0x475d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2846,7 +2837,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x47f7
+						// Method begins at RVA 0x476f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2866,7 +2857,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4800
+						// Method begins at RVA 0x4778
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2890,7 +2881,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4812
+							// Method begins at RVA 0x478a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2908,7 +2899,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4809
+						// Method begins at RVA 0x4781
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2928,7 +2919,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x481b
+						// Method begins at RVA 0x4793
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2946,7 +2937,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47ee
+					// Method begins at RVA 0x4766
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2964,7 +2955,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x47c1
+				// Method begins at RVA 0x4739
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2992,9 +2983,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2c60
+			// Method begins at RVA 0x2c30
 			// Header size: 12
-			// Code size: 1079 (0x437)
+			// Code size: 1072 (0x430)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3008,104 +2999,103 @@
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[9] float64,
 				[10] object,
-				[11] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15,
+				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] string,
-				[16] object,
-				[17] float64,
-				[18] object[],
-				[19] bool,
-				[20] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[21] object,
-				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[23] string
+				[14] string,
+				[15] object,
+				[16] float64,
+				[17] object[],
+				[18] bool,
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[20] object,
+				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[22] string
 			)
 
 			IL_0000: ldarg.3
 			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0006: stloc.s 15
+			IL_0006: stloc.s 14
 			IL_0008: ldstr "id=\""
-			IL_000d: ldloc.s 15
+			IL_000d: ldloc.s 14
 			IL_000f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0014: stloc.s 15
-			IL_0016: ldloc.s 15
+			IL_0014: stloc.s 14
+			IL_0016: ldloc.s 14
 			IL_0018: ldstr "\""
 			IL_001d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0022: stloc.s 15
-			IL_0024: ldloc.s 15
+			IL_0022: stloc.s 14
+			IL_0024: ldloc.s 14
 			IL_0026: stloc.0
 			IL_0027: ldarg.3
 			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002d: stloc.s 15
+			IL_002d: stloc.s 14
 			IL_002f: ldstr "id='"
-			IL_0034: ldloc.s 15
+			IL_0034: ldloc.s 14
 			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.s 15
-			IL_003d: ldloc.s 15
+			IL_003b: stloc.s 14
+			IL_003d: ldloc.s 14
 			IL_003f: ldstr "'"
 			IL_0044: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0049: stloc.s 15
-			IL_004b: ldloc.s 15
+			IL_0049: stloc.s 14
+			IL_004b: ldloc.s 14
 			IL_004d: stloc.1
 			IL_004e: ldarg.2
 			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0054: stloc.s 16
-			IL_0056: ldloc.s 16
+			IL_0054: stloc.s 15
+			IL_0056: ldloc.s 15
 			IL_0058: ldstr "indexOf"
 			IL_005d: ldloc.0
 			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0063: stloc.s 16
-			IL_0065: ldloc.s 16
+			IL_0063: stloc.s 15
+			IL_0065: ldloc.s 15
 			IL_0067: stloc.2
 			IL_0068: ldloc.2
-			IL_0069: stloc.s 16
-			IL_006b: ldloc.s 16
+			IL_0069: stloc.s 15
+			IL_006b: ldloc.s 15
 			IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0072: stloc.s 17
-			IL_0074: ldloc.s 17
+			IL_0072: stloc.s 16
+			IL_0074: ldloc.s 16
 			IL_0076: ldc.r8 0.0
 			IL_007f: clt
 			IL_0081: brfalse IL_00a0
 
 			IL_0086: ldarg.2
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008c: stloc.s 16
-			IL_008e: ldloc.s 16
+			IL_008c: stloc.s 15
+			IL_008e: ldloc.s 15
 			IL_0090: ldstr "indexOf"
 			IL_0095: ldloc.1
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009b: stloc.s 16
-			IL_009d: ldloc.s 16
+			IL_009b: stloc.s 15
+			IL_009d: ldloc.s 15
 			IL_009f: stloc.2
 
 			IL_00a0: ldloc.2
-			IL_00a1: stloc.s 16
-			IL_00a3: ldloc.s 16
+			IL_00a1: stloc.s 15
+			IL_00a3: ldloc.s 15
 			IL_00a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00aa: stloc.s 17
-			IL_00ac: ldloc.s 17
+			IL_00aa: stloc.s 16
+			IL_00ac: ldloc.s 16
 			IL_00ae: ldc.r8 0.0
 			IL_00b7: clt
 			IL_00b9: brfalse IL_0108
 
 			IL_00be: ldarg.3
 			IL_00bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c4: stloc.s 15
+			IL_00c4: stloc.s 14
 			IL_00c6: ldstr "Could not find id '"
-			IL_00cb: ldloc.s 15
+			IL_00cb: ldloc.s 14
 			IL_00cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d2: stloc.s 15
-			IL_00d4: ldloc.s 15
+			IL_00d2: stloc.s 14
+			IL_00d4: ldloc.s 14
 			IL_00d6: ldstr "' in input HTML."
 			IL_00db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e0: stloc.s 15
-			IL_00e2: ldloc.s 15
+			IL_00e0: stloc.s 14
+			IL_00e2: ldloc.s 14
 			IL_00e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ee: stloc.s 16
-			IL_00f0: ldloc.s 16
+			IL_00ee: stloc.s 15
+			IL_00f0: ldloc.s 15
 			IL_00f2: stloc.3
 			IL_00f3: ldloc.3
 			IL_00f4: isinst [System.Runtime]System.Exception
@@ -3121,41 +3111,41 @@
 
 			IL_0108: ldarg.2
 			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010e: stloc.s 16
-			IL_0110: ldloc.s 16
+			IL_010e: stloc.s 15
+			IL_0110: ldloc.s 15
 			IL_0112: ldstr "lastIndexOf"
 			IL_0117: ldstr "<"
 			IL_011c: ldloc.2
 			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0122: stloc.s 16
-			IL_0124: ldloc.s 16
+			IL_0122: stloc.s 15
+			IL_0124: ldloc.s 15
 			IL_0126: stloc.s 4
 			IL_0128: ldloc.s 4
-			IL_012a: stloc.s 16
-			IL_012c: ldloc.s 16
+			IL_012a: stloc.s 15
+			IL_012c: ldloc.s 15
 			IL_012e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0133: stloc.s 17
-			IL_0135: ldloc.s 17
+			IL_0133: stloc.s 16
+			IL_0135: ldloc.s 16
 			IL_0137: ldc.r8 0.0
 			IL_0140: clt
 			IL_0142: brfalse IL_0194
 
 			IL_0147: ldarg.3
 			IL_0148: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_014d: stloc.s 15
+			IL_014d: stloc.s 14
 			IL_014f: ldstr "Could not locate tag start for id '"
-			IL_0154: ldloc.s 15
+			IL_0154: ldloc.s 14
 			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015b: stloc.s 15
-			IL_015d: ldloc.s 15
+			IL_015b: stloc.s 14
+			IL_015d: ldloc.s 14
 			IL_015f: ldstr "'."
 			IL_0164: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0169: stloc.s 15
-			IL_016b: ldloc.s 15
+			IL_0169: stloc.s 14
+			IL_016b: ldloc.s 14
 			IL_016d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0177: stloc.s 16
-			IL_0179: ldloc.s 16
+			IL_0177: stloc.s 15
+			IL_0179: ldloc.s 15
 			IL_017b: stloc.s 5
 			IL_017d: ldloc.s 5
 			IL_017f: isinst [System.Runtime]System.Exception
@@ -3175,40 +3165,40 @@
 			IL_019b: ldc.i4.0
 			IL_019c: ldarg.0
 			IL_019d: stelem.ref
-			IL_019e: stloc.s 18
+			IL_019e: stloc.s 17
 			IL_01a0: ldarg.0
 			IL_01a1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_01a6: ldloc.s 18
+			IL_01a6: ldloc.s 17
 			IL_01a8: ldarg.2
 			IL_01a9: ldloc.s 4
 			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01b0: stloc.s 16
-			IL_01b2: ldloc.s 16
+			IL_01b0: stloc.s 15
+			IL_01b2: ldloc.s 15
 			IL_01b4: stloc.s 6
 			IL_01b6: ldloc.s 6
 			IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_01bd: ldc.i4.0
 			IL_01be: ceq
-			IL_01c0: stloc.s 19
-			IL_01c2: ldloc.s 19
+			IL_01c0: stloc.s 18
+			IL_01c2: ldloc.s 18
 			IL_01c4: brfalse IL_0216
 
 			IL_01c9: ldarg.3
 			IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cf: stloc.s 15
+			IL_01cf: stloc.s 14
 			IL_01d1: ldstr "Could not determine tag name for id '"
-			IL_01d6: ldloc.s 15
+			IL_01d6: ldloc.s 14
 			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01dd: stloc.s 15
-			IL_01df: ldloc.s 15
+			IL_01dd: stloc.s 14
+			IL_01df: ldloc.s 14
 			IL_01e1: ldstr "'."
 			IL_01e6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01eb: stloc.s 15
-			IL_01ed: ldloc.s 15
+			IL_01eb: stloc.s 14
+			IL_01ed: ldloc.s 14
 			IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_01f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01f9: stloc.s 16
-			IL_01fb: ldloc.s 16
+			IL_01f9: stloc.s 15
+			IL_01fb: ldloc.s 15
 			IL_01fd: stloc.s 7
 			IL_01ff: ldloc.s 7
 			IL_0201: isinst [System.Runtime]System.Exception
@@ -3232,23 +3222,23 @@
 			IL_0225: stelem.ref
 			IL_0226: ldloc.s 6
 			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_022d: stloc.s 16
-			IL_022f: ldloc.s 16
+			IL_022d: stloc.s 15
+			IL_022f: ldloc.s 15
 			IL_0231: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0236: stloc.s 15
+			IL_0236: stloc.s 14
 			IL_0238: ldstr "<\\/?"
-			IL_023d: ldloc.s 15
+			IL_023d: ldloc.s 14
 			IL_023f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0244: stloc.s 15
-			IL_0246: ldloc.s 15
+			IL_0244: stloc.s 14
+			IL_0246: ldloc.s 14
 			IL_0248: ldstr "\\b[^>]*>"
 			IL_024d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0252: stloc.s 15
-			IL_0254: ldloc.s 15
+			IL_0252: stloc.s 14
+			IL_0254: ldloc.s 14
 			IL_0256: ldstr "gi"
 			IL_025b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0260: stloc.s 20
-			IL_0262: ldloc.s 20
+			IL_0260: stloc.s 19
+			IL_0262: ldloc.s 19
 			IL_0264: stloc.s 8
 			IL_0266: ldloc.s 8
 			IL_0268: ldstr "lastIndex"
@@ -3264,152 +3254,150 @@
 			IL_0290: stloc.s 10
 			// loop start (head: IL_0292)
 				IL_0292: ldc.i4.1
-				IL_0293: brfalse IL_03c6
+				IL_0293: brfalse IL_03bf
 
-				IL_0298: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_029d: stloc.s 11
-				IL_029f: ldloc.s 8
-				IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02a6: stloc.s 16
-				IL_02a8: ldloc.s 16
-				IL_02aa: ldstr "exec"
-				IL_02af: ldarg.2
-				IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02b5: stloc.s 16
-				IL_02b7: ldloc.s 16
-				IL_02b9: stloc.s 12
-				IL_02bb: ldloc.s 12
-				IL_02bd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02c2: ldc.i4.0
-				IL_02c3: ceq
-				IL_02c5: stloc.s 19
-				IL_02c7: ldloc.s 19
-				IL_02c9: brfalse IL_02d3
+				IL_0298: ldloc.s 8
+				IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_029f: stloc.s 15
+				IL_02a1: ldloc.s 15
+				IL_02a3: ldstr "exec"
+				IL_02a8: ldarg.2
+				IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02ae: stloc.s 15
+				IL_02b0: ldloc.s 15
+				IL_02b2: stloc.s 11
+				IL_02b4: ldloc.s 11
+				IL_02b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02bb: ldc.i4.0
+				IL_02bc: ceq
+				IL_02be: stloc.s 18
+				IL_02c0: ldloc.s 18
+				IL_02c2: brfalse IL_02cc
 
-				IL_02ce: br IL_03c6
+				IL_02c7: br IL_03bf
 
-				IL_02d3: ldloc.s 12
-				IL_02d5: ldc.r8 0.0
-				IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02e3: stloc.s 13
-				IL_02e5: ldloc.s 10
-				IL_02e7: stloc.s 21
-				IL_02e9: ldloc.s 21
-				IL_02eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_02f0: stloc.s 17
-				IL_02f2: ldloc.s 17
-				IL_02f4: ldc.r8 0.0
-				IL_02fd: clt
-				IL_02ff: brfalse IL_0316
+				IL_02cc: ldloc.s 11
+				IL_02ce: ldc.r8 0.0
+				IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02dc: stloc.s 12
+				IL_02de: ldloc.s 10
+				IL_02e0: stloc.s 20
+				IL_02e2: ldloc.s 20
+				IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_02e9: stloc.s 16
+				IL_02eb: ldloc.s 16
+				IL_02ed: ldc.r8 0.0
+				IL_02f6: clt
+				IL_02f8: brfalse IL_030f
 
-				IL_0304: ldloc.s 12
-				IL_0306: ldstr "index"
-				IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0310: stloc.s 16
-				IL_0312: ldloc.s 16
-				IL_0314: stloc.s 10
+				IL_02fd: ldloc.s 11
+				IL_02ff: ldstr "index"
+				IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0309: stloc.s 15
+				IL_030b: ldloc.s 15
+				IL_030d: stloc.s 10
 
-				IL_0316: ldloc.s 13
-				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_031d: stloc.s 16
-				IL_031f: ldloc.s 16
-				IL_0321: ldstr "startsWith"
-				IL_0326: ldstr "</"
-				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0330: stloc.s 16
-				IL_0332: ldloc.s 16
-				IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0339: stloc.s 19
-				IL_033b: ldloc.s 19
-				IL_033d: brfalse IL_03b3
+				IL_030f: ldloc.s 12
+				IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0316: stloc.s 15
+				IL_0318: ldloc.s 15
+				IL_031a: ldstr "startsWith"
+				IL_031f: ldstr "</"
+				IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0329: stloc.s 15
+				IL_032b: ldloc.s 15
+				IL_032d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0332: stloc.s 18
+				IL_0334: ldloc.s 18
+				IL_0336: brfalse IL_03ac
 
-				IL_0342: ldloc.s 9
-				IL_0344: ldc.r8 1
-				IL_034d: sub
-				IL_034e: stloc.s 9
-				IL_0350: ldloc.s 9
-				IL_0352: stloc.s 17
-				IL_0354: ldloc.s 17
-				IL_0356: ldc.r8 0.0
-				IL_035f: ceq
-				IL_0361: brfalse IL_03ae
+				IL_033b: ldloc.s 9
+				IL_033d: ldc.r8 1
+				IL_0346: sub
+				IL_0347: stloc.s 9
+				IL_0349: ldloc.s 9
+				IL_034b: stloc.s 16
+				IL_034d: ldloc.s 16
+				IL_034f: ldc.r8 0.0
+				IL_0358: ceq
+				IL_035a: brfalse IL_03a7
 
-				IL_0366: ldarg.2
-				IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_036c: stloc.s 16
-				IL_036e: ldloc.s 16
-				IL_0370: ldstr "substring"
-				IL_0375: ldloc.s 10
-				IL_0377: ldloc.s 8
-				IL_0379: ldstr "lastIndex"
-				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_0388: stloc.s 16
-				IL_038a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_038f: dup
-				IL_0390: ldstr "tagName"
-				IL_0395: ldloc.s 6
-				IL_0397: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_039c: dup
-				IL_039d: ldstr "html"
-				IL_03a2: ldloc.s 16
-				IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03a9: stloc.s 22
-				IL_03ab: ldloc.s 22
-				IL_03ad: ret
+				IL_035f: ldarg.2
+				IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0365: stloc.s 15
+				IL_0367: ldloc.s 15
+				IL_0369: ldstr "substring"
+				IL_036e: ldloc.s 10
+				IL_0370: ldloc.s 8
+				IL_0372: ldstr "lastIndex"
+				IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0381: stloc.s 15
+				IL_0383: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0388: dup
+				IL_0389: ldstr "tagName"
+				IL_038e: ldloc.s 6
+				IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0395: dup
+				IL_0396: ldstr "html"
+				IL_039b: ldloc.s 15
+				IL_039d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03a2: stloc.s 21
+				IL_03a4: ldloc.s 21
+				IL_03a6: ret
 
-				IL_03ae: br IL_03c1
+				IL_03a7: br IL_03ba
 
-				IL_03b3: ldloc.s 9
-				IL_03b5: ldc.r8 1
-				IL_03be: add
-				IL_03bf: stloc.s 9
+				IL_03ac: ldloc.s 9
+				IL_03ae: ldc.r8 1
+				IL_03b7: add
+				IL_03b8: stloc.s 9
 
-				IL_03c1: br IL_0292
+				IL_03ba: br IL_0292
 			// end loop
 
-			IL_03c6: ldloc.s 6
-			IL_03c8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03cd: stloc.s 15
-			IL_03cf: ldstr "Could not find a matching closing </"
-			IL_03d4: ldloc.s 15
-			IL_03d6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03db: stloc.s 15
-			IL_03dd: ldloc.s 15
-			IL_03df: ldstr "> for id '"
-			IL_03e4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03e9: stloc.s 15
-			IL_03eb: ldarg.3
-			IL_03ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03f1: stloc.s 23
-			IL_03f3: ldloc.s 15
-			IL_03f5: ldloc.s 23
-			IL_03f7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03fc: stloc.s 23
-			IL_03fe: ldloc.s 23
-			IL_0400: ldstr "'."
-			IL_0405: call string [System.Runtime]System.String::Concat(string, string)
-			IL_040a: stloc.s 23
-			IL_040c: ldloc.s 23
-			IL_040e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0413: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0418: stloc.s 16
-			IL_041a: ldloc.s 16
-			IL_041c: stloc.s 14
-			IL_041e: ldloc.s 14
-			IL_0420: isinst [System.Runtime]System.Exception
-			IL_0425: dup
-			IL_0426: brtrue IL_0434
+			IL_03bf: ldloc.s 6
+			IL_03c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03c6: stloc.s 14
+			IL_03c8: ldstr "Could not find a matching closing </"
+			IL_03cd: ldloc.s 14
+			IL_03cf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03d4: stloc.s 14
+			IL_03d6: ldloc.s 14
+			IL_03d8: ldstr "> for id '"
+			IL_03dd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03e2: stloc.s 14
+			IL_03e4: ldarg.3
+			IL_03e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03ea: stloc.s 22
+			IL_03ec: ldloc.s 14
+			IL_03ee: ldloc.s 22
+			IL_03f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f5: stloc.s 22
+			IL_03f7: ldloc.s 22
+			IL_03f9: ldstr "'."
+			IL_03fe: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0403: stloc.s 22
+			IL_0405: ldloc.s 22
+			IL_0407: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0411: stloc.s 15
+			IL_0413: ldloc.s 15
+			IL_0415: stloc.s 13
+			IL_0417: ldloc.s 13
+			IL_0419: isinst [System.Runtime]System.Exception
+			IL_041e: dup
+			IL_041f: brtrue IL_042d
 
-			IL_042b: pop
-			IL_042c: ldloc.s 14
-			IL_042e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0433: throw
+			IL_0424: pop
+			IL_0425: ldloc.s 13
+			IL_0427: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_042c: throw
 
-			IL_0434: throw
+			IL_042d: throw
 
-			IL_0435: ldnull
-			IL_0436: ret
+			IL_042e: ldnull
+			IL_042f: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3429,7 +3417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x482d
+					// Method begins at RVA 0x47a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3447,7 +3435,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4824
+				// Method begins at RVA 0x479c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3475,7 +3463,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x30a4
+			// Method begins at RVA 0x306c
 			// Header size: 12
 			// Code size: 516 (0x204)
 			.maxstack 8
@@ -3703,7 +3691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4836
+				// Method begins at RVA 0x47ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3729,7 +3717,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32b4
+			// Method begins at RVA 0x327c
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -3836,7 +3824,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4848
+					// Method begins at RVA 0x47c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3856,7 +3844,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4851
+					// Method begins at RVA 0x47c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3876,7 +3864,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x485a
+					// Method begins at RVA 0x47d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3900,7 +3888,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x486c
+						// Method begins at RVA 0x47e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3920,7 +3908,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4875
+						// Method begins at RVA 0x47ed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3938,7 +3926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4863
+					// Method begins at RVA 0x47db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3958,7 +3946,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x487e
+					// Method begins at RVA 0x47f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3978,7 +3966,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4887
+					// Method begins at RVA 0x47ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4018,7 +4006,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x483f
+				// Method begins at RVA 0x47b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4042,9 +4030,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3358
+			// Method begins at RVA 0x3320
 			// Header size: 12
-			// Code size: 3116 (0xc2c)
+			// Code size: 3044 (0xbe4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4058,29 +4046,27 @@
 				[8] object,
 				[9] object,
 				[10] string,
-				[11] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17,
+				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9,
+				[17] object,
 				[18] object,
 				[19] object,
 				[20] object,
 				[21] object,
-				[22] object,
+				[22] object[],
 				[23] object,
-				[24] object[],
+				[24] bool,
 				[25] object,
-				[26] bool,
-				[27] object,
-				[28] object,
-				[29] string,
-				[30] string,
-				[31] object,
-				[32] object,
-				[33] object
+				[26] object,
+				[27] string,
+				[28] string,
+				[29] object,
+				[30] object,
+				[31] object
 			)
 
 			IL_0000: ldarg.0
@@ -4113,14 +4099,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 33
+			IL_0048: ldc.i4.s 31
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0144
+			IL_005b: ble IL_012e
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -4168,1320 +4154,1282 @@
 			IL_009b: dup
 			IL_009c: ldc.i4.s 10
 			IL_009e: ldelem.ref
-			IL_009f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17
-			IL_00a4: stloc.s 11
-			IL_00a6: dup
-			IL_00a7: ldc.i4.s 11
-			IL_00a9: ldelem.ref
-			IL_00aa: stloc.s 12
-			IL_00ac: dup
-			IL_00ad: ldc.i4.s 12
-			IL_00af: ldelem.ref
-			IL_00b0: stloc.s 13
-			IL_00b2: dup
-			IL_00b3: ldc.i4.s 13
-			IL_00b5: ldelem.ref
-			IL_00b6: stloc.s 14
-			IL_00b8: dup
-			IL_00b9: ldc.i4.s 14
-			IL_00bb: ldelem.ref
-			IL_00bc: stloc.s 15
-			IL_00be: dup
-			IL_00bf: ldc.i4.s 15
-			IL_00c1: ldelem.ref
-			IL_00c2: stloc.s 16
-			IL_00c4: dup
-			IL_00c5: ldc.i4.s 16
-			IL_00c7: ldelem.ref
-			IL_00c8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9
-			IL_00cd: stloc.s 17
-			IL_00cf: dup
-			IL_00d0: ldc.i4.s 17
-			IL_00d2: ldelem.ref
-			IL_00d3: stloc.s 18
-			IL_00d5: dup
-			IL_00d6: ldc.i4.s 18
-			IL_00d8: ldelem.ref
-			IL_00d9: stloc.s 19
-			IL_00db: dup
-			IL_00dc: ldc.i4.s 19
-			IL_00de: ldelem.ref
-			IL_00df: stloc.s 20
-			IL_00e1: dup
-			IL_00e2: ldc.i4.s 20
-			IL_00e4: ldelem.ref
-			IL_00e5: stloc.s 21
-			IL_00e7: dup
-			IL_00e8: ldc.i4.s 21
-			IL_00ea: ldelem.ref
-			IL_00eb: stloc.s 22
-			IL_00ed: dup
-			IL_00ee: ldc.i4.s 22
-			IL_00f0: ldelem.ref
-			IL_00f1: stloc.s 23
-			IL_00f3: dup
-			IL_00f4: ldc.i4.s 23
-			IL_00f6: ldelem.ref
-			IL_00f7: castclass object[]
-			IL_00fc: stloc.s 24
-			IL_00fe: dup
-			IL_00ff: ldc.i4.s 24
-			IL_0101: ldelem.ref
-			IL_0102: stloc.s 25
-			IL_0104: dup
-			IL_0105: ldc.i4.s 25
-			IL_0107: ldelem.ref
-			IL_0108: unbox.any [System.Runtime]System.Boolean
-			IL_010d: stloc.s 26
-			IL_010f: dup
-			IL_0110: ldc.i4.s 26
-			IL_0112: ldelem.ref
-			IL_0113: stloc.s 27
-			IL_0115: dup
-			IL_0116: ldc.i4.s 27
-			IL_0118: ldelem.ref
+			IL_009f: stloc.s 11
+			IL_00a1: dup
+			IL_00a2: ldc.i4.s 11
+			IL_00a4: ldelem.ref
+			IL_00a5: stloc.s 12
+			IL_00a7: dup
+			IL_00a8: ldc.i4.s 12
+			IL_00aa: ldelem.ref
+			IL_00ab: stloc.s 13
+			IL_00ad: dup
+			IL_00ae: ldc.i4.s 13
+			IL_00b0: ldelem.ref
+			IL_00b1: stloc.s 14
+			IL_00b3: dup
+			IL_00b4: ldc.i4.s 14
+			IL_00b6: ldelem.ref
+			IL_00b7: stloc.s 15
+			IL_00b9: dup
+			IL_00ba: ldc.i4.s 15
+			IL_00bc: ldelem.ref
+			IL_00bd: stloc.s 16
+			IL_00bf: dup
+			IL_00c0: ldc.i4.s 16
+			IL_00c2: ldelem.ref
+			IL_00c3: stloc.s 17
+			IL_00c5: dup
+			IL_00c6: ldc.i4.s 17
+			IL_00c8: ldelem.ref
+			IL_00c9: stloc.s 18
+			IL_00cb: dup
+			IL_00cc: ldc.i4.s 18
+			IL_00ce: ldelem.ref
+			IL_00cf: stloc.s 19
+			IL_00d1: dup
+			IL_00d2: ldc.i4.s 19
+			IL_00d4: ldelem.ref
+			IL_00d5: stloc.s 20
+			IL_00d7: dup
+			IL_00d8: ldc.i4.s 20
+			IL_00da: ldelem.ref
+			IL_00db: stloc.s 21
+			IL_00dd: dup
+			IL_00de: ldc.i4.s 21
+			IL_00e0: ldelem.ref
+			IL_00e1: castclass object[]
+			IL_00e6: stloc.s 22
+			IL_00e8: dup
+			IL_00e9: ldc.i4.s 22
+			IL_00eb: ldelem.ref
+			IL_00ec: stloc.s 23
+			IL_00ee: dup
+			IL_00ef: ldc.i4.s 23
+			IL_00f1: ldelem.ref
+			IL_00f2: unbox.any [System.Runtime]System.Boolean
+			IL_00f7: stloc.s 24
+			IL_00f9: dup
+			IL_00fa: ldc.i4.s 24
+			IL_00fc: ldelem.ref
+			IL_00fd: stloc.s 25
+			IL_00ff: dup
+			IL_0100: ldc.i4.s 25
+			IL_0102: ldelem.ref
+			IL_0103: stloc.s 26
+			IL_0105: dup
+			IL_0106: ldc.i4.s 26
+			IL_0108: ldelem.ref
+			IL_0109: castclass [System.Runtime]System.String
+			IL_010e: stloc.s 27
+			IL_0110: dup
+			IL_0111: ldc.i4.s 27
+			IL_0113: ldelem.ref
+			IL_0114: castclass [System.Runtime]System.String
 			IL_0119: stloc.s 28
 			IL_011b: dup
 			IL_011c: ldc.i4.s 28
 			IL_011e: ldelem.ref
-			IL_011f: castclass [System.Runtime]System.String
-			IL_0124: stloc.s 29
-			IL_0126: dup
-			IL_0127: ldc.i4.s 29
-			IL_0129: ldelem.ref
-			IL_012a: castclass [System.Runtime]System.String
-			IL_012f: stloc.s 30
-			IL_0131: dup
-			IL_0132: ldc.i4.s 30
-			IL_0134: ldelem.ref
-			IL_0135: stloc.s 31
-			IL_0137: dup
-			IL_0138: ldc.i4.s 31
-			IL_013a: ldelem.ref
-			IL_013b: stloc.s 32
-			IL_013d: dup
-			IL_013e: ldc.i4.s 32
-			IL_0140: ldelem.ref
-			IL_0141: stloc.s 33
-			IL_0143: pop
+			IL_011f: stloc.s 29
+			IL_0121: dup
+			IL_0122: ldc.i4.s 29
+			IL_0124: ldelem.ref
+			IL_0125: stloc.s 30
+			IL_0127: dup
+			IL_0128: ldc.i4.s 30
+			IL_012a: ldelem.ref
+			IL_012b: stloc.s 31
+			IL_012d: pop
 
-			IL_0144: ldloc.0
-			IL_0145: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_014a: switch (IL_015f, IL_04fb, IL_0775, IL_0909)
+			IL_012e: ldloc.0
+			IL_012f: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0134: switch (IL_0149, IL_04d2, IL_0740, IL_08c1)
 
-			IL_015f: ldarg.0
-			IL_0160: ldc.i4.1
-			IL_0161: ldelem.ref
-			IL_0162: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0167: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
-			IL_016c: stloc.s 23
-			IL_016e: ldc.i4.1
-			IL_016f: newarr [System.Runtime]System.Object
-			IL_0174: dup
-			IL_0175: ldc.i4.0
-			IL_0176: ldarg.0
-			IL_0177: ldc.i4.1
-			IL_0178: ldelem.ref
-			IL_0179: stelem.ref
-			IL_017a: stloc.s 24
-			IL_017c: ldstr "process"
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0186: stloc.s 25
-			IL_0188: ldloc.s 25
-			IL_018a: ldstr "argv"
-			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0194: stloc.s 25
-			IL_0196: ldloc.s 23
-			IL_0198: ldloc.s 24
-			IL_019a: ldloc.s 25
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01a1: stloc.s 25
-			IL_01a3: ldloc.s 25
-			IL_01a5: stloc.1
-			IL_01a6: ldloc.1
-			IL_01a7: ldstr "section"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01b6: ldc.i4.0
-			IL_01b7: ceq
-			IL_01b9: stloc.s 26
-			IL_01bb: ldloc.s 26
-			IL_01bd: brfalse IL_0205
+			IL_0149: ldarg.0
+			IL_014a: ldc.i4.1
+			IL_014b: ldelem.ref
+			IL_014c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0151: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
+			IL_0156: stloc.s 21
+			IL_0158: ldc.i4.1
+			IL_0159: newarr [System.Runtime]System.Object
+			IL_015e: dup
+			IL_015f: ldc.i4.0
+			IL_0160: ldarg.0
+			IL_0161: ldc.i4.1
+			IL_0162: ldelem.ref
+			IL_0163: stelem.ref
+			IL_0164: stloc.s 22
+			IL_0166: ldstr "process"
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0170: stloc.s 23
+			IL_0172: ldloc.s 23
+			IL_0174: ldstr "argv"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017e: stloc.s 23
+			IL_0180: ldloc.s 21
+			IL_0182: ldloc.s 22
+			IL_0184: ldloc.s 23
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_018b: stloc.s 23
+			IL_018d: ldloc.s 23
+			IL_018f: stloc.1
+			IL_0190: ldloc.1
+			IL_0191: ldstr "section"
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01a0: ldc.i4.0
+			IL_01a1: ceq
+			IL_01a3: stloc.s 24
+			IL_01a5: ldloc.s 24
+			IL_01a7: brfalse IL_01ef
 
-			IL_01c2: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01d1: stloc.s 25
-			IL_01d3: ldloc.s 25
-			IL_01d5: stloc.2
-			IL_01d6: ldloc.0
-			IL_01d7: ldc.i4.m1
-			IL_01d8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01dd: ldloc.0
-			IL_01de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01e8: ldarg.0
-			IL_01e9: ldc.i4.1
-			IL_01ea: newarr [System.Runtime]System.Object
-			IL_01ef: dup
-			IL_01f0: ldc.i4.0
-			IL_01f1: ldloc.2
-			IL_01f2: stelem.ref
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01f8: pop
-			IL_01f9: ldloc.0
-			IL_01fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0204: ret
+			IL_01ac: ldstr "Missing required --section (e.g. 27.3)."
+			IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01bb: stloc.s 23
+			IL_01bd: ldloc.s 23
+			IL_01bf: stloc.2
+			IL_01c0: ldloc.0
+			IL_01c1: ldc.i4.m1
+			IL_01c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c7: ldloc.0
+			IL_01c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01d2: ldarg.0
+			IL_01d3: ldc.i4.1
+			IL_01d4: newarr [System.Runtime]System.Object
+			IL_01d9: dup
+			IL_01da: ldc.i4.0
+			IL_01db: ldloc.2
+			IL_01dc: stelem.ref
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01e2: pop
+			IL_01e3: ldloc.0
+			IL_01e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ee: ret
 
-			IL_0205: ldloc.1
-			IL_0206: ldstr "outFile"
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0215: ldc.i4.0
-			IL_0216: ceq
-			IL_0218: stloc.s 26
-			IL_021a: ldloc.s 26
-			IL_021c: brfalse IL_0264
+			IL_01ef: ldloc.1
+			IL_01f0: ldstr "outFile"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fa: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01ff: ldc.i4.0
+			IL_0200: ceq
+			IL_0202: stloc.s 24
+			IL_0204: ldloc.s 24
+			IL_0206: brfalse IL_024e
 
-			IL_0221: ldstr "Missing required --out <output.html>."
-			IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0230: stloc.s 25
-			IL_0232: ldloc.s 25
-			IL_0234: stloc.3
-			IL_0235: ldloc.0
-			IL_0236: ldc.i4.m1
-			IL_0237: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_023c: ldloc.0
-			IL_023d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0242: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0247: ldarg.0
-			IL_0248: ldc.i4.1
-			IL_0249: newarr [System.Runtime]System.Object
-			IL_024e: dup
-			IL_024f: ldc.i4.0
-			IL_0250: ldloc.3
-			IL_0251: stelem.ref
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0257: pop
-			IL_0258: ldloc.0
-			IL_0259: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_025e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0263: ret
+			IL_020b: ldstr "Missing required --out <output.html>."
+			IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_021a: stloc.s 23
+			IL_021c: ldloc.s 23
+			IL_021e: stloc.3
+			IL_021f: ldloc.0
+			IL_0220: ldc.i4.m1
+			IL_0221: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0226: ldloc.0
+			IL_0227: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0231: ldarg.0
+			IL_0232: ldc.i4.1
+			IL_0233: newarr [System.Runtime]System.Object
+			IL_0238: dup
+			IL_0239: ldc.i4.0
+			IL_023a: ldloc.3
+			IL_023b: stelem.ref
+			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0241: pop
+			IL_0242: ldloc.0
+			IL_0243: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0248: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_024d: ret
 
-			IL_0264: ldloc.1
-			IL_0265: ldstr "url"
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0274: stloc.s 26
-			IL_0276: ldloc.s 26
-			IL_0278: brfalse IL_0292
+			IL_024e: ldloc.1
+			IL_024f: ldstr "url"
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_025e: stloc.s 24
+			IL_0260: ldloc.s 24
+			IL_0262: brfalse IL_027c
 
-			IL_027d: ldc.r8 1
-			IL_0286: box [System.Runtime]System.Double
-			IL_028b: stloc.s 4
-			IL_028d: br IL_02a2
+			IL_0267: ldc.r8 1
+			IL_0270: box [System.Runtime]System.Double
+			IL_0275: stloc.s 4
+			IL_0277: br IL_028c
 
-			IL_0292: ldc.r8 0.0
-			IL_029b: box [System.Runtime]System.Double
-			IL_02a0: stloc.s 4
+			IL_027c: ldc.r8 0.0
+			IL_0285: box [System.Runtime]System.Double
+			IL_028a: stloc.s 4
 
-			IL_02a2: ldloc.s 4
-			IL_02a4: stloc.s 27
-			IL_02a6: ldloc.1
-			IL_02a7: ldstr "auto"
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02b6: stloc.s 26
-			IL_02b8: ldloc.s 26
-			IL_02ba: brfalse IL_02d4
+			IL_028c: ldloc.s 4
+			IL_028e: stloc.s 25
+			IL_0290: ldloc.1
+			IL_0291: ldstr "auto"
+			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a0: stloc.s 24
+			IL_02a2: ldloc.s 24
+			IL_02a4: brfalse IL_02be
 
-			IL_02bf: ldc.r8 1
-			IL_02c8: box [System.Runtime]System.Double
-			IL_02cd: stloc.s 5
-			IL_02cf: br IL_02e4
+			IL_02a9: ldc.r8 1
+			IL_02b2: box [System.Runtime]System.Double
+			IL_02b7: stloc.s 5
+			IL_02b9: br IL_02ce
 
-			IL_02d4: ldc.r8 0.0
-			IL_02dd: box [System.Runtime]System.Double
-			IL_02e2: stloc.s 5
+			IL_02be: ldc.r8 0.0
+			IL_02c7: box [System.Runtime]System.Double
+			IL_02cc: stloc.s 5
 
-			IL_02e4: ldloc.s 27
-			IL_02e6: ldloc.s 5
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ed: stloc.s 27
-			IL_02ef: ldloc.s 27
-			IL_02f1: stloc.s 6
-			IL_02f3: ldloc.s 6
-			IL_02f5: stloc.s 27
-			IL_02f7: ldloc.s 27
-			IL_02f9: ldc.r8 1
-			IL_0302: box [System.Runtime]System.Double
-			IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_030c: stloc.s 26
-			IL_030e: ldloc.s 26
-			IL_0310: brfalse IL_035a
+			IL_02ce: ldloc.s 25
+			IL_02d0: ldloc.s 5
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d7: stloc.s 25
+			IL_02d9: ldloc.s 25
+			IL_02db: stloc.s 6
+			IL_02dd: ldloc.s 6
+			IL_02df: stloc.s 25
+			IL_02e1: ldloc.s 25
+			IL_02e3: ldc.r8 1
+			IL_02ec: box [System.Runtime]System.Double
+			IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02f6: stloc.s 24
+			IL_02f8: ldloc.s 24
+			IL_02fa: brfalse IL_0344
 
-			IL_0315: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_031a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_031f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0324: stloc.s 25
-			IL_0326: ldloc.s 25
-			IL_0328: stloc.s 7
-			IL_032a: ldloc.0
-			IL_032b: ldc.i4.m1
-			IL_032c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0331: ldloc.0
-			IL_0332: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_033c: ldarg.0
-			IL_033d: ldc.i4.1
-			IL_033e: newarr [System.Runtime]System.Object
-			IL_0343: dup
-			IL_0344: ldc.i4.0
-			IL_0345: ldloc.s 7
-			IL_0347: stelem.ref
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_034d: pop
-			IL_034e: ldloc.0
-			IL_034f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0354: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0359: ret
+			IL_02ff: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0304: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0309: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_030e: stloc.s 23
+			IL_0310: ldloc.s 23
+			IL_0312: stloc.s 7
+			IL_0314: ldloc.0
+			IL_0315: ldc.i4.m1
+			IL_0316: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_031b: ldloc.0
+			IL_031c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0321: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0326: ldarg.0
+			IL_0327: ldc.i4.1
+			IL_0328: newarr [System.Runtime]System.Object
+			IL_032d: dup
+			IL_032e: ldc.i4.0
+			IL_032f: ldloc.s 7
+			IL_0331: stelem.ref
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0337: pop
+			IL_0338: ldloc.0
+			IL_0339: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_033e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0343: ret
 
-			IL_035a: ldnull
-			IL_035b: stloc.s 8
-			IL_035d: ldloc.1
-			IL_035e: ldstr "id"
-			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0368: stloc.s 25
-			IL_036a: ldloc.s 25
-			IL_036c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0371: stloc.s 26
-			IL_0373: ldloc.s 26
-			IL_0375: brtrue IL_0386
+			IL_0344: ldnull
+			IL_0345: stloc.s 8
+			IL_0347: ldloc.1
+			IL_0348: ldstr "id"
+			IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0352: stloc.s 23
+			IL_0354: ldloc.s 23
+			IL_0356: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_035b: stloc.s 24
+			IL_035d: ldloc.s 24
+			IL_035f: brtrue IL_0370
 
-			IL_037a: ldstr ""
-			IL_037f: stloc.s 28
-			IL_0381: br IL_038a
+			IL_0364: ldstr ""
+			IL_0369: stloc.s 26
+			IL_036b: br IL_0374
 
-			IL_0386: ldloc.s 25
-			IL_0388: stloc.s 28
+			IL_0370: ldloc.s 23
+			IL_0372: stloc.s 26
 
-			IL_038a: ldloc.s 28
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0391: stloc.s 25
-			IL_0393: ldloc.s 25
-			IL_0395: castclass [System.Runtime]System.String
-			IL_039a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_039f: stloc.s 29
-			IL_03a1: ldloc.s 29
-			IL_03a3: stloc.s 9
-			IL_03a5: ldstr ""
-			IL_03aa: stloc.s 10
-			IL_03ac: ldloc.1
-			IL_03ad: ldstr "auto"
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03bc: stloc.s 26
-			IL_03be: ldloc.s 26
-			IL_03c0: brfalse IL_07d3
+			IL_0374: ldloc.s 26
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037b: stloc.s 23
+			IL_037d: ldloc.s 23
+			IL_037f: castclass [System.Runtime]System.String
+			IL_0384: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0389: stloc.s 27
+			IL_038b: ldloc.s 27
+			IL_038d: stloc.s 9
+			IL_038f: ldstr ""
+			IL_0394: stloc.s 10
+			IL_0396: ldloc.1
+			IL_0397: ldstr "auto"
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a6: stloc.s 24
+			IL_03a8: ldloc.s 24
+			IL_03aa: brfalse IL_079e
 
-			IL_03c5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_03ca: stloc.s 11
-			IL_03cc: ldloc.1
-			IL_03cd: ldstr "indexUrl"
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03dc: stloc.s 25
-			IL_03de: ldloc.s 25
-			IL_03e0: ldstr "trim"
-			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03ea: stloc.s 25
-			IL_03ec: ldloc.s 25
-			IL_03ee: stloc.s 12
-			IL_03f0: ldarg.0
-			IL_03f1: ldc.i4.1
-			IL_03f2: ldelem.ref
-			IL_03f3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03f8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_03fd: ldc.i4.1
-			IL_03fe: newarr [System.Runtime]System.Object
-			IL_0403: dup
-			IL_0404: ldc.i4.0
-			IL_0405: ldarg.0
-			IL_0406: ldc.i4.1
-			IL_0407: ldelem.ref
-			IL_0408: stelem.ref
-			IL_0409: ldloc.s 12
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0410: stloc.s 25
-			IL_0412: ldloc.0
-			IL_0413: ldc.i4.1
-			IL_0414: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0419: ldloc.0
-			IL_041a: ldloc.s 25
-			IL_041c: ldarg.0
-			IL_041d: ldc.i4.1
-			IL_041e: ldloc.0
-			IL_041f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0424: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0429: ldloc.0
-			IL_042a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_042f: dup
-			IL_0430: ldc.i4.0
-			IL_0431: ldloc.1
-			IL_0432: stelem.ref
-			IL_0433: dup
-			IL_0434: ldc.i4.1
-			IL_0435: ldloc.2
+			IL_03af: ldloc.1
+			IL_03b0: ldstr "indexUrl"
+			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03bf: stloc.s 23
+			IL_03c1: ldloc.s 23
+			IL_03c3: ldstr "trim"
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03cd: stloc.s 23
+			IL_03cf: ldloc.s 23
+			IL_03d1: stloc.s 11
+			IL_03d3: ldarg.0
+			IL_03d4: ldc.i4.1
+			IL_03d5: ldelem.ref
+			IL_03d6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03db: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_03e0: ldc.i4.1
+			IL_03e1: newarr [System.Runtime]System.Object
+			IL_03e6: dup
+			IL_03e7: ldc.i4.0
+			IL_03e8: ldarg.0
+			IL_03e9: ldc.i4.1
+			IL_03ea: ldelem.ref
+			IL_03eb: stelem.ref
+			IL_03ec: ldloc.s 11
+			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03f3: stloc.s 23
+			IL_03f5: ldloc.0
+			IL_03f6: ldc.i4.1
+			IL_03f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03fc: ldloc.0
+			IL_03fd: ldloc.s 23
+			IL_03ff: ldarg.0
+			IL_0400: ldc.i4.1
+			IL_0401: ldloc.0
+			IL_0402: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0407: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_040c: ldloc.0
+			IL_040d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0412: dup
+			IL_0413: ldc.i4.0
+			IL_0414: ldloc.1
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.1
+			IL_0418: ldloc.2
+			IL_0419: stelem.ref
+			IL_041a: dup
+			IL_041b: ldc.i4.2
+			IL_041c: ldloc.3
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.3
+			IL_0420: ldloc.s 4
+			IL_0422: stelem.ref
+			IL_0423: dup
+			IL_0424: ldc.i4.4
+			IL_0425: ldloc.s 5
+			IL_0427: stelem.ref
+			IL_0428: dup
+			IL_0429: ldc.i4.5
+			IL_042a: ldloc.s 6
+			IL_042c: stelem.ref
+			IL_042d: dup
+			IL_042e: ldc.i4.6
+			IL_042f: ldloc.s 7
+			IL_0431: stelem.ref
+			IL_0432: dup
+			IL_0433: ldc.i4.7
+			IL_0434: ldloc.s 8
 			IL_0436: stelem.ref
 			IL_0437: dup
-			IL_0438: ldc.i4.2
-			IL_0439: ldloc.3
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.3
-			IL_043d: ldloc.s 4
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.4
-			IL_0442: ldloc.s 5
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.5
-			IL_0447: ldloc.s 6
-			IL_0449: stelem.ref
-			IL_044a: dup
-			IL_044b: ldc.i4.6
-			IL_044c: ldloc.s 7
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.7
-			IL_0451: ldloc.s 8
+			IL_0438: ldc.i4.8
+			IL_0439: ldloc.s 9
+			IL_043b: stelem.ref
+			IL_043c: dup
+			IL_043d: ldc.i4.s 9
+			IL_043f: ldloc.s 10
+			IL_0441: stelem.ref
+			IL_0442: dup
+			IL_0443: ldc.i4.s 10
+			IL_0445: ldloc.s 11
+			IL_0447: stelem.ref
+			IL_0448: dup
+			IL_0449: ldc.i4.s 11
+			IL_044b: ldloc.s 12
+			IL_044d: stelem.ref
+			IL_044e: dup
+			IL_044f: ldc.i4.s 12
+			IL_0451: ldloc.s 13
 			IL_0453: stelem.ref
 			IL_0454: dup
-			IL_0455: ldc.i4.8
-			IL_0456: ldloc.s 9
-			IL_0458: stelem.ref
-			IL_0459: dup
-			IL_045a: ldc.i4.s 9
-			IL_045c: ldloc.s 10
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.s 10
-			IL_0462: ldloc.s 11
-			IL_0464: stelem.ref
-			IL_0465: dup
-			IL_0466: ldc.i4.s 11
-			IL_0468: ldloc.s 12
-			IL_046a: stelem.ref
-			IL_046b: dup
-			IL_046c: ldc.i4.s 12
-			IL_046e: ldloc.s 13
-			IL_0470: stelem.ref
-			IL_0471: dup
-			IL_0472: ldc.i4.s 13
-			IL_0474: ldloc.s 14
-			IL_0476: stelem.ref
-			IL_0477: dup
-			IL_0478: ldc.i4.s 14
-			IL_047a: ldloc.s 15
-			IL_047c: stelem.ref
-			IL_047d: dup
-			IL_047e: ldc.i4.s 15
-			IL_0480: ldloc.s 16
-			IL_0482: stelem.ref
-			IL_0483: dup
-			IL_0484: ldc.i4.s 16
-			IL_0486: ldloc.s 17
-			IL_0488: stelem.ref
-			IL_0489: dup
-			IL_048a: ldc.i4.s 17
-			IL_048c: ldloc.s 18
-			IL_048e: stelem.ref
-			IL_048f: dup
-			IL_0490: ldc.i4.s 18
-			IL_0492: ldloc.s 19
-			IL_0494: stelem.ref
-			IL_0495: dup
-			IL_0496: ldc.i4.s 19
-			IL_0498: ldloc.s 20
+			IL_0455: ldc.i4.s 13
+			IL_0457: ldloc.s 14
+			IL_0459: stelem.ref
+			IL_045a: dup
+			IL_045b: ldc.i4.s 14
+			IL_045d: ldloc.s 15
+			IL_045f: stelem.ref
+			IL_0460: dup
+			IL_0461: ldc.i4.s 15
+			IL_0463: ldloc.s 16
+			IL_0465: stelem.ref
+			IL_0466: dup
+			IL_0467: ldc.i4.s 16
+			IL_0469: ldloc.s 17
+			IL_046b: stelem.ref
+			IL_046c: dup
+			IL_046d: ldc.i4.s 17
+			IL_046f: ldloc.s 18
+			IL_0471: stelem.ref
+			IL_0472: dup
+			IL_0473: ldc.i4.s 18
+			IL_0475: ldloc.s 19
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.s 19
+			IL_047b: ldloc.s 20
+			IL_047d: stelem.ref
+			IL_047e: dup
+			IL_047f: ldc.i4.s 20
+			IL_0481: ldloc.s 21
+			IL_0483: stelem.ref
+			IL_0484: dup
+			IL_0485: ldc.i4.s 21
+			IL_0487: ldloc.s 22
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.s 22
+			IL_048d: ldloc.s 23
+			IL_048f: stelem.ref
+			IL_0490: dup
+			IL_0491: ldc.i4.s 23
+			IL_0493: ldloc.s 24
+			IL_0495: box [System.Runtime]System.Boolean
 			IL_049a: stelem.ref
 			IL_049b: dup
-			IL_049c: ldc.i4.s 20
-			IL_049e: ldloc.s 21
+			IL_049c: ldc.i4.s 24
+			IL_049e: ldloc.s 25
 			IL_04a0: stelem.ref
 			IL_04a1: dup
-			IL_04a2: ldc.i4.s 21
-			IL_04a4: ldloc.s 22
+			IL_04a2: ldc.i4.s 25
+			IL_04a4: ldloc.s 26
 			IL_04a6: stelem.ref
 			IL_04a7: dup
-			IL_04a8: ldc.i4.s 22
-			IL_04aa: ldloc.s 23
+			IL_04a8: ldc.i4.s 26
+			IL_04aa: ldloc.s 27
 			IL_04ac: stelem.ref
 			IL_04ad: dup
-			IL_04ae: ldc.i4.s 23
-			IL_04b0: ldloc.s 24
+			IL_04ae: ldc.i4.s 27
+			IL_04b0: ldloc.s 28
 			IL_04b2: stelem.ref
 			IL_04b3: dup
-			IL_04b4: ldc.i4.s 24
-			IL_04b6: ldloc.s 25
+			IL_04b4: ldc.i4.s 28
+			IL_04b6: ldloc.s 29
 			IL_04b8: stelem.ref
 			IL_04b9: dup
-			IL_04ba: ldc.i4.s 25
-			IL_04bc: ldloc.s 26
-			IL_04be: box [System.Runtime]System.Boolean
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 26
-			IL_04c7: ldloc.s 27
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 27
-			IL_04cd: ldloc.s 28
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.s 28
-			IL_04d3: ldloc.s 29
-			IL_04d5: stelem.ref
-			IL_04d6: dup
-			IL_04d7: ldc.i4.s 29
-			IL_04d9: ldloc.s 30
-			IL_04db: stelem.ref
-			IL_04dc: dup
-			IL_04dd: ldc.i4.s 30
-			IL_04df: ldloc.s 31
-			IL_04e1: stelem.ref
-			IL_04e2: dup
-			IL_04e3: ldc.i4.s 31
-			IL_04e5: ldloc.s 32
-			IL_04e7: stelem.ref
-			IL_04e8: dup
-			IL_04e9: ldc.i4.s 32
-			IL_04eb: ldloc.s 33
-			IL_04ed: stelem.ref
-			IL_04ee: pop
-			IL_04ef: ldloc.0
-			IL_04f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04fa: ret
+			IL_04ba: ldc.i4.s 29
+			IL_04bc: ldloc.s 30
+			IL_04be: stelem.ref
+			IL_04bf: dup
+			IL_04c0: ldc.i4.s 30
+			IL_04c2: ldloc.s 31
+			IL_04c4: stelem.ref
+			IL_04c5: pop
+			IL_04c6: ldloc.0
+			IL_04c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04d1: ret
 
-			IL_04fb: ldloc.0
-			IL_04fc: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0501: stloc.s 25
-			IL_0503: ldloc.s 25
-			IL_0505: stloc.s 13
-			IL_0507: ldarg.0
-			IL_0508: ldc.i4.1
-			IL_0509: ldelem.ref
-			IL_050a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_050f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_0514: stloc.s 25
-			IL_0516: ldc.i4.1
-			IL_0517: newarr [System.Runtime]System.Object
-			IL_051c: dup
-			IL_051d: ldc.i4.0
-			IL_051e: ldarg.0
-			IL_051f: ldc.i4.1
-			IL_0520: ldelem.ref
-			IL_0521: stelem.ref
-			IL_0522: stloc.s 24
-			IL_0524: ldloc.1
-			IL_0525: ldstr "section"
-			IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0534: stloc.s 23
-			IL_0536: ldloc.s 23
-			IL_0538: ldstr "trim"
-			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0542: stloc.s 23
-			IL_0544: ldloc.s 25
-			IL_0546: ldloc.s 24
-			IL_0548: ldloc.s 13
-			IL_054a: ldloc.s 23
-			IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0551: stloc.s 23
-			IL_0553: ldloc.s 23
-			IL_0555: stloc.s 14
-			IL_0557: ldloc.s 14
-			IL_0559: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_055e: ldc.i4.0
-			IL_055f: ceq
-			IL_0561: stloc.s 26
-			IL_0563: ldloc.s 26
-			IL_0565: brfalse IL_05ee
+			IL_04d2: ldloc.0
+			IL_04d3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04d8: stloc.s 23
+			IL_04da: ldloc.s 23
+			IL_04dc: stloc.s 12
+			IL_04de: ldarg.0
+			IL_04df: ldc.i4.1
+			IL_04e0: ldelem.ref
+			IL_04e1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04e6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_04eb: stloc.s 23
+			IL_04ed: ldc.i4.1
+			IL_04ee: newarr [System.Runtime]System.Object
+			IL_04f3: dup
+			IL_04f4: ldc.i4.0
+			IL_04f5: ldarg.0
+			IL_04f6: ldc.i4.1
+			IL_04f7: ldelem.ref
+			IL_04f8: stelem.ref
+			IL_04f9: stloc.s 22
+			IL_04fb: ldloc.1
+			IL_04fc: ldstr "section"
+			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_050b: stloc.s 21
+			IL_050d: ldloc.s 21
+			IL_050f: ldstr "trim"
+			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0519: stloc.s 21
+			IL_051b: ldloc.s 23
+			IL_051d: ldloc.s 22
+			IL_051f: ldloc.s 12
+			IL_0521: ldloc.s 21
+			IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0528: stloc.s 21
+			IL_052a: ldloc.s 21
+			IL_052c: stloc.s 13
+			IL_052e: ldloc.s 13
+			IL_0530: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0535: ldc.i4.0
+			IL_0536: ceq
+			IL_0538: stloc.s 24
+			IL_053a: ldloc.s 24
+			IL_053c: brfalse IL_05c5
 
-			IL_056a: ldloc.1
-			IL_056b: ldstr "section"
-			IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0575: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_057a: stloc.s 29
-			IL_057c: ldstr "Could not find section '"
-			IL_0581: ldloc.s 29
-			IL_0583: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0588: stloc.s 29
-			IL_058a: ldloc.s 29
-			IL_058c: ldstr "' in multipage index: "
-			IL_0591: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0596: stloc.s 29
-			IL_0598: ldloc.s 12
-			IL_059a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_059f: stloc.s 30
-			IL_05a1: ldloc.s 29
-			IL_05a3: ldloc.s 30
-			IL_05a5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05aa: stloc.s 30
-			IL_05ac: ldloc.s 30
-			IL_05ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_05b8: stloc.s 23
-			IL_05ba: ldloc.s 23
-			IL_05bc: stloc.s 15
-			IL_05be: ldloc.0
-			IL_05bf: ldc.i4.m1
-			IL_05c0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c5: ldloc.0
-			IL_05c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05d0: ldarg.0
-			IL_05d1: ldc.i4.1
-			IL_05d2: newarr [System.Runtime]System.Object
-			IL_05d7: dup
-			IL_05d8: ldc.i4.0
-			IL_05d9: ldloc.s 15
-			IL_05db: stelem.ref
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05e1: pop
-			IL_05e2: ldloc.0
-			IL_05e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ed: ret
+			IL_0541: ldloc.1
+			IL_0542: ldstr "section"
+			IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_054c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0551: stloc.s 27
+			IL_0553: ldstr "Could not find section '"
+			IL_0558: ldloc.s 27
+			IL_055a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_055f: stloc.s 27
+			IL_0561: ldloc.s 27
+			IL_0563: ldstr "' in multipage index: "
+			IL_0568: call string [System.Runtime]System.String::Concat(string, string)
+			IL_056d: stloc.s 27
+			IL_056f: ldloc.s 11
+			IL_0571: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0576: stloc.s 28
+			IL_0578: ldloc.s 27
+			IL_057a: ldloc.s 28
+			IL_057c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0581: stloc.s 28
+			IL_0583: ldloc.s 28
+			IL_0585: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_058a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_058f: stloc.s 21
+			IL_0591: ldloc.s 21
+			IL_0593: stloc.s 14
+			IL_0595: ldloc.0
+			IL_0596: ldc.i4.m1
+			IL_0597: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_059c: ldloc.0
+			IL_059d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_05a7: ldarg.0
+			IL_05a8: ldc.i4.1
+			IL_05a9: newarr [System.Runtime]System.Object
+			IL_05ae: dup
+			IL_05af: ldc.i4.0
+			IL_05b0: ldloc.s 14
+			IL_05b2: stelem.ref
+			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05b8: pop
+			IL_05b9: ldloc.0
+			IL_05ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05c4: ret
 
-			IL_05ee: ldarg.0
-			IL_05ef: ldc.i4.1
-			IL_05f0: ldelem.ref
-			IL_05f1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05f6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05fb: stloc.s 23
-			IL_05fd: ldloc.s 14
-			IL_05ff: ldstr "filePart"
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0609: stloc.s 25
-			IL_060b: ldloc.s 25
-			IL_060d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0612: stloc.s 26
-			IL_0614: ldloc.s 26
-			IL_0616: brtrue IL_062e
+			IL_05c5: ldarg.0
+			IL_05c6: ldc.i4.1
+			IL_05c7: ldelem.ref
+			IL_05c8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05cd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_05d2: stloc.s 21
+			IL_05d4: ldloc.s 13
+			IL_05d6: ldstr "filePart"
+			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e0: stloc.s 23
+			IL_05e2: ldloc.s 23
+			IL_05e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05e9: stloc.s 24
+			IL_05eb: ldloc.s 24
+			IL_05ed: brtrue IL_0605
 
-			IL_061b: ldloc.s 14
-			IL_061d: ldstr "href"
-			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0627: stloc.s 31
-			IL_0629: br IL_0632
+			IL_05f2: ldloc.s 13
+			IL_05f4: ldstr "href"
+			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05fe: stloc.s 29
+			IL_0600: br IL_0609
 
-			IL_062e: ldloc.s 25
-			IL_0630: stloc.s 31
+			IL_0605: ldloc.s 23
+			IL_0607: stloc.s 29
 
-			IL_0632: ldc.i4.2
-			IL_0633: newarr [System.Runtime]System.Object
-			IL_0638: dup
-			IL_0639: ldc.i4.0
-			IL_063a: ldloc.s 31
-			IL_063c: stelem.ref
-			IL_063d: dup
-			IL_063e: ldc.i4.1
-			IL_063f: ldloc.s 12
-			IL_0641: stelem.ref
-			IL_0642: stloc.s 24
-			IL_0644: ldloc.s 23
-			IL_0646: ldloc.s 24
-			IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_064d: stloc.s 23
-			IL_064f: ldloc.s 23
-			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0656: stloc.s 23
-			IL_0658: ldloc.s 23
-			IL_065a: ldstr "toString"
-			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0664: stloc.s 23
-			IL_0666: ldloc.s 23
-			IL_0668: stloc.s 16
-			IL_066a: ldarg.0
-			IL_066b: ldc.i4.1
-			IL_066c: ldelem.ref
-			IL_066d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0672: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0677: ldc.i4.1
-			IL_0678: newarr [System.Runtime]System.Object
-			IL_067d: dup
-			IL_067e: ldc.i4.0
-			IL_067f: ldarg.0
-			IL_0680: ldc.i4.1
-			IL_0681: ldelem.ref
-			IL_0682: stelem.ref
-			IL_0683: ldloc.s 16
-			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_068a: stloc.s 23
-			IL_068c: ldloc.0
-			IL_068d: ldc.i4.2
-			IL_068e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0693: ldloc.0
-			IL_0694: ldloc.s 23
-			IL_0696: ldarg.0
-			IL_0697: ldc.i4.2
-			IL_0698: ldloc.0
-			IL_0699: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_069e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_06a3: ldloc.0
-			IL_06a4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06a9: dup
-			IL_06aa: ldc.i4.0
-			IL_06ab: ldloc.1
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.1
-			IL_06af: ldloc.2
-			IL_06b0: stelem.ref
-			IL_06b1: dup
-			IL_06b2: ldc.i4.2
-			IL_06b3: ldloc.3
-			IL_06b4: stelem.ref
-			IL_06b5: dup
-			IL_06b6: ldc.i4.3
-			IL_06b7: ldloc.s 4
-			IL_06b9: stelem.ref
-			IL_06ba: dup
-			IL_06bb: ldc.i4.4
-			IL_06bc: ldloc.s 5
-			IL_06be: stelem.ref
-			IL_06bf: dup
-			IL_06c0: ldc.i4.5
-			IL_06c1: ldloc.s 6
-			IL_06c3: stelem.ref
-			IL_06c4: dup
-			IL_06c5: ldc.i4.6
-			IL_06c6: ldloc.s 7
-			IL_06c8: stelem.ref
-			IL_06c9: dup
-			IL_06ca: ldc.i4.7
-			IL_06cb: ldloc.s 8
+			IL_0609: ldc.i4.2
+			IL_060a: newarr [System.Runtime]System.Object
+			IL_060f: dup
+			IL_0610: ldc.i4.0
+			IL_0611: ldloc.s 29
+			IL_0613: stelem.ref
+			IL_0614: dup
+			IL_0615: ldc.i4.1
+			IL_0616: ldloc.s 11
+			IL_0618: stelem.ref
+			IL_0619: stloc.s 22
+			IL_061b: ldloc.s 21
+			IL_061d: ldloc.s 22
+			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_0624: stloc.s 21
+			IL_0626: ldloc.s 21
+			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_062d: stloc.s 21
+			IL_062f: ldloc.s 21
+			IL_0631: ldstr "toString"
+			IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_063b: stloc.s 21
+			IL_063d: ldloc.s 21
+			IL_063f: stloc.s 15
+			IL_0641: ldarg.0
+			IL_0642: ldc.i4.1
+			IL_0643: ldelem.ref
+			IL_0644: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0649: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_064e: ldc.i4.1
+			IL_064f: newarr [System.Runtime]System.Object
+			IL_0654: dup
+			IL_0655: ldc.i4.0
+			IL_0656: ldarg.0
+			IL_0657: ldc.i4.1
+			IL_0658: ldelem.ref
+			IL_0659: stelem.ref
+			IL_065a: ldloc.s 15
+			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0661: stloc.s 21
+			IL_0663: ldloc.0
+			IL_0664: ldc.i4.2
+			IL_0665: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_066a: ldloc.0
+			IL_066b: ldloc.s 21
+			IL_066d: ldarg.0
+			IL_066e: ldc.i4.2
+			IL_066f: ldloc.0
+			IL_0670: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0675: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_067a: ldloc.0
+			IL_067b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0680: dup
+			IL_0681: ldc.i4.0
+			IL_0682: ldloc.1
+			IL_0683: stelem.ref
+			IL_0684: dup
+			IL_0685: ldc.i4.1
+			IL_0686: ldloc.2
+			IL_0687: stelem.ref
+			IL_0688: dup
+			IL_0689: ldc.i4.2
+			IL_068a: ldloc.3
+			IL_068b: stelem.ref
+			IL_068c: dup
+			IL_068d: ldc.i4.3
+			IL_068e: ldloc.s 4
+			IL_0690: stelem.ref
+			IL_0691: dup
+			IL_0692: ldc.i4.4
+			IL_0693: ldloc.s 5
+			IL_0695: stelem.ref
+			IL_0696: dup
+			IL_0697: ldc.i4.5
+			IL_0698: ldloc.s 6
+			IL_069a: stelem.ref
+			IL_069b: dup
+			IL_069c: ldc.i4.6
+			IL_069d: ldloc.s 7
+			IL_069f: stelem.ref
+			IL_06a0: dup
+			IL_06a1: ldc.i4.7
+			IL_06a2: ldloc.s 8
+			IL_06a4: stelem.ref
+			IL_06a5: dup
+			IL_06a6: ldc.i4.8
+			IL_06a7: ldloc.s 9
+			IL_06a9: stelem.ref
+			IL_06aa: dup
+			IL_06ab: ldc.i4.s 9
+			IL_06ad: ldloc.s 10
+			IL_06af: stelem.ref
+			IL_06b0: dup
+			IL_06b1: ldc.i4.s 10
+			IL_06b3: ldloc.s 11
+			IL_06b5: stelem.ref
+			IL_06b6: dup
+			IL_06b7: ldc.i4.s 11
+			IL_06b9: ldloc.s 12
+			IL_06bb: stelem.ref
+			IL_06bc: dup
+			IL_06bd: ldc.i4.s 12
+			IL_06bf: ldloc.s 13
+			IL_06c1: stelem.ref
+			IL_06c2: dup
+			IL_06c3: ldc.i4.s 13
+			IL_06c5: ldloc.s 14
+			IL_06c7: stelem.ref
+			IL_06c8: dup
+			IL_06c9: ldc.i4.s 14
+			IL_06cb: ldloc.s 15
 			IL_06cd: stelem.ref
 			IL_06ce: dup
-			IL_06cf: ldc.i4.8
-			IL_06d0: ldloc.s 9
-			IL_06d2: stelem.ref
-			IL_06d3: dup
-			IL_06d4: ldc.i4.s 9
-			IL_06d6: ldloc.s 10
-			IL_06d8: stelem.ref
-			IL_06d9: dup
-			IL_06da: ldc.i4.s 10
-			IL_06dc: ldloc.s 11
-			IL_06de: stelem.ref
-			IL_06df: dup
-			IL_06e0: ldc.i4.s 11
-			IL_06e2: ldloc.s 12
-			IL_06e4: stelem.ref
-			IL_06e5: dup
-			IL_06e6: ldc.i4.s 12
-			IL_06e8: ldloc.s 13
-			IL_06ea: stelem.ref
-			IL_06eb: dup
-			IL_06ec: ldc.i4.s 13
-			IL_06ee: ldloc.s 14
-			IL_06f0: stelem.ref
-			IL_06f1: dup
-			IL_06f2: ldc.i4.s 14
-			IL_06f4: ldloc.s 15
-			IL_06f6: stelem.ref
-			IL_06f7: dup
-			IL_06f8: ldc.i4.s 15
-			IL_06fa: ldloc.s 16
-			IL_06fc: stelem.ref
-			IL_06fd: dup
-			IL_06fe: ldc.i4.s 16
-			IL_0700: ldloc.s 17
-			IL_0702: stelem.ref
-			IL_0703: dup
-			IL_0704: ldc.i4.s 17
-			IL_0706: ldloc.s 18
+			IL_06cf: ldc.i4.s 15
+			IL_06d1: ldloc.s 16
+			IL_06d3: stelem.ref
+			IL_06d4: dup
+			IL_06d5: ldc.i4.s 16
+			IL_06d7: ldloc.s 17
+			IL_06d9: stelem.ref
+			IL_06da: dup
+			IL_06db: ldc.i4.s 17
+			IL_06dd: ldloc.s 18
+			IL_06df: stelem.ref
+			IL_06e0: dup
+			IL_06e1: ldc.i4.s 18
+			IL_06e3: ldloc.s 19
+			IL_06e5: stelem.ref
+			IL_06e6: dup
+			IL_06e7: ldc.i4.s 19
+			IL_06e9: ldloc.s 20
+			IL_06eb: stelem.ref
+			IL_06ec: dup
+			IL_06ed: ldc.i4.s 20
+			IL_06ef: ldloc.s 21
+			IL_06f1: stelem.ref
+			IL_06f2: dup
+			IL_06f3: ldc.i4.s 21
+			IL_06f5: ldloc.s 22
+			IL_06f7: stelem.ref
+			IL_06f8: dup
+			IL_06f9: ldc.i4.s 22
+			IL_06fb: ldloc.s 23
+			IL_06fd: stelem.ref
+			IL_06fe: dup
+			IL_06ff: ldc.i4.s 23
+			IL_0701: ldloc.s 24
+			IL_0703: box [System.Runtime]System.Boolean
 			IL_0708: stelem.ref
 			IL_0709: dup
-			IL_070a: ldc.i4.s 18
-			IL_070c: ldloc.s 19
+			IL_070a: ldc.i4.s 24
+			IL_070c: ldloc.s 25
 			IL_070e: stelem.ref
 			IL_070f: dup
-			IL_0710: ldc.i4.s 19
-			IL_0712: ldloc.s 20
+			IL_0710: ldc.i4.s 25
+			IL_0712: ldloc.s 26
 			IL_0714: stelem.ref
 			IL_0715: dup
-			IL_0716: ldc.i4.s 20
-			IL_0718: ldloc.s 21
+			IL_0716: ldc.i4.s 26
+			IL_0718: ldloc.s 27
 			IL_071a: stelem.ref
 			IL_071b: dup
-			IL_071c: ldc.i4.s 21
-			IL_071e: ldloc.s 22
+			IL_071c: ldc.i4.s 27
+			IL_071e: ldloc.s 28
 			IL_0720: stelem.ref
 			IL_0721: dup
-			IL_0722: ldc.i4.s 22
-			IL_0724: ldloc.s 23
+			IL_0722: ldc.i4.s 28
+			IL_0724: ldloc.s 29
 			IL_0726: stelem.ref
 			IL_0727: dup
-			IL_0728: ldc.i4.s 23
-			IL_072a: ldloc.s 24
+			IL_0728: ldc.i4.s 29
+			IL_072a: ldloc.s 30
 			IL_072c: stelem.ref
 			IL_072d: dup
-			IL_072e: ldc.i4.s 24
-			IL_0730: ldloc.s 25
+			IL_072e: ldc.i4.s 30
+			IL_0730: ldloc.s 31
 			IL_0732: stelem.ref
-			IL_0733: dup
-			IL_0734: ldc.i4.s 25
-			IL_0736: ldloc.s 26
-			IL_0738: box [System.Runtime]System.Boolean
-			IL_073d: stelem.ref
-			IL_073e: dup
-			IL_073f: ldc.i4.s 26
-			IL_0741: ldloc.s 27
-			IL_0743: stelem.ref
-			IL_0744: dup
-			IL_0745: ldc.i4.s 27
-			IL_0747: ldloc.s 28
-			IL_0749: stelem.ref
-			IL_074a: dup
-			IL_074b: ldc.i4.s 28
-			IL_074d: ldloc.s 29
-			IL_074f: stelem.ref
-			IL_0750: dup
-			IL_0751: ldc.i4.s 29
-			IL_0753: ldloc.s 30
-			IL_0755: stelem.ref
-			IL_0756: dup
-			IL_0757: ldc.i4.s 30
-			IL_0759: ldloc.s 31
-			IL_075b: stelem.ref
-			IL_075c: dup
-			IL_075d: ldc.i4.s 31
-			IL_075f: ldloc.s 32
-			IL_0761: stelem.ref
-			IL_0762: dup
-			IL_0763: ldc.i4.s 32
-			IL_0765: ldloc.s 33
-			IL_0767: stelem.ref
-			IL_0768: pop
-			IL_0769: ldloc.0
-			IL_076a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_076f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0774: ret
+			IL_0733: pop
+			IL_0734: ldloc.0
+			IL_0735: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_073a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_073f: ret
 
-			IL_0775: ldloc.0
-			IL_0776: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_077b: stloc.s 23
-			IL_077d: ldloc.s 23
-			IL_077f: stloc.s 8
-			IL_0781: ldloc.s 16
-			IL_0783: stloc.s 23
-			IL_0785: ldloc.s 23
-			IL_0787: stloc.s 10
-			IL_0789: ldloc.s 9
-			IL_078b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0790: ldc.i4.0
-			IL_0791: ceq
-			IL_0793: stloc.s 26
-			IL_0795: ldloc.s 26
-			IL_0797: brfalse IL_07ce
+			IL_0740: ldloc.0
+			IL_0741: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0746: stloc.s 21
+			IL_0748: ldloc.s 21
+			IL_074a: stloc.s 8
+			IL_074c: ldloc.s 15
+			IL_074e: stloc.s 21
+			IL_0750: ldloc.s 21
+			IL_0752: stloc.s 10
+			IL_0754: ldloc.s 9
+			IL_0756: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_075b: ldc.i4.0
+			IL_075c: ceq
+			IL_075e: stloc.s 24
+			IL_0760: ldloc.s 24
+			IL_0762: brfalse IL_0799
 
-			IL_079c: ldloc.s 14
-			IL_079e: ldstr "fragment"
-			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a8: stloc.s 23
-			IL_07aa: ldloc.s 23
-			IL_07ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07b1: stloc.s 26
-			IL_07b3: ldloc.s 26
-			IL_07b5: brtrue IL_07c6
+			IL_0767: ldloc.s 13
+			IL_0769: ldstr "fragment"
+			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0773: stloc.s 21
+			IL_0775: ldloc.s 21
+			IL_0777: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_077c: stloc.s 24
+			IL_077e: ldloc.s 24
+			IL_0780: brtrue IL_0791
 
-			IL_07ba: ldstr ""
-			IL_07bf: stloc.s 32
-			IL_07c1: br IL_07ca
+			IL_0785: ldstr ""
+			IL_078a: stloc.s 30
+			IL_078c: br IL_0795
 
-			IL_07c6: ldloc.s 23
-			IL_07c8: stloc.s 32
+			IL_0791: ldloc.s 21
+			IL_0793: stloc.s 30
 
-			IL_07ca: ldloc.s 32
-			IL_07cc: stloc.s 9
+			IL_0795: ldloc.s 30
+			IL_0797: stloc.s 9
 
-			IL_07ce: br IL_091d
+			IL_0799: br IL_08d5
 
-			IL_07d3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_07d8: stloc.s 17
-			IL_07da: ldloc.1
-			IL_07db: ldstr "url"
-			IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ea: stloc.s 23
-			IL_07ec: ldloc.s 23
-			IL_07ee: ldstr "trim"
-			IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_07f8: stloc.s 23
-			IL_07fa: ldloc.s 23
-			IL_07fc: stloc.s 18
-			IL_07fe: ldarg.0
-			IL_07ff: ldc.i4.1
-			IL_0800: ldelem.ref
-			IL_0801: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0806: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_080b: ldc.i4.1
-			IL_080c: newarr [System.Runtime]System.Object
-			IL_0811: dup
-			IL_0812: ldc.i4.0
-			IL_0813: ldarg.0
-			IL_0814: ldc.i4.1
-			IL_0815: ldelem.ref
+			IL_079e: ldloc.1
+			IL_079f: ldstr "url"
+			IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07ae: stloc.s 21
+			IL_07b0: ldloc.s 21
+			IL_07b2: ldstr "trim"
+			IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07bc: stloc.s 21
+			IL_07be: ldloc.s 21
+			IL_07c0: stloc.s 16
+			IL_07c2: ldarg.0
+			IL_07c3: ldc.i4.1
+			IL_07c4: ldelem.ref
+			IL_07c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_07cf: ldc.i4.1
+			IL_07d0: newarr [System.Runtime]System.Object
+			IL_07d5: dup
+			IL_07d6: ldc.i4.0
+			IL_07d7: ldarg.0
+			IL_07d8: ldc.i4.1
+			IL_07d9: ldelem.ref
+			IL_07da: stelem.ref
+			IL_07db: ldloc.s 16
+			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07e2: stloc.s 21
+			IL_07e4: ldloc.0
+			IL_07e5: ldc.i4.3
+			IL_07e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07eb: ldloc.0
+			IL_07ec: ldloc.s 21
+			IL_07ee: ldarg.0
+			IL_07ef: ldc.i4.3
+			IL_07f0: ldloc.0
+			IL_07f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07fb: ldloc.0
+			IL_07fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0801: dup
+			IL_0802: ldc.i4.0
+			IL_0803: ldloc.1
+			IL_0804: stelem.ref
+			IL_0805: dup
+			IL_0806: ldc.i4.1
+			IL_0807: ldloc.2
+			IL_0808: stelem.ref
+			IL_0809: dup
+			IL_080a: ldc.i4.2
+			IL_080b: ldloc.3
+			IL_080c: stelem.ref
+			IL_080d: dup
+			IL_080e: ldc.i4.3
+			IL_080f: ldloc.s 4
+			IL_0811: stelem.ref
+			IL_0812: dup
+			IL_0813: ldc.i4.4
+			IL_0814: ldloc.s 5
 			IL_0816: stelem.ref
-			IL_0817: ldloc.s 18
-			IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_081e: stloc.s 23
-			IL_0820: ldloc.0
-			IL_0821: ldc.i4.3
-			IL_0822: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0827: ldloc.0
-			IL_0828: ldloc.s 23
-			IL_082a: ldarg.0
-			IL_082b: ldc.i4.3
-			IL_082c: ldloc.0
-			IL_082d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0832: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0837: ldloc.0
-			IL_0838: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0817: dup
+			IL_0818: ldc.i4.5
+			IL_0819: ldloc.s 6
+			IL_081b: stelem.ref
+			IL_081c: dup
+			IL_081d: ldc.i4.6
+			IL_081e: ldloc.s 7
+			IL_0820: stelem.ref
+			IL_0821: dup
+			IL_0822: ldc.i4.7
+			IL_0823: ldloc.s 8
+			IL_0825: stelem.ref
+			IL_0826: dup
+			IL_0827: ldc.i4.8
+			IL_0828: ldloc.s 9
+			IL_082a: stelem.ref
+			IL_082b: dup
+			IL_082c: ldc.i4.s 9
+			IL_082e: ldloc.s 10
+			IL_0830: stelem.ref
+			IL_0831: dup
+			IL_0832: ldc.i4.s 10
+			IL_0834: ldloc.s 11
+			IL_0836: stelem.ref
+			IL_0837: dup
+			IL_0838: ldc.i4.s 11
+			IL_083a: ldloc.s 12
+			IL_083c: stelem.ref
 			IL_083d: dup
-			IL_083e: ldc.i4.0
-			IL_083f: ldloc.1
-			IL_0840: stelem.ref
-			IL_0841: dup
-			IL_0842: ldc.i4.1
-			IL_0843: ldloc.2
-			IL_0844: stelem.ref
-			IL_0845: dup
-			IL_0846: ldc.i4.2
-			IL_0847: ldloc.3
+			IL_083e: ldc.i4.s 12
+			IL_0840: ldloc.s 13
+			IL_0842: stelem.ref
+			IL_0843: dup
+			IL_0844: ldc.i4.s 13
+			IL_0846: ldloc.s 14
 			IL_0848: stelem.ref
 			IL_0849: dup
-			IL_084a: ldc.i4.3
-			IL_084b: ldloc.s 4
-			IL_084d: stelem.ref
-			IL_084e: dup
-			IL_084f: ldc.i4.4
-			IL_0850: ldloc.s 5
-			IL_0852: stelem.ref
-			IL_0853: dup
-			IL_0854: ldc.i4.5
-			IL_0855: ldloc.s 6
-			IL_0857: stelem.ref
-			IL_0858: dup
-			IL_0859: ldc.i4.6
-			IL_085a: ldloc.s 7
-			IL_085c: stelem.ref
-			IL_085d: dup
-			IL_085e: ldc.i4.7
-			IL_085f: ldloc.s 8
-			IL_0861: stelem.ref
-			IL_0862: dup
-			IL_0863: ldc.i4.8
-			IL_0864: ldloc.s 9
+			IL_084a: ldc.i4.s 14
+			IL_084c: ldloc.s 15
+			IL_084e: stelem.ref
+			IL_084f: dup
+			IL_0850: ldc.i4.s 15
+			IL_0852: ldloc.s 16
+			IL_0854: stelem.ref
+			IL_0855: dup
+			IL_0856: ldc.i4.s 16
+			IL_0858: ldloc.s 17
+			IL_085a: stelem.ref
+			IL_085b: dup
+			IL_085c: ldc.i4.s 17
+			IL_085e: ldloc.s 18
+			IL_0860: stelem.ref
+			IL_0861: dup
+			IL_0862: ldc.i4.s 18
+			IL_0864: ldloc.s 19
 			IL_0866: stelem.ref
 			IL_0867: dup
-			IL_0868: ldc.i4.s 9
-			IL_086a: ldloc.s 10
+			IL_0868: ldc.i4.s 19
+			IL_086a: ldloc.s 20
 			IL_086c: stelem.ref
 			IL_086d: dup
-			IL_086e: ldc.i4.s 10
-			IL_0870: ldloc.s 11
+			IL_086e: ldc.i4.s 20
+			IL_0870: ldloc.s 21
 			IL_0872: stelem.ref
 			IL_0873: dup
-			IL_0874: ldc.i4.s 11
-			IL_0876: ldloc.s 12
+			IL_0874: ldc.i4.s 21
+			IL_0876: ldloc.s 22
 			IL_0878: stelem.ref
 			IL_0879: dup
-			IL_087a: ldc.i4.s 12
-			IL_087c: ldloc.s 13
+			IL_087a: ldc.i4.s 22
+			IL_087c: ldloc.s 23
 			IL_087e: stelem.ref
 			IL_087f: dup
-			IL_0880: ldc.i4.s 13
-			IL_0882: ldloc.s 14
-			IL_0884: stelem.ref
-			IL_0885: dup
-			IL_0886: ldc.i4.s 14
-			IL_0888: ldloc.s 15
-			IL_088a: stelem.ref
-			IL_088b: dup
-			IL_088c: ldc.i4.s 15
-			IL_088e: ldloc.s 16
-			IL_0890: stelem.ref
-			IL_0891: dup
-			IL_0892: ldc.i4.s 16
-			IL_0894: ldloc.s 17
-			IL_0896: stelem.ref
-			IL_0897: dup
-			IL_0898: ldc.i4.s 17
-			IL_089a: ldloc.s 18
-			IL_089c: stelem.ref
-			IL_089d: dup
-			IL_089e: ldc.i4.s 18
-			IL_08a0: ldloc.s 19
-			IL_08a2: stelem.ref
-			IL_08a3: dup
-			IL_08a4: ldc.i4.s 19
-			IL_08a6: ldloc.s 20
-			IL_08a8: stelem.ref
-			IL_08a9: dup
-			IL_08aa: ldc.i4.s 20
-			IL_08ac: ldloc.s 21
-			IL_08ae: stelem.ref
-			IL_08af: dup
-			IL_08b0: ldc.i4.s 21
-			IL_08b2: ldloc.s 22
-			IL_08b4: stelem.ref
-			IL_08b5: dup
-			IL_08b6: ldc.i4.s 22
-			IL_08b8: ldloc.s 23
-			IL_08ba: stelem.ref
-			IL_08bb: dup
-			IL_08bc: ldc.i4.s 23
-			IL_08be: ldloc.s 24
-			IL_08c0: stelem.ref
-			IL_08c1: dup
-			IL_08c2: ldc.i4.s 24
-			IL_08c4: ldloc.s 25
-			IL_08c6: stelem.ref
-			IL_08c7: dup
-			IL_08c8: ldc.i4.s 25
-			IL_08ca: ldloc.s 26
-			IL_08cc: box [System.Runtime]System.Boolean
-			IL_08d1: stelem.ref
-			IL_08d2: dup
-			IL_08d3: ldc.i4.s 26
-			IL_08d5: ldloc.s 27
-			IL_08d7: stelem.ref
-			IL_08d8: dup
-			IL_08d9: ldc.i4.s 27
-			IL_08db: ldloc.s 28
-			IL_08dd: stelem.ref
-			IL_08de: dup
-			IL_08df: ldc.i4.s 28
-			IL_08e1: ldloc.s 29
-			IL_08e3: stelem.ref
-			IL_08e4: dup
-			IL_08e5: ldc.i4.s 29
-			IL_08e7: ldloc.s 30
-			IL_08e9: stelem.ref
-			IL_08ea: dup
-			IL_08eb: ldc.i4.s 30
-			IL_08ed: ldloc.s 31
-			IL_08ef: stelem.ref
-			IL_08f0: dup
-			IL_08f1: ldc.i4.s 31
-			IL_08f3: ldloc.s 32
-			IL_08f5: stelem.ref
-			IL_08f6: dup
-			IL_08f7: ldc.i4.s 32
-			IL_08f9: ldloc.s 33
-			IL_08fb: stelem.ref
-			IL_08fc: pop
-			IL_08fd: ldloc.0
-			IL_08fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0903: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0908: ret
+			IL_0880: ldc.i4.s 23
+			IL_0882: ldloc.s 24
+			IL_0884: box [System.Runtime]System.Boolean
+			IL_0889: stelem.ref
+			IL_088a: dup
+			IL_088b: ldc.i4.s 24
+			IL_088d: ldloc.s 25
+			IL_088f: stelem.ref
+			IL_0890: dup
+			IL_0891: ldc.i4.s 25
+			IL_0893: ldloc.s 26
+			IL_0895: stelem.ref
+			IL_0896: dup
+			IL_0897: ldc.i4.s 26
+			IL_0899: ldloc.s 27
+			IL_089b: stelem.ref
+			IL_089c: dup
+			IL_089d: ldc.i4.s 27
+			IL_089f: ldloc.s 28
+			IL_08a1: stelem.ref
+			IL_08a2: dup
+			IL_08a3: ldc.i4.s 28
+			IL_08a5: ldloc.s 29
+			IL_08a7: stelem.ref
+			IL_08a8: dup
+			IL_08a9: ldc.i4.s 29
+			IL_08ab: ldloc.s 30
+			IL_08ad: stelem.ref
+			IL_08ae: dup
+			IL_08af: ldc.i4.s 30
+			IL_08b1: ldloc.s 31
+			IL_08b3: stelem.ref
+			IL_08b4: pop
+			IL_08b5: ldloc.0
+			IL_08b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08c0: ret
 
-			IL_0909: ldloc.0
-			IL_090a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_090f: stloc.s 23
-			IL_0911: ldloc.s 23
-			IL_0913: stloc.s 8
-			IL_0915: ldloc.s 18
-			IL_0917: stloc.s 23
-			IL_0919: ldloc.s 23
-			IL_091b: stloc.s 10
+			IL_08c1: ldloc.0
+			IL_08c2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_08c7: stloc.s 21
+			IL_08c9: ldloc.s 21
+			IL_08cb: stloc.s 8
+			IL_08cd: ldloc.s 16
+			IL_08cf: stloc.s 21
+			IL_08d1: ldloc.s 21
+			IL_08d3: stloc.s 10
 
-			IL_091d: ldloc.s 9
-			IL_091f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0924: ldc.i4.0
-			IL_0925: ceq
-			IL_0927: stloc.s 26
-			IL_0929: ldloc.s 26
-			IL_092b: brfalse IL_09a0
+			IL_08d5: ldloc.s 9
+			IL_08d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08dc: ldc.i4.0
+			IL_08dd: ceq
+			IL_08df: stloc.s 24
+			IL_08e1: ldloc.s 24
+			IL_08e3: brfalse IL_0958
 
-			IL_0930: ldloc.1
-			IL_0931: ldstr "section"
-			IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_093b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0940: stloc.s 30
-			IL_0942: ldstr "Could not infer an element id for section '"
-			IL_0947: ldloc.s 30
-			IL_0949: call string [System.Runtime]System.String::Concat(string, string)
-			IL_094e: stloc.s 30
-			IL_0950: ldloc.s 30
-			IL_0952: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0957: call string [System.Runtime]System.String::Concat(string, string)
-			IL_095c: stloc.s 30
-			IL_095e: ldloc.s 30
-			IL_0960: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0965: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_096a: stloc.s 23
-			IL_096c: ldloc.s 23
-			IL_096e: stloc.s 19
-			IL_0970: ldloc.0
-			IL_0971: ldc.i4.m1
-			IL_0972: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0977: ldloc.0
-			IL_0978: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_097d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0982: ldarg.0
-			IL_0983: ldc.i4.1
-			IL_0984: newarr [System.Runtime]System.Object
-			IL_0989: dup
-			IL_098a: ldc.i4.0
-			IL_098b: ldloc.s 19
-			IL_098d: stelem.ref
-			IL_098e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0993: pop
-			IL_0994: ldloc.0
-			IL_0995: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_099a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_099f: ret
+			IL_08e8: ldloc.1
+			IL_08e9: ldstr "section"
+			IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08f8: stloc.s 28
+			IL_08fa: ldstr "Could not infer an element id for section '"
+			IL_08ff: ldloc.s 28
+			IL_0901: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0906: stloc.s 28
+			IL_0908: ldloc.s 28
+			IL_090a: ldstr "'. Try passing --id sec-... explicitly."
+			IL_090f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0914: stloc.s 28
+			IL_0916: ldloc.s 28
+			IL_0918: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_091d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0922: stloc.s 21
+			IL_0924: ldloc.s 21
+			IL_0926: stloc.s 17
+			IL_0928: ldloc.0
+			IL_0929: ldc.i4.m1
+			IL_092a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_092f: ldloc.0
+			IL_0930: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0935: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_093a: ldarg.0
+			IL_093b: ldc.i4.1
+			IL_093c: newarr [System.Runtime]System.Object
+			IL_0941: dup
+			IL_0942: ldc.i4.0
+			IL_0943: ldloc.s 17
+			IL_0945: stelem.ref
+			IL_0946: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_094b: pop
+			IL_094c: ldloc.0
+			IL_094d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0952: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0957: ret
 
-			IL_09a0: ldarg.0
-			IL_09a1: ldc.i4.1
-			IL_09a2: ldelem.ref
-			IL_09a3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09a8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_09ad: ldc.i4.1
-			IL_09ae: newarr [System.Runtime]System.Object
-			IL_09b3: dup
-			IL_09b4: ldc.i4.0
-			IL_09b5: ldarg.0
-			IL_09b6: ldc.i4.1
-			IL_09b7: ldelem.ref
-			IL_09b8: stelem.ref
-			IL_09b9: ldloc.s 8
-			IL_09bb: ldloc.s 9
-			IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_09c2: stloc.s 23
-			IL_09c4: ldloc.s 23
-			IL_09c6: stloc.s 20
-			IL_09c8: ldarg.0
-			IL_09c9: ldc.i4.1
-			IL_09ca: ldelem.ref
-			IL_09cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09d0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_09d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09da: stloc.s 23
-			IL_09dc: ldstr "process"
-			IL_09e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09e6: stloc.s 25
-			IL_09e8: ldloc.s 25
-			IL_09ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ef: stloc.s 25
-			IL_09f1: ldloc.s 25
-			IL_09f3: ldstr "cwd"
-			IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_09fd: stloc.s 25
-			IL_09ff: ldloc.s 23
-			IL_0a01: ldstr "join"
-			IL_0a06: ldloc.s 25
-			IL_0a08: ldloc.1
-			IL_0a09: ldstr "outFile"
-			IL_0a0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a13: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a18: stloc.s 25
-			IL_0a1a: ldloc.s 25
-			IL_0a1c: stloc.s 21
-			IL_0a1e: ldarg.0
-			IL_0a1f: ldc.i4.1
-			IL_0a20: ldelem.ref
-			IL_0a21: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a26: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0a2b: stloc.s 25
-			IL_0a2d: ldc.i4.1
-			IL_0a2e: newarr [System.Runtime]System.Object
-			IL_0a33: dup
-			IL_0a34: ldc.i4.0
-			IL_0a35: ldarg.0
-			IL_0a36: ldc.i4.1
-			IL_0a37: ldelem.ref
-			IL_0a38: stelem.ref
-			IL_0a39: stloc.s 24
-			IL_0a3b: ldloc.s 20
-			IL_0a3d: ldstr "html"
-			IL_0a42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a47: stloc.s 23
-			IL_0a49: ldloc.1
-			IL_0a4a: ldstr "section"
-			IL_0a4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a54: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a59: stloc.s 30
-			IL_0a5b: ldstr "ECMA-262 "
-			IL_0a60: ldloc.s 30
-			IL_0a62: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a67: stloc.s 30
-			IL_0a69: ldloc.s 25
-			IL_0a6b: ldloc.s 24
-			IL_0a6d: ldloc.s 23
-			IL_0a6f: ldloc.s 30
-			IL_0a71: ldloc.s 10
-			IL_0a73: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a78: stloc.s 23
-			IL_0a7a: ldloc.s 23
-			IL_0a7c: stloc.s 22
-			IL_0a7e: ldarg.0
-			IL_0a7f: ldc.i4.1
-			IL_0a80: ldelem.ref
-			IL_0a81: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a86: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a90: stloc.s 23
-			IL_0a92: ldloc.s 23
-			IL_0a94: ldstr "writeFileSync"
-			IL_0a99: ldloc.s 21
-			IL_0a9b: ldloc.s 22
-			IL_0a9d: ldstr "utf8"
-			IL_0aa2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0aa7: pop
-			IL_0aa8: ldstr "console"
-			IL_0aad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ab2: stloc.s 23
-			IL_0ab4: ldloc.s 23
-			IL_0ab6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0abb: stloc.s 23
-			IL_0abd: ldarg.0
-			IL_0abe: ldc.i4.1
-			IL_0abf: ldelem.ref
-			IL_0ac0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ac5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0aca: stloc.s 25
-			IL_0acc: ldc.i4.1
-			IL_0acd: newarr [System.Runtime]System.Object
-			IL_0ad2: dup
-			IL_0ad3: ldc.i4.0
-			IL_0ad4: ldarg.0
-			IL_0ad5: ldc.i4.1
-			IL_0ad6: ldelem.ref
-			IL_0ad7: stelem.ref
-			IL_0ad8: stloc.s 24
-			IL_0ada: ldloc.1
-			IL_0adb: ldstr "section"
-			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ae5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aea: stloc.s 30
-			IL_0aec: ldstr "Extracted section "
-			IL_0af1: ldloc.s 30
-			IL_0af3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0af8: stloc.s 30
-			IL_0afa: ldloc.s 30
-			IL_0afc: ldstr " (id="
-			IL_0b01: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b06: stloc.s 30
-			IL_0b08: ldloc.s 9
-			IL_0b0a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b0f: stloc.s 29
-			IL_0b11: ldloc.s 30
-			IL_0b13: ldloc.s 29
-			IL_0b15: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b1a: stloc.s 29
-			IL_0b1c: ldloc.s 29
-			IL_0b1e: ldstr ", tag="
-			IL_0b23: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b28: stloc.s 29
-			IL_0b2a: ldloc.s 20
-			IL_0b2c: ldstr "tagName"
-			IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b36: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b3b: stloc.s 30
-			IL_0b3d: ldloc.s 29
-			IL_0b3f: ldloc.s 30
-			IL_0b41: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b46: stloc.s 30
-			IL_0b48: ldloc.s 30
-			IL_0b4a: ldstr ") -> "
-			IL_0b4f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b54: stloc.s 30
-			IL_0b56: ldloc.s 21
-			IL_0b58: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b5d: stloc.s 29
-			IL_0b5f: ldloc.s 30
-			IL_0b61: ldloc.s 29
-			IL_0b63: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b68: stloc.s 29
-			IL_0b6a: ldloc.s 25
-			IL_0b6c: ldloc.s 24
-			IL_0b6e: ldloc.s 29
-			IL_0b70: ldloc.s 21
-			IL_0b72: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b77: stloc.s 25
-			IL_0b79: ldloc.s 23
-			IL_0b7b: ldstr "log"
-			IL_0b80: ldloc.s 25
-			IL_0b82: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0b87: pop
-			IL_0b88: ldstr "console"
-			IL_0b8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b92: stloc.s 25
-			IL_0b94: ldloc.s 25
-			IL_0b96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b9b: stloc.s 25
-			IL_0b9d: ldarg.0
-			IL_0b9e: ldc.i4.1
-			IL_0b9f: ldelem.ref
-			IL_0ba0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ba5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0baa: stloc.s 23
-			IL_0bac: ldc.i4.1
-			IL_0bad: newarr [System.Runtime]System.Object
-			IL_0bb2: dup
-			IL_0bb3: ldc.i4.0
-			IL_0bb4: ldarg.0
-			IL_0bb5: ldc.i4.1
-			IL_0bb6: ldelem.ref
-			IL_0bb7: stelem.ref
-			IL_0bb8: stloc.s 24
-			IL_0bba: ldarg.0
-			IL_0bbb: ldc.i4.1
-			IL_0bbc: ldelem.ref
-			IL_0bbd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bc2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0bc7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0bcc: stloc.s 33
-			IL_0bce: ldloc.s 33
-			IL_0bd0: ldstr "readFileSync"
-			IL_0bd5: ldloc.s 21
-			IL_0bd7: ldstr "utf8"
-			IL_0bdc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0be1: stloc.s 33
-			IL_0be3: ldloc.s 23
-			IL_0be5: ldloc.s 24
-			IL_0be7: ldloc.s 33
-			IL_0be9: ldloc.s 21
-			IL_0beb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0bf0: stloc.s 33
-			IL_0bf2: ldloc.s 25
-			IL_0bf4: ldstr "log"
-			IL_0bf9: ldloc.s 33
-			IL_0bfb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0c00: pop
-			IL_0c01: ldloc.0
-			IL_0c02: ldc.i4.m1
-			IL_0c03: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c08: ldloc.0
-			IL_0c09: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c13: ldarg.0
-			IL_0c14: ldc.i4.1
-			IL_0c15: newarr [System.Runtime]System.Object
-			IL_0c1a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c1f: pop
-			IL_0c20: ldloc.0
-			IL_0c21: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c26: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c2b: ret
+			IL_0958: ldarg.0
+			IL_0959: ldc.i4.1
+			IL_095a: ldelem.ref
+			IL_095b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0960: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0965: ldc.i4.1
+			IL_0966: newarr [System.Runtime]System.Object
+			IL_096b: dup
+			IL_096c: ldc.i4.0
+			IL_096d: ldarg.0
+			IL_096e: ldc.i4.1
+			IL_096f: ldelem.ref
+			IL_0970: stelem.ref
+			IL_0971: ldloc.s 8
+			IL_0973: ldloc.s 9
+			IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_097a: stloc.s 21
+			IL_097c: ldloc.s 21
+			IL_097e: stloc.s 18
+			IL_0980: ldarg.0
+			IL_0981: ldc.i4.1
+			IL_0982: ldelem.ref
+			IL_0983: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0988: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_098d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0992: stloc.s 21
+			IL_0994: ldstr "process"
+			IL_0999: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_099e: stloc.s 23
+			IL_09a0: ldloc.s 23
+			IL_09a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09a7: stloc.s 23
+			IL_09a9: ldloc.s 23
+			IL_09ab: ldstr "cwd"
+			IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_09b5: stloc.s 23
+			IL_09b7: ldloc.s 21
+			IL_09b9: ldstr "join"
+			IL_09be: ldloc.s 23
+			IL_09c0: ldloc.1
+			IL_09c1: ldstr "outFile"
+			IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_09d0: stloc.s 23
+			IL_09d2: ldloc.s 23
+			IL_09d4: stloc.s 19
+			IL_09d6: ldarg.0
+			IL_09d7: ldc.i4.1
+			IL_09d8: ldelem.ref
+			IL_09d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09de: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09e3: stloc.s 23
+			IL_09e5: ldc.i4.1
+			IL_09e6: newarr [System.Runtime]System.Object
+			IL_09eb: dup
+			IL_09ec: ldc.i4.0
+			IL_09ed: ldarg.0
+			IL_09ee: ldc.i4.1
+			IL_09ef: ldelem.ref
+			IL_09f0: stelem.ref
+			IL_09f1: stloc.s 22
+			IL_09f3: ldloc.s 18
+			IL_09f5: ldstr "html"
+			IL_09fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ff: stloc.s 21
+			IL_0a01: ldloc.1
+			IL_0a02: ldstr "section"
+			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a11: stloc.s 28
+			IL_0a13: ldstr "ECMA-262 "
+			IL_0a18: ldloc.s 28
+			IL_0a1a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a1f: stloc.s 28
+			IL_0a21: ldloc.s 23
+			IL_0a23: ldloc.s 22
+			IL_0a25: ldloc.s 21
+			IL_0a27: ldloc.s 28
+			IL_0a29: ldloc.s 10
+			IL_0a2b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a30: stloc.s 21
+			IL_0a32: ldloc.s 21
+			IL_0a34: stloc.s 20
+			IL_0a36: ldarg.0
+			IL_0a37: ldc.i4.1
+			IL_0a38: ldelem.ref
+			IL_0a39: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a3e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a48: stloc.s 21
+			IL_0a4a: ldloc.s 21
+			IL_0a4c: ldstr "writeFileSync"
+			IL_0a51: ldloc.s 19
+			IL_0a53: ldloc.s 20
+			IL_0a55: ldstr "utf8"
+			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0a5f: pop
+			IL_0a60: ldstr "console"
+			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a6a: stloc.s 21
+			IL_0a6c: ldloc.s 21
+			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a73: stloc.s 21
+			IL_0a75: ldarg.0
+			IL_0a76: ldc.i4.1
+			IL_0a77: ldelem.ref
+			IL_0a78: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a7d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a82: stloc.s 23
+			IL_0a84: ldc.i4.1
+			IL_0a85: newarr [System.Runtime]System.Object
+			IL_0a8a: dup
+			IL_0a8b: ldc.i4.0
+			IL_0a8c: ldarg.0
+			IL_0a8d: ldc.i4.1
+			IL_0a8e: ldelem.ref
+			IL_0a8f: stelem.ref
+			IL_0a90: stloc.s 22
+			IL_0a92: ldloc.1
+			IL_0a93: ldstr "section"
+			IL_0a98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a9d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aa2: stloc.s 28
+			IL_0aa4: ldstr "Extracted section "
+			IL_0aa9: ldloc.s 28
+			IL_0aab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ab0: stloc.s 28
+			IL_0ab2: ldloc.s 28
+			IL_0ab4: ldstr " (id="
+			IL_0ab9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0abe: stloc.s 28
+			IL_0ac0: ldloc.s 9
+			IL_0ac2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ac7: stloc.s 27
+			IL_0ac9: ldloc.s 28
+			IL_0acb: ldloc.s 27
+			IL_0acd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ad2: stloc.s 27
+			IL_0ad4: ldloc.s 27
+			IL_0ad6: ldstr ", tag="
+			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae0: stloc.s 27
+			IL_0ae2: ldloc.s 18
+			IL_0ae4: ldstr "tagName"
+			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aee: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0af3: stloc.s 28
+			IL_0af5: ldloc.s 27
+			IL_0af7: ldloc.s 28
+			IL_0af9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0afe: stloc.s 28
+			IL_0b00: ldloc.s 28
+			IL_0b02: ldstr ") -> "
+			IL_0b07: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b0c: stloc.s 28
+			IL_0b0e: ldloc.s 19
+			IL_0b10: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b15: stloc.s 27
+			IL_0b17: ldloc.s 28
+			IL_0b19: ldloc.s 27
+			IL_0b1b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b20: stloc.s 27
+			IL_0b22: ldloc.s 23
+			IL_0b24: ldloc.s 22
+			IL_0b26: ldloc.s 27
+			IL_0b28: ldloc.s 19
+			IL_0b2a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b2f: stloc.s 23
+			IL_0b31: ldloc.s 21
+			IL_0b33: ldstr "log"
+			IL_0b38: ldloc.s 23
+			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0b3f: pop
+			IL_0b40: ldstr "console"
+			IL_0b45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b4a: stloc.s 23
+			IL_0b4c: ldloc.s 23
+			IL_0b4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b53: stloc.s 23
+			IL_0b55: ldarg.0
+			IL_0b56: ldc.i4.1
+			IL_0b57: ldelem.ref
+			IL_0b58: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b5d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b62: stloc.s 21
+			IL_0b64: ldc.i4.1
+			IL_0b65: newarr [System.Runtime]System.Object
+			IL_0b6a: dup
+			IL_0b6b: ldc.i4.0
+			IL_0b6c: ldarg.0
+			IL_0b6d: ldc.i4.1
+			IL_0b6e: ldelem.ref
+			IL_0b6f: stelem.ref
+			IL_0b70: stloc.s 22
+			IL_0b72: ldarg.0
+			IL_0b73: ldc.i4.1
+			IL_0b74: ldelem.ref
+			IL_0b75: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b7a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b84: stloc.s 31
+			IL_0b86: ldloc.s 31
+			IL_0b88: ldstr "readFileSync"
+			IL_0b8d: ldloc.s 19
+			IL_0b8f: ldstr "utf8"
+			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b99: stloc.s 31
+			IL_0b9b: ldloc.s 21
+			IL_0b9d: ldloc.s 22
+			IL_0b9f: ldloc.s 31
+			IL_0ba1: ldloc.s 19
+			IL_0ba3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0ba8: stloc.s 31
+			IL_0baa: ldloc.s 23
+			IL_0bac: ldstr "log"
+			IL_0bb1: ldloc.s 31
+			IL_0bb3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0bb8: pop
+			IL_0bb9: ldloc.0
+			IL_0bba: ldc.i4.m1
+			IL_0bbb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0bc0: ldloc.0
+			IL_0bc1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bc6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bcb: ldarg.0
+			IL_0bcc: ldc.i4.1
+			IL_0bcd: newarr [System.Runtime]System.Object
+			IL_0bd2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bd7: pop
+			IL_0bd8: ldloc.0
+			IL_0bd9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bde: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0be3: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5521,7 +5469,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x46c5
+			// Method begins at RVA 0x463d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5797,7 +5745,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4890
+		// Method begins at RVA 0x4808
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x370a
+				// Method begins at RVA 0x36f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3713
+				// Method begins at RVA 0x36ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x371c
+				// Method begins at RVA 0x3708
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3725
+				// Method begins at RVA 0x3711
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -331,7 +331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x372e
+				// Method begins at RVA 0x371a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -507,7 +507,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3740
+					// Method begins at RVA 0x372c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -532,7 +532,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36b8
+				// Method begins at RVA 0x36a4
 				// Header size: 12
 				// Code size: 61 (0x3d)
 				.maxstack 8
@@ -586,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3737
+				// Method begins at RVA 0x3723
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -712,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3749
+				// Method begins at RVA 0x3735
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -736,7 +736,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x375b
+					// Method begins at RVA 0x3747
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -754,7 +754,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3752
+				// Method begins at RVA 0x373e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1068,7 +1068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3764
+				// Method begins at RVA 0x3750
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1092,7 +1092,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3776
+					// Method begins at RVA 0x3762
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1116,7 +1116,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3788
+						// Method begins at RVA 0x3774
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1134,7 +1134,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x377f
+					// Method begins at RVA 0x376b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1152,7 +1152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x376d
+				// Method begins at RVA 0x3759
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1181,7 +1181,7 @@
 			)
 			// Method begins at RVA 0x2888
 			// Header size: 12
-			// Code size: 776 (0x308)
+			// Code size: 769 (0x301)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1193,23 +1193,22 @@
 				[6] bool,
 				[7] bool,
 				[8] object,
-				[9] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/Scope_ForOf_L58C7/Scope_ForOf_L61C9/Block_L61C31,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
-				[13] object,
-				[14] bool,
+				[13] bool,
+				[14] object,
 				[15] object,
 				[16] object,
 				[17] object,
 				[18] object,
 				[19] object,
-				[20] object,
-				[21] object[],
+				[20] object[],
+				[21] object,
 				[22] object,
-				[23] object,
-				[24] string,
-				[25] string
+				[23] string,
+				[24] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -1217,19 +1216,19 @@
 			IL_0006: stloc.0
 			IL_0007: ldarg.2
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_000d: stloc.s 14
-			IL_000f: ldloc.s 14
+			IL_000d: stloc.s 13
+			IL_000f: ldloc.s 13
 			IL_0011: brtrue IL_0023
 
 			IL_0016: ldc.i4.0
 			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_001c: stloc.s 16
+			IL_001c: stloc.s 15
 			IL_001e: br IL_0026
 
 			IL_0023: ldarg.2
-			IL_0024: stloc.s 16
+			IL_0024: stloc.s 15
 
-			IL_0026: ldloc.s 16
+			IL_0026: ldloc.s 15
 			IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
 			IL_002d: stloc.1
 			IL_002e: ldc.i4.0
@@ -1241,17 +1240,17 @@
 				// loop start (head: IL_0032)
 					IL_0032: ldloc.1
 					IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_0038: stloc.s 17
-					IL_003a: ldloc.s 17
+					IL_0038: stloc.s 16
+					IL_003a: ldloc.s 16
 					IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0041: stloc.s 14
-					IL_0043: ldloc.s 14
-					IL_0045: brtrue IL_02d5
+					IL_0041: stloc.s 13
+					IL_0043: ldloc.s 13
+					IL_0045: brtrue IL_02ce
 
-					IL_004a: ldloc.s 17
+					IL_004a: ldloc.s 16
 					IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0051: stloc.s 17
-					IL_0053: ldloc.s 17
+					IL_0051: stloc.s 16
+					IL_0053: ldloc.s 16
 					IL_0055: stloc.s 4
 					IL_0057: ldloc.s 4
 					IL_0059: ldstr "tests"
@@ -1259,14 +1258,14 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 					IL_0068: ldc.i4.0
 					IL_0069: ceq
-					IL_006b: stloc.s 14
-					IL_006d: ldloc.s 14
+					IL_006b: stloc.s 13
+					IL_006d: ldloc.s 13
 					IL_006f: box [System.Runtime]System.Boolean
-					IL_0074: stloc.s 18
-					IL_0076: ldloc.s 18
+					IL_0074: stloc.s 17
+					IL_0076: ldloc.s 17
 					IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_007d: stloc.s 14
-					IL_007f: ldloc.s 14
+					IL_007d: stloc.s 13
+					IL_007f: ldloc.s 13
 					IL_0081: brtrue IL_00b8
 
 					IL_0086: ldloc.s 4
@@ -1277,66 +1276,66 @@
 					IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 					IL_00a1: ldc.i4.0
 					IL_00a2: ceq
-					IL_00a4: stloc.s 14
-					IL_00a6: ldloc.s 14
+					IL_00a4: stloc.s 13
+					IL_00a6: ldloc.s 13
 					IL_00a8: box [System.Runtime]System.Boolean
-					IL_00ad: stloc.s 19
-					IL_00af: ldloc.s 19
-					IL_00b1: stloc.s 20
+					IL_00ad: stloc.s 18
+					IL_00af: ldloc.s 18
+					IL_00b1: stloc.s 19
 					IL_00b3: br IL_00bc
 
-					IL_00b8: ldloc.s 18
-					IL_00ba: stloc.s 20
+					IL_00b8: ldloc.s 17
+					IL_00ba: stloc.s 19
 
-					IL_00bc: ldloc.s 20
+					IL_00bc: ldloc.s 19
 					IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00c3: stloc.s 14
-					IL_00c5: ldloc.s 14
+					IL_00c3: stloc.s 13
+					IL_00c5: ldloc.s 13
 					IL_00c7: brfalse IL_00d1
 
-					IL_00cc: br IL_02c3
+					IL_00cc: br IL_02bc
 
 					IL_00d1: ldarg.0
 					IL_00d2: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-					IL_00d7: stloc.s 17
+					IL_00d7: stloc.s 16
 					IL_00d9: ldc.i4.1
 					IL_00da: newarr [System.Runtime]System.Object
 					IL_00df: dup
 					IL_00e0: ldc.i4.0
 					IL_00e1: ldarg.0
 					IL_00e2: stelem.ref
-					IL_00e3: stloc.s 21
+					IL_00e3: stloc.s 20
 					IL_00e5: ldloc.s 4
 					IL_00e7: ldstr "name"
 					IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_00f1: stloc.s 22
-					IL_00f3: ldloc.s 22
+					IL_00f1: stloc.s 21
+					IL_00f3: ldloc.s 21
 					IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00fa: stloc.s 14
-					IL_00fc: ldloc.s 14
+					IL_00fa: stloc.s 13
+					IL_00fc: ldloc.s 13
 					IL_00fe: brtrue IL_010f
 
 					IL_0103: ldstr ""
-					IL_0108: stloc.s 23
+					IL_0108: stloc.s 22
 					IL_010a: br IL_0113
 
-					IL_010f: ldloc.s 22
-					IL_0111: stloc.s 23
+					IL_010f: ldloc.s 21
+					IL_0111: stloc.s 22
 
-					IL_0113: ldloc.s 17
-					IL_0115: ldloc.s 21
-					IL_0117: ldloc.s 23
+					IL_0113: ldloc.s 16
+					IL_0115: ldloc.s 20
+					IL_0117: ldloc.s 22
 					IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_011e: stloc.s 17
-					IL_0120: ldloc.s 17
+					IL_011e: stloc.s 16
+					IL_0120: ldloc.s 16
 					IL_0122: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0127: stloc.s 24
+					IL_0127: stloc.s 23
 					IL_0129: ldstr "- "
-					IL_012e: ldloc.s 24
+					IL_012e: ldloc.s 23
 					IL_0130: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0135: stloc.s 24
+					IL_0135: stloc.s 23
 					IL_0137: ldloc.0
-					IL_0138: ldloc.s 24
+					IL_0138: ldloc.s 23
 					IL_013a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_013f: pop
 					IL_0140: ldloc.s 4
@@ -1353,180 +1352,178 @@
 						// loop start (head: IL_0159)
 							IL_0159: ldloc.s 5
 							IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_0160: stloc.s 17
-							IL_0162: ldloc.s 17
+							IL_0160: stloc.s 16
+							IL_0162: ldloc.s 16
 							IL_0164: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_0169: stloc.s 14
-							IL_016b: ldloc.s 14
-							IL_016d: brtrue IL_02a5
+							IL_0169: stloc.s 13
+							IL_016b: ldloc.s 13
+							IL_016d: brtrue IL_029e
 
-							IL_0172: ldloc.s 17
+							IL_0172: ldloc.s 16
 							IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_0179: stloc.s 17
-							IL_017b: ldloc.s 17
+							IL_0179: stloc.s 16
+							IL_017b: ldloc.s 16
 							IL_017d: stloc.s 8
-							IL_017f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/Scope_ForOf_L58C7/Scope_ForOf_L61C9/Block_L61C31::.ctor()
-							IL_0184: stloc.s 9
-							IL_0186: ldloc.s 8
-							IL_0188: ldstr "name"
-							IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_0197: stloc.s 14
-							IL_0199: ldloc.s 14
-							IL_019b: brfalse IL_01d4
+							IL_017f: ldloc.s 8
+							IL_0181: ldstr "name"
+							IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_018b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0190: stloc.s 13
+							IL_0192: ldloc.s 13
+							IL_0194: brfalse IL_01cd
 
-							IL_01a0: ldarg.0
-							IL_01a1: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_01a6: stloc.s 17
-							IL_01a8: ldc.i4.1
-							IL_01a9: newarr [System.Runtime]System.Object
-							IL_01ae: dup
-							IL_01af: ldc.i4.0
-							IL_01b0: ldarg.0
-							IL_01b1: stelem.ref
-							IL_01b2: stloc.s 21
-							IL_01b4: ldloc.s 17
-							IL_01b6: ldloc.s 21
-							IL_01b8: ldloc.s 8
-							IL_01ba: ldstr "name"
-							IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_01c9: stloc.s 17
-							IL_01cb: ldloc.s 17
-							IL_01cd: stloc.s 10
-							IL_01cf: br IL_01db
+							IL_0199: ldarg.0
+							IL_019a: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_019f: stloc.s 16
+							IL_01a1: ldc.i4.1
+							IL_01a2: newarr [System.Runtime]System.Object
+							IL_01a7: dup
+							IL_01a8: ldc.i4.0
+							IL_01a9: ldarg.0
+							IL_01aa: stelem.ref
+							IL_01ab: stloc.s 20
+							IL_01ad: ldloc.s 16
+							IL_01af: ldloc.s 20
+							IL_01b1: ldloc.s 8
+							IL_01b3: ldstr "name"
+							IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_01c2: stloc.s 16
+							IL_01c4: ldloc.s 16
+							IL_01c6: stloc.s 9
+							IL_01c8: br IL_01d4
 
-							IL_01d4: ldstr ""
-							IL_01d9: stloc.s 10
+							IL_01cd: ldstr ""
+							IL_01d2: stloc.s 9
 
-							IL_01db: ldloc.s 10
-							IL_01dd: stloc.s 11
-							IL_01df: ldloc.s 8
-							IL_01e1: ldstr "file"
-							IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_01eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_01f0: stloc.s 14
-							IL_01f2: ldloc.s 14
-							IL_01f4: brfalse IL_0252
+							IL_01d4: ldloc.s 9
+							IL_01d6: stloc.s 10
+							IL_01d8: ldloc.s 8
+							IL_01da: ldstr "file"
+							IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_01e9: stloc.s 13
+							IL_01eb: ldloc.s 13
+							IL_01ed: brfalse IL_024b
 
-							IL_01f9: ldarg.0
-							IL_01fa: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_01ff: stloc.s 17
-							IL_0201: ldc.i4.1
-							IL_0202: newarr [System.Runtime]System.Object
-							IL_0207: dup
-							IL_0208: ldc.i4.0
-							IL_0209: ldarg.0
-							IL_020a: stelem.ref
-							IL_020b: stloc.s 21
-							IL_020d: ldloc.s 17
-							IL_020f: ldloc.s 21
-							IL_0211: ldloc.s 8
-							IL_0213: ldstr "file"
-							IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_0222: stloc.s 17
-							IL_0224: ldloc.s 17
-							IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_022b: stloc.s 24
-							IL_022d: ldstr " ("
-							IL_0232: ldloc.s 24
-							IL_0234: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0239: stloc.s 24
-							IL_023b: ldloc.s 24
-							IL_023d: ldstr ")"
-							IL_0242: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0247: stloc.s 24
-							IL_0249: ldloc.s 24
-							IL_024b: stloc.s 12
-							IL_024d: br IL_0259
+							IL_01f2: ldarg.0
+							IL_01f3: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_01f8: stloc.s 16
+							IL_01fa: ldc.i4.1
+							IL_01fb: newarr [System.Runtime]System.Object
+							IL_0200: dup
+							IL_0201: ldc.i4.0
+							IL_0202: ldarg.0
+							IL_0203: stelem.ref
+							IL_0204: stloc.s 20
+							IL_0206: ldloc.s 16
+							IL_0208: ldloc.s 20
+							IL_020a: ldloc.s 8
+							IL_020c: ldstr "file"
+							IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_021b: stloc.s 16
+							IL_021d: ldloc.s 16
+							IL_021f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0224: stloc.s 23
+							IL_0226: ldstr " ("
+							IL_022b: ldloc.s 23
+							IL_022d: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0232: stloc.s 23
+							IL_0234: ldloc.s 23
+							IL_0236: ldstr ")"
+							IL_023b: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0240: stloc.s 23
+							IL_0242: ldloc.s 23
+							IL_0244: stloc.s 11
+							IL_0246: br IL_0252
 
-							IL_0252: ldstr ""
-							IL_0257: stloc.s 12
+							IL_024b: ldstr ""
+							IL_0250: stloc.s 11
 
-							IL_0259: ldloc.s 12
-							IL_025b: stloc.s 13
-							IL_025d: ldloc.s 11
-							IL_025f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0264: stloc.s 24
-							IL_0266: ldstr "  - "
-							IL_026b: ldloc.s 24
-							IL_026d: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0272: stloc.s 24
-							IL_0274: ldloc.s 13
-							IL_0276: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_027b: stloc.s 25
-							IL_027d: ldloc.s 24
-							IL_027f: ldloc.s 25
-							IL_0281: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0286: stloc.s 25
-							IL_0288: ldloc.0
-							IL_0289: ldloc.s 25
-							IL_028b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_0290: pop
-							IL_0291: br IL_0159
+							IL_0252: ldloc.s 11
+							IL_0254: stloc.s 12
+							IL_0256: ldloc.s 10
+							IL_0258: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_025d: stloc.s 23
+							IL_025f: ldstr "  - "
+							IL_0264: ldloc.s 23
+							IL_0266: call string [System.Runtime]System.String::Concat(string, string)
+							IL_026b: stloc.s 23
+							IL_026d: ldloc.s 12
+							IL_026f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0274: stloc.s 24
+							IL_0276: ldloc.s 23
+							IL_0278: ldloc.s 24
+							IL_027a: call string [System.Runtime]System.String::Concat(string, string)
+							IL_027f: stloc.s 24
+							IL_0281: ldloc.0
+							IL_0282: ldloc.s 24
+							IL_0284: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_0289: pop
+							IL_028a: br IL_0159
 						// end loop
-						IL_0296: ldloc.s 5
-						IL_0298: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_029d: ldc.i4.1
-						IL_029e: stloc.s 7
-						IL_02a0: leave IL_02c3
+						IL_028f: ldloc.s 5
+						IL_0291: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_0296: ldc.i4.1
+						IL_0297: stloc.s 7
+						IL_0299: leave IL_02bc
 
-						IL_02a5: ldc.i4.1
-						IL_02a6: stloc.s 6
-						IL_02a8: leave IL_02c3
+						IL_029e: ldc.i4.1
+						IL_029f: stloc.s 6
+						IL_02a1: leave IL_02bc
 					} // end .try
 					finally
 					{
-						IL_02ad: ldloc.s 6
-						IL_02af: brtrue IL_02c2
+						IL_02a6: ldloc.s 6
+						IL_02a8: brtrue IL_02bb
 
-						IL_02b4: ldloc.s 7
-						IL_02b6: brtrue IL_02c2
+						IL_02ad: ldloc.s 7
+						IL_02af: brtrue IL_02bb
 
-						IL_02bb: ldloc.s 5
-						IL_02bd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_02b4: ldloc.s 5
+						IL_02b6: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_02c2: endfinally
+						IL_02bb: endfinally
 					} // end handler
 
-					IL_02c3: br IL_0032
+					IL_02bc: br IL_0032
 				// end loop
-				IL_02c8: ldloc.1
-				IL_02c9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_02ce: ldc.i4.1
-				IL_02cf: stloc.3
-				IL_02d0: leave IL_02ef
+				IL_02c1: ldloc.1
+				IL_02c2: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02c7: ldc.i4.1
+				IL_02c8: stloc.3
+				IL_02c9: leave IL_02e8
 
-				IL_02d5: ldc.i4.1
-				IL_02d6: stloc.2
-				IL_02d7: leave IL_02ef
+				IL_02ce: ldc.i4.1
+				IL_02cf: stloc.2
+				IL_02d0: leave IL_02e8
 			} // end .try
 			finally
 			{
-				IL_02dc: ldloc.2
-				IL_02dd: brtrue IL_02ee
+				IL_02d5: ldloc.2
+				IL_02d6: brtrue IL_02e7
 
-				IL_02e2: ldloc.3
-				IL_02e3: brtrue IL_02ee
+				IL_02db: ldloc.3
+				IL_02dc: brtrue IL_02e7
 
-				IL_02e8: ldloc.1
-				IL_02e9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02e1: ldloc.1
+				IL_02e2: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_02ee: endfinally
+				IL_02e7: endfinally
 			} // end handler
 
-			IL_02ef: ldloc.0
-			IL_02f0: ldc.i4.1
-			IL_02f1: newarr [System.Runtime]System.Object
-			IL_02f6: dup
-			IL_02f7: ldc.i4.0
-			IL_02f8: ldstr "\n"
-			IL_02fd: stelem.ref
-			IL_02fe: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0303: stloc.s 25
-			IL_0305: ldloc.s 25
-			IL_0307: ret
+			IL_02e8: ldloc.0
+			IL_02e9: ldc.i4.1
+			IL_02ea: newarr [System.Runtime]System.Object
+			IL_02ef: dup
+			IL_02f0: ldc.i4.0
+			IL_02f1: ldstr "\n"
+			IL_02f6: stelem.ref
+			IL_02f7: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_02fc: stloc.s 24
+			IL_02fe: ldloc.s 24
+			IL_0300: ret
 		} // end of method renderApiTests::__js_call__
 
 	} // end of class renderApiTests
@@ -1542,7 +1539,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3791
+				// Method begins at RVA 0x377d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1570,7 +1567,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37ac
+						// Method begins at RVA 0x3798
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1590,7 +1587,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37b5
+						// Method begins at RVA 0x37a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1610,7 +1607,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37be
+						// Method begins at RVA 0x37aa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1628,7 +1625,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37a3
+					// Method begins at RVA 0x378f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1646,7 +1643,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x379a
+				// Method begins at RVA 0x3786
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1673,9 +1670,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2bd0
+			// Method begins at RVA 0x2bcc
 			// Header size: 12
-			// Code size: 759 (0x2f7)
+			// Code size: 752 (0x2f0)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1683,19 +1680,18 @@
 				[2] bool,
 				[3] bool,
 				[4] object,
-				[5] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36,
+				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] bool,
+				[8] bool,
+				[9] object,
 				[10] object,
-				[11] object,
+				[11] string,
 				[12] string,
-				[13] string,
-				[14] object[],
+				[13] object[],
+				[14] object,
 				[15] object,
-				[16] object,
-				[17] object
+				[16] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -1712,22 +1708,22 @@
 			IL_001f: ldarg.2
 			IL_0020: ldstr "modules"
 			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002a: stloc.s 8
-			IL_002c: ldloc.s 8
+			IL_002a: stloc.s 7
+			IL_002c: ldloc.s 7
 			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0033: stloc.s 9
-			IL_0035: ldloc.s 9
+			IL_0033: stloc.s 8
+			IL_0035: ldloc.s 8
 			IL_0037: brtrue IL_0049
 
 			IL_003c: ldc.i4.0
 			IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0042: stloc.s 11
+			IL_0042: stloc.s 10
 			IL_0044: br IL_004d
 
-			IL_0049: ldloc.s 8
-			IL_004b: stloc.s 11
+			IL_0049: ldloc.s 7
+			IL_004b: stloc.s 10
 
-			IL_004d: ldloc.s 11
+			IL_004d: ldloc.s 10
 			IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
 			IL_0054: stloc.1
 			IL_0055: ldc.i4.0
@@ -1739,266 +1735,264 @@
 				// loop start (head: IL_0059)
 					IL_0059: ldloc.1
 					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_005f: stloc.s 8
-					IL_0061: ldloc.s 8
+					IL_005f: stloc.s 7
+					IL_0061: ldloc.s 7
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0068: stloc.s 9
-					IL_006a: ldloc.s 9
-					IL_006c: brtrue IL_02c4
+					IL_0068: stloc.s 8
+					IL_006a: ldloc.s 8
+					IL_006c: brtrue IL_02bd
 
-					IL_0071: ldloc.s 8
+					IL_0071: ldloc.s 7
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0078: stloc.s 8
-					IL_007a: ldloc.s 8
+					IL_0078: stloc.s 7
+					IL_007a: ldloc.s 7
 					IL_007c: stloc.s 4
-					IL_007e: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36::.ctor()
-					IL_0083: stloc.s 5
-					IL_0085: ldloc.s 4
-					IL_0087: ldstr "name"
-					IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0091: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0096: stloc.s 12
-					IL_0098: ldstr "### "
-					IL_009d: ldloc.s 12
-					IL_009f: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00a4: stloc.s 12
-					IL_00a6: ldloc.s 12
-					IL_00a8: ldstr " (status: "
-					IL_00ad: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00b2: stloc.s 12
-					IL_00b4: ldloc.s 4
-					IL_00b6: ldstr "status"
-					IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_00c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00c5: stloc.s 13
-					IL_00c7: ldloc.s 12
-					IL_00c9: ldloc.s 13
-					IL_00cb: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00d0: stloc.s 13
-					IL_00d2: ldloc.s 13
-					IL_00d4: ldstr ")"
-					IL_00d9: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00de: stloc.s 13
-					IL_00e0: ldloc.0
-					IL_00e1: ldloc.s 13
-					IL_00e3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_00e8: pop
-					IL_00e9: ldloc.s 4
-					IL_00eb: ldstr "docs"
-					IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00fa: stloc.s 9
-					IL_00fc: ldloc.s 9
-					IL_00fe: brfalse IL_014e
+					IL_007e: ldloc.s 4
+					IL_0080: ldstr "name"
+					IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_008f: stloc.s 11
+					IL_0091: ldstr "### "
+					IL_0096: ldloc.s 11
+					IL_0098: call string [System.Runtime]System.String::Concat(string, string)
+					IL_009d: stloc.s 11
+					IL_009f: ldloc.s 11
+					IL_00a1: ldstr " (status: "
+					IL_00a6: call string [System.Runtime]System.String::Concat(string, string)
+					IL_00ab: stloc.s 11
+					IL_00ad: ldloc.s 4
+					IL_00af: ldstr "status"
+					IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_00be: stloc.s 12
+					IL_00c0: ldloc.s 11
+					IL_00c2: ldloc.s 12
+					IL_00c4: call string [System.Runtime]System.String::Concat(string, string)
+					IL_00c9: stloc.s 12
+					IL_00cb: ldloc.s 12
+					IL_00cd: ldstr ")"
+					IL_00d2: call string [System.Runtime]System.String::Concat(string, string)
+					IL_00d7: stloc.s 12
+					IL_00d9: ldloc.0
+					IL_00da: ldloc.s 12
+					IL_00dc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_00e1: pop
+					IL_00e2: ldloc.s 4
+					IL_00e4: ldstr "docs"
+					IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00f3: stloc.s 8
+					IL_00f5: ldloc.s 8
+					IL_00f7: brfalse IL_0147
 
-					IL_0103: ldarg.0
-					IL_0104: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
-					IL_0109: stloc.s 8
-					IL_010b: ldc.i4.1
-					IL_010c: newarr [System.Runtime]System.Object
-					IL_0111: dup
-					IL_0112: ldc.i4.0
-					IL_0113: ldarg.0
-					IL_0114: stelem.ref
-					IL_0115: stloc.s 14
-					IL_0117: ldloc.s 8
-					IL_0119: ldloc.s 14
-					IL_011b: ldloc.s 4
-					IL_011d: ldstr "docs"
-					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_012c: stloc.s 8
-					IL_012e: ldloc.s 8
-					IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0135: stloc.s 13
-					IL_0137: ldstr "Docs: "
-					IL_013c: ldloc.s 13
-					IL_013e: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0143: stloc.s 13
-					IL_0145: ldloc.0
-					IL_0146: ldloc.s 13
-					IL_0148: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_014d: pop
+					IL_00fc: ldarg.0
+					IL_00fd: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
+					IL_0102: stloc.s 7
+					IL_0104: ldc.i4.1
+					IL_0105: newarr [System.Runtime]System.Object
+					IL_010a: dup
+					IL_010b: ldc.i4.0
+					IL_010c: ldarg.0
+					IL_010d: stelem.ref
+					IL_010e: stloc.s 13
+					IL_0110: ldloc.s 7
+					IL_0112: ldloc.s 13
+					IL_0114: ldloc.s 4
+					IL_0116: ldstr "docs"
+					IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0125: stloc.s 7
+					IL_0127: ldloc.s 7
+					IL_0129: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_012e: stloc.s 12
+					IL_0130: ldstr "Docs: "
+					IL_0135: ldloc.s 12
+					IL_0137: call string [System.Runtime]System.String::Concat(string, string)
+					IL_013c: stloc.s 12
+					IL_013e: ldloc.0
+					IL_013f: ldloc.s 12
+					IL_0141: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0146: pop
 
-					IL_014e: ldloc.s 4
-					IL_0150: ldstr "implementation"
-					IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_015f: stloc.s 9
-					IL_0161: ldloc.s 9
-					IL_0163: brfalse IL_01a8
+					IL_0147: ldloc.s 4
+					IL_0149: ldstr "implementation"
+					IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0153: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0158: stloc.s 8
+					IL_015a: ldloc.s 8
+					IL_015c: brfalse IL_01a1
 
-					IL_0168: ldloc.0
-					IL_0169: ldstr "Implementation:"
-					IL_016e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0173: pop
-					IL_0174: ldarg.0
-					IL_0175: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
-					IL_017a: stloc.s 8
-					IL_017c: ldc.i4.1
-					IL_017d: newarr [System.Runtime]System.Object
-					IL_0182: dup
-					IL_0183: ldc.i4.0
-					IL_0184: ldarg.0
-					IL_0185: stelem.ref
-					IL_0186: stloc.s 14
-					IL_0188: ldloc.s 8
-					IL_018a: ldloc.s 14
-					IL_018c: ldloc.s 4
-					IL_018e: ldstr "implementation"
-					IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_019d: stloc.s 8
-					IL_019f: ldloc.0
-					IL_01a0: ldloc.s 8
-					IL_01a2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01a7: pop
+					IL_0161: ldloc.0
+					IL_0162: ldstr "Implementation:"
+					IL_0167: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_016c: pop
+					IL_016d: ldarg.0
+					IL_016e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
+					IL_0173: stloc.s 7
+					IL_0175: ldc.i4.1
+					IL_0176: newarr [System.Runtime]System.Object
+					IL_017b: dup
+					IL_017c: ldc.i4.0
+					IL_017d: ldarg.0
+					IL_017e: stelem.ref
+					IL_017f: stloc.s 13
+					IL_0181: ldloc.s 7
+					IL_0183: ldloc.s 13
+					IL_0185: ldloc.s 4
+					IL_0187: ldstr "implementation"
+					IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0196: stloc.s 7
+					IL_0198: ldloc.0
+					IL_0199: ldloc.s 7
+					IL_019b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01a0: pop
 
-					IL_01a8: ldloc.0
-					IL_01a9: ldstr ""
-					IL_01ae: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01b3: pop
-					IL_01b4: ldarg.0
-					IL_01b5: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApisTable
-					IL_01ba: stloc.s 8
-					IL_01bc: ldc.i4.1
-					IL_01bd: newarr [System.Runtime]System.Object
-					IL_01c2: dup
-					IL_01c3: ldc.i4.0
-					IL_01c4: ldarg.0
-					IL_01c5: stelem.ref
-					IL_01c6: stloc.s 14
-					IL_01c8: ldloc.s 4
-					IL_01ca: ldstr "apis"
-					IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01d4: stloc.s 15
-					IL_01d6: ldloc.s 15
-					IL_01d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01dd: stloc.s 9
-					IL_01df: ldloc.s 9
-					IL_01e1: brtrue IL_01f3
+					IL_01a1: ldloc.0
+					IL_01a2: ldstr ""
+					IL_01a7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ac: pop
+					IL_01ad: ldarg.0
+					IL_01ae: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApisTable
+					IL_01b3: stloc.s 7
+					IL_01b5: ldc.i4.1
+					IL_01b6: newarr [System.Runtime]System.Object
+					IL_01bb: dup
+					IL_01bc: ldc.i4.0
+					IL_01bd: ldarg.0
+					IL_01be: stelem.ref
+					IL_01bf: stloc.s 13
+					IL_01c1: ldloc.s 4
+					IL_01c3: ldstr "apis"
+					IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01cd: stloc.s 14
+					IL_01cf: ldloc.s 14
+					IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01d6: stloc.s 8
+					IL_01d8: ldloc.s 8
+					IL_01da: brtrue IL_01ec
 
-					IL_01e6: ldc.i4.0
-					IL_01e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_01ec: stloc.s 16
-					IL_01ee: br IL_01f7
+					IL_01df: ldc.i4.0
+					IL_01e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01e5: stloc.s 15
+					IL_01e7: br IL_01f0
 
-					IL_01f3: ldloc.s 15
-					IL_01f5: stloc.s 16
+					IL_01ec: ldloc.s 14
+					IL_01ee: stloc.s 15
 
-					IL_01f7: ldloc.s 8
-					IL_01f9: ldloc.s 14
-					IL_01fb: ldloc.s 16
-					IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0202: stloc.s 8
-					IL_0204: ldloc.s 8
-					IL_0206: stloc.s 6
-					IL_0208: ldloc.s 6
-					IL_020a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_020f: stloc.s 9
-					IL_0211: ldloc.s 9
-					IL_0213: brfalse IL_022d
+					IL_01f0: ldloc.s 7
+					IL_01f2: ldloc.s 13
+					IL_01f4: ldloc.s 15
+					IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_01fb: stloc.s 7
+					IL_01fd: ldloc.s 7
+					IL_01ff: stloc.s 5
+					IL_0201: ldloc.s 5
+					IL_0203: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0208: stloc.s 8
+					IL_020a: ldloc.s 8
+					IL_020c: brfalse IL_0226
 
-					IL_0218: ldloc.0
-					IL_0219: ldloc.s 6
-					IL_021b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0220: pop
-					IL_0221: ldloc.0
-					IL_0222: ldstr ""
-					IL_0227: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_022c: pop
+					IL_0211: ldloc.0
+					IL_0212: ldloc.s 5
+					IL_0214: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0219: pop
+					IL_021a: ldloc.0
+					IL_021b: ldstr ""
+					IL_0220: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0225: pop
 
-					IL_022d: ldarg.0
-					IL_022e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApiTests
-					IL_0233: stloc.s 8
-					IL_0235: ldc.i4.1
-					IL_0236: newarr [System.Runtime]System.Object
-					IL_023b: dup
-					IL_023c: ldc.i4.0
-					IL_023d: ldarg.0
-					IL_023e: stelem.ref
-					IL_023f: stloc.s 14
-					IL_0241: ldloc.s 4
-					IL_0243: ldstr "apis"
-					IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_024d: stloc.s 15
-					IL_024f: ldloc.s 15
-					IL_0251: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0256: stloc.s 9
-					IL_0258: ldloc.s 9
-					IL_025a: brtrue IL_026c
+					IL_0226: ldarg.0
+					IL_0227: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApiTests
+					IL_022c: stloc.s 7
+					IL_022e: ldc.i4.1
+					IL_022f: newarr [System.Runtime]System.Object
+					IL_0234: dup
+					IL_0235: ldc.i4.0
+					IL_0236: ldarg.0
+					IL_0237: stelem.ref
+					IL_0238: stloc.s 13
+					IL_023a: ldloc.s 4
+					IL_023c: ldstr "apis"
+					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0246: stloc.s 14
+					IL_0248: ldloc.s 14
+					IL_024a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_024f: stloc.s 8
+					IL_0251: ldloc.s 8
+					IL_0253: brtrue IL_0265
 
-					IL_025f: ldc.i4.0
-					IL_0260: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0265: stloc.s 17
-					IL_0267: br IL_0270
+					IL_0258: ldc.i4.0
+					IL_0259: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_025e: stloc.s 16
+					IL_0260: br IL_0269
 
-					IL_026c: ldloc.s 15
-					IL_026e: stloc.s 17
+					IL_0265: ldloc.s 14
+					IL_0267: stloc.s 16
 
-					IL_0270: ldloc.s 8
-					IL_0272: ldloc.s 14
-					IL_0274: ldloc.s 17
-					IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_027b: stloc.s 8
-					IL_027d: ldloc.s 8
-					IL_027f: stloc.s 7
-					IL_0281: ldloc.s 7
-					IL_0283: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0288: stloc.s 9
-					IL_028a: ldloc.s 9
-					IL_028c: brfalse IL_02b2
+					IL_0269: ldloc.s 7
+					IL_026b: ldloc.s 13
+					IL_026d: ldloc.s 16
+					IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0274: stloc.s 7
+					IL_0276: ldloc.s 7
+					IL_0278: stloc.s 6
+					IL_027a: ldloc.s 6
+					IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0281: stloc.s 8
+					IL_0283: ldloc.s 8
+					IL_0285: brfalse IL_02ab
 
-					IL_0291: ldloc.0
-					IL_0292: ldstr "Tests:"
-					IL_0297: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_029c: pop
-					IL_029d: ldloc.0
-					IL_029e: ldloc.s 7
-					IL_02a0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02a5: pop
-					IL_02a6: ldloc.0
-					IL_02a7: ldstr ""
-					IL_02ac: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02b1: pop
+					IL_028a: ldloc.0
+					IL_028b: ldstr "Tests:"
+					IL_0290: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0295: pop
+					IL_0296: ldloc.0
+					IL_0297: ldloc.s 6
+					IL_0299: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_029e: pop
+					IL_029f: ldloc.0
+					IL_02a0: ldstr ""
+					IL_02a5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02aa: pop
 
-					IL_02b2: br IL_0059
+					IL_02ab: br IL_0059
 				// end loop
-				IL_02b7: ldloc.1
-				IL_02b8: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_02bd: ldc.i4.1
-				IL_02be: stloc.3
-				IL_02bf: leave IL_02de
+				IL_02b0: ldloc.1
+				IL_02b1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02b6: ldc.i4.1
+				IL_02b7: stloc.3
+				IL_02b8: leave IL_02d7
 
-				IL_02c4: ldc.i4.1
-				IL_02c5: stloc.2
-				IL_02c6: leave IL_02de
+				IL_02bd: ldc.i4.1
+				IL_02be: stloc.2
+				IL_02bf: leave IL_02d7
 			} // end .try
 			finally
 			{
-				IL_02cb: ldloc.2
-				IL_02cc: brtrue IL_02dd
+				IL_02c4: ldloc.2
+				IL_02c5: brtrue IL_02d6
 
-				IL_02d1: ldloc.3
-				IL_02d2: brtrue IL_02dd
+				IL_02ca: ldloc.3
+				IL_02cb: brtrue IL_02d6
 
-				IL_02d7: ldloc.1
-				IL_02d8: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02d0: ldloc.1
+				IL_02d1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_02dd: endfinally
+				IL_02d6: endfinally
 			} // end handler
 
-			IL_02de: ldloc.0
-			IL_02df: ldc.i4.1
-			IL_02e0: newarr [System.Runtime]System.Object
-			IL_02e5: dup
-			IL_02e6: ldc.i4.0
-			IL_02e7: ldstr "\n"
-			IL_02ec: stelem.ref
-			IL_02ed: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_02f2: stloc.s 13
-			IL_02f4: ldloc.s 13
-			IL_02f6: ret
+			IL_02d7: ldloc.0
+			IL_02d8: ldc.i4.1
+			IL_02d9: newarr [System.Runtime]System.Object
+			IL_02de: dup
+			IL_02df: ldc.i4.0
+			IL_02e0: ldstr "\n"
+			IL_02e5: stelem.ref
+			IL_02e6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_02eb: stloc.s 12
+			IL_02ed: ldloc.s 12
+			IL_02ef: ret
 		} // end of method renderModules::__js_call__
 
 	} // end of class renderModules
@@ -2014,7 +2008,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37c7
+				// Method begins at RVA 0x37b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2042,7 +2036,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37e2
+						// Method begins at RVA 0x37ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2062,7 +2056,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37eb
+						// Method begins at RVA 0x37d7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2082,7 +2076,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37f4
+						// Method begins at RVA 0x37e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2106,7 +2100,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3806
+							// Method begins at RVA 0x37f2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2124,7 +2118,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37fd
+						// Method begins at RVA 0x37e9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2142,7 +2136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37d9
+					// Method begins at RVA 0x37c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2160,7 +2154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37d0
+				// Method begins at RVA 0x37bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2187,9 +2181,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2ef0
+			// Method begins at RVA 0x2ee4
 			// Header size: 12
-			// Code size: 1033 (0x409)
+			// Code size: 1026 (0x402)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2201,19 +2195,18 @@
 				[6] bool,
 				[7] bool,
 				[8] object,
-				[9] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] bool,
+				[14] bool,
+				[15] object,
 				[16] object,
-				[17] object,
+				[17] string,
 				[18] string,
-				[19] string,
-				[20] object[],
-				[21] object
+				[19] object[],
+				[20] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -2230,22 +2223,22 @@
 			IL_001f: ldarg.2
 			IL_0020: ldstr "globals"
 			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002a: stloc.s 14
-			IL_002c: ldloc.s 14
+			IL_002a: stloc.s 13
+			IL_002c: ldloc.s 13
 			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0033: stloc.s 15
-			IL_0035: ldloc.s 15
+			IL_0033: stloc.s 14
+			IL_0035: ldloc.s 14
 			IL_0037: brtrue IL_0049
 
 			IL_003c: ldc.i4.0
 			IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0042: stloc.s 17
+			IL_0042: stloc.s 16
 			IL_0044: br IL_004d
 
-			IL_0049: ldloc.s 14
-			IL_004b: stloc.s 17
+			IL_0049: ldloc.s 13
+			IL_004b: stloc.s 16
 
-			IL_004d: ldloc.s 17
+			IL_004d: ldloc.s 16
 			IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
 			IL_0054: stloc.1
 			IL_0055: ldc.i4.0
@@ -2257,82 +2250,82 @@
 				// loop start (head: IL_0059)
 					IL_0059: ldloc.1
 					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_005f: stloc.s 14
-					IL_0061: ldloc.s 14
+					IL_005f: stloc.s 13
+					IL_0061: ldloc.s 13
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0068: stloc.s 15
-					IL_006a: ldloc.s 15
-					IL_006c: brtrue IL_03d6
+					IL_0068: stloc.s 14
+					IL_006a: ldloc.s 14
+					IL_006c: brtrue IL_03cf
 
-					IL_0071: ldloc.s 14
+					IL_0071: ldloc.s 13
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0078: stloc.s 14
-					IL_007a: ldloc.s 14
+					IL_0078: stloc.s 13
+					IL_007a: ldloc.s 13
 					IL_007c: stloc.s 4
 					IL_007e: ldloc.s 4
 					IL_0080: ldstr "name"
 					IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_008f: stloc.s 18
+					IL_008f: stloc.s 17
 					IL_0091: ldstr "### "
-					IL_0096: ldloc.s 18
+					IL_0096: ldloc.s 17
 					IL_0098: call string [System.Runtime]System.String::Concat(string, string)
-					IL_009d: stloc.s 18
-					IL_009f: ldloc.s 18
+					IL_009d: stloc.s 17
+					IL_009f: ldloc.s 17
 					IL_00a1: ldstr " (status: "
 					IL_00a6: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00ab: stloc.s 18
+					IL_00ab: stloc.s 17
 					IL_00ad: ldloc.s 4
 					IL_00af: ldstr "status"
 					IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_00be: stloc.s 19
-					IL_00c0: ldloc.s 18
-					IL_00c2: ldloc.s 19
+					IL_00be: stloc.s 18
+					IL_00c0: ldloc.s 17
+					IL_00c2: ldloc.s 18
 					IL_00c4: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00c9: stloc.s 19
-					IL_00cb: ldloc.s 19
+					IL_00c9: stloc.s 18
+					IL_00cb: ldloc.s 18
 					IL_00cd: ldstr ")"
 					IL_00d2: call string [System.Runtime]System.String::Concat(string, string)
-					IL_00d7: stloc.s 19
+					IL_00d7: stloc.s 18
 					IL_00d9: ldloc.0
-					IL_00da: ldloc.s 19
+					IL_00da: ldloc.s 18
 					IL_00dc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_00e1: pop
 					IL_00e2: ldloc.s 4
 					IL_00e4: ldstr "docs"
 					IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00f3: stloc.s 15
-					IL_00f5: ldloc.s 15
+					IL_00f3: stloc.s 14
+					IL_00f5: ldloc.s 14
 					IL_00f7: brfalse IL_0147
 
 					IL_00fc: ldarg.0
 					IL_00fd: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
-					IL_0102: stloc.s 14
+					IL_0102: stloc.s 13
 					IL_0104: ldc.i4.1
 					IL_0105: newarr [System.Runtime]System.Object
 					IL_010a: dup
 					IL_010b: ldc.i4.0
 					IL_010c: ldarg.0
 					IL_010d: stelem.ref
-					IL_010e: stloc.s 20
-					IL_0110: ldloc.s 14
-					IL_0112: ldloc.s 20
+					IL_010e: stloc.s 19
+					IL_0110: ldloc.s 13
+					IL_0112: ldloc.s 19
 					IL_0114: ldloc.s 4
 					IL_0116: ldstr "docs"
 					IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0125: stloc.s 14
-					IL_0127: ldloc.s 14
+					IL_0125: stloc.s 13
+					IL_0127: ldloc.s 13
 					IL_0129: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_012e: stloc.s 19
+					IL_012e: stloc.s 18
 					IL_0130: ldstr "Docs: "
-					IL_0135: ldloc.s 19
+					IL_0135: ldloc.s 18
 					IL_0137: call string [System.Runtime]System.String::Concat(string, string)
-					IL_013c: stloc.s 19
+					IL_013c: stloc.s 18
 					IL_013e: ldloc.0
-					IL_013f: ldloc.s 19
+					IL_013f: ldloc.s 18
 					IL_0141: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_0146: pop
 
@@ -2340,8 +2333,8 @@
 					IL_0149: ldstr "implementation"
 					IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0153: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0158: stloc.s 15
-					IL_015a: ldloc.s 15
+					IL_0158: stloc.s 14
+					IL_015a: ldloc.s 14
 					IL_015c: brfalse IL_01a1
 
 					IL_0161: ldloc.0
@@ -2350,23 +2343,23 @@
 					IL_016c: pop
 					IL_016d: ldarg.0
 					IL_016e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
-					IL_0173: stloc.s 14
+					IL_0173: stloc.s 13
 					IL_0175: ldc.i4.1
 					IL_0176: newarr [System.Runtime]System.Object
 					IL_017b: dup
 					IL_017c: ldc.i4.0
 					IL_017d: ldarg.0
 					IL_017e: stelem.ref
-					IL_017f: stloc.s 20
-					IL_0181: ldloc.s 14
-					IL_0183: ldloc.s 20
+					IL_017f: stloc.s 19
+					IL_0181: ldloc.s 13
+					IL_0183: ldloc.s 19
 					IL_0185: ldloc.s 4
 					IL_0187: ldstr "implementation"
 					IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0196: stloc.s 14
+					IL_0196: stloc.s 13
 					IL_0198: ldloc.0
-					IL_0199: ldloc.s 14
+					IL_0199: ldloc.s 13
 					IL_019b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_01a0: pop
 
@@ -2374,8 +2367,8 @@
 					IL_01a3: ldstr "notes"
 					IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_01ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01b2: stloc.s 15
-					IL_01b4: ldloc.s 15
+					IL_01b2: stloc.s 14
+					IL_01b4: ldloc.s 14
 					IL_01b6: brfalse IL_01da
 
 					IL_01bb: ldloc.0
@@ -2392,11 +2385,11 @@
 					IL_01da: ldloc.s 4
 					IL_01dc: ldstr "tests"
 					IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01e6: stloc.s 14
-					IL_01e8: ldloc.s 14
+					IL_01e6: stloc.s 13
+					IL_01e8: ldloc.s 13
 					IL_01ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01ef: stloc.s 15
-					IL_01f1: ldloc.s 15
+					IL_01ef: stloc.s 14
+					IL_01f1: ldloc.s 14
 					IL_01f3: brfalse IL_0215
 
 					IL_01f8: ldloc.s 4
@@ -2404,17 +2397,17 @@
 					IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0204: ldstr "length"
 					IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_020e: stloc.s 21
+					IL_020e: stloc.s 20
 					IL_0210: br IL_0219
 
-					IL_0215: ldloc.s 14
-					IL_0217: stloc.s 21
+					IL_0215: ldloc.s 13
+					IL_0217: stloc.s 20
 
-					IL_0219: ldloc.s 21
+					IL_0219: ldloc.s 20
 					IL_021b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0220: stloc.s 15
-					IL_0222: ldloc.s 15
-					IL_0224: brfalse IL_03b8
+					IL_0220: stloc.s 14
+					IL_0222: ldloc.s 14
+					IL_0224: brfalse IL_03b1
 
 					IL_0229: ldloc.0
 					IL_022a: ldstr "Tests:"
@@ -2434,184 +2427,182 @@
 						// loop start (head: IL_024e)
 							IL_024e: ldloc.s 5
 							IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_0255: stloc.s 14
-							IL_0257: ldloc.s 14
+							IL_0255: stloc.s 13
+							IL_0257: ldloc.s 13
 							IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_025e: stloc.s 15
-							IL_0260: ldloc.s 15
-							IL_0262: brtrue IL_039a
+							IL_025e: stloc.s 14
+							IL_0260: ldloc.s 14
+							IL_0262: brtrue IL_0393
 
-							IL_0267: ldloc.s 14
+							IL_0267: ldloc.s 13
 							IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_026e: stloc.s 14
-							IL_0270: ldloc.s 14
+							IL_026e: stloc.s 13
+							IL_0270: ldloc.s 13
 							IL_0272: stloc.s 8
-							IL_0274: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
-							IL_0279: stloc.s 9
-							IL_027b: ldloc.s 8
-							IL_027d: ldstr "name"
-							IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_028c: stloc.s 15
-							IL_028e: ldloc.s 15
-							IL_0290: brfalse IL_02c9
+							IL_0274: ldloc.s 8
+							IL_0276: ldstr "name"
+							IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0285: stloc.s 14
+							IL_0287: ldloc.s 14
+							IL_0289: brfalse IL_02c2
 
-							IL_0295: ldarg.0
-							IL_0296: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_029b: stloc.s 14
-							IL_029d: ldc.i4.1
-							IL_029e: newarr [System.Runtime]System.Object
-							IL_02a3: dup
-							IL_02a4: ldc.i4.0
-							IL_02a5: ldarg.0
-							IL_02a6: stelem.ref
-							IL_02a7: stloc.s 20
-							IL_02a9: ldloc.s 14
-							IL_02ab: ldloc.s 20
-							IL_02ad: ldloc.s 8
-							IL_02af: ldstr "name"
-							IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_02be: stloc.s 14
-							IL_02c0: ldloc.s 14
-							IL_02c2: stloc.s 10
-							IL_02c4: br IL_02d0
+							IL_028e: ldarg.0
+							IL_028f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_0294: stloc.s 13
+							IL_0296: ldc.i4.1
+							IL_0297: newarr [System.Runtime]System.Object
+							IL_029c: dup
+							IL_029d: ldc.i4.0
+							IL_029e: ldarg.0
+							IL_029f: stelem.ref
+							IL_02a0: stloc.s 19
+							IL_02a2: ldloc.s 13
+							IL_02a4: ldloc.s 19
+							IL_02a6: ldloc.s 8
+							IL_02a8: ldstr "name"
+							IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_02b7: stloc.s 13
+							IL_02b9: ldloc.s 13
+							IL_02bb: stloc.s 9
+							IL_02bd: br IL_02c9
 
-							IL_02c9: ldstr ""
-							IL_02ce: stloc.s 10
+							IL_02c2: ldstr ""
+							IL_02c7: stloc.s 9
 
-							IL_02d0: ldloc.s 10
-							IL_02d2: stloc.s 11
-							IL_02d4: ldloc.s 8
-							IL_02d6: ldstr "file"
-							IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_02e5: stloc.s 15
-							IL_02e7: ldloc.s 15
-							IL_02e9: brfalse IL_0347
+							IL_02c9: ldloc.s 9
+							IL_02cb: stloc.s 10
+							IL_02cd: ldloc.s 8
+							IL_02cf: ldstr "file"
+							IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_02de: stloc.s 14
+							IL_02e0: ldloc.s 14
+							IL_02e2: brfalse IL_0340
 
-							IL_02ee: ldarg.0
-							IL_02ef: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_02f4: stloc.s 14
-							IL_02f6: ldc.i4.1
-							IL_02f7: newarr [System.Runtime]System.Object
-							IL_02fc: dup
-							IL_02fd: ldc.i4.0
-							IL_02fe: ldarg.0
-							IL_02ff: stelem.ref
-							IL_0300: stloc.s 20
-							IL_0302: ldloc.s 14
-							IL_0304: ldloc.s 20
-							IL_0306: ldloc.s 8
-							IL_0308: ldstr "file"
-							IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_0317: stloc.s 14
-							IL_0319: ldloc.s 14
-							IL_031b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0320: stloc.s 19
-							IL_0322: ldstr " ("
-							IL_0327: ldloc.s 19
-							IL_0329: call string [System.Runtime]System.String::Concat(string, string)
-							IL_032e: stloc.s 19
-							IL_0330: ldloc.s 19
-							IL_0332: ldstr ")"
-							IL_0337: call string [System.Runtime]System.String::Concat(string, string)
-							IL_033c: stloc.s 19
-							IL_033e: ldloc.s 19
-							IL_0340: stloc.s 12
-							IL_0342: br IL_034e
+							IL_02e7: ldarg.0
+							IL_02e8: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_02ed: stloc.s 13
+							IL_02ef: ldc.i4.1
+							IL_02f0: newarr [System.Runtime]System.Object
+							IL_02f5: dup
+							IL_02f6: ldc.i4.0
+							IL_02f7: ldarg.0
+							IL_02f8: stelem.ref
+							IL_02f9: stloc.s 19
+							IL_02fb: ldloc.s 13
+							IL_02fd: ldloc.s 19
+							IL_02ff: ldloc.s 8
+							IL_0301: ldstr "file"
+							IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_0310: stloc.s 13
+							IL_0312: ldloc.s 13
+							IL_0314: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0319: stloc.s 18
+							IL_031b: ldstr " ("
+							IL_0320: ldloc.s 18
+							IL_0322: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0327: stloc.s 18
+							IL_0329: ldloc.s 18
+							IL_032b: ldstr ")"
+							IL_0330: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0335: stloc.s 18
+							IL_0337: ldloc.s 18
+							IL_0339: stloc.s 11
+							IL_033b: br IL_0347
 
-							IL_0347: ldstr ""
-							IL_034c: stloc.s 12
+							IL_0340: ldstr ""
+							IL_0345: stloc.s 11
 
-							IL_034e: ldloc.s 12
-							IL_0350: stloc.s 13
-							IL_0352: ldloc.s 11
-							IL_0354: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0359: stloc.s 19
-							IL_035b: ldstr "- "
-							IL_0360: ldloc.s 19
-							IL_0362: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0367: stloc.s 19
-							IL_0369: ldloc.s 13
-							IL_036b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0370: stloc.s 18
-							IL_0372: ldloc.s 19
-							IL_0374: ldloc.s 18
-							IL_0376: call string [System.Runtime]System.String::Concat(string, string)
-							IL_037b: stloc.s 18
-							IL_037d: ldloc.0
-							IL_037e: ldloc.s 18
-							IL_0380: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_0385: pop
-							IL_0386: br IL_024e
+							IL_0347: ldloc.s 11
+							IL_0349: stloc.s 12
+							IL_034b: ldloc.s 10
+							IL_034d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0352: stloc.s 18
+							IL_0354: ldstr "- "
+							IL_0359: ldloc.s 18
+							IL_035b: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0360: stloc.s 18
+							IL_0362: ldloc.s 12
+							IL_0364: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0369: stloc.s 17
+							IL_036b: ldloc.s 18
+							IL_036d: ldloc.s 17
+							IL_036f: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0374: stloc.s 17
+							IL_0376: ldloc.0
+							IL_0377: ldloc.s 17
+							IL_0379: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_037e: pop
+							IL_037f: br IL_024e
 						// end loop
-						IL_038b: ldloc.s 5
-						IL_038d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_0392: ldc.i4.1
-						IL_0393: stloc.s 7
-						IL_0395: leave IL_03b8
+						IL_0384: ldloc.s 5
+						IL_0386: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_038b: ldc.i4.1
+						IL_038c: stloc.s 7
+						IL_038e: leave IL_03b1
 
-						IL_039a: ldc.i4.1
-						IL_039b: stloc.s 6
-						IL_039d: leave IL_03b8
+						IL_0393: ldc.i4.1
+						IL_0394: stloc.s 6
+						IL_0396: leave IL_03b1
 					} // end .try
 					finally
 					{
-						IL_03a2: ldloc.s 6
-						IL_03a4: brtrue IL_03b7
+						IL_039b: ldloc.s 6
+						IL_039d: brtrue IL_03b0
 
-						IL_03a9: ldloc.s 7
-						IL_03ab: brtrue IL_03b7
+						IL_03a2: ldloc.s 7
+						IL_03a4: brtrue IL_03b0
 
-						IL_03b0: ldloc.s 5
-						IL_03b2: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_03a9: ldloc.s 5
+						IL_03ab: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_03b7: endfinally
+						IL_03b0: endfinally
 					} // end handler
 
-					IL_03b8: ldloc.0
-					IL_03b9: ldstr ""
-					IL_03be: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_03c3: pop
-					IL_03c4: br IL_0059
+					IL_03b1: ldloc.0
+					IL_03b2: ldstr ""
+					IL_03b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_03bc: pop
+					IL_03bd: br IL_0059
 				// end loop
-				IL_03c9: ldloc.1
-				IL_03ca: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_03cf: ldc.i4.1
-				IL_03d0: stloc.3
-				IL_03d1: leave IL_03f0
+				IL_03c2: ldloc.1
+				IL_03c3: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_03c8: ldc.i4.1
+				IL_03c9: stloc.3
+				IL_03ca: leave IL_03e9
 
-				IL_03d6: ldc.i4.1
-				IL_03d7: stloc.2
-				IL_03d8: leave IL_03f0
+				IL_03cf: ldc.i4.1
+				IL_03d0: stloc.2
+				IL_03d1: leave IL_03e9
 			} // end .try
 			finally
 			{
-				IL_03dd: ldloc.2
-				IL_03de: brtrue IL_03ef
+				IL_03d6: ldloc.2
+				IL_03d7: brtrue IL_03e8
 
-				IL_03e3: ldloc.3
-				IL_03e4: brtrue IL_03ef
+				IL_03dc: ldloc.3
+				IL_03dd: brtrue IL_03e8
 
-				IL_03e9: ldloc.1
-				IL_03ea: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_03e2: ldloc.1
+				IL_03e3: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_03ef: endfinally
+				IL_03e8: endfinally
 			} // end handler
 
-			IL_03f0: ldloc.0
-			IL_03f1: ldc.i4.1
-			IL_03f2: newarr [System.Runtime]System.Object
-			IL_03f7: dup
-			IL_03f8: ldc.i4.0
-			IL_03f9: ldstr "\n"
-			IL_03fe: stelem.ref
-			IL_03ff: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0404: stloc.s 18
-			IL_0406: ldloc.s 18
-			IL_0408: ret
+			IL_03e9: ldloc.0
+			IL_03ea: ldc.i4.1
+			IL_03eb: newarr [System.Runtime]System.Object
+			IL_03f0: dup
+			IL_03f1: ldc.i4.0
+			IL_03f2: ldstr "\n"
+			IL_03f7: stelem.ref
+			IL_03f8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03fd: stloc.s 17
+			IL_03ff: ldloc.s 17
+			IL_0401: ret
 		} // end of method renderGlobals::__js_call__
 
 	} // end of class renderGlobals
@@ -2627,7 +2618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x380f
+				// Method begins at RVA 0x37fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2647,7 +2638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3818
+				// Method begins at RVA 0x3804
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2671,7 +2662,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x333c
+			// Method begins at RVA 0x3328
 			// Header size: 12
 			// Code size: 278 (0x116)
 			.maxstack 8
@@ -2824,7 +2815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3821
+				// Method begins at RVA 0x380d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2850,7 +2841,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x3470
+			// Method begins at RVA 0x345c
 			// Header size: 12
 			// Code size: 570 (0x23a)
 			.maxstack 8
@@ -3137,7 +3128,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3701
+			// Method begins at RVA 0x36ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3438,7 +3429,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x382a
+		// Method begins at RVA 0x3816
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x252d
+				// Method begins at RVA 0x2521
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2536
+				// Method begins at RVA 0x252a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253f
+				// Method begins at RVA 0x2533
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2548
+				// Method begins at RVA 0x253c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2524
+			// Method begins at RVA 0x2518
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1196 (0x4ac)
+		// Code size: 1182 (0x49e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope,
@@ -130,19 +130,17 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L20C12,
-			[6] class [System.Runtime]System.Exception,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
 			[7] object,
 			[8] object,
-			[9] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L28C12,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[10] object,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[12] object,
-			[13] object,
-			[14] string,
-			[15] float64,
-			[16] bool,
-			[17] object
+			[11] object,
+			[12] string,
+			[13] float64,
+			[14] bool,
+			[15] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope::.ctor()
@@ -151,16 +149,16 @@
 		IL_0007: ldstr "\\u{1F600}."
 		IL_000c: ldstr "dus"
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0016: stloc.s 11
-		IL_0018: ldloc.s 11
+		IL_0016: stloc.s 9
+		IL_0018: ldloc.s 9
 		IL_001a: stloc.1
 		IL_001b: ldstr "console"
 		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0025: stloc.s 12
-		IL_0027: ldloc.s 12
+		IL_0025: stloc.s 10
+		IL_0027: ldloc.s 10
 		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: stloc.s 12
-		IL_0030: ldloc.s 12
+		IL_002e: stloc.s 10
+		IL_0030: ldloc.s 10
 		IL_0032: ldstr "log"
 		IL_0037: ldloc.1
 		IL_0038: ldstr "dotAll"
@@ -169,11 +167,11 @@
 		IL_0047: pop
 		IL_0048: ldstr "console"
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0052: stloc.s 12
-		IL_0054: ldloc.s 12
+		IL_0052: stloc.s 10
+		IL_0054: ldloc.s 10
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: stloc.s 12
-		IL_005d: ldloc.s 12
+		IL_005b: stloc.s 10
+		IL_005d: ldloc.s 10
 		IL_005f: ldstr "log"
 		IL_0064: ldloc.1
 		IL_0065: ldstr "unicode"
@@ -182,11 +180,11 @@
 		IL_0074: pop
 		IL_0075: ldstr "console"
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007f: stloc.s 12
-		IL_0081: ldloc.s 12
+		IL_007f: stloc.s 10
+		IL_0081: ldloc.s 10
 		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0088: stloc.s 12
-		IL_008a: ldloc.s 12
+		IL_0088: stloc.s 10
+		IL_008a: ldloc.s 10
 		IL_008c: ldstr "log"
 		IL_0091: ldloc.1
 		IL_0092: ldstr "hasIndices"
@@ -195,11 +193,11 @@
 		IL_00a1: pop
 		IL_00a2: ldstr "console"
 		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ac: stloc.s 12
-		IL_00ae: ldloc.s 12
+		IL_00ac: stloc.s 10
+		IL_00ae: ldloc.s 10
 		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b5: stloc.s 12
-		IL_00b7: ldloc.s 12
+		IL_00b5: stloc.s 10
+		IL_00b7: ldloc.s 10
 		IL_00b9: ldstr "log"
 		IL_00be: ldloc.1
 		IL_00bf: ldstr "sticky"
@@ -208,11 +206,11 @@
 		IL_00ce: pop
 		IL_00cf: ldstr "console"
 		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d9: stloc.s 12
-		IL_00db: ldloc.s 12
+		IL_00d9: stloc.s 10
+		IL_00db: ldloc.s 10
 		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e2: stloc.s 12
-		IL_00e4: ldloc.s 12
+		IL_00e2: stloc.s 10
+		IL_00e4: ldloc.s 10
 		IL_00e6: ldstr "log"
 		IL_00eb: ldloc.1
 		IL_00ec: ldstr "flags"
@@ -221,140 +219,140 @@
 		IL_00fb: pop
 		IL_00fc: ldstr "console"
 		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0106: stloc.s 12
-		IL_0108: ldloc.s 12
+		IL_0106: stloc.s 10
+		IL_0108: ldloc.s 10
 		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010f: stloc.s 12
+		IL_010f: stloc.s 10
 		IL_0111: ldstr "^.$"
 		IL_0116: ldstr "u"
 		IL_011b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0120: stloc.s 11
-		IL_0122: ldloc.s 11
+		IL_0120: stloc.s 9
+		IL_0122: ldloc.s 9
 		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0129: stloc.s 13
-		IL_012b: ldloc.s 13
+		IL_0129: stloc.s 11
+		IL_012b: ldloc.s 11
 		IL_012d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0132: ldstr "\ud83d\ude00"
 		IL_0137: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_013c: stloc.s 13
-		IL_013e: ldloc.s 12
+		IL_013c: stloc.s 11
+		IL_013e: ldloc.s 10
 		IL_0140: ldstr "log"
-		IL_0145: ldloc.s 13
+		IL_0145: ldloc.s 11
 		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_014c: pop
 		IL_014d: ldstr "console"
 		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0157: stloc.s 13
-		IL_0159: ldloc.s 13
+		IL_0157: stloc.s 11
+		IL_0159: ldloc.s 11
 		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0160: stloc.s 13
+		IL_0160: stloc.s 11
 		IL_0162: ldstr "\\u{1F600}"
 		IL_0167: ldstr "u"
 		IL_016c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0171: stloc.s 11
-		IL_0173: ldloc.s 11
+		IL_0171: stloc.s 9
+		IL_0173: ldloc.s 9
 		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017a: stloc.s 12
-		IL_017c: ldloc.s 12
+		IL_017a: stloc.s 10
+		IL_017c: ldloc.s 10
 		IL_017e: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0183: ldstr "\ud83d\ude00"
 		IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_018d: stloc.s 12
-		IL_018f: ldloc.s 13
+		IL_018d: stloc.s 10
+		IL_018f: ldloc.s 11
 		IL_0191: ldstr "log"
-		IL_0196: ldloc.s 12
+		IL_0196: ldloc.s 10
 		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_019d: pop
 		IL_019e: ldstr "console"
 		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a8: stloc.s 12
-		IL_01aa: ldloc.s 12
+		IL_01a8: stloc.s 10
+		IL_01aa: ldloc.s 10
 		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b1: stloc.s 12
+		IL_01b1: stloc.s 10
 		IL_01b3: ldstr "^.$"
 		IL_01b8: ldstr "s"
 		IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_01c2: stloc.s 11
-		IL_01c4: ldloc.s 11
+		IL_01c2: stloc.s 9
+		IL_01c4: ldloc.s 9
 		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cb: stloc.s 13
-		IL_01cd: ldloc.s 13
+		IL_01cb: stloc.s 11
+		IL_01cd: ldloc.s 11
 		IL_01cf: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_01d4: ldstr "\n"
 		IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_01de: stloc.s 13
-		IL_01e0: ldloc.s 12
+		IL_01de: stloc.s 11
+		IL_01e0: ldloc.s 10
 		IL_01e2: ldstr "log"
-		IL_01e7: ldloc.s 13
+		IL_01e7: ldloc.s 11
 		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01ee: pop
 		IL_01ef: ldstr "console"
 		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f9: stloc.s 13
-		IL_01fb: ldloc.s 13
+		IL_01f9: stloc.s 11
+		IL_01fb: ldloc.s 11
 		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0202: stloc.s 13
+		IL_0202: stloc.s 11
 		IL_0204: ldstr "^.$"
 		IL_0209: ldstr ""
 		IL_020e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0213: stloc.s 11
-		IL_0215: ldloc.s 11
+		IL_0213: stloc.s 9
+		IL_0215: ldloc.s 9
 		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021c: stloc.s 12
-		IL_021e: ldloc.s 12
+		IL_021c: stloc.s 10
+		IL_021e: ldloc.s 10
 		IL_0220: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0225: ldstr "\r"
 		IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_022f: stloc.s 12
-		IL_0231: ldloc.s 13
+		IL_022f: stloc.s 10
+		IL_0231: ldloc.s 11
 		IL_0233: ldstr "log"
-		IL_0238: ldloc.s 12
+		IL_0238: ldloc.s 10
 		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_023f: pop
 		IL_0240: ldstr "console"
 		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024a: stloc.s 12
-		IL_024c: ldloc.s 12
+		IL_024a: stloc.s 10
+		IL_024c: ldloc.s 10
 		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0253: stloc.s 12
+		IL_0253: stloc.s 10
 		IL_0255: ldstr "^.$"
 		IL_025a: ldstr ""
 		IL_025f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0264: stloc.s 11
-		IL_0266: ldloc.s 11
+		IL_0264: stloc.s 9
+		IL_0266: ldloc.s 9
 		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026d: stloc.s 13
-		IL_026f: ldloc.s 13
+		IL_026d: stloc.s 11
+		IL_026f: ldloc.s 11
 		IL_0271: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_0276: ldstr "\u2028"
 		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_0280: stloc.s 13
-		IL_0282: ldloc.s 12
+		IL_0280: stloc.s 11
+		IL_0282: ldloc.s 10
 		IL_0284: ldstr "log"
-		IL_0289: ldloc.s 13
+		IL_0289: ldloc.s 11
 		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0290: pop
 		IL_0291: ldstr "console"
 		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029b: stloc.s 13
-		IL_029d: ldloc.s 13
+		IL_029b: stloc.s 11
+		IL_029d: ldloc.s 11
 		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a4: stloc.s 13
+		IL_02a4: stloc.s 11
 		IL_02a6: ldstr "^.$"
 		IL_02ab: ldstr ""
 		IL_02b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_02b5: stloc.s 11
-		IL_02b7: ldloc.s 11
+		IL_02b5: stloc.s 9
+		IL_02b7: ldloc.s 9
 		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02be: stloc.s 12
-		IL_02c0: ldloc.s 12
+		IL_02be: stloc.s 10
+		IL_02c0: ldloc.s 10
 		IL_02c2: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 		IL_02c7: ldstr "\u2029"
 		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-		IL_02d1: stloc.s 12
-		IL_02d3: ldloc.s 13
+		IL_02d1: stloc.s 10
+		IL_02d3: ldloc.s 11
 		IL_02d5: ldstr "log"
-		IL_02da: ldloc.s 12
+		IL_02da: ldloc.s 10
 		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_02e1: pop
 		.try
@@ -366,16 +364,16 @@
 			IL_02f2: pop
 			IL_02f3: ldstr "console"
 			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02fd: stloc.s 12
-			IL_02ff: ldloc.s 12
+			IL_02fd: stloc.s 10
+			IL_02ff: ldloc.s 10
 			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0306: stloc.s 12
-			IL_0308: ldloc.s 12
+			IL_0306: stloc.s 10
+			IL_0308: ldloc.s 10
 			IL_030a: ldstr "log"
 			IL_030f: ldstr "no-error"
 			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0319: pop
-			IL_031a: leave IL_03fb
+			IL_031a: leave IL_03f4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -401,129 +399,125 @@
 			IL_0347: stloc.3
 
 			IL_0348: ldloc.3
-			IL_0349: stloc.s 12
-			IL_034b: ldloc.s 12
+			IL_0349: stloc.s 10
+			IL_034b: ldloc.s 10
 			IL_034d: stloc.s 4
-			IL_034f: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L20C12::.ctor()
-			IL_0354: stloc.s 5
-			IL_0356: ldstr "console"
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0360: stloc.s 12
-			IL_0362: ldloc.s 12
-			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0369: stloc.s 12
-			IL_036b: ldloc.s 12
-			IL_036d: ldstr "log"
-			IL_0372: ldloc.s 4
-			IL_0374: ldstr "name"
-			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0383: pop
-			IL_0384: ldstr "console"
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_038e: stloc.s 12
-			IL_0390: ldloc.s 12
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0397: stloc.s 12
-			IL_0399: ldloc.s 4
-			IL_039b: ldstr "message"
-			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03aa: stloc.s 14
-			IL_03ac: ldloc.s 14
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b3: stloc.s 13
-			IL_03b5: ldloc.s 13
-			IL_03b7: castclass [System.Runtime]System.String
-			IL_03bc: ldstr "v"
-			IL_03c1: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_03c6: stloc.s 15
-			IL_03c8: ldloc.s 15
-			IL_03ca: stloc.s 15
-			IL_03cc: ldloc.s 15
-			IL_03ce: ldc.r8 0.0
-			IL_03d7: clt
-			IL_03d9: ldc.i4.0
-			IL_03da: ceq
-			IL_03dc: stloc.s 16
-			IL_03de: ldloc.s 16
-			IL_03e0: box [System.Runtime]System.Boolean
-			IL_03e5: stloc.s 17
-			IL_03e7: ldloc.s 12
-			IL_03e9: ldstr "log"
-			IL_03ee: ldloc.s 17
-			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03f5: pop
-			IL_03f6: leave IL_03fb
+			IL_034f: ldstr "console"
+			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0359: stloc.s 10
+			IL_035b: ldloc.s 10
+			IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0362: stloc.s 10
+			IL_0364: ldloc.s 10
+			IL_0366: ldstr "log"
+			IL_036b: ldloc.s 4
+			IL_036d: ldstr "name"
+			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_037c: pop
+			IL_037d: ldstr "console"
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0387: stloc.s 10
+			IL_0389: ldloc.s 10
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0390: stloc.s 10
+			IL_0392: ldloc.s 4
+			IL_0394: ldstr "message"
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_039e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a3: stloc.s 12
+			IL_03a5: ldloc.s 12
+			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ac: stloc.s 11
+			IL_03ae: ldloc.s 11
+			IL_03b0: castclass [System.Runtime]System.String
+			IL_03b5: ldstr "v"
+			IL_03ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_03bf: stloc.s 13
+			IL_03c1: ldloc.s 13
+			IL_03c3: stloc.s 13
+			IL_03c5: ldloc.s 13
+			IL_03c7: ldc.r8 0.0
+			IL_03d0: clt
+			IL_03d2: ldc.i4.0
+			IL_03d3: ceq
+			IL_03d5: stloc.s 14
+			IL_03d7: ldloc.s 14
+			IL_03d9: box [System.Runtime]System.Boolean
+			IL_03de: stloc.s 15
+			IL_03e0: ldloc.s 10
+			IL_03e2: ldstr "log"
+			IL_03e7: ldloc.s 15
+			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03ee: pop
+			IL_03ef: leave IL_03f4
 		} // end handler
 		.try
 		{
-			IL_03fb: nop
-			IL_03fc: ldstr "a"
-			IL_0401: ldstr "gg"
-			IL_0406: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_040b: pop
-			IL_040c: ldstr "console"
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0416: stloc.s 12
-			IL_0418: ldloc.s 12
-			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_041f: stloc.s 12
-			IL_0421: ldloc.s 12
-			IL_0423: ldstr "log"
-			IL_0428: ldstr "no-error"
-			IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0432: pop
-			IL_0433: leave IL_04a8
+			IL_03f4: nop
+			IL_03f5: ldstr "a"
+			IL_03fa: ldstr "gg"
+			IL_03ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0404: pop
+			IL_0405: ldstr "console"
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_040f: stloc.s 10
+			IL_0411: ldloc.s 10
+			IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0418: stloc.s 10
+			IL_041a: ldloc.s 10
+			IL_041c: ldstr "log"
+			IL_0421: ldstr "no-error"
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_042b: pop
+			IL_042c: leave IL_049a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0438: stloc.s 6
-			IL_043a: ldloc.s 6
-			IL_043c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0441: dup
-			IL_0442: brtrue IL_0458
+			IL_0431: stloc.s 5
+			IL_0433: ldloc.s 5
+			IL_0435: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_043a: dup
+			IL_043b: brtrue IL_0451
 
-			IL_0447: pop
-			IL_0448: ldloc.s 6
-			IL_044a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_044f: dup
-			IL_0450: brtrue IL_0464
+			IL_0440: pop
+			IL_0441: ldloc.s 5
+			IL_0443: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0448: dup
+			IL_0449: brtrue IL_045d
 
-			IL_0455: pop
-			IL_0456: rethrow
+			IL_044e: pop
+			IL_044f: rethrow
 
-			IL_0458: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_045d: stloc.s 7
-			IL_045f: br IL_0466
+			IL_0451: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0456: stloc.s 6
+			IL_0458: br IL_045f
 
-			IL_0464: stloc.s 7
+			IL_045d: stloc.s 6
 
-			IL_0466: ldloc.s 7
-			IL_0468: stloc.s 12
-			IL_046a: ldloc.s 12
-			IL_046c: stloc.s 8
-			IL_046e: newobj instance void Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope/Block_L28C12::.ctor()
-			IL_0473: stloc.s 9
-			IL_0475: ldstr "console"
-			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_047f: stloc.s 12
-			IL_0481: ldloc.s 12
-			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0488: stloc.s 12
-			IL_048a: ldloc.s 12
-			IL_048c: ldstr "log"
-			IL_0491: ldloc.s 8
-			IL_0493: ldstr "name"
-			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04a2: pop
-			IL_04a3: leave IL_04a8
+			IL_045f: ldloc.s 6
+			IL_0461: stloc.s 10
+			IL_0463: ldloc.s 10
+			IL_0465: stloc.s 7
+			IL_0467: ldstr "console"
+			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0471: stloc.s 10
+			IL_0473: ldloc.s 10
+			IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_047a: stloc.s 10
+			IL_047c: ldloc.s 10
+			IL_047e: ldstr "log"
+			IL_0483: ldloc.s 7
+			IL_0485: ldstr "name"
+			IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0494: pop
+			IL_0495: leave IL_049a
 		} // end handler
 
-		IL_04a8: ldnull
-		IL_04a9: stloc.s 10
-		IL_04ab: ret
+		IL_049a: ldnull
+		IL_049b: stloc.s 8
+		IL_049d: ret
 	} // end of method IntrinsicCallables_RegExp_ModernFlags_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic
@@ -535,7 +529,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2551
+		// Method begins at RVA 0x2545
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_Symbol_Registry_WellKnown.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_Symbol_Registry_WellKnown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e9
+				// Method begins at RVA 0x22e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x22ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22d8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 626 (0x272)
+		// Code size: 619 (0x26b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_Symbol_Registry_WellKnown/Scope,
@@ -92,13 +92,12 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.IntrinsicCallables_Symbol_Registry_WellKnown/Scope/Block_L18C12,
+			[7] object,
 			[8] object,
 			[9] object,
-			[10] object,
-			[11] bool,
-			[12] object,
-			[13] object
+			[10] bool,
+			[11] object,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_Symbol_Registry_WellKnown/Scope::.ctor()
@@ -106,156 +105,156 @@
 		IL_0006: nop
 		IL_0007: ldstr "registry-key"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::for(object)
-		IL_0011: stloc.s 9
-		IL_0013: ldloc.s 9
+		IL_0011: stloc.s 8
+		IL_0013: ldloc.s 8
 		IL_0015: stloc.1
 		IL_0016: ldstr "registry-key"
 		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::for(object)
-		IL_0020: stloc.s 9
-		IL_0022: ldloc.s 9
+		IL_0020: stloc.s 8
+		IL_0022: ldloc.s 8
 		IL_0024: stloc.2
 		IL_0025: ldstr "registry-key"
 		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-		IL_002f: stloc.s 9
-		IL_0031: ldloc.s 9
+		IL_002f: stloc.s 8
+		IL_0031: ldloc.s 8
 		IL_0033: stloc.3
 		IL_0034: ldstr "console"
 		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003e: stloc.s 9
-		IL_0040: ldloc.s 9
+		IL_003e: stloc.s 8
+		IL_0040: ldloc.s 8
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0047: stloc.s 9
+		IL_0047: stloc.s 8
 		IL_0049: ldloc.1
-		IL_004a: stloc.s 10
-		IL_004c: ldloc.s 10
+		IL_004a: stloc.s 9
+		IL_004c: ldloc.s 9
 		IL_004e: ldloc.2
 		IL_004f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0054: stloc.s 11
-		IL_0056: ldloc.s 11
+		IL_0054: stloc.s 10
+		IL_0056: ldloc.s 10
 		IL_0058: box [System.Runtime]System.Boolean
-		IL_005d: stloc.s 12
-		IL_005f: ldloc.s 9
+		IL_005d: stloc.s 11
+		IL_005f: ldloc.s 8
 		IL_0061: ldstr "log"
-		IL_0066: ldloc.s 12
+		IL_0066: ldloc.s 11
 		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_006d: pop
 		IL_006e: ldstr "console"
 		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0078: stloc.s 9
-		IL_007a: ldloc.s 9
+		IL_0078: stloc.s 8
+		IL_007a: ldloc.s 8
 		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0081: stloc.s 9
+		IL_0081: stloc.s 8
 		IL_0083: ldloc.1
-		IL_0084: stloc.s 10
-		IL_0086: ldloc.s 10
+		IL_0084: stloc.s 9
+		IL_0086: ldloc.s 9
 		IL_0088: ldloc.3
 		IL_0089: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_008e: stloc.s 11
-		IL_0090: ldloc.s 11
+		IL_008e: stloc.s 10
+		IL_0090: ldloc.s 10
 		IL_0092: box [System.Runtime]System.Boolean
-		IL_0097: stloc.s 12
-		IL_0099: ldloc.s 9
+		IL_0097: stloc.s 11
+		IL_0099: ldloc.s 8
 		IL_009b: ldstr "log"
-		IL_00a0: ldloc.s 12
+		IL_00a0: ldloc.s 11
 		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00a7: pop
 		IL_00a8: ldstr "console"
 		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b2: stloc.s 9
-		IL_00b4: ldloc.s 9
+		IL_00b2: stloc.s 8
+		IL_00b4: ldloc.s 8
 		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bb: stloc.s 9
+		IL_00bb: stloc.s 8
 		IL_00bd: ldloc.1
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::keyFor(object)
-		IL_00c3: stloc.s 10
-		IL_00c5: ldloc.s 9
+		IL_00c3: stloc.s 9
+		IL_00c5: ldloc.s 8
 		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 10
+		IL_00cc: ldloc.s 9
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d3: pop
 		IL_00d4: ldstr "console"
 		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: stloc.s 10
-		IL_00e0: ldloc.s 10
+		IL_00de: stloc.s 9
+		IL_00e0: ldloc.s 9
 		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e7: stloc.s 10
+		IL_00e7: stloc.s 9
 		IL_00e9: ldloc.3
 		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::keyFor(object)
-		IL_00ef: stloc.s 9
-		IL_00f1: ldloc.s 9
+		IL_00ef: stloc.s 8
+		IL_00f1: ldloc.s 8
 		IL_00f3: ldc.i4.0
 		IL_00f4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_00f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_00fe: stloc.s 11
-		IL_0100: ldloc.s 11
+		IL_00fe: stloc.s 10
+		IL_0100: ldloc.s 10
 		IL_0102: box [System.Runtime]System.Boolean
-		IL_0107: stloc.s 12
-		IL_0109: ldloc.s 10
+		IL_0107: stloc.s 11
+		IL_0109: ldloc.s 9
 		IL_010b: ldstr "log"
-		IL_0110: ldloc.s 12
+		IL_0110: ldloc.s 11
 		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0117: pop
 		IL_0118: ldstr "console"
 		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0122: stloc.s 10
-		IL_0124: ldloc.s 10
+		IL_0122: stloc.s 9
+		IL_0124: ldloc.s 9
 		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: stloc.s 10
+		IL_012b: stloc.s 9
 		IL_012d: ldstr "iterator"
 		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0137: stloc.s 9
-		IL_0139: ldloc.s 10
+		IL_0137: stloc.s 8
+		IL_0139: ldloc.s 9
 		IL_013b: ldstr "log"
-		IL_0140: ldloc.s 9
+		IL_0140: ldloc.s 8
 		IL_0142: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_014c: pop
 		IL_014d: ldstr "console"
 		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0157: stloc.s 10
-		IL_0159: ldloc.s 10
+		IL_0157: stloc.s 9
+		IL_0159: ldloc.s 9
 		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0160: stloc.s 10
+		IL_0160: stloc.s 9
 		IL_0162: ldstr "iterator"
 		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_016c: stloc.s 9
+		IL_016c: stloc.s 8
 		IL_016e: ldstr "iterator"
 		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0178: stloc.s 13
-		IL_017a: ldloc.s 9
-		IL_017c: ldloc.s 13
+		IL_0178: stloc.s 12
+		IL_017a: ldloc.s 8
+		IL_017c: ldloc.s 12
 		IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0183: stloc.s 11
-		IL_0185: ldloc.s 11
+		IL_0183: stloc.s 10
+		IL_0185: ldloc.s 10
 		IL_0187: box [System.Runtime]System.Boolean
-		IL_018c: stloc.s 12
-		IL_018e: ldloc.s 10
+		IL_018c: stloc.s 11
+		IL_018e: ldloc.s 9
 		IL_0190: ldstr "log"
-		IL_0195: ldloc.s 12
+		IL_0195: ldloc.s 11
 		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_019c: pop
 		IL_019d: ldstr "console"
 		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a7: stloc.s 10
-		IL_01a9: ldloc.s 10
+		IL_01a7: stloc.s 9
+		IL_01a9: ldloc.s 9
 		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b0: stloc.s 10
+		IL_01b0: stloc.s 9
 		IL_01b2: ldstr "toPrimitive"
 		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_01bc: stloc.s 13
+		IL_01bc: stloc.s 12
 		IL_01be: ldstr "toPrimitive"
 		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_01c8: stloc.s 9
-		IL_01ca: ldloc.s 13
-		IL_01cc: ldloc.s 9
+		IL_01c8: stloc.s 8
+		IL_01ca: ldloc.s 12
+		IL_01cc: ldloc.s 8
 		IL_01ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01d3: stloc.s 11
-		IL_01d5: ldloc.s 11
+		IL_01d3: stloc.s 10
+		IL_01d5: ldloc.s 10
 		IL_01d7: box [System.Runtime]System.Boolean
-		IL_01dc: stloc.s 12
-		IL_01de: ldloc.s 10
+		IL_01dc: stloc.s 11
+		IL_01de: ldloc.s 9
 		IL_01e0: ldstr "log"
-		IL_01e5: ldloc.s 12
+		IL_01e5: ldloc.s 11
 		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01ec: pop
 		.try
@@ -264,7 +263,7 @@
 			IL_01ee: ldstr "not-a-symbol"
 			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::keyFor(object)
 			IL_01f8: pop
-			IL_01f9: leave IL_026e
+			IL_01f9: leave IL_0267
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -290,30 +289,28 @@
 			IL_022a: stloc.s 5
 
 			IL_022c: ldloc.s 5
-			IL_022e: stloc.s 10
-			IL_0230: ldloc.s 10
+			IL_022e: stloc.s 9
+			IL_0230: ldloc.s 9
 			IL_0232: stloc.s 6
-			IL_0234: newobj instance void Modules.IntrinsicCallables_Symbol_Registry_WellKnown/Scope/Block_L18C12::.ctor()
-			IL_0239: stloc.s 7
-			IL_023b: ldstr "console"
-			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0245: stloc.s 10
-			IL_0247: ldloc.s 10
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_024e: stloc.s 10
-			IL_0250: ldloc.s 10
-			IL_0252: ldstr "log"
-			IL_0257: ldloc.s 6
-			IL_0259: ldstr "name"
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0268: pop
-			IL_0269: leave IL_026e
+			IL_0234: ldstr "console"
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_023e: stloc.s 9
+			IL_0240: ldloc.s 9
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0247: stloc.s 9
+			IL_0249: ldloc.s 9
+			IL_024b: ldstr "log"
+			IL_0250: ldloc.s 6
+			IL_0252: ldstr "name"
+			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0261: pop
+			IL_0262: leave IL_0267
 		} // end handler
 
-		IL_026e: ldnull
-		IL_026f: stloc.s 8
-		IL_0271: ret
+		IL_0267: ldnull
+		IL_0268: stloc.s 7
+		IL_026a: ret
 	} // end of method IntrinsicCallables_Symbol_Registry_WellKnown::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_Symbol_Registry_WellKnown
@@ -325,7 +322,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22fb
+		// Method begins at RVA 0x22f3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_TypeError_GlobalSurface.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_TypeError_GlobalSurface.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2311
+				// Method begins at RVA 0x2309
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231a
+				// Method begins at RVA 0x2312
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2308
+			// Method begins at RVA 0x2300
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 665 (0x299)
+		// Code size: 658 (0x292)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_TypeError_GlobalSurface/Scope,
@@ -90,14 +90,13 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.IntrinsicCallables_TypeError_GlobalSurface/Scope/Block_L11C12,
+			[5] object,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] object,
-			[10] object,
-			[11] bool,
-			[12] object
+			[10] bool,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.IntrinsicCallables_TypeError_GlobalSurface/Scope::.ctor()
@@ -106,126 +105,126 @@
 		IL_0007: ldstr "oops"
 		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_0016: stloc.s 7
-		IL_0018: ldloc.s 7
+		IL_0016: stloc.s 6
+		IL_0018: ldloc.s 6
 		IL_001a: stloc.1
 		IL_001b: ldstr "console"
 		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0025: stloc.s 7
-		IL_0027: ldloc.s 7
+		IL_0025: stloc.s 6
+		IL_0027: ldloc.s 6
 		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002e: stloc.s 7
+		IL_002e: stloc.s 6
 		IL_0030: ldloc.1
 		IL_0031: ldstr "name"
 		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_003b: ldstr ":"
 		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0045: stloc.s 8
-		IL_0047: ldloc.s 8
+		IL_0045: stloc.s 7
+		IL_0047: ldloc.s 7
 		IL_0049: ldloc.1
 		IL_004a: ldstr "message"
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0059: stloc.s 8
-		IL_005b: ldloc.s 7
+		IL_0059: stloc.s 7
+		IL_005b: ldloc.s 6
 		IL_005d: ldstr "log"
-		IL_0062: ldloc.s 8
+		IL_0062: ldloc.s 7
 		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0069: pop
 		IL_006a: ldstr "console"
 		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0074: stloc.s 7
-		IL_0076: ldloc.s 7
+		IL_0074: stloc.s 6
+		IL_0076: ldloc.s 6
 		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007d: stloc.s 7
+		IL_007d: stloc.s 6
 		IL_007f: ldloc.1
-		IL_0080: stloc.s 9
+		IL_0080: stloc.s 8
 		IL_0082: ldstr "TypeError"
 		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008c: stloc.s 10
-		IL_008e: ldloc.s 9
-		IL_0090: ldloc.s 10
+		IL_008c: stloc.s 9
+		IL_008e: ldloc.s 8
+		IL_0090: ldloc.s 9
 		IL_0092: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0097: stloc.s 11
-		IL_0099: ldloc.s 11
+		IL_0097: stloc.s 10
+		IL_0099: ldloc.s 10
 		IL_009b: box [System.Runtime]System.Boolean
-		IL_00a0: stloc.s 12
-		IL_00a2: ldloc.s 7
+		IL_00a0: stloc.s 11
+		IL_00a2: ldloc.s 6
 		IL_00a4: ldstr "log"
-		IL_00a9: ldloc.s 12
+		IL_00a9: ldloc.s 11
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00b0: pop
 		IL_00b1: ldstr "console"
 		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 7
+		IL_00bb: stloc.s 6
+		IL_00bd: ldloc.s 6
 		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c4: stloc.s 7
+		IL_00c4: stloc.s 6
 		IL_00c6: ldstr "TypeError"
 		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d0: stloc.s 10
-		IL_00d2: ldloc.s 10
+		IL_00d0: stloc.s 9
+		IL_00d2: ldloc.s 9
 		IL_00d4: ldstr "prototype"
 		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00de: stloc.s 10
-		IL_00e0: ldloc.s 10
+		IL_00de: stloc.s 9
+		IL_00e0: ldloc.s 9
 		IL_00e2: ldstr "constructor"
 		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ec: stloc.s 10
+		IL_00ec: stloc.s 9
 		IL_00ee: ldstr "TypeError"
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f8: stloc.s 9
-		IL_00fa: ldloc.s 10
-		IL_00fc: ldloc.s 9
+		IL_00f8: stloc.s 8
+		IL_00fa: ldloc.s 9
+		IL_00fc: ldloc.s 8
 		IL_00fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0103: stloc.s 11
-		IL_0105: ldloc.s 11
+		IL_0103: stloc.s 10
+		IL_0105: ldloc.s 10
 		IL_0107: box [System.Runtime]System.Boolean
-		IL_010c: stloc.s 12
-		IL_010e: ldloc.s 7
+		IL_010c: stloc.s 11
+		IL_010e: ldloc.s 6
 		IL_0110: ldstr "log"
-		IL_0115: ldloc.s 12
+		IL_0115: ldloc.s 11
 		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_011c: pop
 		IL_011d: ldstr "console"
 		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0127: stloc.s 7
-		IL_0129: ldloc.s 7
+		IL_0127: stloc.s 6
+		IL_0129: ldloc.s 6
 		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0130: stloc.s 7
+		IL_0130: stloc.s 6
 		IL_0132: ldstr "TypeError"
 		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013c: stloc.s 9
-		IL_013e: ldloc.s 9
+		IL_013c: stloc.s 8
+		IL_013e: ldloc.s 8
 		IL_0140: ldstr "prototype"
 		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014a: stloc.s 9
-		IL_014c: ldloc.s 9
+		IL_014a: stloc.s 8
+		IL_014c: ldloc.s 8
 		IL_014e: ldstr "name"
 		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0158: stloc.s 9
-		IL_015a: ldloc.s 9
+		IL_0158: stloc.s 8
+		IL_015a: ldloc.s 8
 		IL_015c: ldstr ":"
 		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0166: stloc.s 8
+		IL_0166: stloc.s 7
 		IL_0168: ldstr "TypeError"
 		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0172: stloc.s 9
-		IL_0174: ldloc.s 9
+		IL_0172: stloc.s 8
+		IL_0174: ldloc.s 8
 		IL_0176: ldstr "prototype"
 		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0180: stloc.s 9
-		IL_0182: ldloc.s 9
+		IL_0180: stloc.s 8
+		IL_0182: ldloc.s 8
 		IL_0184: ldstr "message"
 		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018e: stloc.s 9
-		IL_0190: ldloc.s 8
-		IL_0192: ldloc.s 9
+		IL_018e: stloc.s 8
+		IL_0190: ldloc.s 7
+		IL_0192: ldloc.s 8
 		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0199: stloc.s 8
-		IL_019b: ldloc.s 7
+		IL_0199: stloc.s 7
+		IL_019b: ldloc.s 6
 		IL_019d: ldstr "log"
-		IL_01a2: ldloc.s 8
+		IL_01a2: ldloc.s 7
 		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01a9: pop
 		.try
@@ -235,7 +234,7 @@
 			IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_01b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
 			IL_01ba: pop
-			IL_01bb: leave IL_0295
+			IL_01bb: leave IL_028e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -261,63 +260,61 @@
 			IL_01e8: stloc.3
 
 			IL_01e9: ldloc.3
-			IL_01ea: stloc.s 7
-			IL_01ec: ldloc.s 7
+			IL_01ea: stloc.s 6
+			IL_01ec: ldloc.s 6
 			IL_01ee: stloc.s 4
-			IL_01f0: newobj instance void Modules.IntrinsicCallables_TypeError_GlobalSurface/Scope/Block_L11C12::.ctor()
-			IL_01f5: stloc.s 5
-			IL_01f7: ldstr "console"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0201: stloc.s 7
-			IL_0203: ldloc.s 7
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_020a: stloc.s 7
-			IL_020c: ldloc.s 4
-			IL_020e: stloc.s 9
-			IL_0210: ldstr "TypeError"
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_021a: stloc.s 10
-			IL_021c: ldloc.s 9
-			IL_021e: ldloc.s 10
-			IL_0220: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0225: stloc.s 11
-			IL_0227: ldloc.s 11
-			IL_0229: box [System.Runtime]System.Boolean
-			IL_022e: stloc.s 12
-			IL_0230: ldloc.s 7
-			IL_0232: ldstr "log"
-			IL_0237: ldloc.s 12
-			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_023e: pop
-			IL_023f: ldstr "console"
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0249: stloc.s 7
-			IL_024b: ldloc.s 7
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0252: stloc.s 7
-			IL_0254: ldloc.s 4
-			IL_0256: ldstr "name"
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0260: ldstr ":"
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_026a: stloc.s 8
-			IL_026c: ldloc.s 8
-			IL_026e: ldloc.s 4
-			IL_0270: ldstr "message"
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_027f: stloc.s 8
+			IL_01f0: ldstr "console"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01fa: stloc.s 6
+			IL_01fc: ldloc.s 6
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0203: stloc.s 6
+			IL_0205: ldloc.s 4
+			IL_0207: stloc.s 8
+			IL_0209: ldstr "TypeError"
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0213: stloc.s 9
+			IL_0215: ldloc.s 8
+			IL_0217: ldloc.s 9
+			IL_0219: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_021e: stloc.s 10
+			IL_0220: ldloc.s 10
+			IL_0222: box [System.Runtime]System.Boolean
+			IL_0227: stloc.s 11
+			IL_0229: ldloc.s 6
+			IL_022b: ldstr "log"
+			IL_0230: ldloc.s 11
+			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0237: pop
+			IL_0238: ldstr "console"
+			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0242: stloc.s 6
+			IL_0244: ldloc.s 6
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024b: stloc.s 6
+			IL_024d: ldloc.s 4
+			IL_024f: ldstr "name"
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0259: ldstr ":"
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0263: stloc.s 7
+			IL_0265: ldloc.s 7
+			IL_0267: ldloc.s 4
+			IL_0269: ldstr "message"
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0278: stloc.s 7
+			IL_027a: ldloc.s 6
+			IL_027c: ldstr "log"
 			IL_0281: ldloc.s 7
-			IL_0283: ldstr "log"
-			IL_0288: ldloc.s 8
-			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_028f: pop
-			IL_0290: leave IL_0295
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0288: pop
+			IL_0289: leave IL_028e
 		} // end handler
 
-		IL_0295: ldnull
-		IL_0296: stloc.s 6
-		IL_0298: ret
+		IL_028e: ldnull
+		IL_028f: stloc.s 5
+		IL_0291: ret
 	} // end of method IntrinsicCallables_TypeError_GlobalSurface::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_TypeError_GlobalSurface
@@ -329,7 +326,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2323
+		// Method begins at RVA 0x231b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318a
+					// Method begins at RVA 0x316e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ca1
+				// Method begins at RVA 0x2c85
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -76,7 +76,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x319c
+						// Method begins at RVA 0x3180
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -100,7 +100,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f58
+					// Method begins at RVA 0x2f3c
 					// Header size: 12
 					// Code size: 131 (0x83)
 					.maxstack 8
@@ -171,7 +171,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a5
+						// Method begins at RVA 0x3189
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -195,7 +195,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fe8
+					// Method begins at RVA 0x2fcc
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -238,7 +238,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3193
+					// Method begins at RVA 0x3177
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -262,7 +262,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cb0
+				// Method begins at RVA 0x2c94
 				// Header size: 12
 				// Code size: 168 (0xa8)
 				.maxstack 8
@@ -371,7 +371,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3181
+				// Method begins at RVA 0x3165
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -398,7 +398,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x29cc
+			// Method begins at RVA 0x29b0
 			// Header size: 12
 			// Code size: 190 (0xbe)
 			.maxstack 8
@@ -507,7 +507,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ae
+				// Method begins at RVA 0x3192
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -531,7 +531,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a96
+			// Method begins at RVA 0x2a7a
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -560,7 +560,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b7
+				// Method begins at RVA 0x319b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +584,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a9c
+			// Method begins at RVA 0x2a80
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -635,7 +635,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31d2
+				// Method begins at RVA 0x31b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -659,7 +659,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ad4
+			// Method begins at RVA 0x2ab8
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -715,7 +715,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3208
+							// Method begins at RVA 0x31ec
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -733,7 +733,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31ff
+						// Method begins at RVA 0x31e3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -757,7 +757,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3034
+					// Method begins at RVA 0x3018
 					// Header size: 12
 					// Code size: 104 (0x68)
 					.maxstack 8
@@ -818,7 +818,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3211
+						// Method begins at RVA 0x31f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -842,7 +842,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x30a8
+					// Method begins at RVA 0x308c
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -885,7 +885,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f6
+					// Method begins at RVA 0x31da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -909,7 +909,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d64
+				// Method begins at RVA 0x2d48
 				// Header size: 12
 				// Code size: 160 (0xa0)
 				.maxstack 8
@@ -1016,7 +1016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ed
+				// Method begins at RVA 0x31d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1043,7 +1043,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2b0c
+			// Method begins at RVA 0x2af0
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -1115,7 +1115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x321a
+				// Method begins at RVA 0x31fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1139,7 +1139,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b70
+			// Method begins at RVA 0x2b54
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1191,7 +1191,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3247
+						// Method begins at RVA 0x322b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1209,7 +1209,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x323e
+					// Method begins at RVA 0x3222
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1233,7 +1233,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e10
+				// Method begins at RVA 0x2df4
 				// Header size: 12
 				// Code size: 100 (0x64)
 				.maxstack 8
@@ -1290,7 +1290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3250
+					// Method begins at RVA 0x3234
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1314,7 +1314,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e80
+				// Method begins at RVA 0x2e64
 				// Header size: 12
 				// Code size: 64 (0x40)
 				.maxstack 8
@@ -1357,7 +1357,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3235
+				// Method begins at RVA 0x3219
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1383,7 +1383,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2ba8
+			// Method begins at RVA 0x2b8c
 			// Header size: 12
 			// Code size: 144 (0x90)
 			.maxstack 8
@@ -1479,7 +1479,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x326b
+						// Method begins at RVA 0x324f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1502,7 +1502,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x30f4
+					// Method begins at RVA 0x30d8
 					// Header size: 12
 					// Code size: 41 (0x29)
 					.maxstack 8
@@ -1546,7 +1546,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3274
+						// Method begins at RVA 0x3258
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1570,7 +1570,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x312c
+					// Method begins at RVA 0x3110
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -1606,7 +1606,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3262
+					// Method begins at RVA 0x3246
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1630,7 +1630,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ecc
+				// Method begins at RVA 0x2eb0
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 8
@@ -1716,7 +1716,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3259
+				// Method begins at RVA 0x323d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1743,7 +1743,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2c44
+			// Method begins at RVA 0x2c28
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1818,7 +1818,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c0
+				// Method begins at RVA 0x31a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1838,7 +1838,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c9
+				// Method begins at RVA 0x31ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1858,7 +1858,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31db
+				// Method begins at RVA 0x31bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1878,7 +1878,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e4
+				// Method begins at RVA 0x31c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1898,7 +1898,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3223
+				// Method begins at RVA 0x3207
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1918,7 +1918,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x322c
+				// Method begins at RVA 0x3210
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1938,7 +1938,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x327d
+				// Method begins at RVA 0x3261
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1958,7 +1958,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3286
+				// Method begins at RVA 0x326a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1982,7 +1982,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3178
+			// Method begins at RVA 0x315c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2008,7 +2008,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2362 (0x93a)
+		// Code size: 2334 (0x91e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -2020,33 +2020,29 @@
 			[6] class [System.Runtime]System.Exception,
 			[7] object,
 			[8] object,
-			[9] class Modules.Iterator_Helper_Cleanup/Scope/Block_L40C16,
+			[9] object,
 			[10] object,
-			[11] object,
-			[12] class [System.Runtime]System.Exception,
+			[11] class [System.Runtime]System.Exception,
+			[12] object,
 			[13] object,
 			[14] object,
-			[15] class Modules.Iterator_Helper_Cleanup/Scope/Block_L50C16,
+			[15] object,
 			[16] object,
 			[17] object,
 			[18] object,
-			[19] object,
+			[19] class [System.Runtime]System.Exception,
 			[20] object,
-			[21] class [System.Runtime]System.Exception,
+			[21] object,
 			[22] object,
-			[23] object,
-			[24] class Modules.Iterator_Helper_Cleanup/Scope/Block_L89C16,
+			[23] class [System.Runtime]System.Exception,
+			[24] object,
 			[25] object,
-			[26] class [System.Runtime]System.Exception,
+			[26] object,
 			[27] object,
-			[28] object,
-			[29] class Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16,
+			[28] object[],
+			[29] object,
 			[30] object,
-			[31] object,
-			[32] object[],
-			[33] object,
-			[34] object,
-			[35] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[31] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/Scope::.ctor()
@@ -2068,37 +2064,37 @@
 		IL_0029: ldc.i4.0
 		IL_002a: ldc.i4.1
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0030: stloc.s 31
-		IL_0032: ldloc.s 31
+		IL_0030: stloc.s 27
+		IL_0032: ldloc.s 27
 		IL_0034: stloc.1
 		IL_0035: nop
 		IL_0036: nop
 		IL_0037: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003c: stloc.s 32
+		IL_003c: stloc.s 28
 		IL_003e: ldloc.1
-		IL_003f: ldloc.s 32
+		IL_003f: ldloc.s 28
 		IL_0041: ldc.r8 2
 		IL_004a: box [System.Runtime]System.Double
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0054: stloc.s 31
-		IL_0056: ldloc.s 31
+		IL_0054: stloc.s 27
+		IL_0056: ldloc.s 27
 		IL_0058: stloc.2
 		IL_0059: ldstr "Iterator"
 		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0063: stloc.s 31
-		IL_0065: ldloc.s 31
+		IL_0063: stloc.s 27
+		IL_0065: ldloc.s 27
 		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.s 31
-		IL_006e: ldloc.s 31
+		IL_006c: stloc.s 27
+		IL_006e: ldloc.s 27
 		IL_0070: ldstr "from"
 		IL_0075: ldloc.2
 		IL_0076: ldstr "iterable"
 		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0085: stloc.s 31
-		IL_0087: ldloc.s 31
+		IL_0085: stloc.s 27
+		IL_0087: ldloc.s 27
 		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008e: stloc.s 31
+		IL_008e: stloc.s 27
 		IL_0090: ldnull
 		IL_0091: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56::__js_call__(object, object)
 		IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -2117,94 +2113,94 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00c3: stloc.s 33
-		IL_00c5: ldloc.s 31
+		IL_00c3: stloc.s 29
+		IL_00c5: ldloc.s 27
 		IL_00c7: ldstr "map"
-		IL_00cc: ldloc.s 33
+		IL_00cc: ldloc.s 29
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d3: stloc.s 33
-		IL_00d5: ldloc.s 33
+		IL_00d3: stloc.s 29
+		IL_00d5: ldloc.s 29
 		IL_00d7: stloc.3
 		IL_00d8: ldloc.3
 		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: stloc.s 33
-		IL_00e0: ldloc.s 33
+		IL_00de: stloc.s 29
+		IL_00e0: ldloc.s 29
 		IL_00e2: ldstr "next"
 		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00ec: pop
 		IL_00ed: ldloc.3
 		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f3: stloc.s 33
-		IL_00f5: ldloc.s 33
+		IL_00f3: stloc.s 29
+		IL_00f5: ldloc.s 29
 		IL_00f7: ldstr "next"
 		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_0101: pop
 		IL_0102: ldstr "console"
 		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010c: stloc.s 33
-		IL_010e: ldloc.s 33
+		IL_010c: stloc.s 29
+		IL_010e: ldloc.s 29
 		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0115: stloc.s 33
+		IL_0115: stloc.s 29
 		IL_0117: ldloc.3
 		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011d: stloc.s 31
-		IL_011f: ldloc.s 31
+		IL_011d: stloc.s 27
+		IL_011f: ldloc.s 27
 		IL_0121: ldstr "next"
 		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_012b: stloc.s 31
-		IL_012d: ldloc.s 31
+		IL_012b: stloc.s 27
+		IL_012d: ldloc.s 27
 		IL_012f: ldstr "done"
 		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0139: stloc.s 31
-		IL_013b: ldloc.s 33
+		IL_0139: stloc.s 27
+		IL_013b: ldloc.s 29
 		IL_013d: ldstr "log"
-		IL_0142: ldloc.s 31
+		IL_0142: ldloc.s 27
 		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0149: pop
 		IL_014a: ldstr "console"
 		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0154: stloc.s 31
-		IL_0156: ldloc.s 31
+		IL_0154: stloc.s 27
+		IL_0156: ldloc.s 27
 		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015d: stloc.s 31
+		IL_015d: stloc.s 27
 		IL_015f: ldloc.2
 		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0165: stloc.s 33
-		IL_0167: ldloc.s 33
+		IL_0165: stloc.s 29
+		IL_0167: ldloc.s 29
 		IL_0169: ldstr "getClosed"
 		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0173: stloc.s 33
-		IL_0175: ldloc.s 31
+		IL_0173: stloc.s 29
+		IL_0175: ldloc.s 27
 		IL_0177: ldstr "log"
-		IL_017c: ldloc.s 33
+		IL_017c: ldloc.s 29
 		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0183: pop
 		IL_0184: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0189: stloc.s 32
+		IL_0189: stloc.s 28
 		IL_018b: ldloc.1
-		IL_018c: ldloc.s 32
+		IL_018c: ldloc.s 28
 		IL_018e: ldc.r8 2
 		IL_0197: box [System.Runtime]System.Double
 		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01a1: stloc.s 33
-		IL_01a3: ldloc.s 33
+		IL_01a1: stloc.s 29
+		IL_01a3: ldloc.s 29
 		IL_01a5: stloc.s 4
 		IL_01a7: ldstr "Iterator"
 		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b1: stloc.s 33
-		IL_01b3: ldloc.s 33
+		IL_01b1: stloc.s 29
+		IL_01b3: ldloc.s 29
 		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ba: stloc.s 33
-		IL_01bc: ldloc.s 33
+		IL_01ba: stloc.s 29
+		IL_01bc: ldloc.s 29
 		IL_01be: ldstr "from"
 		IL_01c3: ldloc.s 4
 		IL_01c5: ldstr "iterable"
 		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d4: stloc.s 33
-		IL_01d6: ldloc.s 33
+		IL_01d4: stloc.s 29
+		IL_01d6: ldloc.s 29
 		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dd: stloc.s 33
+		IL_01dd: stloc.s 29
 		IL_01df: ldnull
 		IL_01e0: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68::__js_call__(object, object)
 		IL_01e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -2223,25 +2219,25 @@
 		IL_0207: ldc.i4.0
 		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0212: stloc.s 31
-		IL_0214: ldloc.s 33
+		IL_0212: stloc.s 27
+		IL_0214: ldloc.s 29
 		IL_0216: ldstr "map"
-		IL_021b: ldloc.s 31
+		IL_021b: ldloc.s 27
 		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0222: stloc.s 31
-		IL_0224: ldloc.s 31
+		IL_0222: stloc.s 27
+		IL_0224: ldloc.s 27
 		IL_0226: stloc.s 5
 		.try
 		{
 			IL_0228: nop
 			IL_0229: ldloc.s 5
 			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0230: stloc.s 31
-			IL_0232: ldloc.s 31
+			IL_0230: stloc.s 27
+			IL_0232: ldloc.s 27
 			IL_0234: ldstr "next"
 			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_023e: pop
-			IL_023f: leave IL_0286
+			IL_023f: leave IL_027f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -2267,596 +2263,588 @@
 			IL_0270: stloc.s 7
 
 			IL_0272: ldloc.s 7
-			IL_0274: stloc.s 31
-			IL_0276: ldloc.s 31
+			IL_0274: stloc.s 27
+			IL_0276: ldloc.s 27
 			IL_0278: stloc.s 8
-			IL_027a: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L40C16::.ctor()
-			IL_027f: stloc.s 9
-			IL_0281: leave IL_0286
+			IL_027a: leave IL_027f
 		} // end handler
 
-		IL_0286: ldstr "console"
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0290: stloc.s 31
-		IL_0292: ldloc.s 31
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0299: stloc.s 31
-		IL_029b: ldloc.s 4
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a2: stloc.s 33
-		IL_02a4: ldloc.s 33
-		IL_02a6: ldstr "getClosed"
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_02b0: stloc.s 33
-		IL_02b2: ldloc.s 31
-		IL_02b4: ldstr "log"
-		IL_02b9: ldloc.s 33
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02c0: pop
-		IL_02c1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02c6: stloc.s 32
-		IL_02c8: ldloc.1
-		IL_02c9: ldloc.s 32
-		IL_02cb: ldc.r8 2
-		IL_02d4: box [System.Runtime]System.Double
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02de: stloc.s 33
-		IL_02e0: ldloc.s 33
-		IL_02e2: stloc.s 10
-		IL_02e4: ldstr "Iterator"
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ee: stloc.s 33
-		IL_02f0: ldloc.s 33
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f7: stloc.s 33
-		IL_02f9: ldloc.s 33
-		IL_02fb: ldstr "from"
-		IL_0300: ldloc.s 10
-		IL_0302: ldstr "iterable"
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0311: stloc.s 33
-		IL_0313: ldloc.s 33
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031a: stloc.s 33
-		IL_031c: ldnull
-		IL_031d: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77::__js_call__(object, object)
-		IL_0323: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0328: ldc.i4.1
-		IL_0329: newarr [System.Runtime]System.Object
-		IL_032e: dup
-		IL_032f: ldc.i4.0
-		IL_0330: ldloc.0
-		IL_0331: stelem.ref
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_033c: ldc.i4.1
-		IL_033d: conv.r8
-		IL_033e: ldstr ""
-		IL_0343: ldc.i4.0
-		IL_0344: ldc.i4.0
-		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_034f: stloc.s 31
-		IL_0351: ldloc.s 33
-		IL_0353: ldstr "filter"
-		IL_0358: ldloc.s 31
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_035f: stloc.s 31
-		IL_0361: ldloc.s 31
-		IL_0363: stloc.s 11
+		IL_027f: ldstr "console"
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0289: stloc.s 27
+		IL_028b: ldloc.s 27
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0292: stloc.s 27
+		IL_0294: ldloc.s 4
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029b: stloc.s 29
+		IL_029d: ldloc.s 29
+		IL_029f: ldstr "getClosed"
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_02a9: stloc.s 29
+		IL_02ab: ldloc.s 27
+		IL_02ad: ldstr "log"
+		IL_02b2: ldloc.s 29
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02b9: pop
+		IL_02ba: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02bf: stloc.s 28
+		IL_02c1: ldloc.1
+		IL_02c2: ldloc.s 28
+		IL_02c4: ldc.r8 2
+		IL_02cd: box [System.Runtime]System.Double
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02d7: stloc.s 29
+		IL_02d9: ldloc.s 29
+		IL_02db: stloc.s 9
+		IL_02dd: ldstr "Iterator"
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e7: stloc.s 29
+		IL_02e9: ldloc.s 29
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f0: stloc.s 29
+		IL_02f2: ldloc.s 29
+		IL_02f4: ldstr "from"
+		IL_02f9: ldloc.s 9
+		IL_02fb: ldstr "iterable"
+		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_030a: stloc.s 29
+		IL_030c: ldloc.s 29
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0313: stloc.s 29
+		IL_0315: ldnull
+		IL_0316: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77::__js_call__(object, object)
+		IL_031c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0321: ldc.i4.1
+		IL_0322: newarr [System.Runtime]System.Object
+		IL_0327: dup
+		IL_0328: ldc.i4.0
+		IL_0329: ldloc.0
+		IL_032a: stelem.ref
+		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0335: ldc.i4.1
+		IL_0336: conv.r8
+		IL_0337: ldstr ""
+		IL_033c: ldc.i4.0
+		IL_033d: ldc.i4.0
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0348: stloc.s 27
+		IL_034a: ldloc.s 29
+		IL_034c: ldstr "filter"
+		IL_0351: ldloc.s 27
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0358: stloc.s 27
+		IL_035a: ldloc.s 27
+		IL_035c: stloc.s 10
 		.try
 		{
-			IL_0365: nop
-			IL_0366: ldloc.s 11
-			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036d: stloc.s 31
-			IL_036f: ldloc.s 31
-			IL_0371: ldstr "next"
-			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_037b: pop
-			IL_037c: leave IL_03c3
+			IL_035e: nop
+			IL_035f: ldloc.s 10
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0366: stloc.s 27
+			IL_0368: ldloc.s 27
+			IL_036a: ldstr "next"
+			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0374: pop
+			IL_0375: leave IL_03b5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0381: stloc.s 12
-			IL_0383: ldloc.s 12
-			IL_0385: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_038a: dup
-			IL_038b: brtrue IL_03a1
+			IL_037a: stloc.s 11
+			IL_037c: ldloc.s 11
+			IL_037e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0383: dup
+			IL_0384: brtrue IL_039a
 
-			IL_0390: pop
-			IL_0391: ldloc.s 12
-			IL_0393: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0398: dup
-			IL_0399: brtrue IL_03ad
+			IL_0389: pop
+			IL_038a: ldloc.s 11
+			IL_038c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0391: dup
+			IL_0392: brtrue IL_03a6
 
-			IL_039e: pop
-			IL_039f: rethrow
+			IL_0397: pop
+			IL_0398: rethrow
 
-			IL_03a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03a6: stloc.s 13
-			IL_03a8: br IL_03af
+			IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_039f: stloc.s 12
+			IL_03a1: br IL_03a8
 
-			IL_03ad: stloc.s 13
+			IL_03a6: stloc.s 12
 
-			IL_03af: ldloc.s 13
-			IL_03b1: stloc.s 31
-			IL_03b3: ldloc.s 31
-			IL_03b5: stloc.s 14
-			IL_03b7: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L50C16::.ctor()
-			IL_03bc: stloc.s 15
-			IL_03be: leave IL_03c3
+			IL_03a8: ldloc.s 12
+			IL_03aa: stloc.s 27
+			IL_03ac: ldloc.s 27
+			IL_03ae: stloc.s 13
+			IL_03b0: leave IL_03b5
 		} // end handler
 
-		IL_03c3: ldstr "console"
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03cd: stloc.s 31
-		IL_03cf: ldloc.s 31
-		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d6: stloc.s 31
-		IL_03d8: ldloc.s 10
-		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03df: stloc.s 33
-		IL_03e1: ldloc.s 33
-		IL_03e3: ldstr "getClosed"
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03ed: stloc.s 33
-		IL_03ef: ldloc.s 31
-		IL_03f1: ldstr "log"
-		IL_03f6: ldloc.s 33
-		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03fd: pop
-		IL_03fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0403: stloc.s 32
-		IL_0405: ldloc.1
-		IL_0406: ldloc.s 32
-		IL_0408: ldc.r8 3
-		IL_0411: box [System.Runtime]System.Double
-		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_041b: stloc.s 33
-		IL_041d: ldloc.s 33
-		IL_041f: stloc.s 16
-		IL_0421: ldstr "Iterator"
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_042b: stloc.s 33
-		IL_042d: ldloc.s 33
-		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0434: stloc.s 33
-		IL_0436: ldloc.s 33
-		IL_0438: ldstr "from"
-		IL_043d: ldloc.s 16
-		IL_043f: ldstr "iterable"
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_044e: stloc.s 33
-		IL_0450: ldloc.s 33
-		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0457: stloc.s 33
-		IL_0459: ldloc.s 33
-		IL_045b: ldstr "take"
-		IL_0460: ldc.r8 0.0
-		IL_0469: box [System.Runtime]System.Double
-		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0473: stloc.s 33
-		IL_0475: ldloc.s 33
-		IL_0477: stloc.s 17
-		IL_0479: ldstr "console"
-		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0483: stloc.s 33
-		IL_0485: ldloc.s 33
-		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_048c: stloc.s 33
-		IL_048e: ldloc.s 17
-		IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0495: stloc.s 31
-		IL_0497: ldloc.s 31
-		IL_0499: ldstr "next"
-		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_04a3: stloc.s 31
-		IL_04a5: ldloc.s 31
-		IL_04a7: ldstr "done"
-		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b1: stloc.s 31
-		IL_04b3: ldloc.s 33
-		IL_04b5: ldstr "log"
-		IL_04ba: ldloc.s 31
-		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04c1: pop
-		IL_04c2: ldstr "console"
-		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04cc: stloc.s 31
-		IL_04ce: ldloc.s 31
-		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04d5: stloc.s 31
-		IL_04d7: ldloc.s 16
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04de: stloc.s 33
-		IL_04e0: ldloc.s 33
-		IL_04e2: ldstr "getClosed"
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_04ec: stloc.s 33
-		IL_04ee: ldloc.s 31
-		IL_04f0: ldstr "log"
-		IL_04f5: ldloc.s 33
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04fc: pop
-		IL_04fd: ldloc.0
-		IL_04fe: ldc.r8 0.0
-		IL_0507: box [System.Runtime]System.Double
-		IL_050c: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_0511: ldstr "Iterator"
-		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_051b: stloc.s 33
-		IL_051d: ldloc.s 33
-		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0524: stloc.s 33
-		IL_0526: ldloc.s 33
-		IL_0528: ldstr "from"
-		IL_052d: ldc.i4.1
-		IL_052e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0533: dup
-		IL_0534: ldc.r8 1
-		IL_053d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0542: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0547: stloc.s 33
-		IL_0549: ldloc.s 33
-		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0550: stloc.s 33
-		IL_0552: ldc.i4.1
-		IL_0553: newarr [System.Runtime]System.Object
-		IL_0558: dup
-		IL_0559: ldc.i4.0
-		IL_055a: ldloc.0
-		IL_055b: stelem.ref
-		IL_055c: ldc.i4.0
-		IL_055d: ldelem.ref
-		IL_055e: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0563: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0569: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_056e: ldc.i4.1
-		IL_056f: newarr [System.Runtime]System.Object
-		IL_0574: dup
-		IL_0575: ldc.i4.0
-		IL_0576: ldloc.0
-		IL_0577: stelem.ref
-		IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0582: ldc.i4.1
-		IL_0583: conv.r8
-		IL_0584: ldstr ""
-		IL_0589: ldc.i4.0
-		IL_058a: ldc.i4.0
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0590: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0595: stloc.s 31
-		IL_0597: ldloc.s 33
-		IL_0599: ldstr "flatMap"
-		IL_059e: ldloc.s 31
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_05a5: stloc.s 31
-		IL_05a7: ldloc.s 31
-		IL_05a9: stloc.s 18
-		IL_05ab: ldloc.s 18
-		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05b2: stloc.s 31
-		IL_05b4: ldloc.s 31
-		IL_05b6: ldstr "next"
-		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_05c0: pop
-		IL_05c1: ldstr "console"
-		IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05cb: stloc.s 31
-		IL_05cd: ldloc.s 31
-		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d4: stloc.s 31
-		IL_05d6: ldloc.s 18
-		IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05dd: stloc.s 33
-		IL_05df: ldloc.s 33
-		IL_05e1: ldstr "next"
-		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_05eb: stloc.s 33
-		IL_05ed: ldloc.s 33
-		IL_05ef: ldstr "done"
-		IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f9: stloc.s 33
-		IL_05fb: ldloc.s 31
-		IL_05fd: ldstr "log"
-		IL_0602: ldloc.s 33
-		IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0609: pop
-		IL_060a: ldstr "console"
-		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0614: stloc.s 33
-		IL_0616: ldloc.s 33
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_061d: stloc.s 33
-		IL_061f: ldloc.s 33
-		IL_0621: ldstr "log"
-		IL_0626: ldloc.0
-		IL_0627: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0631: pop
-		IL_0632: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0637: stloc.s 32
-		IL_0639: ldloc.1
-		IL_063a: ldloc.s 32
-		IL_063c: ldc.r8 2
-		IL_0645: box [System.Runtime]System.Double
-		IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_064f: stloc.s 33
-		IL_0651: ldloc.s 33
-		IL_0653: stloc.s 19
-		IL_0655: ldstr "Iterator"
-		IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_065f: stloc.s 33
-		IL_0661: ldloc.s 33
-		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0668: stloc.s 33
-		IL_066a: ldloc.s 33
-		IL_066c: ldstr "from"
-		IL_0671: ldloc.s 19
-		IL_0673: ldstr "iterable"
-		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0682: stloc.s 33
-		IL_0684: ldloc.s 33
-		IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_068b: stloc.s 33
-		IL_068d: ldnull
-		IL_068e: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74::__js_call__(object, object)
-		IL_0694: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0699: ldc.i4.1
-		IL_069a: newarr [System.Runtime]System.Object
-		IL_069f: dup
-		IL_06a0: ldc.i4.0
-		IL_06a1: ldloc.0
-		IL_06a2: stelem.ref
-		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_06ad: ldc.i4.1
-		IL_06ae: conv.r8
-		IL_06af: ldstr ""
-		IL_06b4: ldc.i4.0
-		IL_06b5: ldc.i4.0
-		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_06c0: stloc.s 31
-		IL_06c2: ldloc.s 33
-		IL_06c4: ldstr "flatMap"
-		IL_06c9: ldloc.s 31
-		IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_06d0: stloc.s 31
-		IL_06d2: ldloc.s 31
-		IL_06d4: stloc.s 20
+		IL_03b5: ldstr "console"
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03bf: stloc.s 27
+		IL_03c1: ldloc.s 27
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c8: stloc.s 27
+		IL_03ca: ldloc.s 9
+		IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d1: stloc.s 29
+		IL_03d3: ldloc.s 29
+		IL_03d5: ldstr "getClosed"
+		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03df: stloc.s 29
+		IL_03e1: ldloc.s 27
+		IL_03e3: ldstr "log"
+		IL_03e8: ldloc.s 29
+		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03ef: pop
+		IL_03f0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03f5: stloc.s 28
+		IL_03f7: ldloc.1
+		IL_03f8: ldloc.s 28
+		IL_03fa: ldc.r8 3
+		IL_0403: box [System.Runtime]System.Double
+		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_040d: stloc.s 29
+		IL_040f: ldloc.s 29
+		IL_0411: stloc.s 14
+		IL_0413: ldstr "Iterator"
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_041d: stloc.s 29
+		IL_041f: ldloc.s 29
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0426: stloc.s 29
+		IL_0428: ldloc.s 29
+		IL_042a: ldstr "from"
+		IL_042f: ldloc.s 14
+		IL_0431: ldstr "iterable"
+		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0440: stloc.s 29
+		IL_0442: ldloc.s 29
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0449: stloc.s 29
+		IL_044b: ldloc.s 29
+		IL_044d: ldstr "take"
+		IL_0452: ldc.r8 0.0
+		IL_045b: box [System.Runtime]System.Double
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0465: stloc.s 29
+		IL_0467: ldloc.s 29
+		IL_0469: stloc.s 15
+		IL_046b: ldstr "console"
+		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0475: stloc.s 29
+		IL_0477: ldloc.s 29
+		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_047e: stloc.s 29
+		IL_0480: ldloc.s 15
+		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0487: stloc.s 27
+		IL_0489: ldloc.s 27
+		IL_048b: ldstr "next"
+		IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0495: stloc.s 27
+		IL_0497: ldloc.s 27
+		IL_0499: ldstr "done"
+		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04a3: stloc.s 27
+		IL_04a5: ldloc.s 29
+		IL_04a7: ldstr "log"
+		IL_04ac: ldloc.s 27
+		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04b3: pop
+		IL_04b4: ldstr "console"
+		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04be: stloc.s 27
+		IL_04c0: ldloc.s 27
+		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04c7: stloc.s 27
+		IL_04c9: ldloc.s 14
+		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d0: stloc.s 29
+		IL_04d2: ldloc.s 29
+		IL_04d4: ldstr "getClosed"
+		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_04de: stloc.s 29
+		IL_04e0: ldloc.s 27
+		IL_04e2: ldstr "log"
+		IL_04e7: ldloc.s 29
+		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04ee: pop
+		IL_04ef: ldloc.0
+		IL_04f0: ldc.r8 0.0
+		IL_04f9: box [System.Runtime]System.Double
+		IL_04fe: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_0503: ldstr "Iterator"
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_050d: stloc.s 29
+		IL_050f: ldloc.s 29
+		IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0516: stloc.s 29
+		IL_0518: ldloc.s 29
+		IL_051a: ldstr "from"
+		IL_051f: ldc.i4.1
+		IL_0520: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0525: dup
+		IL_0526: ldc.r8 1
+		IL_052f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0539: stloc.s 29
+		IL_053b: ldloc.s 29
+		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0542: stloc.s 29
+		IL_0544: ldc.i4.1
+		IL_0545: newarr [System.Runtime]System.Object
+		IL_054a: dup
+		IL_054b: ldc.i4.0
+		IL_054c: ldloc.0
+		IL_054d: stelem.ref
+		IL_054e: ldc.i4.0
+		IL_054f: ldelem.ref
+		IL_0550: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0555: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_055b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0560: ldc.i4.1
+		IL_0561: newarr [System.Runtime]System.Object
+		IL_0566: dup
+		IL_0567: ldc.i4.0
+		IL_0568: ldloc.0
+		IL_0569: stelem.ref
+		IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0574: ldc.i4.1
+		IL_0575: conv.r8
+		IL_0576: ldstr ""
+		IL_057b: ldc.i4.0
+		IL_057c: ldc.i4.0
+		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0587: stloc.s 27
+		IL_0589: ldloc.s 29
+		IL_058b: ldstr "flatMap"
+		IL_0590: ldloc.s 27
+		IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0597: stloc.s 27
+		IL_0599: ldloc.s 27
+		IL_059b: stloc.s 16
+		IL_059d: ldloc.s 16
+		IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05a4: stloc.s 27
+		IL_05a6: ldloc.s 27
+		IL_05a8: ldstr "next"
+		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_05b2: pop
+		IL_05b3: ldstr "console"
+		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05bd: stloc.s 27
+		IL_05bf: ldloc.s 27
+		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c6: stloc.s 27
+		IL_05c8: ldloc.s 16
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05cf: stloc.s 29
+		IL_05d1: ldloc.s 29
+		IL_05d3: ldstr "next"
+		IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_05dd: stloc.s 29
+		IL_05df: ldloc.s 29
+		IL_05e1: ldstr "done"
+		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05eb: stloc.s 29
+		IL_05ed: ldloc.s 27
+		IL_05ef: ldstr "log"
+		IL_05f4: ldloc.s 29
+		IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05fb: pop
+		IL_05fc: ldstr "console"
+		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0606: stloc.s 29
+		IL_0608: ldloc.s 29
+		IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_060f: stloc.s 29
+		IL_0611: ldloc.s 29
+		IL_0613: ldstr "log"
+		IL_0618: ldloc.0
+		IL_0619: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0623: pop
+		IL_0624: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0629: stloc.s 28
+		IL_062b: ldloc.1
+		IL_062c: ldloc.s 28
+		IL_062e: ldc.r8 2
+		IL_0637: box [System.Runtime]System.Double
+		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0641: stloc.s 29
+		IL_0643: ldloc.s 29
+		IL_0645: stloc.s 17
+		IL_0647: ldstr "Iterator"
+		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0651: stloc.s 29
+		IL_0653: ldloc.s 29
+		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_065a: stloc.s 29
+		IL_065c: ldloc.s 29
+		IL_065e: ldstr "from"
+		IL_0663: ldloc.s 17
+		IL_0665: ldstr "iterable"
+		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0674: stloc.s 29
+		IL_0676: ldloc.s 29
+		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_067d: stloc.s 29
+		IL_067f: ldnull
+		IL_0680: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74::__js_call__(object, object)
+		IL_0686: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_068b: ldc.i4.1
+		IL_068c: newarr [System.Runtime]System.Object
+		IL_0691: dup
+		IL_0692: ldc.i4.0
+		IL_0693: ldloc.0
+		IL_0694: stelem.ref
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_069f: ldc.i4.1
+		IL_06a0: conv.r8
+		IL_06a1: ldstr ""
+		IL_06a6: ldc.i4.0
+		IL_06a7: ldc.i4.0
+		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_06b2: stloc.s 27
+		IL_06b4: ldloc.s 29
+		IL_06b6: ldstr "flatMap"
+		IL_06bb: ldloc.s 27
+		IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06c2: stloc.s 27
+		IL_06c4: ldloc.s 27
+		IL_06c6: stloc.s 18
 		.try
 		{
-			IL_06d6: nop
-			IL_06d7: ldloc.s 20
-			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06de: stloc.s 31
-			IL_06e0: ldloc.s 31
-			IL_06e2: ldstr "next"
-			IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_06ec: pop
-			IL_06ed: leave IL_0734
+			IL_06c8: nop
+			IL_06c9: ldloc.s 18
+			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d0: stloc.s 27
+			IL_06d2: ldloc.s 27
+			IL_06d4: ldstr "next"
+			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_06de: pop
+			IL_06df: leave IL_071f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06f2: stloc.s 21
-			IL_06f4: ldloc.s 21
-			IL_06f6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06e4: stloc.s 19
+			IL_06e6: ldloc.s 19
+			IL_06e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06ed: dup
+			IL_06ee: brtrue IL_0704
+
+			IL_06f3: pop
+			IL_06f4: ldloc.s 19
+			IL_06f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_06fb: dup
-			IL_06fc: brtrue IL_0712
+			IL_06fc: brtrue IL_0710
 
 			IL_0701: pop
-			IL_0702: ldloc.s 21
-			IL_0704: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0709: dup
-			IL_070a: brtrue IL_071e
+			IL_0702: rethrow
 
-			IL_070f: pop
-			IL_0710: rethrow
+			IL_0704: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0709: stloc.s 20
+			IL_070b: br IL_0712
 
-			IL_0712: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0717: stloc.s 22
-			IL_0719: br IL_0720
+			IL_0710: stloc.s 20
 
-			IL_071e: stloc.s 22
-
-			IL_0720: ldloc.s 22
-			IL_0722: stloc.s 31
-			IL_0724: ldloc.s 31
-			IL_0726: stloc.s 23
-			IL_0728: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L89C16::.ctor()
-			IL_072d: stloc.s 24
-			IL_072f: leave IL_0734
+			IL_0712: ldloc.s 20
+			IL_0714: stloc.s 27
+			IL_0716: ldloc.s 27
+			IL_0718: stloc.s 21
+			IL_071a: leave IL_071f
 		} // end handler
 
-		IL_0734: ldstr "console"
-		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_073e: stloc.s 31
-		IL_0740: ldloc.s 31
-		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0747: stloc.s 31
-		IL_0749: ldloc.s 19
-		IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0750: stloc.s 33
-		IL_0752: ldloc.s 33
-		IL_0754: ldstr "getClosed"
-		IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_075e: stloc.s 33
-		IL_0760: ldloc.s 31
-		IL_0762: ldstr "log"
-		IL_0767: ldloc.s 33
-		IL_0769: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_076e: pop
-		IL_076f: ldloc.0
-		IL_0770: ldc.r8 0.0
-		IL_0779: box [System.Runtime]System.Double
-		IL_077e: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0783: ldloc.0
-		IL_0784: ldc.r8 0.0
-		IL_078d: box [System.Runtime]System.Double
-		IL_0792: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0797: ldstr "Iterator"
-		IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07a1: stloc.s 33
-		IL_07a3: ldloc.s 33
-		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07aa: stloc.s 33
-		IL_07ac: ldstr "iterator"
-		IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_07b6: stloc.s 31
-		IL_07b8: ldc.i4.1
-		IL_07b9: newarr [System.Runtime]System.Object
-		IL_07be: dup
+		IL_071f: ldstr "console"
+		IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0729: stloc.s 27
+		IL_072b: ldloc.s 27
+		IL_072d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0732: stloc.s 27
+		IL_0734: ldloc.s 17
+		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_073b: stloc.s 29
+		IL_073d: ldloc.s 29
+		IL_073f: ldstr "getClosed"
+		IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0749: stloc.s 29
+		IL_074b: ldloc.s 27
+		IL_074d: ldstr "log"
+		IL_0752: ldloc.s 29
+		IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0759: pop
+		IL_075a: ldloc.0
+		IL_075b: ldc.r8 0.0
+		IL_0764: box [System.Runtime]System.Double
+		IL_0769: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_076e: ldloc.0
+		IL_076f: ldc.r8 0.0
+		IL_0778: box [System.Runtime]System.Double
+		IL_077d: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0782: ldstr "Iterator"
+		IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_078c: stloc.s 29
+		IL_078e: ldloc.s 29
+		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0795: stloc.s 29
+		IL_0797: ldstr "iterator"
+		IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_07a1: stloc.s 27
+		IL_07a3: ldc.i4.1
+		IL_07a4: newarr [System.Runtime]System.Object
+		IL_07a9: dup
+		IL_07aa: ldc.i4.0
+		IL_07ab: ldloc.0
+		IL_07ac: stelem.ref
+		IL_07ad: ldc.i4.0
+		IL_07ae: ldelem.ref
+		IL_07af: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_07b4: ldftn object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
+		IL_07ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_07bf: ldc.i4.0
-		IL_07c0: ldloc.0
-		IL_07c1: stelem.ref
-		IL_07c2: ldc.i4.0
-		IL_07c3: ldelem.ref
-		IL_07c4: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_07c9: ldftn object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
-		IL_07cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_07d4: ldc.i4.0
-		IL_07d5: conv.r8
-		IL_07d6: ldstr ""
-		IL_07db: ldc.i4.0
-		IL_07dc: ldc.i4.1
-		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_07e2: stloc.s 34
-		IL_07e4: ldloc.s 34
-		IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_07eb: stloc.s 34
-		IL_07ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_07f2: stloc.s 35
-		IL_07f4: ldloc.s 35
-		IL_07f6: ldloc.s 31
-		IL_07f8: ldloc.s 34
-		IL_07fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_07ff: pop
-		IL_0800: ldloc.s 33
-		IL_0802: ldstr "from"
-		IL_0807: ldloc.s 35
-		IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_080e: stloc.s 33
-		IL_0810: ldloc.s 33
-		IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0817: stloc.s 33
-		IL_0819: ldc.i4.1
-		IL_081a: newarr [System.Runtime]System.Object
-		IL_081f: dup
-		IL_0820: ldc.i4.0
-		IL_0821: ldloc.0
-		IL_0822: stelem.ref
-		IL_0823: ldc.i4.0
-		IL_0824: ldelem.ref
-		IL_0825: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_082a: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0830: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0835: ldc.i4.1
-		IL_0836: newarr [System.Runtime]System.Object
-		IL_083b: dup
+		IL_07c0: conv.r8
+		IL_07c1: ldstr ""
+		IL_07c6: ldc.i4.0
+		IL_07c7: ldc.i4.1
+		IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_07cd: stloc.s 30
+		IL_07cf: ldloc.s 30
+		IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_07d6: stloc.s 30
+		IL_07d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07dd: stloc.s 31
+		IL_07df: ldloc.s 31
+		IL_07e1: ldloc.s 27
+		IL_07e3: ldloc.s 30
+		IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_07ea: pop
+		IL_07eb: ldloc.s 29
+		IL_07ed: ldstr "from"
+		IL_07f2: ldloc.s 31
+		IL_07f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_07f9: stloc.s 29
+		IL_07fb: ldloc.s 29
+		IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0802: stloc.s 29
+		IL_0804: ldc.i4.1
+		IL_0805: newarr [System.Runtime]System.Object
+		IL_080a: dup
+		IL_080b: ldc.i4.0
+		IL_080c: ldloc.0
+		IL_080d: stelem.ref
+		IL_080e: ldc.i4.0
+		IL_080f: ldelem.ref
+		IL_0810: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0815: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_081b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0820: ldc.i4.1
+		IL_0821: newarr [System.Runtime]System.Object
+		IL_0826: dup
+		IL_0827: ldc.i4.0
+		IL_0828: ldloc.0
+		IL_0829: stelem.ref
+		IL_082a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_082f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0834: ldc.i4.1
+		IL_0835: conv.r8
+		IL_0836: ldstr ""
+		IL_083b: ldc.i4.0
 		IL_083c: ldc.i4.0
-		IL_083d: ldloc.0
-		IL_083e: stelem.ref
-		IL_083f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0844: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0849: ldc.i4.1
-		IL_084a: conv.r8
-		IL_084b: ldstr ""
-		IL_0850: ldc.i4.0
-		IL_0851: ldc.i4.0
-		IL_0852: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_085c: stloc.s 34
-		IL_085e: ldloc.s 33
-		IL_0860: ldstr "flatMap"
-		IL_0865: ldloc.s 34
-		IL_0867: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_086c: stloc.s 34
-		IL_086e: ldloc.s 34
-		IL_0870: stloc.s 25
+		IL_083d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0842: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0847: stloc.s 30
+		IL_0849: ldloc.s 29
+		IL_084b: ldstr "flatMap"
+		IL_0850: ldloc.s 30
+		IL_0852: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0857: stloc.s 30
+		IL_0859: ldloc.s 30
+		IL_085b: stloc.s 22
 		.try
 		{
-			IL_0872: nop
-			IL_0873: ldloc.s 25
-			IL_0875: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_087a: stloc.s 34
-			IL_087c: ldloc.s 34
-			IL_087e: ldstr "next"
-			IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0888: pop
-			IL_0889: ldloc.s 25
-			IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0890: stloc.s 34
-			IL_0892: ldloc.s 34
-			IL_0894: ldstr "next"
-			IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_089e: pop
-			IL_089f: leave IL_08e6
+			IL_085d: nop
+			IL_085e: ldloc.s 22
+			IL_0860: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0865: stloc.s 30
+			IL_0867: ldloc.s 30
+			IL_0869: ldstr "next"
+			IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0873: pop
+			IL_0874: ldloc.s 22
+			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_087b: stloc.s 30
+			IL_087d: ldloc.s 30
+			IL_087f: ldstr "next"
+			IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0889: pop
+			IL_088a: leave IL_08ca
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_08a4: stloc.s 26
-			IL_08a6: ldloc.s 26
-			IL_08a8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_08ad: dup
-			IL_08ae: brtrue IL_08c4
+			IL_088f: stloc.s 23
+			IL_0891: ldloc.s 23
+			IL_0893: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0898: dup
+			IL_0899: brtrue IL_08af
 
-			IL_08b3: pop
-			IL_08b4: ldloc.s 26
-			IL_08b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_08bb: dup
-			IL_08bc: brtrue IL_08d0
+			IL_089e: pop
+			IL_089f: ldloc.s 23
+			IL_08a1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08a6: dup
+			IL_08a7: brtrue IL_08bb
 
-			IL_08c1: pop
-			IL_08c2: rethrow
+			IL_08ac: pop
+			IL_08ad: rethrow
 
-			IL_08c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_08c9: stloc.s 27
-			IL_08cb: br IL_08d2
+			IL_08af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_08b4: stloc.s 24
+			IL_08b6: br IL_08bd
 
-			IL_08d0: stloc.s 27
+			IL_08bb: stloc.s 24
 
-			IL_08d2: ldloc.s 27
-			IL_08d4: stloc.s 34
-			IL_08d6: ldloc.s 34
-			IL_08d8: stloc.s 28
-			IL_08da: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16::.ctor()
-			IL_08df: stloc.s 29
-			IL_08e1: leave IL_08e6
+			IL_08bd: ldloc.s 24
+			IL_08bf: stloc.s 30
+			IL_08c1: ldloc.s 30
+			IL_08c3: stloc.s 25
+			IL_08c5: leave IL_08ca
 		} // end handler
 
-		IL_08e6: ldstr "console"
-		IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08f0: stloc.s 34
-		IL_08f2: ldloc.s 34
-		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08f9: stloc.s 34
-		IL_08fb: ldloc.s 34
-		IL_08fd: ldstr "log"
-		IL_0902: ldloc.0
-		IL_0903: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0908: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_090d: pop
-		IL_090e: ldstr "console"
-		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0918: stloc.s 34
-		IL_091a: ldloc.s 34
-		IL_091c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0921: stloc.s 34
-		IL_0923: ldloc.s 34
-		IL_0925: ldstr "log"
-		IL_092a: ldloc.0
-		IL_092b: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0935: pop
-		IL_0936: ldnull
-		IL_0937: stloc.s 30
-		IL_0939: ret
+		IL_08ca: ldstr "console"
+		IL_08cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08d4: stloc.s 30
+		IL_08d6: ldloc.s 30
+		IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08dd: stloc.s 30
+		IL_08df: ldloc.s 30
+		IL_08e1: ldstr "log"
+		IL_08e6: ldloc.0
+		IL_08e7: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_08ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_08f1: pop
+		IL_08f2: ldstr "console"
+		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08fc: stloc.s 30
+		IL_08fe: ldloc.s 30
+		IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0905: stloc.s 30
+		IL_0907: ldloc.s 30
+		IL_0909: ldstr "log"
+		IL_090e: ldloc.0
+		IL_090f: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0914: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0919: pop
+		IL_091a: ldnull
+		IL_091b: stloc.s 26
+		IL_091d: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup
@@ -2868,7 +2856,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x328f
+		// Method begins at RVA 0x3273
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2940
+						// Method begins at RVA 0x2938
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2937
+					// Method begins at RVA 0x292f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26c4
+				// Method begins at RVA 0x26bc
 				// Header size: 12
 				// Code size: 191 (0xbf)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x292e
+				// Method begins at RVA 0x2926
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -197,7 +197,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2438
+			// Method begins at RVA 0x2430
 			// Header size: 12
 			// Code size: 225 (0xe1)
 			.maxstack 8
@@ -306,7 +306,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x295b
+						// Method begins at RVA 0x2953
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -324,7 +324,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2952
+					// Method begins at RVA 0x294a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -348,7 +348,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2790
+				// Method begins at RVA 0x2788
 				// Header size: 12
 				// Code size: 191 (0xbf)
 				.maxstack 8
@@ -446,7 +446,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2964
+					// Method begins at RVA 0x295c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -470,7 +470,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x285b
+				// Method begins at RVA 0x2853
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -508,7 +508,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2949
+				// Method begins at RVA 0x2941
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -534,7 +534,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2528
+			// Method begins at RVA 0x2520
 			// Header size: 12
 			// Code size: 244 (0xf4)
 			.maxstack 8
@@ -657,7 +657,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x297f
+						// Method begins at RVA 0x2977
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -675,7 +675,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2976
+					// Method begins at RVA 0x296e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -699,7 +699,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2884
+				// Method begins at RVA 0x287c
 				// Header size: 12
 				// Code size: 111 (0x6f)
 				.maxstack 8
@@ -762,7 +762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2988
+					// Method begins at RVA 0x2980
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -786,7 +786,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28ff
+				// Method begins at RVA 0x28f7
 				// Header size: 1
 				// Code size: 37 (0x25)
 				.maxstack 8
@@ -822,7 +822,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x296d
+				// Method begins at RVA 0x2965
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -848,7 +848,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2628
+			// Method begins at RVA 0x2620
 			// Header size: 12
 			// Code size: 144 (0x90)
 			.maxstack 8
@@ -946,7 +946,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2991
+				// Method begins at RVA 0x2989
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -966,7 +966,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x299a
+				// Method begins at RVA 0x2992
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -988,7 +988,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2925
+			// Method begins at RVA 0x291d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1014,7 +1014,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 969 (0x3c9)
+		// Code size: 962 (0x3c2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Iterable/Scope,
@@ -1027,14 +1027,13 @@
 			[7] class [System.Runtime]System.Exception,
 			[8] object,
 			[9] object,
-			[10] class Modules.Map_Constructor_Iterable/Scope/Block_L89C16,
+			[10] object,
 			[11] object,
 			[12] object,
-			[13] object,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[16] bool,
-			[17] object
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[15] bool,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.Map_Constructor_Iterable/Scope::.ctor()
@@ -1042,7 +1041,7 @@
 		IL_0006: nop
 		IL_0007: ldstr "iterator"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0011: stloc.s 12
+		IL_0011: stloc.s 11
 		IL_0013: ldc.i4.1
 		IL_0014: newarr [System.Runtime]System.Object
 		IL_0019: dup
@@ -1060,31 +1059,31 @@
 		IL_0036: ldc.i4.0
 		IL_0037: ldc.i4.1
 		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_003d: stloc.s 13
-		IL_003f: ldloc.s 13
+		IL_003d: stloc.s 12
+		IL_003f: ldloc.s 12
 		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0046: stloc.s 13
+		IL_0046: stloc.s 12
 		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_004d: stloc.s 14
-		IL_004f: ldloc.s 14
-		IL_0051: ldloc.s 12
-		IL_0053: ldloc.s 13
+		IL_004d: stloc.s 13
+		IL_004f: ldloc.s 13
+		IL_0051: ldloc.s 11
+		IL_0053: ldloc.s 12
 		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_005a: pop
-		IL_005b: ldloc.s 14
+		IL_005b: ldloc.s 13
 		IL_005d: stloc.1
 		IL_005e: ldloc.1
 		IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_0064: stloc.s 15
-		IL_0066: ldloc.s 15
+		IL_0064: stloc.s 14
+		IL_0066: ldloc.s 14
 		IL_0068: stloc.2
 		IL_0069: ldstr "console"
 		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0073: stloc.s 13
-		IL_0075: ldloc.s 13
+		IL_0073: stloc.s 12
+		IL_0075: ldloc.s 12
 		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007c: stloc.s 13
-		IL_007e: ldloc.s 13
+		IL_007c: stloc.s 12
+		IL_007e: ldloc.s 12
 		IL_0080: ldstr "log"
 		IL_0085: ldloc.2
 		IL_0086: ldstr "size"
@@ -1093,40 +1092,40 @@
 		IL_0095: pop
 		IL_0096: ldstr "console"
 		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a0: stloc.s 13
-		IL_00a2: ldloc.s 13
+		IL_00a0: stloc.s 12
+		IL_00a2: ldloc.s 12
 		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a9: stloc.s 13
+		IL_00a9: stloc.s 12
 		IL_00ab: ldloc.2
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b1: stloc.s 12
-		IL_00b3: ldloc.s 12
+		IL_00b1: stloc.s 11
+		IL_00b3: ldloc.s 11
 		IL_00b5: ldstr "get"
 		IL_00ba: ldstr "alpha"
 		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c4: stloc.s 12
-		IL_00c6: ldloc.s 13
+		IL_00c4: stloc.s 11
+		IL_00c6: ldloc.s 12
 		IL_00c8: ldstr "log"
-		IL_00cd: ldloc.s 12
+		IL_00cd: ldloc.s 11
 		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d4: pop
 		IL_00d5: ldstr "console"
 		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00df: stloc.s 12
-		IL_00e1: ldloc.s 12
+		IL_00df: stloc.s 11
+		IL_00e1: ldloc.s 11
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: stloc.s 12
+		IL_00e8: stloc.s 11
 		IL_00ea: ldloc.2
 		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f0: stloc.s 13
-		IL_00f2: ldloc.s 13
+		IL_00f0: stloc.s 12
+		IL_00f2: ldloc.s 12
 		IL_00f4: ldstr "get"
 		IL_00f9: ldstr "beta"
 		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0103: stloc.s 13
-		IL_0105: ldloc.s 12
+		IL_0103: stloc.s 12
+		IL_0105: ldloc.s 11
 		IL_0107: ldstr "log"
-		IL_010c: ldloc.s 13
+		IL_010c: ldloc.s 12
 		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0113: pop
 		IL_0114: ldloc.0
@@ -1135,7 +1134,7 @@
 		IL_011b: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
 		IL_0120: ldstr "iterator"
 		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_012a: stloc.s 13
+		IL_012a: stloc.s 12
 		IL_012c: ldc.i4.1
 		IL_012d: newarr [System.Runtime]System.Object
 		IL_0132: dup
@@ -1153,31 +1152,31 @@
 		IL_014f: ldc.i4.0
 		IL_0150: ldc.i4.1
 		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0156: stloc.s 12
-		IL_0158: ldloc.s 12
+		IL_0156: stloc.s 11
+		IL_0158: ldloc.s 11
 		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_015f: stloc.s 12
+		IL_015f: stloc.s 11
 		IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0166: stloc.s 14
-		IL_0168: ldloc.s 14
-		IL_016a: ldloc.s 13
-		IL_016c: ldloc.s 12
+		IL_0166: stloc.s 13
+		IL_0168: ldloc.s 13
+		IL_016a: ldloc.s 12
+		IL_016c: ldloc.s 11
 		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0173: pop
-		IL_0174: ldloc.s 14
+		IL_0174: ldloc.s 13
 		IL_0176: stloc.3
 		IL_0177: ldloc.3
 		IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_017d: stloc.s 15
-		IL_017f: ldloc.s 15
+		IL_017d: stloc.s 14
+		IL_017f: ldloc.s 14
 		IL_0181: stloc.s 4
 		IL_0183: ldstr "console"
 		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018d: stloc.s 12
-		IL_018f: ldloc.s 12
+		IL_018d: stloc.s 11
+		IL_018f: ldloc.s 11
 		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0196: stloc.s 12
-		IL_0198: ldloc.s 12
+		IL_0196: stloc.s 11
+		IL_0198: ldloc.s 11
 		IL_019a: ldstr "log"
 		IL_019f: ldloc.0
 		IL_01a0: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
@@ -1185,11 +1184,11 @@
 		IL_01aa: pop
 		IL_01ab: ldstr "console"
 		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b5: stloc.s 12
-		IL_01b7: ldloc.s 12
+		IL_01b5: stloc.s 11
+		IL_01b7: ldloc.s 11
 		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01be: stloc.s 12
-		IL_01c0: ldloc.s 12
+		IL_01be: stloc.s 11
+		IL_01c0: ldloc.s 11
 		IL_01c2: ldstr "log"
 		IL_01c7: ldloc.s 4
 		IL_01c9: ldstr "size"
@@ -1206,52 +1205,52 @@
 		IL_01ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_01f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_01f6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_01fb: stloc.s 15
-		IL_01fd: ldloc.s 15
+		IL_01fb: stloc.s 14
+		IL_01fd: ldloc.s 14
 		IL_01ff: stloc.s 5
 		IL_0201: ldstr "console"
 		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020b: stloc.s 12
-		IL_020d: ldloc.s 12
+		IL_020b: stloc.s 11
+		IL_020d: ldloc.s 11
 		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0214: stloc.s 12
+		IL_0214: stloc.s 11
 		IL_0216: ldloc.s 5
 		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021d: stloc.s 13
-		IL_021f: ldloc.s 13
+		IL_021d: stloc.s 12
+		IL_021f: ldloc.s 12
 		IL_0221: ldstr "has"
 		IL_0226: ldstr "short"
 		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0230: stloc.s 13
-		IL_0232: ldloc.s 12
+		IL_0230: stloc.s 12
+		IL_0232: ldloc.s 11
 		IL_0234: ldstr "log"
-		IL_0239: ldloc.s 13
+		IL_0239: ldloc.s 12
 		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0240: pop
 		IL_0241: ldstr "console"
 		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024b: stloc.s 13
-		IL_024d: ldloc.s 13
+		IL_024b: stloc.s 12
+		IL_024d: ldloc.s 12
 		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0254: stloc.s 13
+		IL_0254: stloc.s 12
 		IL_0256: ldloc.s 5
 		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025d: stloc.s 12
-		IL_025f: ldloc.s 12
+		IL_025d: stloc.s 11
+		IL_025f: ldloc.s 11
 		IL_0261: ldstr "get"
 		IL_0266: ldstr "short"
 		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0270: stloc.s 12
-		IL_0272: ldloc.s 12
+		IL_0270: stloc.s 11
+		IL_0272: ldloc.s 11
 		IL_0274: ldnull
 		IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_027a: stloc.s 16
-		IL_027c: ldloc.s 16
+		IL_027a: stloc.s 15
+		IL_027c: ldloc.s 15
 		IL_027e: box [System.Runtime]System.Boolean
-		IL_0283: stloc.s 17
-		IL_0285: ldloc.s 13
+		IL_0283: stloc.s 16
+		IL_0285: ldloc.s 12
 		IL_0287: ldstr "log"
-		IL_028c: ldloc.s 17
+		IL_028c: ldloc.s 16
 		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0293: pop
 		IL_0294: ldloc.0
@@ -1260,7 +1259,7 @@
 		IL_029b: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
 		IL_02a0: ldstr "iterator"
 		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02aa: stloc.s 13
+		IL_02aa: stloc.s 12
 		IL_02ac: ldc.i4.1
 		IL_02ad: newarr [System.Runtime]System.Object
 		IL_02b2: dup
@@ -1278,18 +1277,18 @@
 		IL_02cf: ldc.i4.0
 		IL_02d0: ldc.i4.1
 		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02d6: stloc.s 12
-		IL_02d8: ldloc.s 12
+		IL_02d6: stloc.s 11
+		IL_02d8: ldloc.s 11
 		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02df: stloc.s 12
+		IL_02df: stloc.s 11
 		IL_02e1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02e6: stloc.s 14
-		IL_02e8: ldloc.s 14
-		IL_02ea: ldloc.s 13
-		IL_02ec: ldloc.s 12
+		IL_02e6: stloc.s 13
+		IL_02e8: ldloc.s 13
+		IL_02ea: ldloc.s 12
+		IL_02ec: ldloc.s 11
 		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_02f3: pop
-		IL_02f4: ldloc.s 14
+		IL_02f4: ldloc.s 13
 		IL_02f6: stloc.s 6
 		.try
 		{
@@ -1299,16 +1298,16 @@
 			IL_0300: pop
 			IL_0301: ldstr "console"
 			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_030b: stloc.s 12
-			IL_030d: ldloc.s 12
+			IL_030b: stloc.s 11
+			IL_030d: ldloc.s 11
 			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0314: stloc.s 12
-			IL_0316: ldloc.s 12
+			IL_0314: stloc.s 11
+			IL_0316: ldloc.s 11
 			IL_0318: ldstr "log"
 			IL_031d: ldstr "no error"
 			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0327: pop
-			IL_0328: leave IL_039d
+			IL_0328: leave IL_0396
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -1334,42 +1333,40 @@
 			IL_0359: stloc.s 8
 
 			IL_035b: ldloc.s 8
-			IL_035d: stloc.s 12
-			IL_035f: ldloc.s 12
+			IL_035d: stloc.s 11
+			IL_035f: ldloc.s 11
 			IL_0361: stloc.s 9
-			IL_0363: newobj instance void Modules.Map_Constructor_Iterable/Scope/Block_L89C16::.ctor()
-			IL_0368: stloc.s 10
-			IL_036a: ldstr "console"
-			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0374: stloc.s 12
-			IL_0376: ldloc.s 12
-			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_037d: stloc.s 12
-			IL_037f: ldloc.s 12
-			IL_0381: ldstr "log"
-			IL_0386: ldloc.s 9
-			IL_0388: ldstr "name"
-			IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0397: pop
-			IL_0398: leave IL_039d
+			IL_0363: ldstr "console"
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_036d: stloc.s 11
+			IL_036f: ldloc.s 11
+			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0376: stloc.s 11
+			IL_0378: ldloc.s 11
+			IL_037a: ldstr "log"
+			IL_037f: ldloc.s 9
+			IL_0381: ldstr "name"
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0390: pop
+			IL_0391: leave IL_0396
 		} // end handler
 
-		IL_039d: ldstr "console"
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a7: stloc.s 12
-		IL_03a9: ldloc.s 12
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b0: stloc.s 12
-		IL_03b2: ldloc.s 12
-		IL_03b4: ldstr "log"
-		IL_03b9: ldloc.0
-		IL_03ba: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03c4: pop
-		IL_03c5: ldnull
-		IL_03c6: stloc.s 11
-		IL_03c8: ret
+		IL_0396: ldstr "console"
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a0: stloc.s 11
+		IL_03a2: ldloc.s 11
+		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a9: stloc.s 11
+		IL_03ab: ldloc.s 11
+		IL_03ad: ldstr "log"
+		IL_03b2: ldloc.0
+		IL_03b3: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03bd: pop
+		IL_03be: ldnull
+		IL_03bf: stloc.s 10
+		IL_03c1: ret
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable
@@ -1381,7 +1378,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29a3
+		// Method begins at RVA 0x299b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Prototype_Surface.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2631
+				// Method begins at RVA 0x2629
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x263a
+				// Method begins at RVA 0x2632
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2628
+			// Method begins at RVA 0x2620
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1466 (0x5ba)
+		// Code size: 1459 (0x5b3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Prototype_Surface/Scope,
@@ -92,15 +92,14 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Map_Constructor_Prototype_Surface/Scope/Block_L26C12,
+			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
-			[11] object,
-			[12] bool,
-			[13] object,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.Map,
-			[15] object
+			[11] bool,
+			[12] object,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Map,
+			[14] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -121,166 +120,166 @@
 		IL_0047: nop
 		IL_0048: ldstr "console"
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0052: stloc.s 9
-		IL_0054: ldloc.s 9
+		IL_0052: stloc.s 8
+		IL_0054: ldloc.s 8
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: stloc.s 9
+		IL_005b: stloc.s 8
 		IL_005d: ldstr "globalThis"
 		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: stloc.s 10
-		IL_0069: ldloc.s 10
+		IL_0067: stloc.s 9
+		IL_0069: ldloc.s 9
 		IL_006b: ldstr "Map"
 		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0075: stloc.s 10
+		IL_0075: stloc.s 9
 		IL_0077: ldstr "Map"
 		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0081: stloc.s 11
-		IL_0083: ldloc.s 10
-		IL_0085: ldloc.s 11
+		IL_0081: stloc.s 10
+		IL_0083: ldloc.s 9
+		IL_0085: ldloc.s 10
 		IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_008c: stloc.s 12
-		IL_008e: ldloc.s 12
+		IL_008c: stloc.s 11
+		IL_008e: ldloc.s 11
 		IL_0090: box [System.Runtime]System.Boolean
-		IL_0095: stloc.s 13
-		IL_0097: ldloc.s 9
+		IL_0095: stloc.s 12
+		IL_0097: ldloc.s 8
 		IL_0099: ldstr "log"
-		IL_009e: ldloc.s 13
+		IL_009e: ldloc.s 12
 		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00a5: pop
 		IL_00a6: ldstr "console"
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b0: stloc.s 9
-		IL_00b2: ldloc.s 9
+		IL_00b0: stloc.s 8
+		IL_00b2: ldloc.s 8
 		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b9: stloc.s 9
+		IL_00b9: stloc.s 8
 		IL_00bb: ldstr "Map"
 		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c5: stloc.s 11
-		IL_00c7: ldloc.s 11
+		IL_00c5: stloc.s 10
+		IL_00c7: ldloc.s 10
 		IL_00c9: ldstr "prototype"
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d3: stloc.s 11
-		IL_00d5: ldloc.s 11
+		IL_00d3: stloc.s 10
+		IL_00d5: ldloc.s 10
 		IL_00d7: ldstr "constructor"
 		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e1: stloc.s 11
+		IL_00e1: stloc.s 10
 		IL_00e3: ldstr "Map"
 		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ed: stloc.s 10
-		IL_00ef: ldloc.s 11
-		IL_00f1: ldloc.s 10
+		IL_00ed: stloc.s 9
+		IL_00ef: ldloc.s 10
+		IL_00f1: ldloc.s 9
 		IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f8: stloc.s 12
-		IL_00fa: ldloc.s 12
+		IL_00f8: stloc.s 11
+		IL_00fa: ldloc.s 11
 		IL_00fc: box [System.Runtime]System.Boolean
-		IL_0101: stloc.s 13
-		IL_0103: ldloc.s 9
+		IL_0101: stloc.s 12
+		IL_0103: ldloc.s 8
 		IL_0105: ldstr "log"
-		IL_010a: ldloc.s 13
+		IL_010a: ldloc.s 12
 		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0111: pop
 		IL_0112: ldstr "console"
 		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011c: stloc.s 9
-		IL_011e: ldloc.s 9
+		IL_011c: stloc.s 8
+		IL_011e: ldloc.s 8
 		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0125: stloc.s 9
+		IL_0125: stloc.s 8
 		IL_0127: ldstr "Map"
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0131: stloc.s 10
+		IL_0131: stloc.s 9
 		IL_0133: ldstr "Function"
 		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013d: stloc.s 11
-		IL_013f: ldloc.s 10
-		IL_0141: ldloc.s 11
+		IL_013d: stloc.s 10
+		IL_013f: ldloc.s 9
+		IL_0141: ldloc.s 10
 		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0148: stloc.s 12
-		IL_014a: ldloc.s 12
+		IL_0148: stloc.s 11
+		IL_014a: ldloc.s 11
 		IL_014c: box [System.Runtime]System.Boolean
-		IL_0151: stloc.s 13
-		IL_0153: ldloc.s 9
+		IL_0151: stloc.s 12
+		IL_0153: ldloc.s 8
 		IL_0155: ldstr "log"
-		IL_015a: ldloc.s 13
+		IL_015a: ldloc.s 12
 		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0161: pop
 		IL_0162: ldstr "console"
 		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016c: stloc.s 9
-		IL_016e: ldloc.s 9
+		IL_016c: stloc.s 8
+		IL_016e: ldloc.s 8
 		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0175: stloc.s 9
+		IL_0175: stloc.s 8
 		IL_0177: ldstr "Map"
 		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0181: stloc.s 11
-		IL_0183: ldloc.s 11
+		IL_0181: stloc.s 10
+		IL_0183: ldloc.s 10
 		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_018a: stloc.s 11
+		IL_018a: stloc.s 10
 		IL_018c: ldstr "Function"
 		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0196: stloc.s 10
-		IL_0198: ldloc.s 10
+		IL_0196: stloc.s 9
+		IL_0198: ldloc.s 9
 		IL_019a: ldstr "prototype"
 		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: stloc.s 10
-		IL_01a6: ldloc.s 11
-		IL_01a8: ldloc.s 10
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 10
+		IL_01a8: ldloc.s 9
 		IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01af: stloc.s 12
-		IL_01b1: ldloc.s 12
+		IL_01af: stloc.s 11
+		IL_01b1: ldloc.s 11
 		IL_01b3: box [System.Runtime]System.Boolean
-		IL_01b8: stloc.s 13
-		IL_01ba: ldloc.s 9
+		IL_01b8: stloc.s 12
+		IL_01ba: ldloc.s 8
 		IL_01bc: ldstr "log"
-		IL_01c1: ldloc.s 13
+		IL_01c1: ldloc.s 12
 		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01c8: pop
 		IL_01c9: ldstr "console"
 		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d3: stloc.s 9
-		IL_01d5: ldloc.s 9
+		IL_01d3: stloc.s 8
+		IL_01d5: ldloc.s 8
 		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dc: stloc.s 9
+		IL_01dc: stloc.s 8
 		IL_01de: ldstr "Map"
 		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e8: stloc.s 10
-		IL_01ea: ldloc.s 10
+		IL_01e8: stloc.s 9
+		IL_01ea: ldloc.s 9
 		IL_01ec: ldstr "prototype"
 		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f6: stloc.s 10
-		IL_01f8: ldloc.s 10
+		IL_01f6: stloc.s 9
+		IL_01f8: ldloc.s 9
 		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_01ff: stloc.s 10
+		IL_01ff: stloc.s 9
 		IL_0201: ldstr "Object"
 		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020b: stloc.s 11
-		IL_020d: ldloc.s 11
+		IL_020b: stloc.s 10
+		IL_020d: ldloc.s 10
 		IL_020f: ldstr "prototype"
 		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0219: stloc.s 11
-		IL_021b: ldloc.s 10
-		IL_021d: ldloc.s 11
+		IL_0219: stloc.s 10
+		IL_021b: ldloc.s 9
+		IL_021d: ldloc.s 10
 		IL_021f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0224: stloc.s 12
-		IL_0226: ldloc.s 12
+		IL_0224: stloc.s 11
+		IL_0226: ldloc.s 11
 		IL_0228: box [System.Runtime]System.Boolean
-		IL_022d: stloc.s 13
-		IL_022f: ldloc.s 9
+		IL_022d: stloc.s 12
+		IL_022f: ldloc.s 8
 		IL_0231: ldstr "log"
-		IL_0236: ldloc.s 13
+		IL_0236: ldloc.s 12
 		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_023d: pop
 		IL_023e: ldstr "Map"
 		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0248: stloc.s 9
-		IL_024a: ldloc.s 9
+		IL_0248: stloc.s 8
+		IL_024a: ldloc.s 8
 		IL_024c: ldstr "prototype"
 		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0256: stloc.s 9
-		IL_0258: ldloc.s 9
+		IL_0256: stloc.s 8
+		IL_0258: ldloc.s 8
 		IL_025a: stloc.1
 		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0260: stloc.s 9
-		IL_0262: ldloc.s 9
+		IL_0260: stloc.s 8
+		IL_0262: ldloc.s 8
 		IL_0264: ldstr "descriptor"
 		IL_0269: ldloc.1
 		IL_026a: ldc.i4.0
@@ -288,11 +287,11 @@
 		IL_0270: pop
 		IL_0271: ldstr "console"
 		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027b: stloc.s 9
-		IL_027d: ldloc.s 9
+		IL_027b: stloc.s 8
+		IL_027d: ldloc.s 8
 		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0284: stloc.s 9
-		IL_0286: ldloc.s 9
+		IL_0284: stloc.s 8
+		IL_0286: ldloc.s 8
 		IL_0288: ldstr "log"
 		IL_028d: ldloc.1
 		IL_028e: ldstr "writable"
@@ -301,11 +300,11 @@
 		IL_029d: pop
 		IL_029e: ldstr "console"
 		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a8: stloc.s 9
-		IL_02aa: ldloc.s 9
+		IL_02a8: stloc.s 8
+		IL_02aa: ldloc.s 8
 		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b1: stloc.s 9
-		IL_02b3: ldloc.s 9
+		IL_02b1: stloc.s 8
+		IL_02b3: ldloc.s 8
 		IL_02b5: ldstr "log"
 		IL_02ba: ldloc.1
 		IL_02bb: ldstr "enumerable"
@@ -314,11 +313,11 @@
 		IL_02ca: pop
 		IL_02cb: ldstr "console"
 		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d5: stloc.s 9
-		IL_02d7: ldloc.s 9
+		IL_02d5: stloc.s 8
+		IL_02d7: ldloc.s 8
 		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02de: stloc.s 9
-		IL_02e0: ldloc.s 9
+		IL_02de: stloc.s 8
+		IL_02e0: ldloc.s 8
 		IL_02e2: ldstr "log"
 		IL_02e7: ldloc.1
 		IL_02e8: ldstr "configurable"
@@ -326,12 +325,12 @@
 		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_02f7: pop
 		IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
-		IL_02fd: stloc.s 14
-		IL_02ff: ldloc.s 14
+		IL_02fd: stloc.s 13
+		IL_02ff: ldloc.s 13
 		IL_0301: stloc.2
 		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0307: stloc.s 9
-		IL_0309: ldloc.s 9
+		IL_0307: stloc.s 8
+		IL_0309: ldloc.s 8
 		IL_030b: ldstr "map"
 		IL_0310: ldloc.2
 		IL_0311: ldc.i4.0
@@ -339,95 +338,95 @@
 		IL_0317: pop
 		IL_0318: ldstr "console"
 		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0322: stloc.s 9
-		IL_0324: ldloc.s 9
+		IL_0322: stloc.s 8
+		IL_0324: ldloc.s 8
 		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032b: stloc.s 9
+		IL_032b: stloc.s 8
 		IL_032d: ldloc.2
 		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0333: stloc.s 11
+		IL_0333: stloc.s 10
 		IL_0335: ldstr "Map"
 		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_033f: stloc.s 10
-		IL_0341: ldloc.s 10
+		IL_033f: stloc.s 9
+		IL_0341: ldloc.s 9
 		IL_0343: ldstr "prototype"
 		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_034d: stloc.s 10
-		IL_034f: ldloc.s 11
-		IL_0351: ldloc.s 10
+		IL_034d: stloc.s 9
+		IL_034f: ldloc.s 10
+		IL_0351: ldloc.s 9
 		IL_0353: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0358: stloc.s 12
-		IL_035a: ldloc.s 12
+		IL_0358: stloc.s 11
+		IL_035a: ldloc.s 11
 		IL_035c: box [System.Runtime]System.Boolean
-		IL_0361: stloc.s 13
-		IL_0363: ldloc.s 9
+		IL_0361: stloc.s 12
+		IL_0363: ldloc.s 8
 		IL_0365: ldstr "log"
-		IL_036a: ldloc.s 13
+		IL_036a: ldloc.s 12
 		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0371: pop
 		IL_0372: ldstr "console"
 		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037c: stloc.s 9
-		IL_037e: ldloc.s 9
+		IL_037c: stloc.s 8
+		IL_037e: ldloc.s 8
 		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0385: stloc.s 9
+		IL_0385: stloc.s 8
 		IL_0387: ldloc.2
-		IL_0388: stloc.s 14
+		IL_0388: stloc.s 13
 		IL_038a: ldstr "Map"
 		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0394: stloc.s 10
-		IL_0396: ldloc.s 14
-		IL_0398: ldloc.s 10
+		IL_0394: stloc.s 9
+		IL_0396: ldloc.s 13
+		IL_0398: ldloc.s 9
 		IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_039f: stloc.s 12
-		IL_03a1: ldloc.s 12
+		IL_039f: stloc.s 11
+		IL_03a1: ldloc.s 11
 		IL_03a3: box [System.Runtime]System.Boolean
-		IL_03a8: stloc.s 13
-		IL_03aa: ldloc.s 9
+		IL_03a8: stloc.s 12
+		IL_03aa: ldloc.s 8
 		IL_03ac: ldstr "log"
-		IL_03b1: ldloc.s 13
+		IL_03b1: ldloc.s 12
 		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_03b8: pop
 		IL_03b9: ldstr "console"
 		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c3: stloc.s 9
-		IL_03c5: ldloc.s 9
+		IL_03c3: stloc.s 8
+		IL_03c5: ldloc.s 8
 		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03cc: stloc.s 9
+		IL_03cc: stloc.s 8
 		IL_03ce: ldloc.2
 		IL_03cf: ldstr "constructor"
 		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d9: stloc.s 10
+		IL_03d9: stloc.s 9
 		IL_03db: ldstr "Map"
 		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e5: stloc.s 11
-		IL_03e7: ldloc.s 10
-		IL_03e9: ldloc.s 11
+		IL_03e5: stloc.s 10
+		IL_03e7: ldloc.s 9
+		IL_03e9: ldloc.s 10
 		IL_03eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03f0: stloc.s 12
-		IL_03f2: ldloc.s 12
+		IL_03f0: stloc.s 11
+		IL_03f2: ldloc.s 11
 		IL_03f4: box [System.Runtime]System.Boolean
-		IL_03f9: stloc.s 13
-		IL_03fb: ldloc.s 9
+		IL_03f9: stloc.s 12
+		IL_03fb: ldloc.s 8
 		IL_03fd: ldstr "log"
-		IL_0402: ldloc.s 13
+		IL_0402: ldloc.s 12
 		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0409: pop
 		IL_040a: ldstr "Map"
 		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0414: stloc.s 9
-		IL_0416: ldloc.s 9
+		IL_0414: stloc.s 8
+		IL_0416: ldloc.s 8
 		IL_0418: ldstr "prototype"
 		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0422: stloc.s 9
-		IL_0424: ldloc.s 9
+		IL_0422: stloc.s 8
+		IL_0424: ldloc.s 8
 		IL_0426: ldstr "set"
 		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0430: stloc.s 9
-		IL_0432: ldloc.s 9
+		IL_0430: stloc.s 8
+		IL_0432: ldloc.s 8
 		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0439: stloc.s 9
-		IL_043b: ldloc.s 9
+		IL_0439: stloc.s 8
+		IL_043b: ldloc.s 8
 		IL_043d: ldstr "call"
 		IL_0442: ldloc.2
 		IL_0443: ldstr "answer"
@@ -437,33 +436,33 @@
 		IL_045b: pop
 		IL_045c: ldstr "console"
 		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0466: stloc.s 9
-		IL_0468: ldloc.s 9
+		IL_0466: stloc.s 8
+		IL_0468: ldloc.s 8
 		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046f: stloc.s 9
+		IL_046f: stloc.s 8
 		IL_0471: ldstr "Map"
 		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_047b: stloc.s 11
-		IL_047d: ldloc.s 11
+		IL_047b: stloc.s 10
+		IL_047d: ldloc.s 10
 		IL_047f: ldstr "prototype"
 		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0489: stloc.s 11
-		IL_048b: ldloc.s 11
+		IL_0489: stloc.s 10
+		IL_048b: ldloc.s 10
 		IL_048d: ldstr "get"
 		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0497: stloc.s 11
-		IL_0499: ldloc.s 11
+		IL_0497: stloc.s 10
+		IL_0499: ldloc.s 10
 		IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04a0: stloc.s 11
-		IL_04a2: ldloc.s 11
+		IL_04a0: stloc.s 10
+		IL_04a2: ldloc.s 10
 		IL_04a4: ldstr "call"
 		IL_04a9: ldloc.2
 		IL_04aa: ldstr "answer"
 		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_04b4: stloc.s 11
-		IL_04b6: ldloc.s 9
+		IL_04b4: stloc.s 10
+		IL_04b6: ldloc.s 8
 		IL_04b8: ldstr "log"
-		IL_04bd: ldloc.s 11
+		IL_04bd: ldloc.s 10
 		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_04c4: pop
 		.try
@@ -471,12 +470,12 @@
 			IL_04c5: nop
 			IL_04c6: ldstr "Map"
 			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04d0: stloc.s 11
-			IL_04d2: ldloc.s 11
+			IL_04d0: stloc.s 10
+			IL_04d2: ldloc.s 10
 			IL_04d4: stloc.3
 			IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_04da: stloc.s 11
-			IL_04dc: ldloc.s 11
+			IL_04da: stloc.s 10
+			IL_04dc: ldloc.s 10
 			IL_04de: ldstr "mapCtor"
 			IL_04e3: ldloc.3
 			IL_04e4: ldc.i4.0
@@ -488,16 +487,16 @@
 			IL_04f6: pop
 			IL_04f7: ldstr "console"
 			IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0501: stloc.s 11
-			IL_0503: ldloc.s 11
+			IL_0501: stloc.s 10
+			IL_0503: ldloc.s 10
 			IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_050a: stloc.s 11
-			IL_050c: ldloc.s 11
+			IL_050a: stloc.s 10
+			IL_050c: ldloc.s 10
 			IL_050e: ldstr "log"
 			IL_0513: ldstr "no-throw"
 			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_051d: pop
-			IL_051e: leave IL_05b6
+			IL_051e: leave IL_05af
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -523,40 +522,38 @@
 			IL_054f: stloc.s 5
 
 			IL_0551: ldloc.s 5
-			IL_0553: stloc.s 11
-			IL_0555: ldloc.s 11
+			IL_0553: stloc.s 10
+			IL_0555: ldloc.s 10
 			IL_0557: stloc.s 6
-			IL_0559: newobj instance void Modules.Map_Constructor_Prototype_Surface/Scope/Block_L26C12::.ctor()
-			IL_055e: stloc.s 7
-			IL_0560: ldstr "console"
-			IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_056a: stloc.s 11
-			IL_056c: ldloc.s 11
-			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0573: stloc.s 11
-			IL_0575: ldloc.s 6
-			IL_0577: ldstr "name"
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0581: ldstr ": "
-			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_058b: stloc.s 15
-			IL_058d: ldloc.s 15
-			IL_058f: ldloc.s 6
-			IL_0591: ldstr "message"
-			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05a0: stloc.s 15
-			IL_05a2: ldloc.s 11
-			IL_05a4: ldstr "log"
-			IL_05a9: ldloc.s 15
-			IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05b0: pop
-			IL_05b1: leave IL_05b6
+			IL_0559: ldstr "console"
+			IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0563: stloc.s 10
+			IL_0565: ldloc.s 10
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_056c: stloc.s 10
+			IL_056e: ldloc.s 6
+			IL_0570: ldstr "name"
+			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057a: ldstr ": "
+			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0584: stloc.s 14
+			IL_0586: ldloc.s 14
+			IL_0588: ldloc.s 6
+			IL_058a: ldstr "message"
+			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0599: stloc.s 14
+			IL_059b: ldloc.s 10
+			IL_059d: ldstr "log"
+			IL_05a2: ldloc.s 14
+			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05a9: pop
+			IL_05aa: leave IL_05af
 		} // end handler
 
-		IL_05b6: ldnull
-		IL_05b7: stloc.s 8
-		IL_05b9: ret
+		IL_05af: ldnull
+		IL_05b0: stloc.s 7
+		IL_05b2: ret
 	} // end of method Map_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Prototype_Surface
@@ -568,7 +565,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2643
+		// Method begins at RVA 0x263b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3396
+						// Method begins at RVA 0x3350
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x338d
+					// Method begins at RVA 0x3347
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3384
+				// Method begins at RVA 0x333e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,22 +103,20 @@
 			)
 			// Method begins at RVA 0x2654
 			// Header size: 12
-			// Code size: 280 (0x118)
+			// Code size: 266 (0x10a)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0,
-				[1] float64,
+				[0] float64,
+				[1] object,
 				[2] object,
-				[3] object,
-				[4] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0/Block_L221C1,
-				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[3] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[4] object,
+				[5] float64,
 				[6] object,
-				[7] float64,
-				[8] object,
-				[9] object[],
-				[10] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
-				[11] float64,
-				[12] object
+				[7] object[],
+				[8] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[9] float64,
+				[10] object
 			)
 
 			IL_0000: ldarg.3
@@ -128,101 +126,98 @@
 			IL_000f: box [System.Runtime]System.Double
 			IL_0014: starg.s timeLimitSeconds
 
-			IL_0016: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0::.ctor()
-			IL_001b: stloc.0
-			IL_001c: ldc.r8 0.0
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0031: stloc.s 6
-			IL_0033: ldloc.s 6
-			IL_0035: ldstr "now"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003f: stloc.s 6
-			IL_0041: ldloc.s 6
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: stloc.s 6
-			IL_0047: ldarg.0
-			IL_0048: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 6
-			IL_0051: ldarg.3
-			IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0057: ldloc.s 7
-			IL_0059: mul
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_005f: stloc.s 8
-			IL_0061: ldloc.s 8
-			IL_0063: stloc.3
-			// loop start (head: IL_0064)
-				IL_0064: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23/Scope/Block_L214C0/Block_L221C1::.ctor()
-				IL_0069: stloc.s 4
-				IL_006b: ldc.i4.1
-				IL_006c: newarr [System.Runtime]System.Object
-				IL_0071: dup
-				IL_0072: ldc.i4.0
-				IL_0073: ldarg.0
-				IL_0074: stelem.ref
-				IL_0075: stloc.s 9
-				IL_0077: ldloc.s 9
-				IL_0079: ldc.i4.1
-				IL_007a: newarr [System.Runtime]System.Object
-				IL_007f: dup
-				IL_0080: ldc.i4.0
-				IL_0081: ldarg.2
-				IL_0082: stelem.ref
-				IL_0083: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_0088: ldarg.2
-				IL_0089: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
-				IL_008e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_0093: stloc.s 10
-				IL_0095: ldloc.s 10
-				IL_0097: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_009c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_00a1: ldstr "prototype"
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
-				IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_00b0: ldloc.s 10
-				IL_00b2: stloc.s 5
-				IL_00b4: ldloc.s 5
-				IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve>(!!0)
-				IL_00bb: stloc.s 10
-				IL_00bd: ldloc.s 10
-				IL_00bf: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
-				IL_00c4: pop
-				IL_00c5: ldloc.1
-				IL_00c6: ldc.r8 1
-				IL_00cf: add
-				IL_00d0: stloc.1
-				IL_00d1: ldarg.0
-				IL_00d2: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00dc: stloc.s 6
-				IL_00de: ldloc.s 6
-				IL_00e0: ldstr "now"
-				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00ea: stloc.s 6
-				IL_00ec: ldloc.s 6
-				IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f3: stloc.s 7
-				IL_00f5: ldloc.3
-				IL_00f6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00fb: stloc.s 11
-				IL_00fd: ldloc.s 7
-				IL_00ff: ldloc.s 11
-				IL_0101: clt
-				IL_0103: brfalse IL_010d
+			IL_0016: ldc.r8 0.0
+			IL_001f: stloc.0
+			IL_0020: ldarg.0
+			IL_0021: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_002b: stloc.s 4
+			IL_002d: ldloc.s 4
+			IL_002f: ldstr "now"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0039: stloc.s 4
+			IL_003b: ldloc.s 4
+			IL_003d: stloc.1
+			IL_003e: ldloc.1
+			IL_003f: stloc.s 4
+			IL_0041: ldarg.0
+			IL_0042: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
+			IL_0047: stloc.s 5
+			IL_0049: ldloc.s 4
+			IL_004b: ldarg.3
+			IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0051: ldloc.s 5
+			IL_0053: mul
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0059: stloc.s 6
+			IL_005b: ldloc.s 6
+			IL_005d: stloc.2
+			// loop start (head: IL_005e)
+				IL_005e: nop
+				IL_005f: ldc.i4.1
+				IL_0060: newarr [System.Runtime]System.Object
+				IL_0065: dup
+				IL_0066: ldc.i4.0
+				IL_0067: ldarg.0
+				IL_0068: stelem.ref
+				IL_0069: stloc.s 7
+				IL_006b: ldloc.s 7
+				IL_006d: ldc.i4.1
+				IL_006e: newarr [System.Runtime]System.Object
+				IL_0073: dup
+				IL_0074: ldc.i4.0
+				IL_0075: ldarg.2
+				IL_0076: stelem.ref
+				IL_0077: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_007c: ldarg.2
+				IL_007d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
+				IL_0082: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_0087: stloc.s 8
+				IL_0089: ldloc.s 8
+				IL_008b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0090: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_0095: ldstr "prototype"
+				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::GetProperty(object, string)
+				IL_009f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_00a4: ldloc.s 8
+				IL_00a6: stloc.3
+				IL_00a7: ldloc.3
+				IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve>(!!0)
+				IL_00ad: stloc.s 8
+				IL_00af: ldloc.s 8
+				IL_00b1: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
+				IL_00b6: pop
+				IL_00b7: ldloc.0
+				IL_00b8: ldc.r8 1
+				IL_00c1: add
+				IL_00c2: stloc.0
+				IL_00c3: ldarg.0
+				IL_00c4: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ce: stloc.s 4
+				IL_00d0: ldloc.s 4
+				IL_00d2: ldstr "now"
+				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_00dc: stloc.s 4
+				IL_00de: ldloc.s 4
+				IL_00e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00e5: stloc.s 5
+				IL_00e7: ldloc.2
+				IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ed: stloc.s 9
+				IL_00ef: ldloc.s 5
+				IL_00f1: ldloc.s 9
+				IL_00f3: clt
+				IL_00f5: brfalse IL_00ff
 
-				IL_0108: br IL_0064
+				IL_00fa: br IL_005e
 			// end loop
 
-			IL_010d: ldloc.1
-			IL_010e: box [System.Runtime]System.Double
-			IL_0113: stloc.s 12
-			IL_0115: ldloc.s 12
-			IL_0117: ret
+			IL_00ff: ldloc.0
+			IL_0100: box [System.Runtime]System.Double
+			IL_0105: stloc.s 10
+			IL_0107: ldloc.s 10
+			IL_0109: ret
 		} // end of method ArrowFunction_L213C23::__js_call__
 
 	} // end of class ArrowFunction_L213C23
@@ -253,7 +248,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x339f
+				// Method begins at RVA 0x3359
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -280,7 +275,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2778
+			// Method begins at RVA 0x276c
 			// Header size: 12
 			// Code size: 451 (0x1c3)
 			.maxstack 8
@@ -462,7 +457,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3276
+				// Method begins at RVA 0x3230
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -482,7 +477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x327f
+				// Method begins at RVA 0x3239
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -502,7 +497,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3288
+				// Method begins at RVA 0x3242
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -530,7 +525,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32a3
+						// Method begins at RVA 0x325d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -554,7 +549,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x32b5
+							// Method begins at RVA 0x326f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -572,7 +567,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32ac
+						// Method begins at RVA 0x3266
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -590,7 +585,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x329a
+					// Method begins at RVA 0x3254
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -618,7 +613,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x32d0
+							// Method begins at RVA 0x328a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -636,7 +631,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32c7
+						// Method begins at RVA 0x3281
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -654,7 +649,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32be
+					// Method begins at RVA 0x3278
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -678,7 +673,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x32e2
+						// Method begins at RVA 0x329c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -696,7 +691,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32d9
+					// Method begins at RVA 0x3293
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +709,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3291
+				// Method begins at RVA 0x324b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -734,7 +729,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32eb
+				// Method begins at RVA 0x32a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -758,7 +753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32fd
+					// Method begins at RVA 0x32b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f4
+				// Method begins at RVA 0x32ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -804,7 +799,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b0
+			// Method begins at RVA 0x29a4
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -853,7 +848,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c84
+			// Method begins at RVA 0x2c60
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -923,27 +918,24 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a48
+			// Method begins at RVA 0x2a3c
 			// Header size: 12
-			// Code size: 560 (0x230)
+			// Code size: 534 (0x216)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26,
+				[0] float64,
 				[1] float64,
 				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75,
+				[5] float64,
 				[6] float64,
 				[7] float64,
 				[8] float64,
 				[9] float64,
 				[10] float64,
 				[11] float64,
-				[12] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29,
-				[13] float64,
-				[14] float64,
-				[15] float64
+				[12] float64
 			)
 
 			IL_0000: ldarg.2
@@ -956,266 +948,260 @@
 			IL_0013: ldc.r8 2
 			IL_001c: div
 			IL_001d: cgt
-			IL_001f: brfalse IL_013d
+			IL_001f: brfalse IL_012a
 
-			IL_0024: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
-			IL_0029: stloc.0
-			IL_002a: ldarg.1
-			IL_002b: ldc.r8 32
-			IL_0034: ldarg.2
-			IL_0035: mul
-			IL_0036: add
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: stloc.s 15
-			IL_003b: ldloc.s 15
-			IL_003d: ldarg.3
-			IL_003e: cgt
-			IL_0040: brfalse IL_006b
+			IL_0024: ldarg.1
+			IL_0025: ldc.r8 32
+			IL_002e: ldarg.2
+			IL_002f: mul
+			IL_0030: add
+			IL_0031: stloc.0
+			IL_0032: ldloc.0
+			IL_0033: stloc.s 12
+			IL_0035: ldloc.s 12
+			IL_0037: ldarg.3
+			IL_0038: cgt
+			IL_003a: brfalse IL_0065
 
-			IL_0045: ldarg.1
-			IL_0046: stloc.2
-			// loop start (head: IL_0047)
-				IL_0047: ldloc.2
-				IL_0048: stloc.s 15
-				IL_004a: ldloc.s 15
-				IL_004c: ldarg.3
-				IL_004d: clt
-				IL_004f: brfalse IL_0069
+			IL_003f: ldarg.1
+			IL_0040: stloc.1
+			// loop start (head: IL_0041)
+				IL_0041: ldloc.1
+				IL_0042: stloc.s 12
+				IL_0044: ldloc.s 12
+				IL_0046: ldarg.3
+				IL_0047: clt
+				IL_0049: brfalse IL_0063
 
-				IL_0054: ldarg.0
-				IL_0055: ldloc.2
-				IL_0056: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-				IL_005b: pop
-				IL_005c: ldloc.2
-				IL_005d: ldarg.2
-				IL_005e: add
-				IL_005f: stloc.s 15
-				IL_0061: ldloc.s 15
-				IL_0063: stloc.2
-				IL_0064: br IL_0047
+				IL_004e: ldarg.0
+				IL_004f: ldloc.1
+				IL_0050: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+				IL_0055: pop
+				IL_0056: ldloc.1
+				IL_0057: ldarg.2
+				IL_0058: add
+				IL_0059: stloc.s 12
+				IL_005b: ldloc.s 12
+				IL_005d: stloc.1
+				IL_005e: br IL_0041
 			// end loop
 
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_0063: ldnull
+			IL_0064: ret
 
-			IL_006b: ldarg.3
-			IL_006c: conv.i4
-			IL_006d: conv.u4
-			IL_006e: ldc.r8 5
-			IL_0077: conv.i4
-			IL_0078: shr.un
-			IL_0079: conv.r.un
-			IL_007a: stloc.s 15
-			IL_007c: ldloc.s 15
-			IL_007e: stloc.3
-			IL_007f: ldarg.1
-			IL_0080: stloc.s 4
-			// loop start (head: IL_0082)
-				IL_0082: ldloc.s 4
-				IL_0084: stloc.s 15
-				IL_0086: ldloc.s 15
-				IL_0088: ldloc.1
-				IL_0089: clt
-				IL_008b: brfalse IL_013b
+			IL_0065: ldarg.3
+			IL_0066: conv.i4
+			IL_0067: conv.u4
+			IL_0068: ldc.r8 5
+			IL_0071: conv.i4
+			IL_0072: shr.un
+			IL_0073: conv.r.un
+			IL_0074: stloc.s 12
+			IL_0076: ldloc.s 12
+			IL_0078: stloc.2
+			IL_0079: ldarg.1
+			IL_007a: stloc.3
+			// loop start (head: IL_007b)
+				IL_007b: ldloc.3
+				IL_007c: stloc.s 12
+				IL_007e: ldloc.s 12
+				IL_0080: ldloc.0
+				IL_0081: clt
+				IL_0083: brfalse IL_0128
 
-				IL_0090: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
-				IL_0095: stloc.s 5
-				IL_0097: ldloc.s 4
-				IL_0099: stloc.s 15
-				IL_009b: ldloc.s 15
-				IL_009d: conv.i4
-				IL_009e: conv.u4
-				IL_009f: ldc.r8 5
-				IL_00a8: conv.i4
-				IL_00a9: shr.un
-				IL_00aa: conv.r.un
-				IL_00ab: stloc.s 15
-				IL_00ad: ldloc.s 15
-				IL_00af: stloc.s 6
-				IL_00b1: ldloc.s 4
-				IL_00b3: stloc.s 15
-				IL_00b5: ldloc.s 15
-				IL_00b7: conv.i4
-				IL_00b8: ldc.r8 31
-				IL_00c1: conv.i4
-				IL_00c2: and
-				IL_00c3: conv.r8
-				IL_00c4: stloc.s 15
-				IL_00c6: ldloc.s 15
-				IL_00c8: stloc.s 7
-				IL_00ca: ldc.r8 1
-				IL_00d3: conv.i4
-				IL_00d4: ldloc.s 7
-				IL_00d6: conv.i4
-				IL_00d7: shl
-				IL_00d8: conv.r8
-				IL_00d9: stloc.s 15
-				IL_00db: ldloc.s 15
-				IL_00dd: stloc.s 8
-				// loop start (head: IL_00df)
-					IL_00df: nop
-					IL_00e0: ldarg.0
-					IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_00e6: ldloc.s 6
-					IL_00e8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_00ed: stloc.s 15
-					IL_00ef: ldloc.s 15
-					IL_00f1: stloc.s 15
-					IL_00f3: ldloc.s 15
-					IL_00f5: conv.i4
-					IL_00f6: ldloc.s 8
-					IL_00f8: conv.i4
-					IL_00f9: or
-					IL_00fa: conv.r8
-					IL_00fb: stloc.s 15
-					IL_00fd: ldarg.0
-					IL_00fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_0103: ldloc.s 6
-					IL_0105: ldloc.s 15
-					IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_010c: ldloc.s 6
-					IL_010e: ldarg.2
-					IL_010f: add
-					IL_0110: stloc.s 15
-					IL_0112: ldloc.s 15
-					IL_0114: stloc.s 6
-					IL_0116: ldloc.s 6
-					IL_0118: stloc.s 15
-					IL_011a: ldloc.s 15
-					IL_011c: ldloc.3
-					IL_011d: cgt
-					IL_011f: ldc.i4.0
-					IL_0120: ceq
-					IL_0122: brfalse IL_012c
+				IL_0088: ldloc.3
+				IL_0089: stloc.s 12
+				IL_008b: ldloc.s 12
+				IL_008d: conv.i4
+				IL_008e: conv.u4
+				IL_008f: ldc.r8 5
+				IL_0098: conv.i4
+				IL_0099: shr.un
+				IL_009a: conv.r.un
+				IL_009b: stloc.s 12
+				IL_009d: ldloc.s 12
+				IL_009f: stloc.s 4
+				IL_00a1: ldloc.3
+				IL_00a2: stloc.s 12
+				IL_00a4: ldloc.s 12
+				IL_00a6: conv.i4
+				IL_00a7: ldc.r8 31
+				IL_00b0: conv.i4
+				IL_00b1: and
+				IL_00b2: conv.r8
+				IL_00b3: stloc.s 12
+				IL_00b5: ldloc.s 12
+				IL_00b7: stloc.s 5
+				IL_00b9: ldc.r8 1
+				IL_00c2: conv.i4
+				IL_00c3: ldloc.s 5
+				IL_00c5: conv.i4
+				IL_00c6: shl
+				IL_00c7: conv.r8
+				IL_00c8: stloc.s 12
+				IL_00ca: ldloc.s 12
+				IL_00cc: stloc.s 6
+				// loop start (head: IL_00ce)
+					IL_00ce: nop
+					IL_00cf: ldarg.0
+					IL_00d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00d5: ldloc.s 4
+					IL_00d7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00dc: stloc.s 12
+					IL_00de: ldloc.s 12
+					IL_00e0: stloc.s 12
+					IL_00e2: ldloc.s 12
+					IL_00e4: conv.i4
+					IL_00e5: ldloc.s 6
+					IL_00e7: conv.i4
+					IL_00e8: or
+					IL_00e9: conv.r8
+					IL_00ea: stloc.s 12
+					IL_00ec: ldarg.0
+					IL_00ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00f2: ldloc.s 4
+					IL_00f4: ldloc.s 12
+					IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_00fb: ldloc.s 4
+					IL_00fd: ldarg.2
+					IL_00fe: add
+					IL_00ff: stloc.s 12
+					IL_0101: ldloc.s 12
+					IL_0103: stloc.s 4
+					IL_0105: ldloc.s 4
+					IL_0107: stloc.s 12
+					IL_0109: ldloc.s 12
+					IL_010b: ldloc.2
+					IL_010c: cgt
+					IL_010e: ldc.i4.0
+					IL_010f: ceq
+					IL_0111: brfalse IL_011b
 
-					IL_0127: br IL_00df
+					IL_0116: br IL_00ce
 				// end loop
 
-				IL_012c: ldloc.s 4
-				IL_012e: ldarg.2
-				IL_012f: add
-				IL_0130: stloc.s 15
-				IL_0132: ldloc.s 15
-				IL_0134: stloc.s 4
-				IL_0136: br IL_0082
+				IL_011b: ldloc.3
+				IL_011c: ldarg.2
+				IL_011d: add
+				IL_011e: stloc.s 12
+				IL_0120: ldloc.s 12
+				IL_0122: stloc.3
+				IL_0123: br IL_007b
 			// end loop
 
-			IL_013b: ldnull
-			IL_013c: ret
+			IL_0128: ldnull
+			IL_0129: ret
 
-			IL_013d: ldarg.1
-			IL_013e: stloc.s 9
-			IL_0140: ldloc.s 9
-			IL_0142: stloc.s 15
-			IL_0144: ldloc.s 15
-			IL_0146: conv.i4
-			IL_0147: conv.u4
-			IL_0148: ldc.r8 5
-			IL_0151: conv.i4
-			IL_0152: shr.un
-			IL_0153: conv.r.un
-			IL_0154: stloc.s 15
-			IL_0156: ldloc.s 15
-			IL_0158: stloc.s 10
-			IL_015a: ldarg.0
-			IL_015b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0160: ldloc.s 10
-			IL_0162: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0167: stloc.s 15
-			IL_0169: ldloc.s 15
-			IL_016b: stloc.s 11
-			// loop start (head: IL_016d)
-				IL_016d: ldloc.s 9
-				IL_016f: stloc.s 15
-				IL_0171: ldloc.s 15
-				IL_0173: ldarg.3
-				IL_0174: clt
-				IL_0176: brfalse IL_021f
+			IL_012a: ldarg.1
+			IL_012b: stloc.s 7
+			IL_012d: ldloc.s 7
+			IL_012f: stloc.s 12
+			IL_0131: ldloc.s 12
+			IL_0133: conv.i4
+			IL_0134: conv.u4
+			IL_0135: ldc.r8 5
+			IL_013e: conv.i4
+			IL_013f: shr.un
+			IL_0140: conv.r.un
+			IL_0141: stloc.s 12
+			IL_0143: ldloc.s 12
+			IL_0145: stloc.s 8
+			IL_0147: ldarg.0
+			IL_0148: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_014d: ldloc.s 8
+			IL_014f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0154: stloc.s 12
+			IL_0156: ldloc.s 12
+			IL_0158: stloc.s 9
+			// loop start (head: IL_015a)
+				IL_015a: ldloc.s 7
+				IL_015c: stloc.s 12
+				IL_015e: ldloc.s 12
+				IL_0160: ldarg.3
+				IL_0161: clt
+				IL_0163: brfalse IL_0205
 
-				IL_017b: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
-				IL_0180: stloc.s 12
-				IL_0182: ldloc.s 9
-				IL_0184: stloc.s 15
-				IL_0186: ldloc.s 15
-				IL_0188: conv.i4
-				IL_0189: ldc.r8 31
-				IL_0192: conv.i4
-				IL_0193: and
-				IL_0194: conv.r8
-				IL_0195: stloc.s 15
-				IL_0197: ldloc.s 15
-				IL_0199: stloc.s 13
-				IL_019b: ldc.r8 1
-				IL_01a4: conv.i4
-				IL_01a5: ldloc.s 13
-				IL_01a7: conv.i4
-				IL_01a8: shl
-				IL_01a9: conv.r8
-				IL_01aa: stloc.s 15
-				IL_01ac: ldloc.s 11
-				IL_01ae: conv.i4
-				IL_01af: ldloc.s 15
-				IL_01b1: conv.i4
-				IL_01b2: or
-				IL_01b3: conv.r8
-				IL_01b4: stloc.s 15
-				IL_01b6: ldloc.s 15
-				IL_01b8: stloc.s 11
-				IL_01ba: ldloc.s 9
-				IL_01bc: ldarg.2
-				IL_01bd: add
-				IL_01be: stloc.s 15
-				IL_01c0: ldloc.s 15
-				IL_01c2: stloc.s 9
-				IL_01c4: ldloc.s 9
-				IL_01c6: stloc.s 15
-				IL_01c8: ldloc.s 15
-				IL_01ca: conv.i4
-				IL_01cb: conv.u4
-				IL_01cc: ldc.r8 5
-				IL_01d5: conv.i4
-				IL_01d6: shr.un
-				IL_01d7: conv.r.un
-				IL_01d8: stloc.s 15
-				IL_01da: ldloc.s 15
-				IL_01dc: stloc.s 14
-				IL_01de: ldloc.s 14
-				IL_01e0: stloc.s 15
-				IL_01e2: ldloc.s 15
-				IL_01e4: ldloc.s 10
-				IL_01e6: ceq
-				IL_01e8: ldc.i4.0
-				IL_01e9: ceq
-				IL_01eb: brfalse IL_021a
+				IL_0168: ldloc.s 7
+				IL_016a: stloc.s 12
+				IL_016c: ldloc.s 12
+				IL_016e: conv.i4
+				IL_016f: ldc.r8 31
+				IL_0178: conv.i4
+				IL_0179: and
+				IL_017a: conv.r8
+				IL_017b: stloc.s 12
+				IL_017d: ldloc.s 12
+				IL_017f: stloc.s 10
+				IL_0181: ldc.r8 1
+				IL_018a: conv.i4
+				IL_018b: ldloc.s 10
+				IL_018d: conv.i4
+				IL_018e: shl
+				IL_018f: conv.r8
+				IL_0190: stloc.s 12
+				IL_0192: ldloc.s 9
+				IL_0194: conv.i4
+				IL_0195: ldloc.s 12
+				IL_0197: conv.i4
+				IL_0198: or
+				IL_0199: conv.r8
+				IL_019a: stloc.s 12
+				IL_019c: ldloc.s 12
+				IL_019e: stloc.s 9
+				IL_01a0: ldloc.s 7
+				IL_01a2: ldarg.2
+				IL_01a3: add
+				IL_01a4: stloc.s 12
+				IL_01a6: ldloc.s 12
+				IL_01a8: stloc.s 7
+				IL_01aa: ldloc.s 7
+				IL_01ac: stloc.s 12
+				IL_01ae: ldloc.s 12
+				IL_01b0: conv.i4
+				IL_01b1: conv.u4
+				IL_01b2: ldc.r8 5
+				IL_01bb: conv.i4
+				IL_01bc: shr.un
+				IL_01bd: conv.r.un
+				IL_01be: stloc.s 12
+				IL_01c0: ldloc.s 12
+				IL_01c2: stloc.s 11
+				IL_01c4: ldloc.s 11
+				IL_01c6: stloc.s 12
+				IL_01c8: ldloc.s 12
+				IL_01ca: ldloc.s 8
+				IL_01cc: ceq
+				IL_01ce: ldc.i4.0
+				IL_01cf: ceq
+				IL_01d1: brfalse IL_0200
 
-				IL_01f0: ldarg.0
-				IL_01f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_01f6: ldloc.s 10
-				IL_01f8: ldloc.s 11
-				IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_01ff: ldloc.s 14
-				IL_0201: stloc.s 15
-				IL_0203: ldloc.s 15
-				IL_0205: stloc.s 10
-				IL_0207: ldarg.0
-				IL_0208: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_020d: ldloc.s 10
-				IL_020f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_0214: stloc.s 15
-				IL_0216: ldloc.s 15
-				IL_0218: stloc.s 11
+				IL_01d6: ldarg.0
+				IL_01d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01dc: ldloc.s 8
+				IL_01de: ldloc.s 9
+				IL_01e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01e5: ldloc.s 11
+				IL_01e7: stloc.s 12
+				IL_01e9: ldloc.s 12
+				IL_01eb: stloc.s 8
+				IL_01ed: ldarg.0
+				IL_01ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01f3: ldloc.s 8
+				IL_01f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_01fa: stloc.s 12
+				IL_01fc: ldloc.s 12
+				IL_01fe: stloc.s 9
 
-				IL_021a: br IL_016d
+				IL_0200: br IL_015a
 			// end loop
 
-			IL_021f: ldarg.0
-			IL_0220: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0225: ldloc.s 10
-			IL_0227: ldloc.s 11
-			IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_022e: ldnull
-			IL_022f: ret
+			IL_0205: ldarg.0
+			IL_0206: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_020b: ldloc.s 8
+			IL_020d: ldloc.s 9
+			IL_020f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0214: ldnull
+			IL_0215: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1226,7 +1212,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ce8
+			// Method begins at RVA 0x2cc4
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1290,7 +1276,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a00
+			// Method begins at RVA 0x29f4
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1338,7 +1324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3306
+				// Method begins at RVA 0x32c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1358,7 +1344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x330f
+				// Method begins at RVA 0x32c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1382,7 +1368,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3321
+					// Method begins at RVA 0x32db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1400,7 +1386,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3318
+				// Method begins at RVA 0x32d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1420,7 +1406,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x332a
+				// Method begins at RVA 0x32e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1448,7 +1434,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3345
+						// Method begins at RVA 0x32ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1466,7 +1452,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x333c
+					// Method begins at RVA 0x32f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1484,7 +1470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3333
+				// Method begins at RVA 0x32ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1508,7 +1494,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3357
+					// Method begins at RVA 0x3311
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1532,7 +1518,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3369
+						// Method begins at RVA 0x3323
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1550,7 +1536,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3360
+					// Method begins at RVA 0x331a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1568,7 +1554,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x334e
+				// Method begins at RVA 0x3308
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1592,7 +1578,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x337b
+					// Method begins at RVA 0x3335
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1610,7 +1596,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3372
+				// Method begins at RVA 0x332c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1640,7 +1626,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2948
+			// Method begins at RVA 0x293c
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1697,109 +1683,106 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d44
+			// Method begins at RVA 0x2d20
 			// Header size: 12
-			// Code size: 217 (0xd9)
+			// Code size: 209 (0xd1)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/Block_L136C2,
+				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] float64,
-				[6] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
-				[7] object
+				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
+				[6] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
 			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
-			IL_000b: stloc.s 5
-			IL_000d: ldloc.s 5
+			IL_000b: stloc.s 4
+			IL_000d: ldloc.s 4
 			IL_000f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::ceil(float64)
-			IL_0014: stloc.s 5
-			IL_0016: ldloc.s 5
+			IL_0014: stloc.s 4
+			IL_0016: ldloc.s 4
 			IL_0018: stloc.0
 			IL_0019: ldc.r8 1
 			IL_0022: stloc.1
 			// loop start (head: IL_0023)
 				IL_0023: ldloc.1
-				IL_0024: stloc.s 5
-				IL_0026: ldloc.s 5
+				IL_0024: stloc.s 4
+				IL_0026: ldloc.s 4
 				IL_0028: ldloc.0
 				IL_0029: clt
-				IL_002b: brfalse IL_00d7
+				IL_002b: brfalse IL_00cf
 
-				IL_0030: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/Block_L136C2::.ctor()
-				IL_0035: stloc.2
-				IL_0036: ldloc.1
-				IL_0037: stloc.s 5
-				IL_0039: ldloc.s 5
-				IL_003b: ldc.r8 2
-				IL_0044: mul
-				IL_0045: stloc.s 5
-				IL_0047: ldloc.s 5
-				IL_0049: ldc.r8 1
-				IL_0052: add
-				IL_0053: stloc.s 5
-				IL_0055: ldloc.s 5
-				IL_0057: stloc.3
-				IL_0058: ldloc.1
-				IL_0059: stloc.s 5
-				IL_005b: ldloc.s 5
-				IL_005d: ldloc.1
-				IL_005e: mul
-				IL_005f: stloc.s 5
-				IL_0061: ldloc.s 5
-				IL_0063: ldc.r8 2
-				IL_006c: mul
-				IL_006d: stloc.s 5
-				IL_006f: ldloc.s 5
+				IL_0030: ldloc.1
+				IL_0031: stloc.s 4
+				IL_0033: ldloc.s 4
+				IL_0035: ldc.r8 2
+				IL_003e: mul
+				IL_003f: stloc.s 4
+				IL_0041: ldloc.s 4
+				IL_0043: ldc.r8 1
+				IL_004c: add
+				IL_004d: stloc.s 4
+				IL_004f: ldloc.s 4
+				IL_0051: stloc.2
+				IL_0052: ldloc.1
+				IL_0053: stloc.s 4
+				IL_0055: ldloc.s 4
+				IL_0057: ldloc.1
+				IL_0058: mul
+				IL_0059: stloc.s 4
+				IL_005b: ldloc.s 4
+				IL_005d: ldc.r8 2
+				IL_0066: mul
+				IL_0067: stloc.s 4
+				IL_0069: ldloc.s 4
+				IL_006b: ldloc.1
+				IL_006c: add
+				IL_006d: stloc.s 4
+				IL_006f: ldloc.s 4
 				IL_0071: ldloc.1
 				IL_0072: add
-				IL_0073: stloc.s 5
-				IL_0075: ldloc.s 5
-				IL_0077: ldloc.1
-				IL_0078: add
-				IL_0079: stloc.s 5
-				IL_007b: ldloc.s 5
-				IL_007d: stloc.s 4
-				IL_007f: ldarg.0
-				IL_0080: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
-				IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
-				IL_008a: stloc.s 6
-				IL_008c: ldloc.s 6
-				IL_008e: ldloc.s 4
-				IL_0090: ldloc.3
-				IL_0091: ldarg.0
-				IL_0092: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
-				IL_0097: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
-				IL_009c: pop
-				IL_009d: ldarg.0
-				IL_009e: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
-				IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
-				IL_00a8: stloc.s 6
-				IL_00aa: ldloc.1
-				IL_00ab: stloc.s 5
-				IL_00ad: ldloc.s 5
-				IL_00af: ldc.r8 1
-				IL_00b8: add
-				IL_00b9: stloc.s 5
-				IL_00bb: ldloc.s 5
-				IL_00bd: box [System.Runtime]System.Double
-				IL_00c2: stloc.s 7
-				IL_00c4: ldloc.s 6
-				IL_00c6: ldloc.s 7
-				IL_00c8: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(object)
-				IL_00cd: stloc.s 5
-				IL_00cf: ldloc.s 5
-				IL_00d1: stloc.1
-				IL_00d2: br IL_0023
+				IL_0073: stloc.s 4
+				IL_0075: ldloc.s 4
+				IL_0077: stloc.3
+				IL_0078: ldarg.0
+				IL_0079: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
+				IL_007e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
+				IL_0083: stloc.s 5
+				IL_0085: ldloc.s 5
+				IL_0087: ldloc.3
+				IL_0088: ldloc.2
+				IL_0089: ldarg.0
+				IL_008a: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
+				IL_008f: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
+				IL_0094: pop
+				IL_0095: ldarg.0
+				IL_0096: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
+				IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
+				IL_00a0: stloc.s 5
+				IL_00a2: ldloc.1
+				IL_00a3: stloc.s 4
+				IL_00a5: ldloc.s 4
+				IL_00a7: ldc.r8 1
+				IL_00b0: add
+				IL_00b1: stloc.s 4
+				IL_00b3: ldloc.s 4
+				IL_00b5: box [System.Runtime]System.Double
+				IL_00ba: stloc.s 6
+				IL_00bc: ldloc.s 5
+				IL_00be: ldloc.s 6
+				IL_00c0: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(object)
+				IL_00c5: stloc.s 4
+				IL_00c7: ldloc.s 4
+				IL_00c9: stloc.1
+				IL_00ca: br IL_0023
 			// end loop
 
-			IL_00d7: ldarg.0
-			IL_00d8: ret
+			IL_00cf: ldarg.0
+			IL_00d0: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
@@ -1808,7 +1791,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30fc
+			// Method begins at RVA 0x30c8
 			// Header size: 12
 			// Code size: 112 (0x70)
 			.maxstack 8
@@ -1875,19 +1858,18 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3178
+			// Method begins at RVA 0x3144
 			// Header size: 12
-			// Code size: 233 (0xe9)
+			// Code size: 215 (0xd7)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/Block_L160C1,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] float64,
 				[2] float64,
 				[3] float64,
-				[4] float64,
-				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
-				[6] object,
-				[7] bool
+				[4] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
+				[5] object,
+				[6] bool
 			)
 
 			IL_0000: ldarg.1
@@ -1897,85 +1879,83 @@
 			IL_000f: box [System.Runtime]System.Double
 			IL_0014: starg.s max
 
-			IL_0016: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/Block_L160C1::.ctor()
-			IL_001b: stloc.0
-			IL_001c: ldc.i4.1
-			IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0022: dup
-			IL_0023: ldc.r8 2
-			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0031: stloc.1
-			IL_0032: ldc.r8 1
-			IL_003b: stloc.2
-			IL_003c: ldc.r8 0.0
-			IL_0045: stloc.3
-			// loop start (head: IL_0046)
-				IL_0046: ldloc.2
-				IL_0047: stloc.s 4
-				IL_0049: ldloc.s 4
-				IL_004b: ldarg.0
-				IL_004c: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
-				IL_0051: clt
-				IL_0053: brfalse IL_00e7
+			IL_0016: ldc.i4.1
+			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_001c: dup
+			IL_001d: ldc.r8 2
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_002b: stloc.0
+			IL_002c: ldc.r8 1
+			IL_0035: stloc.1
+			IL_0036: ldc.r8 0.0
+			IL_003f: stloc.2
+			// loop start (head: IL_0040)
+				IL_0040: ldloc.1
+				IL_0041: stloc.3
+				IL_0042: ldloc.3
+				IL_0043: ldarg.0
+				IL_0044: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
+				IL_0049: clt
+				IL_004b: brfalse IL_00d5
 
-				IL_0058: ldloc.3
-				IL_0059: stloc.s 4
-				IL_005b: ldloc.s 4
-				IL_005d: ldarg.1
-				IL_005e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0063: clt
-				IL_0065: ldc.i4.0
-				IL_0066: ceq
-				IL_0068: brfalse IL_0072
+				IL_0050: ldloc.2
+				IL_0051: stloc.3
+				IL_0052: ldloc.3
+				IL_0053: ldarg.1
+				IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0059: clt
+				IL_005b: ldc.i4.0
+				IL_005c: ceq
+				IL_005e: brfalse IL_0068
 
-				IL_006d: br IL_00e7
+				IL_0063: br IL_00d5
 
-				IL_0072: ldarg.0
-				IL_0073: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
-				IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
-				IL_007d: stloc.s 5
-				IL_007f: ldloc.2
-				IL_0080: box [System.Runtime]System.Double
-				IL_0085: stloc.s 6
-				IL_0087: ldloc.s 5
-				IL_0089: ldloc.s 6
-				IL_008b: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(object)
-				IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
-				IL_0095: ldc.i4.0
-				IL_0096: ceq
-				IL_0098: stloc.s 7
-				IL_009a: ldloc.s 7
-				IL_009c: brfalse IL_00d6
+				IL_0068: ldarg.0
+				IL_0069: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
+				IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
+				IL_0073: stloc.s 4
+				IL_0075: ldloc.1
+				IL_0076: box [System.Runtime]System.Double
+				IL_007b: stloc.s 5
+				IL_007d: ldloc.s 4
+				IL_007f: ldloc.s 5
+				IL_0081: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(object)
+				IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
+				IL_008b: ldc.i4.0
+				IL_008c: ceq
+				IL_008e: stloc.s 6
+				IL_0090: ldloc.s 6
+				IL_0092: brfalse IL_00c4
 
-				IL_00a1: ldloc.2
-				IL_00a2: stloc.s 4
-				IL_00a4: ldloc.s 4
-				IL_00a6: ldc.r8 2
-				IL_00af: mul
-				IL_00b0: stloc.s 4
-				IL_00b2: ldloc.s 4
-				IL_00b4: ldc.r8 1
-				IL_00bd: add
-				IL_00be: stloc.s 4
-				IL_00c0: ldloc.s 4
-				IL_00c2: box [System.Runtime]System.Double
-				IL_00c7: stloc.s 6
-				IL_00c9: ldloc.1
-				IL_00ca: ldloc.s 6
-				IL_00cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00d1: stloc.s 4
-				IL_00d3: ldloc.s 4
-				IL_00d5: stloc.3
+				IL_0097: ldloc.1
+				IL_0098: stloc.3
+				IL_0099: ldloc.3
+				IL_009a: ldc.r8 2
+				IL_00a3: mul
+				IL_00a4: stloc.3
+				IL_00a5: ldloc.3
+				IL_00a6: ldc.r8 1
+				IL_00af: add
+				IL_00b0: stloc.3
+				IL_00b1: ldloc.3
+				IL_00b2: box [System.Runtime]System.Double
+				IL_00b7: stloc.s 5
+				IL_00b9: ldloc.0
+				IL_00ba: ldloc.s 5
+				IL_00bc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00c1: stloc.3
+				IL_00c2: ldloc.3
+				IL_00c3: stloc.2
 
-				IL_00d6: ldloc.2
-				IL_00d7: ldc.r8 1
-				IL_00e0: add
-				IL_00e1: stloc.2
-				IL_00e2: br IL_0046
+				IL_00c4: ldloc.1
+				IL_00c5: ldc.r8 1
+				IL_00ce: add
+				IL_00cf: stloc.1
+				IL_00d0: br IL_0040
 			// end loop
 
-			IL_00e7: ldloc.1
-			IL_00e8: ret
+			IL_00d5: ldloc.0
+			IL_00d6: ret
 		} // end of method PrimeSieve::getPrimes
 
 		.method public hidebysig 
@@ -1986,9 +1966,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e2c
+			// Method begins at RVA 0x2e00
 			// Header size: 12
-			// Code size: 706 (0x2c2)
+			// Code size: 699 (0x2bb)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1996,15 +1976,14 @@
 				[2] float64,
 				[3] object,
 				[4] object,
-				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/Block_L190C2,
-				[6] object,
-				[7] float64,
+				[5] object,
+				[6] float64,
+				[7] object,
 				[8] object,
-				[9] object,
-				[10] bool,
-				[11] object,
-				[12] string,
-				[13] string
+				[9] bool,
+				[10] object,
+				[11] string,
+				[12] string
 			)
 
 			IL_0000: ldc.r8 100
@@ -2045,17 +2024,17 @@
 			IL_00af: stloc.1
 			IL_00b0: ldarg.0
 			IL_00b1: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::countPrimes()
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
+			IL_00b6: stloc.s 6
+			IL_00b8: ldloc.s 6
 			IL_00ba: stloc.2
 			IL_00bb: ldloc.0
 			IL_00bc: box [System.Runtime]System.Double
-			IL_00c1: stloc.s 8
+			IL_00c1: stloc.s 7
 			IL_00c3: ldarg.0
-			IL_00c4: ldloc.s 8
+			IL_00c4: ldloc.s 7
 			IL_00c6: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::getPrimes(object)
-			IL_00cb: stloc.s 9
-			IL_00cd: ldloc.s 9
+			IL_00cb: stloc.s 8
+			IL_00cd: ldloc.s 8
 			IL_00cf: stloc.3
 			IL_00d0: ldc.i4.0
 			IL_00d1: box [System.Runtime]System.Boolean
@@ -2064,165 +2043,163 @@
 			IL_00d9: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
 			IL_00de: ldloc.1
 			IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-			IL_00e4: stloc.s 10
-			IL_00e6: ldloc.s 10
-			IL_00e8: brfalse IL_01e1
+			IL_00e4: stloc.s 9
+			IL_00e6: ldloc.s 9
+			IL_00e8: brfalse IL_01da
 
-			IL_00ed: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/Block_L190C2::.ctor()
-			IL_00f2: stloc.s 5
-			IL_00f4: ldloc.1
-			IL_00f5: ldarg.0
-			IL_00f6: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
-			IL_0104: stloc.s 6
-			IL_0106: ldloc.s 6
-			IL_0108: stloc.s 9
-			IL_010a: ldloc.2
-			IL_010b: box [System.Runtime]System.Double
-			IL_0110: stloc.s 8
-			IL_0112: ldloc.s 9
-			IL_0114: ldloc.s 8
-			IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-			IL_011b: stloc.s 10
-			IL_011d: ldloc.s 10
-			IL_011f: box [System.Runtime]System.Boolean
-			IL_0124: stloc.s 11
-			IL_0126: ldloc.s 11
-			IL_0128: stloc.s 4
-			IL_012a: ldloc.s 4
-			IL_012c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0131: ldc.i4.0
-			IL_0132: ceq
-			IL_0134: stloc.s 10
-			IL_0136: ldloc.s 10
-			IL_0138: brfalse IL_01dc
+			IL_00ed: ldloc.1
+			IL_00ee: ldarg.0
+			IL_00ef: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_00f9: stloc.s 8
+			IL_00fb: ldloc.s 8
+			IL_00fd: stloc.s 5
+			IL_00ff: ldloc.s 5
+			IL_0101: stloc.s 8
+			IL_0103: ldloc.2
+			IL_0104: box [System.Runtime]System.Double
+			IL_0109: stloc.s 7
+			IL_010b: ldloc.s 8
+			IL_010d: ldloc.s 7
+			IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+			IL_0114: stloc.s 9
+			IL_0116: ldloc.s 9
+			IL_0118: box [System.Runtime]System.Boolean
+			IL_011d: stloc.s 10
+			IL_011f: ldloc.s 10
+			IL_0121: stloc.s 4
+			IL_0123: ldloc.s 4
+			IL_0125: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_012a: ldc.i4.0
+			IL_012b: ceq
+			IL_012d: stloc.s 9
+			IL_012f: ldloc.s 9
+			IL_0131: brfalse IL_01d5
 
-			IL_013d: ldstr "console"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0147: stloc.s 9
-			IL_0149: ldloc.s 9
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0150: stloc.s 9
-			IL_0152: ldarg.0
-			IL_0153: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
-			IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_015d: stloc.s 12
-			IL_015f: ldstr "Limit for "
-			IL_0164: ldloc.s 12
-			IL_0166: call string [System.Runtime]System.String::Concat(string, string)
-			IL_016b: stloc.s 12
-			IL_016d: ldloc.s 12
-			IL_016f: ldstr " should be "
-			IL_0174: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0179: stloc.s 12
-			IL_017b: ldloc.s 6
-			IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0182: stloc.s 13
-			IL_0184: ldloc.s 12
-			IL_0186: ldloc.s 13
-			IL_0188: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018d: stloc.s 13
-			IL_018f: ldloc.s 13
-			IL_0191: ldstr " "
-			IL_0196: call string [System.Runtime]System.String::Concat(string, string)
-			IL_019b: stloc.s 13
-			IL_019d: ldloc.2
-			IL_019e: box [System.Runtime]System.Double
-			IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a8: stloc.s 12
-			IL_01aa: ldstr "but result contains "
-			IL_01af: ldloc.s 12
-			IL_01b1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b6: stloc.s 12
-			IL_01b8: ldloc.s 12
-			IL_01ba: ldstr " primes"
-			IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c4: stloc.s 12
-			IL_01c6: ldloc.s 9
-			IL_01c8: ldstr "log"
-			IL_01cd: ldstr "\nError: invalid result."
-			IL_01d2: ldloc.s 13
-			IL_01d4: ldloc.s 12
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01db: pop
+			IL_0136: ldstr "console"
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0140: stloc.s 8
+			IL_0142: ldloc.s 8
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0149: stloc.s 8
+			IL_014b: ldarg.0
+			IL_014c: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
+			IL_0151: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0156: stloc.s 11
+			IL_0158: ldstr "Limit for "
+			IL_015d: ldloc.s 11
+			IL_015f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0164: stloc.s 11
+			IL_0166: ldloc.s 11
+			IL_0168: ldstr " should be "
+			IL_016d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0172: stloc.s 11
+			IL_0174: ldloc.s 5
+			IL_0176: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_017b: stloc.s 12
+			IL_017d: ldloc.s 11
+			IL_017f: ldloc.s 12
+			IL_0181: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0186: stloc.s 12
+			IL_0188: ldloc.s 12
+			IL_018a: ldstr " "
+			IL_018f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0194: stloc.s 12
+			IL_0196: ldloc.2
+			IL_0197: box [System.Runtime]System.Double
+			IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01a1: stloc.s 11
+			IL_01a3: ldstr "but result contains "
+			IL_01a8: ldloc.s 11
+			IL_01aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01af: stloc.s 11
+			IL_01b1: ldloc.s 11
+			IL_01b3: ldstr " primes"
+			IL_01b8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01bd: stloc.s 11
+			IL_01bf: ldloc.s 8
+			IL_01c1: ldstr "log"
+			IL_01c6: ldstr "\nError: invalid result."
+			IL_01cb: ldloc.s 12
+			IL_01cd: ldloc.s 11
+			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01d4: pop
 
-			IL_01dc: br IL_0259
+			IL_01d5: br IL_0252
 
-			IL_01e1: ldstr "console"
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01eb: stloc.s 9
-			IL_01ed: ldloc.s 9
-			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f4: stloc.s 9
-			IL_01f6: ldloc.2
-			IL_01f7: box [System.Runtime]System.Double
-			IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0201: stloc.s 12
-			IL_0203: ldstr "Warning: cannot validate result of "
-			IL_0208: ldloc.s 12
-			IL_020a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020f: stloc.s 12
-			IL_0211: ldloc.s 12
-			IL_0213: ldstr " primes:"
-			IL_0218: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021d: stloc.s 12
-			IL_021f: ldarg.0
-			IL_0220: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
-			IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022a: stloc.s 13
-			IL_022c: ldstr "limit "
-			IL_0231: ldloc.s 13
-			IL_0233: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0238: stloc.s 13
-			IL_023a: ldloc.s 13
-			IL_023c: ldstr " is not in the known list of number of primes!"
-			IL_0241: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0246: stloc.s 13
-			IL_0248: ldloc.s 9
-			IL_024a: ldstr "log"
-			IL_024f: ldloc.s 12
-			IL_0251: ldloc.s 13
-			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0258: pop
+			IL_01da: ldstr "console"
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01e4: stloc.s 8
+			IL_01e6: ldloc.s 8
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ed: stloc.s 8
+			IL_01ef: ldloc.2
+			IL_01f0: box [System.Runtime]System.Double
+			IL_01f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01fa: stloc.s 11
+			IL_01fc: ldstr "Warning: cannot validate result of "
+			IL_0201: ldloc.s 11
+			IL_0203: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0208: stloc.s 11
+			IL_020a: ldloc.s 11
+			IL_020c: ldstr " primes:"
+			IL_0211: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0216: stloc.s 11
+			IL_0218: ldarg.0
+			IL_0219: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSize
+			IL_021e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0223: stloc.s 12
+			IL_0225: ldstr "limit "
+			IL_022a: ldloc.s 12
+			IL_022c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0231: stloc.s 12
+			IL_0233: ldloc.s 12
+			IL_0235: ldstr " is not in the known list of number of primes!"
+			IL_023a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_023f: stloc.s 12
+			IL_0241: ldloc.s 8
+			IL_0243: ldstr "log"
+			IL_0248: ldloc.s 11
+			IL_024a: ldloc.s 12
+			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0251: pop
 
-			IL_0259: ldarg.1
-			IL_025a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_025f: stloc.s 10
-			IL_0261: ldloc.s 10
-			IL_0263: brfalse IL_02b6
+			IL_0252: ldarg.1
+			IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0258: stloc.s 9
+			IL_025a: ldloc.s 9
+			IL_025c: brfalse IL_02af
 
-			IL_0268: ldstr "console"
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0272: stloc.s 9
-			IL_0274: ldloc.s 9
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027b: stloc.s 9
-			IL_027d: ldloc.0
-			IL_027e: box [System.Runtime]System.Double
-			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0288: stloc.s 13
-			IL_028a: ldstr "\nThe first "
-			IL_028f: ldloc.s 13
-			IL_0291: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0296: stloc.s 13
-			IL_0298: ldloc.s 13
-			IL_029a: ldstr " found primes are:"
-			IL_029f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a4: stloc.s 13
-			IL_02a6: ldloc.s 9
-			IL_02a8: ldstr "log"
-			IL_02ad: ldloc.s 13
-			IL_02af: ldloc.3
-			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02b5: pop
+			IL_0261: ldstr "console"
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_026b: stloc.s 8
+			IL_026d: ldloc.s 8
+			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0274: stloc.s 8
+			IL_0276: ldloc.0
+			IL_0277: box [System.Runtime]System.Double
+			IL_027c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0281: stloc.s 12
+			IL_0283: ldstr "\nThe first "
+			IL_0288: ldloc.s 12
+			IL_028a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_028f: stloc.s 12
+			IL_0291: ldloc.s 12
+			IL_0293: ldstr " found primes are:"
+			IL_0298: call string [System.Runtime]System.String::Concat(string, string)
+			IL_029d: stloc.s 12
+			IL_029f: ldloc.s 8
+			IL_02a1: ldstr "log"
+			IL_02a6: ldloc.s 12
+			IL_02a8: ldloc.3
+			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02ae: pop
 
-			IL_02b6: ldloc.s 4
-			IL_02b8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02bd: stloc.s 10
-			IL_02bf: ldloc.s 10
-			IL_02c1: ret
+			IL_02af: ldloc.s 4
+			IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02b6: stloc.s 9
+			IL_02b8: ldloc.s 9
+			IL_02ba: ret
 		} // end of method PrimeSieve::validatePrimeCount
 
 	} // end of class PrimeSieve
@@ -2253,7 +2230,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x326d
+			// Method begins at RVA 0x3227
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2283,7 +2260,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33a8
+				// Method begins at RVA 0x3362
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2296,7 +2273,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x33b0
+				// Method begins at RVA 0x336a
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2311,7 +2288,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x33b8
+				// Method begins at RVA 0x3372
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2329,7 +2306,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x33cd
+				// Method begins at RVA 0x3387
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2344,7 +2321,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x33d5
+				// Method begins at RVA 0x338f
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2362,7 +2339,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x33ea
+				// Method begins at RVA 0x33a4
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2377,7 +2354,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x33f2
+				// Method begins at RVA 0x33ac
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2395,7 +2372,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3407
+				// Method begins at RVA 0x33c1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2410,7 +2387,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x340f
+				// Method begins at RVA 0x33c9
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -3094,7 +3071,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3424
+		// Method begins at RVA 0x33de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23bd
+				// Method begins at RVA 0x23b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c6
+				// Method begins at RVA 0x23ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x23a8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 827 (0x33b)
+		// Code size: 814 (0x32e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope,
@@ -93,19 +93,17 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L14C4,
+			[8] object,
 			[9] object,
-			[10] object,
-			[11] class [System.Runtime]System.Exception,
+			[10] class [System.Runtime]System.Exception,
+			[11] object,
 			[12] object,
 			[13] object,
-			[14] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L18C12,
-			[15] object,
+			[14] object,
+			[15] bool,
 			[16] object,
-			[17] bool,
-			[18] object,
-			[19] float64,
-			[20] object
+			[17] float64,
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_ChildProcess_ExecFileSync_Basic/Scope::.ctor()
@@ -114,21 +112,21 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "child_process"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 16
-		IL_0014: ldloc.s 16
+		IL_0012: stloc.s 14
+		IL_0014: ldloc.s 14
 		IL_0016: stloc.1
 		IL_0017: ldstr "process"
 		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0021: stloc.s 16
-		IL_0023: ldloc.s 16
+		IL_0021: stloc.s 14
+		IL_0023: ldloc.s 14
 		IL_0025: ldstr "platform"
 		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_002f: stloc.s 16
-		IL_0031: ldloc.s 16
+		IL_002f: stloc.s 14
+		IL_0031: ldloc.s 14
 		IL_0033: ldstr "win32"
 		IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_003d: stloc.s 17
-		IL_003f: ldloc.s 17
+		IL_003d: stloc.s 15
+		IL_003f: ldloc.s 15
 		IL_0041: stloc.2
 		IL_0042: ldloc.2
 		IL_0043: brfalse IL_0053
@@ -170,8 +168,8 @@
 		IL_00a5: stloc.s 6
 		IL_00a7: ldloc.1
 		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ad: stloc.s 16
-		IL_00af: ldloc.s 16
+		IL_00ad: stloc.s 14
+		IL_00af: ldloc.s 14
 		IL_00b1: ldstr "execFileSync"
 		IL_00b6: ldloc.s 4
 		IL_00b8: ldloc.s 6
@@ -181,208 +179,205 @@
 		IL_00c5: ldstr "utf8"
 		IL_00ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d4: stloc.s 16
-		IL_00d6: ldloc.s 16
+		IL_00d4: stloc.s 14
+		IL_00d6: ldloc.s 14
 		IL_00d8: stloc.s 7
 		IL_00da: ldstr "console"
 		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e4: stloc.s 16
-		IL_00e6: ldloc.s 16
+		IL_00e4: stloc.s 14
+		IL_00e6: ldloc.s 14
 		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ed: stloc.s 16
+		IL_00ed: stloc.s 14
 		IL_00ef: ldloc.s 7
 		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f6: stloc.s 18
-		IL_00f8: ldloc.s 18
+		IL_00f6: stloc.s 16
+		IL_00f8: ldloc.s 16
 		IL_00fa: ldstr "indexOf"
 		IL_00ff: ldstr "hello"
 		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0109: stloc.s 18
-		IL_010b: ldloc.s 18
+		IL_0109: stloc.s 16
+		IL_010b: ldloc.s 16
 		IL_010d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0112: stloc.s 19
-		IL_0114: ldloc.s 19
+		IL_0112: stloc.s 17
+		IL_0114: ldloc.s 17
 		IL_0116: ldc.r8 0.0
 		IL_011f: clt
 		IL_0121: ldc.i4.0
 		IL_0122: ceq
-		IL_0124: stloc.s 17
-		IL_0126: ldloc.s 17
+		IL_0124: stloc.s 15
+		IL_0126: ldloc.s 15
 		IL_0128: box [System.Runtime]System.Boolean
-		IL_012d: stloc.s 20
-		IL_012f: ldloc.s 16
+		IL_012d: stloc.s 18
+		IL_012f: ldloc.s 14
 		IL_0131: ldstr "log"
 		IL_0136: ldstr "stdout contains hello:"
-		IL_013b: ldloc.s 20
+		IL_013b: ldloc.s 18
 		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0142: pop
 		.try
 		{
-			IL_0143: newobj instance void Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L14C4::.ctor()
-			IL_0148: stloc.s 8
-			IL_014a: ldloc.2
-			IL_014b: brfalse IL_0173
+			IL_0143: nop
+			IL_0144: ldloc.2
+			IL_0145: brfalse IL_016d
 
-			IL_0150: ldc.i4.2
-			IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0156: dup
-			IL_0157: ldstr "/c"
-			IL_015c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0161: dup
-			IL_0162: ldstr "exit 5"
-			IL_0167: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_016c: stloc.s 9
-			IL_016e: br IL_0191
+			IL_014a: ldc.i4.2
+			IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0150: dup
+			IL_0151: ldstr "/c"
+			IL_0156: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015b: dup
+			IL_015c: ldstr "exit 5"
+			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0166: stloc.s 8
+			IL_0168: br IL_018b
 
-			IL_0173: ldc.i4.2
-			IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0179: dup
-			IL_017a: ldstr "-c"
-			IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0184: dup
-			IL_0185: ldstr "exit 5"
-			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_018f: stloc.s 9
+			IL_016d: ldc.i4.2
+			IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0173: dup
+			IL_0174: ldstr "-c"
+			IL_0179: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_017e: dup
+			IL_017f: ldstr "exit 5"
+			IL_0184: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0189: stloc.s 8
 
-			IL_0191: ldloc.s 9
-			IL_0193: stloc.s 10
-			IL_0195: ldloc.1
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_019b: stloc.s 16
-			IL_019d: ldloc.s 16
-			IL_019f: ldstr "execFileSync"
-			IL_01a4: ldloc.s 4
-			IL_01a6: ldloc.s 10
-			IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01ad: dup
-			IL_01ae: ldstr "encoding"
-			IL_01b3: ldstr "utf8"
-			IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01c2: pop
-			IL_01c3: ldstr "console"
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01cd: stloc.s 16
-			IL_01cf: ldloc.s 16
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d6: stloc.s 16
-			IL_01d8: ldloc.s 16
-			IL_01da: ldstr "log"
-			IL_01df: ldstr "expected error not thrown"
-			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01e9: pop
-			IL_01ea: leave IL_0337
+			IL_018b: ldloc.s 8
+			IL_018d: stloc.s 9
+			IL_018f: ldloc.1
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0195: stloc.s 14
+			IL_0197: ldloc.s 14
+			IL_0199: ldstr "execFileSync"
+			IL_019e: ldloc.s 4
+			IL_01a0: ldloc.s 9
+			IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01a7: dup
+			IL_01a8: ldstr "encoding"
+			IL_01ad: ldstr "utf8"
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01bc: pop
+			IL_01bd: ldstr "console"
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c7: stloc.s 14
+			IL_01c9: ldloc.s 14
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d0: stloc.s 14
+			IL_01d2: ldloc.s 14
+			IL_01d4: ldstr "log"
+			IL_01d9: ldstr "expected error not thrown"
+			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01e3: pop
+			IL_01e4: leave IL_032a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01ef: stloc.s 11
-			IL_01f1: ldloc.s 11
-			IL_01f3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01f8: dup
-			IL_01f9: brtrue IL_020f
+			IL_01e9: stloc.s 10
+			IL_01eb: ldloc.s 10
+			IL_01ed: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_01f2: dup
+			IL_01f3: brtrue IL_0209
 
-			IL_01fe: pop
-			IL_01ff: ldloc.s 11
-			IL_0201: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0206: dup
-			IL_0207: brtrue IL_021b
+			IL_01f8: pop
+			IL_01f9: ldloc.s 10
+			IL_01fb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0200: dup
+			IL_0201: brtrue IL_0215
 
-			IL_020c: pop
-			IL_020d: rethrow
+			IL_0206: pop
+			IL_0207: rethrow
 
-			IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0214: stloc.s 12
-			IL_0216: br IL_021d
+			IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_020e: stloc.s 11
+			IL_0210: br IL_0217
 
-			IL_021b: stloc.s 12
+			IL_0215: stloc.s 11
 
-			IL_021d: ldloc.s 12
-			IL_021f: stloc.s 16
-			IL_0221: ldloc.s 16
-			IL_0223: stloc.s 13
-			IL_0225: newobj instance void Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L18C12::.ctor()
-			IL_022a: stloc.s 14
-			IL_022c: ldstr "console"
-			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0236: stloc.s 16
-			IL_0238: ldloc.s 16
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023f: stloc.s 16
-			IL_0241: ldloc.s 16
-			IL_0243: ldstr "log"
-			IL_0248: ldstr "throws on non-zero:"
-			IL_024d: ldc.i4.1
-			IL_024e: box [System.Runtime]System.Boolean
-			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0258: pop
-			IL_0259: ldstr "console"
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0263: stloc.s 16
-			IL_0265: ldloc.s 16
-			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026c: stloc.s 16
-			IL_026e: ldloc.s 16
-			IL_0270: ldstr "log"
-			IL_0275: ldstr "status:"
-			IL_027a: ldloc.s 13
-			IL_027c: ldstr "status"
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_028b: pop
-			IL_028c: ldstr "console"
-			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0296: stloc.s 16
-			IL_0298: ldloc.s 16
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029f: stloc.s 16
-			IL_02a1: ldloc.s 16
-			IL_02a3: ldstr "log"
-			IL_02a8: ldstr "code:"
-			IL_02ad: ldloc.s 13
-			IL_02af: ldstr "code"
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02be: pop
-			IL_02bf: ldstr "console"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c9: stloc.s 16
-			IL_02cb: ldloc.s 16
-			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d2: stloc.s 16
-			IL_02d4: ldloc.s 13
-			IL_02d6: ldstr "message"
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e5: stloc.s 18
-			IL_02e7: ldloc.s 18
-			IL_02e9: ldstr "indexOf"
-			IL_02ee: ldstr "exit code 5"
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02f8: stloc.s 18
-			IL_02fa: ldloc.s 18
-			IL_02fc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0301: stloc.s 19
-			IL_0303: ldloc.s 19
-			IL_0305: ldc.r8 0.0
-			IL_030e: clt
-			IL_0310: ldc.i4.0
-			IL_0311: ceq
-			IL_0313: stloc.s 17
-			IL_0315: ldloc.s 17
-			IL_0317: box [System.Runtime]System.Boolean
-			IL_031c: stloc.s 20
-			IL_031e: ldloc.s 16
-			IL_0320: ldstr "log"
-			IL_0325: ldstr "message has exit code:"
-			IL_032a: ldloc.s 20
-			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0331: pop
-			IL_0332: leave IL_0337
+			IL_0217: ldloc.s 11
+			IL_0219: stloc.s 14
+			IL_021b: ldloc.s 14
+			IL_021d: stloc.s 12
+			IL_021f: ldstr "console"
+			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0229: stloc.s 14
+			IL_022b: ldloc.s 14
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0232: stloc.s 14
+			IL_0234: ldloc.s 14
+			IL_0236: ldstr "log"
+			IL_023b: ldstr "throws on non-zero:"
+			IL_0240: ldc.i4.1
+			IL_0241: box [System.Runtime]System.Boolean
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_024b: pop
+			IL_024c: ldstr "console"
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0256: stloc.s 14
+			IL_0258: ldloc.s 14
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025f: stloc.s 14
+			IL_0261: ldloc.s 14
+			IL_0263: ldstr "log"
+			IL_0268: ldstr "status:"
+			IL_026d: ldloc.s 12
+			IL_026f: ldstr "status"
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_027e: pop
+			IL_027f: ldstr "console"
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0289: stloc.s 14
+			IL_028b: ldloc.s 14
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0292: stloc.s 14
+			IL_0294: ldloc.s 14
+			IL_0296: ldstr "log"
+			IL_029b: ldstr "code:"
+			IL_02a0: ldloc.s 12
+			IL_02a2: ldstr "code"
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02b1: pop
+			IL_02b2: ldstr "console"
+			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02bc: stloc.s 14
+			IL_02be: ldloc.s 14
+			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c5: stloc.s 14
+			IL_02c7: ldloc.s 12
+			IL_02c9: ldstr "message"
+			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d8: stloc.s 16
+			IL_02da: ldloc.s 16
+			IL_02dc: ldstr "indexOf"
+			IL_02e1: ldstr "exit code 5"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02eb: stloc.s 16
+			IL_02ed: ldloc.s 16
+			IL_02ef: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_02f4: stloc.s 17
+			IL_02f6: ldloc.s 17
+			IL_02f8: ldc.r8 0.0
+			IL_0301: clt
+			IL_0303: ldc.i4.0
+			IL_0304: ceq
+			IL_0306: stloc.s 15
+			IL_0308: ldloc.s 15
+			IL_030a: box [System.Runtime]System.Boolean
+			IL_030f: stloc.s 18
+			IL_0311: ldloc.s 14
+			IL_0313: ldstr "log"
+			IL_0318: ldstr "message has exit code:"
+			IL_031d: ldloc.s 18
+			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0324: pop
+			IL_0325: leave IL_032a
 		} // end handler
 
-		IL_0337: ldnull
-		IL_0338: stloc.s 15
-		IL_033a: ret
+		IL_032a: ldnull
+		IL_032b: stloc.s 13
+		IL_032d: ret
 	} // end of method Require_ChildProcess_ExecFileSync_Basic::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_ExecFileSync_Basic
@@ -394,7 +389,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23cf
+		// Method begins at RVA 0x23c3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Unsupported_Options.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25cd
+				// Method begins at RVA 0x25a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d6
+				// Method begins at RVA 0x25ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25df
+				// Method begins at RVA 0x25b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e8
+				// Method begins at RVA 0x25c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f1
+				// Method begins at RVA 0x25c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25fa
+				// Method begins at RVA 0x25d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2603
+				// Method begins at RVA 0x25db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260c
+				// Method begins at RVA 0x25e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25c4
+			// Method begins at RVA 0x259c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1282 (0x502)
+		// Code size: 1242 (0x4da)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope,
@@ -210,34 +210,28 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L7C14,
-			[6] class [System.Runtime]System.Exception,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L13C14,
-			[10] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L17C4,
-			[11] bool,
+			[8] bool,
+			[9] object,
+			[10] object,
+			[11] class [System.Runtime]System.Exception,
 			[12] object,
 			[13] object,
-			[14] class [System.Runtime]System.Exception,
+			[14] bool,
 			[15] object,
 			[16] object,
-			[17] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L23C14,
-			[18] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L27C4,
-			[19] bool,
+			[17] class [System.Runtime]System.Exception,
+			[18] object,
+			[19] object,
 			[20] object,
 			[21] object,
-			[22] class [System.Runtime]System.Exception,
+			[22] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[23] object,
-			[24] object,
-			[25] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L33C14,
-			[26] object,
-			[27] object,
-			[28] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[29] object,
-			[30] float64,
-			[31] bool,
-			[32] object
+			[24] float64,
+			[25] bool,
+			[26] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope::.ctor()
@@ -246,22 +240,22 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "child_process"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 27
-		IL_0014: ldloc.s 27
+		IL_0012: stloc.s 21
+		IL_0014: ldloc.s 21
 		IL_0016: stloc.1
 		.try
 		{
 			IL_0017: nop
 			IL_0018: ldloc.1
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001e: stloc.s 27
+			IL_001e: stloc.s 21
 			IL_0020: ldc.i4.0
 			IL_0021: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0026: stloc.s 28
-			IL_0028: ldloc.s 27
+			IL_0026: stloc.s 22
+			IL_0028: ldloc.s 21
 			IL_002a: ldstr "fork"
 			IL_002f: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
-			IL_0034: ldloc.s 28
+			IL_0034: ldloc.s 22
 			IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_003b: dup
 			IL_003c: ldstr "detached"
@@ -269,7 +263,7 @@
 			IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 			IL_004c: pop
-			IL_004d: leave IL_0101
+			IL_004d: leave IL_00fa
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -295,406 +289,396 @@
 			IL_007a: stloc.3
 
 			IL_007b: ldloc.3
-			IL_007c: stloc.s 27
-			IL_007e: ldloc.s 27
+			IL_007c: stloc.s 21
+			IL_007e: ldloc.s 21
 			IL_0080: stloc.s 4
-			IL_0082: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L7C14::.ctor()
-			IL_0087: stloc.s 5
-			IL_0089: ldstr "console"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0093: stloc.s 27
-			IL_0095: ldloc.s 27
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009c: stloc.s 27
-			IL_009e: ldloc.s 4
-			IL_00a0: ldstr "message"
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00af: stloc.s 29
-			IL_00b1: ldloc.s 29
-			IL_00b3: ldstr "indexOf"
-			IL_00b8: ldstr "detached child processes"
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c2: stloc.s 29
-			IL_00c4: ldloc.s 29
-			IL_00c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00cb: stloc.s 30
-			IL_00cd: ldloc.s 30
-			IL_00cf: ldc.r8 0.0
-			IL_00d8: clt
-			IL_00da: ldc.i4.0
-			IL_00db: ceq
-			IL_00dd: stloc.s 31
-			IL_00df: ldloc.s 31
-			IL_00e1: box [System.Runtime]System.Boolean
-			IL_00e6: stloc.s 32
-			IL_00e8: ldloc.s 27
-			IL_00ea: ldstr "log"
-			IL_00ef: ldstr "detached error:"
-			IL_00f4: ldloc.s 32
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fb: pop
-			IL_00fc: leave IL_0101
+			IL_0082: ldstr "console"
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_008c: stloc.s 21
+			IL_008e: ldloc.s 21
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0095: stloc.s 21
+			IL_0097: ldloc.s 4
+			IL_0099: ldstr "message"
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a8: stloc.s 23
+			IL_00aa: ldloc.s 23
+			IL_00ac: ldstr "indexOf"
+			IL_00b1: ldstr "detached child processes"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00bb: stloc.s 23
+			IL_00bd: ldloc.s 23
+			IL_00bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c4: stloc.s 24
+			IL_00c6: ldloc.s 24
+			IL_00c8: ldc.r8 0.0
+			IL_00d1: clt
+			IL_00d3: ldc.i4.0
+			IL_00d4: ceq
+			IL_00d6: stloc.s 25
+			IL_00d8: ldloc.s 25
+			IL_00da: box [System.Runtime]System.Boolean
+			IL_00df: stloc.s 26
+			IL_00e1: ldloc.s 21
+			IL_00e3: ldstr "log"
+			IL_00e8: ldstr "detached error:"
+			IL_00ed: ldloc.s 26
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f4: pop
+			IL_00f5: leave IL_00fa
 		} // end handler
 		.try
 		{
-			IL_0101: nop
-			IL_0102: ldloc.1
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0108: stloc.s 27
-			IL_010a: ldc.i4.0
-			IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0110: stloc.s 28
-			IL_0112: ldloc.s 27
-			IL_0114: ldstr "fork"
-			IL_0119: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
-			IL_011e: ldloc.s 28
-			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0125: dup
-			IL_0126: ldstr "serialization"
-			IL_012b: ldstr "advanced"
-			IL_0130: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_013a: pop
-			IL_013b: leave IL_01f5
+			IL_00fa: nop
+			IL_00fb: ldloc.1
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0101: stloc.s 21
+			IL_0103: ldc.i4.0
+			IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0109: stloc.s 22
+			IL_010b: ldloc.s 21
+			IL_010d: ldstr "fork"
+			IL_0112: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
+			IL_0117: ldloc.s 22
+			IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_011e: dup
+			IL_011f: ldstr "serialization"
+			IL_0124: ldstr "advanced"
+			IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0133: pop
+			IL_0134: leave IL_01e7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0140: stloc.s 6
-			IL_0142: ldloc.s 6
-			IL_0144: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0149: dup
-			IL_014a: brtrue IL_0160
+			IL_0139: stloc.s 5
+			IL_013b: ldloc.s 5
+			IL_013d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0142: dup
+			IL_0143: brtrue IL_0159
 
-			IL_014f: pop
-			IL_0150: ldloc.s 6
-			IL_0152: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0157: dup
-			IL_0158: brtrue IL_016c
+			IL_0148: pop
+			IL_0149: ldloc.s 5
+			IL_014b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0150: dup
+			IL_0151: brtrue IL_0165
 
-			IL_015d: pop
-			IL_015e: rethrow
+			IL_0156: pop
+			IL_0157: rethrow
 
-			IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0165: stloc.s 7
-			IL_0167: br IL_016e
+			IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_015e: stloc.s 6
+			IL_0160: br IL_0167
 
-			IL_016c: stloc.s 7
+			IL_0165: stloc.s 6
 
-			IL_016e: ldloc.s 7
-			IL_0170: stloc.s 27
-			IL_0172: ldloc.s 27
-			IL_0174: stloc.s 8
-			IL_0176: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L13C14::.ctor()
-			IL_017b: stloc.s 9
-			IL_017d: ldstr "console"
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0187: stloc.s 27
-			IL_0189: ldloc.s 27
-			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0190: stloc.s 27
-			IL_0192: ldloc.s 8
-			IL_0194: ldstr "message"
-			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a3: stloc.s 29
-			IL_01a5: ldloc.s 29
-			IL_01a7: ldstr "indexOf"
-			IL_01ac: ldstr "JSON message serialization"
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01b6: stloc.s 29
-			IL_01b8: ldloc.s 29
-			IL_01ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01bf: stloc.s 30
-			IL_01c1: ldloc.s 30
-			IL_01c3: ldc.r8 0.0
-			IL_01cc: clt
-			IL_01ce: ldc.i4.0
-			IL_01cf: ceq
-			IL_01d1: stloc.s 31
-			IL_01d3: ldloc.s 31
-			IL_01d5: box [System.Runtime]System.Boolean
-			IL_01da: stloc.s 32
-			IL_01dc: ldloc.s 27
-			IL_01de: ldstr "log"
-			IL_01e3: ldstr "serialization error:"
-			IL_01e8: ldloc.s 32
-			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01ef: pop
-			IL_01f0: leave IL_01f5
+			IL_0167: ldloc.s 6
+			IL_0169: stloc.s 21
+			IL_016b: ldloc.s 21
+			IL_016d: stloc.s 7
+			IL_016f: ldstr "console"
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0179: stloc.s 21
+			IL_017b: ldloc.s 21
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0182: stloc.s 21
+			IL_0184: ldloc.s 7
+			IL_0186: ldstr "message"
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0195: stloc.s 23
+			IL_0197: ldloc.s 23
+			IL_0199: ldstr "indexOf"
+			IL_019e: ldstr "JSON message serialization"
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a8: stloc.s 23
+			IL_01aa: ldloc.s 23
+			IL_01ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01b1: stloc.s 24
+			IL_01b3: ldloc.s 24
+			IL_01b5: ldc.r8 0.0
+			IL_01be: clt
+			IL_01c0: ldc.i4.0
+			IL_01c1: ceq
+			IL_01c3: stloc.s 25
+			IL_01c5: ldloc.s 25
+			IL_01c7: box [System.Runtime]System.Boolean
+			IL_01cc: stloc.s 26
+			IL_01ce: ldloc.s 21
+			IL_01d0: ldstr "log"
+			IL_01d5: ldstr "serialization error:"
+			IL_01da: ldloc.s 26
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01e1: pop
+			IL_01e2: leave IL_01e7
 		} // end handler
 		.try
 		{
-			IL_01f5: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L17C4::.ctor()
-			IL_01fa: stloc.s 10
-			IL_01fc: ldstr "process"
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0206: stloc.s 27
-			IL_0208: ldloc.s 27
-			IL_020a: ldstr "platform"
-			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0214: stloc.s 27
-			IL_0216: ldloc.s 27
-			IL_0218: ldstr "win32"
-			IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0222: stloc.s 31
-			IL_0224: ldloc.s 31
-			IL_0226: stloc.s 11
-			IL_0228: ldloc.1
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022e: stloc.s 27
-			IL_0230: ldloc.s 11
-			IL_0232: brfalse IL_0243
+			IL_01e7: nop
+			IL_01e8: ldstr "process"
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f2: stloc.s 21
+			IL_01f4: ldloc.s 21
+			IL_01f6: ldstr "platform"
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0200: stloc.s 21
+			IL_0202: ldloc.s 21
+			IL_0204: ldstr "win32"
+			IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_020e: stloc.s 25
+			IL_0210: ldloc.s 25
+			IL_0212: stloc.s 8
+			IL_0214: ldloc.1
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021a: stloc.s 21
+			IL_021c: ldloc.s 8
+			IL_021e: brfalse IL_022f
 
-			IL_0237: ldstr "cmd.exe"
-			IL_023c: stloc.s 12
-			IL_023e: br IL_024a
+			IL_0223: ldstr "cmd.exe"
+			IL_0228: stloc.s 9
+			IL_022a: br IL_0236
 
-			IL_0243: ldstr "/bin/sh"
-			IL_0248: stloc.s 12
+			IL_022f: ldstr "/bin/sh"
+			IL_0234: stloc.s 9
 
-			IL_024a: ldloc.s 11
-			IL_024c: brfalse IL_028a
+			IL_0236: ldloc.s 8
+			IL_0238: brfalse IL_0276
 
-			IL_0251: ldc.i4.4
-			IL_0252: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0257: dup
-			IL_0258: ldstr "/d"
-			IL_025d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0262: dup
-			IL_0263: ldstr "/s"
-			IL_0268: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_026d: dup
-			IL_026e: ldstr "/c"
-			IL_0273: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0278: dup
-			IL_0279: ldstr "exit /b 0"
-			IL_027e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0283: stloc.s 13
-			IL_0285: br IL_02a8
+			IL_023d: ldc.i4.4
+			IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0243: dup
+			IL_0244: ldstr "/d"
+			IL_0249: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_024e: dup
+			IL_024f: ldstr "/s"
+			IL_0254: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0259: dup
+			IL_025a: ldstr "/c"
+			IL_025f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0264: dup
+			IL_0265: ldstr "exit /b 0"
+			IL_026a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_026f: stloc.s 10
+			IL_0271: br IL_0294
 
-			IL_028a: ldc.i4.2
-			IL_028b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0290: dup
-			IL_0291: ldstr "-c"
-			IL_0296: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_029b: dup
-			IL_029c: ldstr "exit 0"
-			IL_02a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02a6: stloc.s 13
+			IL_0276: ldc.i4.2
+			IL_0277: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_027c: dup
+			IL_027d: ldstr "-c"
+			IL_0282: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0287: dup
+			IL_0288: ldstr "exit 0"
+			IL_028d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0292: stloc.s 10
 
-			IL_02a8: ldloc.s 27
-			IL_02aa: ldstr "spawn"
-			IL_02af: ldloc.s 12
-			IL_02b1: ldloc.s 13
-			IL_02b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02b8: dup
-			IL_02b9: ldstr "stdio"
-			IL_02be: ldc.i4.4
-			IL_02bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02c4: dup
-			IL_02c5: ldstr "pipe"
-			IL_02ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02cf: dup
-			IL_02d0: ldstr "pipe"
-			IL_02d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02da: dup
-			IL_02db: ldstr "pipe"
-			IL_02e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e5: dup
-			IL_02e6: ldstr "ipc"
-			IL_02eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_02fa: pop
-			IL_02fb: leave IL_036f
+			IL_0294: ldloc.s 21
+			IL_0296: ldstr "spawn"
+			IL_029b: ldloc.s 9
+			IL_029d: ldloc.s 10
+			IL_029f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a4: dup
+			IL_02a5: ldstr "stdio"
+			IL_02aa: ldc.i4.4
+			IL_02ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02b0: dup
+			IL_02b1: ldstr "pipe"
+			IL_02b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02bb: dup
+			IL_02bc: ldstr "pipe"
+			IL_02c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02c6: dup
+			IL_02c7: ldstr "pipe"
+			IL_02cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02d1: dup
+			IL_02d2: ldstr "ipc"
+			IL_02d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02e6: pop
+			IL_02e7: leave IL_0354
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0300: stloc.s 14
-			IL_0302: ldloc.s 14
-			IL_0304: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0309: dup
-			IL_030a: brtrue IL_0320
+			IL_02ec: stloc.s 11
+			IL_02ee: ldloc.s 11
+			IL_02f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02f5: dup
+			IL_02f6: brtrue IL_030c
 
-			IL_030f: pop
-			IL_0310: ldloc.s 14
-			IL_0312: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0317: dup
-			IL_0318: brtrue IL_032c
+			IL_02fb: pop
+			IL_02fc: ldloc.s 11
+			IL_02fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0303: dup
+			IL_0304: brtrue IL_0318
 
-			IL_031d: pop
-			IL_031e: rethrow
+			IL_0309: pop
+			IL_030a: rethrow
 
-			IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0325: stloc.s 15
-			IL_0327: br IL_032e
+			IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0311: stloc.s 12
+			IL_0313: br IL_031a
 
-			IL_032c: stloc.s 15
+			IL_0318: stloc.s 12
 
-			IL_032e: ldloc.s 15
-			IL_0330: stloc.s 27
-			IL_0332: ldloc.s 27
-			IL_0334: stloc.s 16
-			IL_0336: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L23C14::.ctor()
-			IL_033b: stloc.s 17
-			IL_033d: ldstr "console"
-			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0347: stloc.s 27
-			IL_0349: ldloc.s 27
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0350: stloc.s 27
-			IL_0352: ldloc.s 27
-			IL_0354: ldstr "log"
-			IL_0359: ldstr "spawn ipc error:"
-			IL_035e: ldc.i4.1
-			IL_035f: box [System.Runtime]System.Boolean
-			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0369: pop
-			IL_036a: leave IL_036f
+			IL_031a: ldloc.s 12
+			IL_031c: stloc.s 21
+			IL_031e: ldloc.s 21
+			IL_0320: stloc.s 13
+			IL_0322: ldstr "console"
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_032c: stloc.s 21
+			IL_032e: ldloc.s 21
+			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0335: stloc.s 21
+			IL_0337: ldloc.s 21
+			IL_0339: ldstr "log"
+			IL_033e: ldstr "spawn ipc error:"
+			IL_0343: ldc.i4.1
+			IL_0344: box [System.Runtime]System.Boolean
+			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_034e: pop
+			IL_034f: leave IL_0354
 		} // end handler
 		.try
 		{
-			IL_036f: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L27C4::.ctor()
-			IL_0374: stloc.s 18
-			IL_0376: ldstr "process"
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0380: stloc.s 27
-			IL_0382: ldloc.s 27
-			IL_0384: ldstr "platform"
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038e: stloc.s 27
-			IL_0390: ldloc.s 27
-			IL_0392: ldstr "win32"
-			IL_0397: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_039c: stloc.s 31
-			IL_039e: ldloc.s 31
-			IL_03a0: stloc.s 19
-			IL_03a2: ldloc.1
-			IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a8: stloc.s 27
-			IL_03aa: ldloc.s 19
-			IL_03ac: brfalse IL_03bd
+			IL_0354: nop
+			IL_0355: ldstr "process"
+			IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_035f: stloc.s 21
+			IL_0361: ldloc.s 21
+			IL_0363: ldstr "platform"
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036d: stloc.s 21
+			IL_036f: ldloc.s 21
+			IL_0371: ldstr "win32"
+			IL_0376: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_037b: stloc.s 25
+			IL_037d: ldloc.s 25
+			IL_037f: stloc.s 14
+			IL_0381: ldloc.1
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0387: stloc.s 21
+			IL_0389: ldloc.s 14
+			IL_038b: brfalse IL_039c
 
-			IL_03b1: ldstr "cmd.exe"
-			IL_03b6: stloc.s 20
-			IL_03b8: br IL_03c4
+			IL_0390: ldstr "cmd.exe"
+			IL_0395: stloc.s 15
+			IL_0397: br IL_03a3
 
-			IL_03bd: ldstr "/bin/sh"
-			IL_03c2: stloc.s 20
+			IL_039c: ldstr "/bin/sh"
+			IL_03a1: stloc.s 15
 
-			IL_03c4: ldloc.s 19
-			IL_03c6: brfalse IL_0404
+			IL_03a3: ldloc.s 14
+			IL_03a5: brfalse IL_03e3
 
-			IL_03cb: ldc.i4.4
-			IL_03cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03aa: ldc.i4.4
+			IL_03ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03b0: dup
+			IL_03b1: ldstr "/d"
+			IL_03b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03bb: dup
+			IL_03bc: ldstr "/s"
+			IL_03c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03c6: dup
+			IL_03c7: ldstr "/c"
+			IL_03cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_03d1: dup
-			IL_03d2: ldstr "/d"
+			IL_03d2: ldstr "exit /b 0"
 			IL_03d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03dc: dup
-			IL_03dd: ldstr "/s"
-			IL_03e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03e7: dup
-			IL_03e8: ldstr "/c"
-			IL_03ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03f2: dup
-			IL_03f3: ldstr "exit /b 0"
-			IL_03f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03fd: stloc.s 21
-			IL_03ff: br IL_0422
+			IL_03dc: stloc.s 16
+			IL_03de: br IL_0401
 
-			IL_0404: ldc.i4.2
-			IL_0405: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_040a: dup
-			IL_040b: ldstr "-c"
-			IL_0410: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0415: dup
-			IL_0416: ldstr "exit 0"
-			IL_041b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0420: stloc.s 21
+			IL_03e3: ldc.i4.2
+			IL_03e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03e9: dup
+			IL_03ea: ldstr "-c"
+			IL_03ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03f4: dup
+			IL_03f5: ldstr "exit 0"
+			IL_03fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03ff: stloc.s 16
 
-			IL_0422: ldloc.s 27
-			IL_0424: ldstr "spawn"
-			IL_0429: ldloc.s 20
-			IL_042b: ldloc.s 21
-			IL_042d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0432: dup
-			IL_0433: ldstr "detached"
-			IL_0438: ldc.i4.1
-			IL_0439: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0443: pop
-			IL_0444: leave IL_04fe
+			IL_0401: ldloc.s 21
+			IL_0403: ldstr "spawn"
+			IL_0408: ldloc.s 15
+			IL_040a: ldloc.s 16
+			IL_040c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0411: dup
+			IL_0412: ldstr "detached"
+			IL_0417: ldc.i4.1
+			IL_0418: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0422: pop
+			IL_0423: leave IL_04d6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0449: stloc.s 22
-			IL_044b: ldloc.s 22
-			IL_044d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0452: dup
-			IL_0453: brtrue IL_0469
+			IL_0428: stloc.s 17
+			IL_042a: ldloc.s 17
+			IL_042c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0431: dup
+			IL_0432: brtrue IL_0448
 
-			IL_0458: pop
-			IL_0459: ldloc.s 22
-			IL_045b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0460: dup
-			IL_0461: brtrue IL_0475
+			IL_0437: pop
+			IL_0438: ldloc.s 17
+			IL_043a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_043f: dup
+			IL_0440: brtrue IL_0454
 
-			IL_0466: pop
-			IL_0467: rethrow
+			IL_0445: pop
+			IL_0446: rethrow
 
-			IL_0469: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_046e: stloc.s 23
-			IL_0470: br IL_0477
+			IL_0448: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_044d: stloc.s 18
+			IL_044f: br IL_0456
 
-			IL_0475: stloc.s 23
+			IL_0454: stloc.s 18
 
-			IL_0477: ldloc.s 23
-			IL_0479: stloc.s 27
-			IL_047b: ldloc.s 27
-			IL_047d: stloc.s 24
-			IL_047f: newobj instance void Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope/Block_L33C14::.ctor()
-			IL_0484: stloc.s 25
-			IL_0486: ldstr "console"
-			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0490: stloc.s 27
-			IL_0492: ldloc.s 27
-			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0499: stloc.s 27
-			IL_049b: ldloc.s 24
-			IL_049d: ldstr "message"
-			IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ac: stloc.s 29
-			IL_04ae: ldloc.s 29
-			IL_04b0: ldstr "indexOf"
-			IL_04b5: ldstr "detached child processes"
-			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04bf: stloc.s 29
-			IL_04c1: ldloc.s 29
-			IL_04c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_04c8: stloc.s 30
-			IL_04ca: ldloc.s 30
-			IL_04cc: ldc.r8 0.0
-			IL_04d5: clt
-			IL_04d7: ldc.i4.0
-			IL_04d8: ceq
-			IL_04da: stloc.s 31
-			IL_04dc: ldloc.s 31
-			IL_04de: box [System.Runtime]System.Boolean
-			IL_04e3: stloc.s 32
-			IL_04e5: ldloc.s 27
-			IL_04e7: ldstr "log"
-			IL_04ec: ldstr "spawn detached error:"
-			IL_04f1: ldloc.s 32
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04f8: pop
-			IL_04f9: leave IL_04fe
+			IL_0456: ldloc.s 18
+			IL_0458: stloc.s 21
+			IL_045a: ldloc.s 21
+			IL_045c: stloc.s 19
+			IL_045e: ldstr "console"
+			IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0468: stloc.s 21
+			IL_046a: ldloc.s 21
+			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0471: stloc.s 21
+			IL_0473: ldloc.s 19
+			IL_0475: ldstr "message"
+			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0484: stloc.s 23
+			IL_0486: ldloc.s 23
+			IL_0488: ldstr "indexOf"
+			IL_048d: ldstr "detached child processes"
+			IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0497: stloc.s 23
+			IL_0499: ldloc.s 23
+			IL_049b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_04a0: stloc.s 24
+			IL_04a2: ldloc.s 24
+			IL_04a4: ldc.r8 0.0
+			IL_04ad: clt
+			IL_04af: ldc.i4.0
+			IL_04b0: ceq
+			IL_04b2: stloc.s 25
+			IL_04b4: ldloc.s 25
+			IL_04b6: box [System.Runtime]System.Boolean
+			IL_04bb: stloc.s 26
+			IL_04bd: ldloc.s 21
+			IL_04bf: ldstr "log"
+			IL_04c4: ldstr "spawn detached error:"
+			IL_04c9: ldloc.s 26
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04d0: pop
+			IL_04d1: leave IL_04d6
 		} // end handler
 
-		IL_04fe: ldnull
-		IL_04ff: stloc.s 26
-		IL_0501: ret
+		IL_04d6: ldnull
+		IL_04d7: stloc.s 20
+		IL_04d9: ret
 	} // end of method Require_ChildProcess_Fork_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Unsupported_Options
@@ -706,7 +690,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2615
+		// Method begins at RVA 0x25ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f57
+					// Method begins at RVA 0x3f2f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f60
+					// Method begins at RVA 0x3f38
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f4e
+				// Method begins at RVA 0x3f26
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -87,16 +87,15 @@
 			)
 			// Method begins at RVA 0x28a8
 			// Header size: 12
-			// Code size: 312 (0x138)
+			// Code size: 304 (0x130)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
 				[1] object,
 				[2] object,
-				[3] class Modules.Require_Crypto_ErrorPaths/logError/Scope/Block_L9C20,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			.try
@@ -108,22 +107,22 @@
 				IL_000c: pop
 				IL_000d: ldstr "console"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0017: stloc.s 5
-				IL_0019: ldloc.s 5
+				IL_0017: stloc.s 4
+				IL_0019: ldloc.s 4
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.s 5
+				IL_0020: stloc.s 4
 				IL_0022: ldarg.1
 				IL_0023: ldstr " threw:"
 				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_002d: stloc.s 6
-				IL_002f: ldloc.s 5
+				IL_002d: stloc.s 5
+				IL_002f: ldloc.s 4
 				IL_0031: ldstr "log"
-				IL_0036: ldloc.s 6
+				IL_0036: ldloc.s 5
 				IL_0038: ldc.i4.0
 				IL_0039: box [System.Runtime]System.Boolean
 				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 				IL_0043: pop
-				IL_0044: leave IL_0132
+				IL_0044: leave IL_012c
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -149,71 +148,69 @@
 				IL_0071: stloc.1
 
 				IL_0072: ldloc.1
-				IL_0073: stloc.s 5
-				IL_0075: ldloc.s 5
+				IL_0073: stloc.s 4
+				IL_0075: ldloc.s 4
 				IL_0077: stloc.2
-				IL_0078: newobj instance void Modules.Require_Crypto_ErrorPaths/logError/Scope/Block_L9C20::.ctor()
-				IL_007d: stloc.3
-				IL_007e: ldstr "console"
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0088: stloc.s 5
-				IL_008a: ldloc.s 5
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0091: stloc.s 5
-				IL_0093: ldarg.1
-				IL_0094: ldstr " threw:"
-				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_009e: stloc.s 6
-				IL_00a0: ldloc.s 5
-				IL_00a2: ldstr "log"
-				IL_00a7: ldloc.s 6
-				IL_00a9: ldc.i4.1
-				IL_00aa: box [System.Runtime]System.Boolean
-				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00b4: pop
-				IL_00b5: ldstr "console"
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00bf: stloc.s 5
-				IL_00c1: ldloc.s 5
-				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c8: stloc.s 5
-				IL_00ca: ldarg.1
-				IL_00cb: ldstr " name:"
-				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d5: stloc.s 6
-				IL_00d7: ldloc.s 5
-				IL_00d9: ldstr "log"
-				IL_00de: ldloc.s 6
-				IL_00e0: ldloc.2
-				IL_00e1: ldstr "name"
-				IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00f0: pop
-				IL_00f1: ldstr "console"
-				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00fb: stloc.s 5
-				IL_00fd: ldloc.s 5
-				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0104: stloc.s 5
-				IL_0106: ldarg.1
-				IL_0107: ldstr " message:"
-				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0111: stloc.s 6
-				IL_0113: ldloc.s 5
-				IL_0115: ldstr "log"
-				IL_011a: ldloc.s 6
-				IL_011c: ldloc.2
-				IL_011d: ldstr "message"
-				IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_012c: pop
-				IL_012d: leave IL_0132
+				IL_0078: ldstr "console"
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0082: stloc.s 4
+				IL_0084: ldloc.s 4
+				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008b: stloc.s 4
+				IL_008d: ldarg.1
+				IL_008e: ldstr " threw:"
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0098: stloc.s 5
+				IL_009a: ldloc.s 4
+				IL_009c: ldstr "log"
+				IL_00a1: ldloc.s 5
+				IL_00a3: ldc.i4.1
+				IL_00a4: box [System.Runtime]System.Boolean
+				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00ae: pop
+				IL_00af: ldstr "console"
+				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00b9: stloc.s 4
+				IL_00bb: ldloc.s 4
+				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c2: stloc.s 4
+				IL_00c4: ldarg.1
+				IL_00c5: ldstr " name:"
+				IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00cf: stloc.s 5
+				IL_00d1: ldloc.s 4
+				IL_00d3: ldstr "log"
+				IL_00d8: ldloc.s 5
+				IL_00da: ldloc.2
+				IL_00db: ldstr "name"
+				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00ea: pop
+				IL_00eb: ldstr "console"
+				IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00f5: stloc.s 4
+				IL_00f7: ldloc.s 4
+				IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00fe: stloc.s 4
+				IL_0100: ldarg.1
+				IL_0101: ldstr " message:"
+				IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_010b: stloc.s 5
+				IL_010d: ldloc.s 4
+				IL_010f: ldstr "log"
+				IL_0114: ldloc.s 5
+				IL_0116: ldloc.2
+				IL_0117: ldstr "message"
+				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0126: pop
+				IL_0127: leave IL_012c
 			} // end handler
 
-			IL_0132: ldnull
-			IL_0133: stloc.s 4
-			IL_0135: ldloc.s 4
-			IL_0137: ret
+			IL_012c: ldnull
+			IL_012d: stloc.3
+			IL_012e: ldloc.3
+			IL_012f: ret
 		} // end of method logError::__js_call__
 
 	} // end of class logError
@@ -229,7 +226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f69
+				// Method begins at RVA 0x3f41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +252,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29fc
+			// Method begins at RVA 0x29f4
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -290,7 +287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f72
+				// Method begins at RVA 0x3f4a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -316,7 +313,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x2a28
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -350,7 +347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f7b
+				// Method begins at RVA 0x3f53
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -376,7 +373,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a5c
+			// Method begins at RVA 0x2a54
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -412,7 +409,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f84
+				// Method begins at RVA 0x3f5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -438,7 +435,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a98
+			// Method begins at RVA 0x2a90
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -473,7 +470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f8d
+				// Method begins at RVA 0x3f65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -499,7 +496,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2ac8
+			// Method begins at RVA 0x2ac0
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -535,7 +532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f96
+				// Method begins at RVA 0x3f6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -561,7 +558,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2afc
+			// Method begins at RVA 0x2af4
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -597,7 +594,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f9f
+				// Method begins at RVA 0x3f77
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -623,7 +620,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b38
+			// Method begins at RVA 0x2b30
 			// Header size: 12
 			// Code size: 82 (0x52)
 			.maxstack 8
@@ -676,7 +673,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fa8
+				// Method begins at RVA 0x3f80
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -702,7 +699,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b98
+			// Method begins at RVA 0x2b90
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -759,7 +756,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fb1
+				// Method begins at RVA 0x3f89
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -785,7 +782,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c00
+			// Method begins at RVA 0x2bf8
 			// Header size: 12
 			// Code size: 99 (0x63)
 			.maxstack 8
@@ -843,7 +840,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fba
+				// Method begins at RVA 0x3f92
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -869,7 +866,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c70
+			// Method begins at RVA 0x2c68
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -927,7 +924,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fc3
+				// Method begins at RVA 0x3f9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -953,7 +950,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2cd8
+			// Method begins at RVA 0x2cd0
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1009,7 +1006,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fcc
+				// Method begins at RVA 0x3fa4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1035,7 +1032,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d38
+			// Method begins at RVA 0x2d30
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1092,7 +1089,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fd5
+				// Method begins at RVA 0x3fad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1118,7 +1115,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2da0
+			// Method begins at RVA 0x2d98
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1175,7 +1172,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fde
+				// Method begins at RVA 0x3fb6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1201,7 +1198,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e08
+			// Method begins at RVA 0x2e00
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1258,7 +1255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fe7
+				// Method begins at RVA 0x3fbf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1284,7 +1281,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e70
+			// Method begins at RVA 0x2e68
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -1345,7 +1342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ff0
+				// Method begins at RVA 0x3fc8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1371,7 +1368,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2edc
+			// Method begins at RVA 0x2ed4
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -1405,7 +1402,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ff9
+				// Method begins at RVA 0x3fd1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1431,7 +1428,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2f08
+			// Method begins at RVA 0x2f00
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1467,7 +1464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4002
+				// Method begins at RVA 0x3fda
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1493,7 +1490,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2f40
+			// Method begins at RVA 0x2f38
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -1527,7 +1524,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x400b
+				// Method begins at RVA 0x3fe3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1553,7 +1550,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2f6c
+			// Method begins at RVA 0x2f64
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -1601,7 +1598,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x401d
+					// Method begins at RVA 0x3ff5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1621,7 +1618,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4026
+					// Method begins at RVA 0x3ffe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1645,7 +1642,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4014
+				// Method begins at RVA 0x3fec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1671,16 +1668,15 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2fa0
+			// Method begins at RVA 0x2f98
 			// Header size: 12
-			// Code size: 557 (0x22d)
+			// Code size: 528 (0x210)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_ErrorPaths/logPromiseError/Scope,
 				[1] object,
-				[2] class Modules.Require_Crypto_ErrorPaths/logPromiseError/Scope/Block_L46C20,
-				[3] object,
-				[4] object
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -1723,14 +1719,14 @@
 			IL_0050: brtrue IL_0061
 
 			IL_0055: ldloc.0
-			IL_0056: ldc.i4.4
+			IL_0056: ldc.i4.3
 			IL_0057: newarr [System.Runtime]System.Object
 			IL_005c: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0061: ldloc.0
 			IL_0062: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0067: ldc.i4.0
-			IL_0068: ble IL_008a
+			IL_0068: ble IL_0080
 
 			IL_006d: ldloc.0
 			IL_006e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -1741,176 +1737,165 @@
 			IL_0077: dup
 			IL_0078: ldc.i4.1
 			IL_0079: ldelem.ref
-			IL_007a: castclass Modules.Require_Crypto_ErrorPaths/logPromiseError/Scope/Block_L46C20
-			IL_007f: stloc.2
-			IL_0080: dup
-			IL_0081: ldc.i4.2
-			IL_0082: ldelem.ref
-			IL_0083: stloc.3
-			IL_0084: dup
-			IL_0085: ldc.i4.3
-			IL_0086: ldelem.ref
-			IL_0087: stloc.s 4
-			IL_0089: pop
+			IL_007a: stloc.2
+			IL_007b: dup
+			IL_007c: ldc.i4.2
+			IL_007d: ldelem.ref
+			IL_007e: stloc.3
+			IL_007f: pop
 
-			IL_008a: ldloc.0
-			IL_008b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0090: switch (IL_00a1, IL_013f, IL_0100)
+			IL_0080: ldloc.0
+			IL_0081: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0086: switch (IL_0097, IL_012e, IL_00f1)
 
-			IL_00a1: ldloc.0
-			IL_00a2: ldc.i4.0
-			IL_00a3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00a8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_00ad: ldarg.3
-			IL_00ae: ldc.i4.1
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: dup
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldarg.0
-			IL_00b7: ldc.i4.1
-			IL_00b8: ldelem.ref
-			IL_00b9: stelem.ref
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00bf: stloc.3
-			IL_00c0: ldloc.0
-			IL_00c1: ldc.i4.2
-			IL_00c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c7: ldloc.0
-			IL_00c8: ldloc.3
-			IL_00c9: ldarg.0
-			IL_00ca: ldc.i4.1
-			IL_00cb: ldloc.0
-			IL_00cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00d1: ldc.i4.1
-			IL_00d2: ldstr "_pendingException"
-			IL_00d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_00dc: ldloc.0
-			IL_00dd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00e2: dup
-			IL_00e3: ldc.i4.0
-			IL_00e4: ldloc.1
-			IL_00e5: stelem.ref
-			IL_00e6: dup
-			IL_00e7: ldc.i4.1
-			IL_00e8: ldloc.2
-			IL_00e9: stelem.ref
-			IL_00ea: dup
-			IL_00eb: ldc.i4.2
-			IL_00ec: ldloc.3
-			IL_00ed: stelem.ref
-			IL_00ee: dup
-			IL_00ef: ldc.i4.3
-			IL_00f0: ldloc.s 4
-			IL_00f2: stelem.ref
-			IL_00f3: pop
-			IL_00f4: ldloc.0
-			IL_00f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00fa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_00ff: ret
+			IL_0097: ldloc.0
+			IL_0098: ldc.i4.0
+			IL_0099: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_009e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00a3: ldarg.3
+			IL_00a4: ldc.i4.1
+			IL_00a5: newarr [System.Runtime]System.Object
+			IL_00aa: dup
+			IL_00ab: ldc.i4.0
+			IL_00ac: ldarg.0
+			IL_00ad: ldc.i4.1
+			IL_00ae: ldelem.ref
+			IL_00af: stelem.ref
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b5: stloc.2
+			IL_00b6: ldloc.0
+			IL_00b7: ldc.i4.2
+			IL_00b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00bd: ldloc.0
+			IL_00be: ldloc.2
+			IL_00bf: ldarg.0
+			IL_00c0: ldc.i4.1
+			IL_00c1: ldloc.0
+			IL_00c2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00c7: ldc.i4.1
+			IL_00c8: ldstr "_pendingException"
+			IL_00cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_00d2: ldloc.0
+			IL_00d3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00d8: dup
+			IL_00d9: ldc.i4.0
+			IL_00da: ldloc.1
+			IL_00db: stelem.ref
+			IL_00dc: dup
+			IL_00dd: ldc.i4.1
+			IL_00de: ldloc.2
+			IL_00df: stelem.ref
+			IL_00e0: dup
+			IL_00e1: ldc.i4.2
+			IL_00e2: ldloc.3
+			IL_00e3: stelem.ref
+			IL_00e4: pop
+			IL_00e5: ldloc.0
+			IL_00e6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00f0: ret
 
-			IL_0100: ldloc.0
-			IL_0101: ldfld object Modules.Require_Crypto_ErrorPaths/logPromiseError/Scope::_awaited1
-			IL_0106: pop
-			IL_0107: ldstr "console"
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0111: stloc.3
-			IL_0112: ldloc.3
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0118: stloc.3
-			IL_0119: ldarg.2
-			IL_011a: ldstr " threw:"
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0124: stloc.s 4
-			IL_0126: ldloc.3
-			IL_0127: ldstr "log"
-			IL_012c: ldloc.s 4
-			IL_012e: ldc.i4.0
-			IL_012f: box [System.Runtime]System.Boolean
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0139: pop
-			IL_013a: br IL_0202
+			IL_00f1: ldloc.0
+			IL_00f2: ldfld object Modules.Require_Crypto_ErrorPaths/logPromiseError/Scope::_awaited1
+			IL_00f7: pop
+			IL_00f8: ldstr "console"
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0102: stloc.2
+			IL_0103: ldloc.2
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0109: stloc.2
+			IL_010a: ldarg.2
+			IL_010b: ldstr " threw:"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0115: stloc.3
+			IL_0116: ldloc.2
+			IL_0117: ldstr "log"
+			IL_011c: ldloc.3
+			IL_011d: ldc.i4.0
+			IL_011e: box [System.Runtime]System.Boolean
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0128: pop
+			IL_0129: br IL_01e5
 
-			IL_013f: ldloc.0
-			IL_0140: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0145: stloc.3
-			IL_0146: ldloc.0
-			IL_0147: ldc.i4.0
-			IL_0148: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_014d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0152: ldloc.3
-			IL_0153: stloc.1
-			IL_0154: newobj instance void Modules.Require_Crypto_ErrorPaths/logPromiseError/Scope/Block_L46C20::.ctor()
-			IL_0159: stloc.2
-			IL_015a: ldstr "console"
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0164: stloc.3
-			IL_0165: ldloc.3
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016b: stloc.3
-			IL_016c: ldarg.2
-			IL_016d: ldstr " threw:"
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0177: stloc.s 4
-			IL_0179: ldloc.3
-			IL_017a: ldstr "log"
-			IL_017f: ldloc.s 4
-			IL_0181: ldc.i4.1
-			IL_0182: box [System.Runtime]System.Boolean
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_018c: pop
-			IL_018d: ldstr "console"
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0197: stloc.3
+			IL_012e: ldloc.0
+			IL_012f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0134: stloc.2
+			IL_0135: ldloc.0
+			IL_0136: ldc.i4.0
+			IL_0137: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_013c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0141: ldloc.2
+			IL_0142: stloc.1
+			IL_0143: ldstr "console"
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_014d: stloc.2
+			IL_014e: ldloc.2
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0154: stloc.2
+			IL_0155: ldarg.2
+			IL_0156: ldstr " threw:"
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0160: stloc.3
+			IL_0161: ldloc.2
+			IL_0162: ldstr "log"
+			IL_0167: ldloc.3
+			IL_0168: ldc.i4.1
+			IL_0169: box [System.Runtime]System.Boolean
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0173: pop
+			IL_0174: ldstr "console"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017e: stloc.2
+			IL_017f: ldloc.2
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0185: stloc.2
+			IL_0186: ldarg.2
+			IL_0187: ldstr " name:"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0191: stloc.3
+			IL_0192: ldloc.2
+			IL_0193: ldstr "log"
 			IL_0198: ldloc.3
-			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_019e: stloc.3
-			IL_019f: ldarg.2
-			IL_01a0: ldstr " name:"
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01aa: stloc.s 4
-			IL_01ac: ldloc.3
-			IL_01ad: ldstr "log"
-			IL_01b2: ldloc.s 4
-			IL_01b4: ldloc.1
-			IL_01b5: ldstr "name"
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c4: pop
-			IL_01c5: ldstr "console"
-			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01cf: stloc.3
-			IL_01d0: ldloc.3
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d6: stloc.3
-			IL_01d7: ldarg.2
-			IL_01d8: ldstr " message:"
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01e2: stloc.s 4
-			IL_01e4: ldloc.3
-			IL_01e5: ldstr "log"
-			IL_01ea: ldloc.s 4
-			IL_01ec: ldloc.1
-			IL_01ed: ldstr "message"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01fc: pop
-			IL_01fd: br IL_0202
+			IL_0199: ldloc.1
+			IL_019a: ldstr "name"
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01a9: pop
+			IL_01aa: ldstr "console"
+			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b4: stloc.2
+			IL_01b5: ldloc.2
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bb: stloc.2
+			IL_01bc: ldarg.2
+			IL_01bd: ldstr " message:"
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01c7: stloc.3
+			IL_01c8: ldloc.2
+			IL_01c9: ldstr "log"
+			IL_01ce: ldloc.3
+			IL_01cf: ldloc.1
+			IL_01d0: ldstr "message"
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01df: pop
+			IL_01e0: br IL_01e5
 
-			IL_0202: ldloc.0
-			IL_0203: ldc.i4.m1
-			IL_0204: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0209: ldloc.0
-			IL_020a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0214: ldarg.0
-			IL_0215: ldc.i4.1
-			IL_0216: newarr [System.Runtime]System.Object
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0220: pop
-			IL_0221: ldloc.0
-			IL_0222: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0227: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_022c: ret
+			IL_01e5: ldloc.0
+			IL_01e6: ldc.i4.m1
+			IL_01e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ec: ldloc.0
+			IL_01ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01f7: ldarg.0
+			IL_01f8: ldc.i4.1
+			IL_01f9: newarr [System.Runtime]System.Object
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0203: pop
+			IL_0204: ldloc.0
+			IL_0205: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_020a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_020f: ret
 		} // end of method logPromiseError::__js_call__
 
 	} // end of class logPromiseError
@@ -1930,7 +1915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4038
+					// Method begins at RVA 0x4010
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1954,7 +1939,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a54
+				// Method begins at RVA 0x3a2c
 				// Header size: 12
 				// Code size: 50 (0x32)
 				.maxstack 8
@@ -1996,7 +1981,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4041
+					// Method begins at RVA 0x4019
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2020,7 +2005,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a94
+				// Method begins at RVA 0x3a6c
 				// Header size: 12
 				// Code size: 135 (0x87)
 				.maxstack 8
@@ -2101,7 +2086,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x404a
+					// Method begins at RVA 0x4022
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2125,7 +2110,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b28
+				// Method begins at RVA 0x3b00
 				// Header size: 12
 				// Code size: 126 (0x7e)
 				.maxstack 9
@@ -2199,7 +2184,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4053
+					// Method begins at RVA 0x402b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2223,7 +2208,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3bb4
+				// Method begins at RVA 0x3b8c
 				// Header size: 12
 				// Code size: 124 (0x7c)
 				.maxstack 8
@@ -2301,7 +2286,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x405c
+					// Method begins at RVA 0x4034
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2325,7 +2310,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c3c
+				// Method begins at RVA 0x3c14
 				// Header size: 12
 				// Code size: 135 (0x87)
 				.maxstack 8
@@ -2406,7 +2391,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4065
+					// Method begins at RVA 0x403d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2430,7 +2415,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cd0
+				// Method begins at RVA 0x3ca8
 				// Header size: 12
 				// Code size: 135 (0x87)
 				.maxstack 8
@@ -2511,7 +2496,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x406e
+					// Method begins at RVA 0x4046
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2535,7 +2520,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d64
+				// Method begins at RVA 0x3d3c
 				// Header size: 12
 				// Code size: 144 (0x90)
 				.maxstack 8
@@ -2617,7 +2602,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4077
+					// Method begins at RVA 0x404f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2641,7 +2626,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e00
+				// Method begins at RVA 0x3dd8
 				// Header size: 12
 				// Code size: 155 (0x9b)
 				.maxstack 8
@@ -2726,7 +2711,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4080
+					// Method begins at RVA 0x4058
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2750,7 +2735,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ea8
+				// Method begins at RVA 0x3e80
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2800,7 +2785,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4089
+					// Method begins at RVA 0x4061
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2824,7 +2809,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ef8
+				// Method begins at RVA 0x3ed0
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2902,7 +2887,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x402f
+				// Method begins at RVA 0x4007
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2926,7 +2911,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31dc
+			// Method begins at RVA 0x31b4
 			// Header size: 12
 			// Code size: 2101 (0x835)
 			.maxstack 8
@@ -3945,7 +3930,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4092
+				// Method begins at RVA 0x406a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3968,7 +3953,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3a20
+			// Method begins at RVA 0x39f8
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -4020,7 +4005,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3f45
+			// Method begins at RVA 0x3f1d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4880,7 +4865,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x409b
+		// Method begins at RVA 0x4073
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e6
+				// Method begins at RVA 0x30b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3101
+						// Method begins at RVA 0x30cf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f8
+					// Method begins at RVA 0x30c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ef
+				// Method begins at RVA 0x30bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -684,7 +684,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x311c
+						// Method begins at RVA 0x30ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -708,7 +708,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x312e
+							// Method begins at RVA 0x30fc
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -726,7 +726,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3125
+						// Method begins at RVA 0x30f3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -746,7 +746,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3137
+						// Method begins at RVA 0x3105
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -770,7 +770,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3113
+					// Method begins at RVA 0x30e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -794,9 +794,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cf4
+				// Method begins at RVA 0x2ce0
 				// Header size: 12
-				// Code size: 989 (0x3dd)
+				// Code size: 959 (0x3bf)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope,
@@ -807,9 +807,8 @@
 					[5] bool,
 					[6] bool,
 					[7] object,
-					[8] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16,
-					[9] object,
-					[10] bool
+					[8] object,
+					[9] bool
 				)
 
 				IL_0000: ldarg.0
@@ -842,14 +841,14 @@
 				IL_0042: brtrue IL_0054
 
 				IL_0047: ldloc.0
-				IL_0048: ldc.i4.s 10
+				IL_0048: ldc.i4.s 9
 				IL_004a: newarr [System.Runtime]System.Object
 				IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 				IL_0054: ldloc.0
 				IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 				IL_005a: ldc.i4.0
-				IL_005b: ble IL_00ba
+				IL_005b: ble IL_00af
 
 				IL_0060: ldloc.0
 				IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -889,349 +888,334 @@
 				IL_009f: dup
 				IL_00a0: ldc.i4.7
 				IL_00a1: ldelem.ref
-				IL_00a2: castclass Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16
-				IL_00a7: stloc.s 8
-				IL_00a9: dup
-				IL_00aa: ldc.i4.8
-				IL_00ab: ldelem.ref
+				IL_00a2: stloc.s 8
+				IL_00a4: dup
+				IL_00a5: ldc.i4.8
+				IL_00a6: ldelem.ref
+				IL_00a7: unbox.any [System.Runtime]System.Boolean
 				IL_00ac: stloc.s 9
-				IL_00ae: dup
-				IL_00af: ldc.i4.s 9
-				IL_00b1: ldelem.ref
-				IL_00b2: unbox.any [System.Runtime]System.Boolean
-				IL_00b7: stloc.s 10
-				IL_00b9: pop
+				IL_00ae: pop
 
-				IL_00ba: ldloc.0
-				IL_00bb: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_00c0: switch (IL_00dd, IL_0367, IL_020f, IL_02bd, IL_01a7, IL_02b1)
+				IL_00af: ldloc.0
+				IL_00b0: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_00b5: switch (IL_00d2, IL_0350, IL_01fe, IL_02a6, IL_0196, IL_029a)
 
-				IL_00dd: ldloc.0
-				IL_00de: ldc.i4.0
-				IL_00df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_00e4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_00e9: ldarg.0
-				IL_00ea: ldc.i4.2
-				IL_00eb: ldelem.ref
-				IL_00ec: castclass Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope
-				IL_00f1: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-				IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-				IL_00fb: stloc.1
-				IL_00fc: ldc.i4.0
-				IL_00fd: stloc.2
-				IL_00fe: ldc.i4.0
-				IL_00ff: stloc.3
-				IL_0100: ldloc.0
-				IL_0101: ldc.i4.0
-				IL_0102: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0107: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_010c: ldloc.0
-				IL_010d: ldc.i4.0
-				IL_010e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0113: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-				IL_0118: ldloc.0
-				IL_0119: ldc.i4.0
-				IL_011a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_011f: ldloc.0
-				IL_0120: ldc.i4.0
-				IL_0121: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_00d2: ldloc.0
+				IL_00d3: ldc.i4.0
+				IL_00d4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_00d9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_00de: ldarg.0
+				IL_00df: ldc.i4.2
+				IL_00e0: ldelem.ref
+				IL_00e1: castclass Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope
+				IL_00e6: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
+				IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+				IL_00f0: stloc.1
+				IL_00f1: ldc.i4.0
+				IL_00f2: stloc.2
+				IL_00f3: ldc.i4.0
+				IL_00f4: stloc.3
+				IL_00f5: ldloc.0
+				IL_00f6: ldc.i4.0
+				IL_00f7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_00fc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0101: ldloc.0
+				IL_0102: ldc.i4.0
+				IL_0103: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0108: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+				IL_010d: ldloc.0
+				IL_010e: ldc.i4.0
+				IL_010f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_0114: ldloc.0
+				IL_0115: ldc.i4.0
+				IL_0116: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-				IL_0126: ldloc.1
-				IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-				IL_012c: stloc.s 9
-				IL_012e: ldloc.0
-				IL_012f: ldc.i4.4
-				IL_0130: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0135: ldloc.0
-				IL_0136: ldloc.s 9
-				IL_0138: ldarg.0
-				IL_0139: ldc.i4.1
-				IL_013a: ldloc.0
-				IL_013b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-				IL_0140: ldc.i4.2
-				IL_0141: ldstr "_pendingException"
-				IL_0146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-				IL_014b: ldloc.0
-				IL_014c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-				IL_0151: dup
-				IL_0152: ldc.i4.0
-				IL_0153: ldloc.1
-				IL_0154: stelem.ref
-				IL_0155: dup
-				IL_0156: ldc.i4.1
-				IL_0157: ldloc.2
-				IL_0158: box [System.Runtime]System.Boolean
-				IL_015d: stelem.ref
-				IL_015e: dup
-				IL_015f: ldc.i4.2
-				IL_0160: ldloc.3
-				IL_0161: box [System.Runtime]System.Boolean
-				IL_0166: stelem.ref
-				IL_0167: dup
-				IL_0168: ldc.i4.3
-				IL_0169: ldloc.s 4
-				IL_016b: stelem.ref
-				IL_016c: dup
-				IL_016d: ldc.i4.4
-				IL_016e: ldloc.s 5
-				IL_0170: box [System.Runtime]System.Boolean
-				IL_0175: stelem.ref
-				IL_0176: dup
-				IL_0177: ldc.i4.5
-				IL_0178: ldloc.s 6
-				IL_017a: box [System.Runtime]System.Boolean
-				IL_017f: stelem.ref
-				IL_0180: dup
-				IL_0181: ldc.i4.6
-				IL_0182: ldloc.s 7
-				IL_0184: stelem.ref
-				IL_0185: dup
-				IL_0186: ldc.i4.7
-				IL_0187: ldloc.s 8
-				IL_0189: stelem.ref
-				IL_018a: dup
-				IL_018b: ldc.i4.8
-				IL_018c: ldloc.s 9
-				IL_018e: stelem.ref
-				IL_018f: dup
-				IL_0190: ldc.i4.s 9
-				IL_0192: ldloc.s 10
-				IL_0194: box [System.Runtime]System.Boolean
-				IL_0199: stelem.ref
-				IL_019a: pop
-				IL_019b: ldloc.0
-				IL_019c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_01a1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_01a6: ret
+				IL_011b: ldloc.1
+				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+				IL_0121: stloc.s 8
+				IL_0123: ldloc.0
+				IL_0124: ldc.i4.4
+				IL_0125: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_012a: ldloc.0
+				IL_012b: ldloc.s 8
+				IL_012d: ldarg.0
+				IL_012e: ldc.i4.1
+				IL_012f: ldloc.0
+				IL_0130: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+				IL_0135: ldc.i4.2
+				IL_0136: ldstr "_pendingException"
+				IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+				IL_0140: ldloc.0
+				IL_0141: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+				IL_0146: dup
+				IL_0147: ldc.i4.0
+				IL_0148: ldloc.1
+				IL_0149: stelem.ref
+				IL_014a: dup
+				IL_014b: ldc.i4.1
+				IL_014c: ldloc.2
+				IL_014d: box [System.Runtime]System.Boolean
+				IL_0152: stelem.ref
+				IL_0153: dup
+				IL_0154: ldc.i4.2
+				IL_0155: ldloc.3
+				IL_0156: box [System.Runtime]System.Boolean
+				IL_015b: stelem.ref
+				IL_015c: dup
+				IL_015d: ldc.i4.3
+				IL_015e: ldloc.s 4
+				IL_0160: stelem.ref
+				IL_0161: dup
+				IL_0162: ldc.i4.4
+				IL_0163: ldloc.s 5
+				IL_0165: box [System.Runtime]System.Boolean
+				IL_016a: stelem.ref
+				IL_016b: dup
+				IL_016c: ldc.i4.5
+				IL_016d: ldloc.s 6
+				IL_016f: box [System.Runtime]System.Boolean
+				IL_0174: stelem.ref
+				IL_0175: dup
+				IL_0176: ldc.i4.6
+				IL_0177: ldloc.s 7
+				IL_0179: stelem.ref
+				IL_017a: dup
+				IL_017b: ldc.i4.7
+				IL_017c: ldloc.s 8
+				IL_017e: stelem.ref
+				IL_017f: dup
+				IL_0180: ldc.i4.8
+				IL_0181: ldloc.s 9
+				IL_0183: box [System.Runtime]System.Boolean
+				IL_0188: stelem.ref
+				IL_0189: pop
+				IL_018a: ldloc.0
+				IL_018b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0190: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_0195: ret
 
-				IL_01a7: ldloc.0
-				IL_01a8: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited1
-				IL_01ad: stloc.s 9
-				IL_01af: ldloc.s 9
-				IL_01b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_01b6: stloc.s 10
-				IL_01b8: ldloc.s 10
-				IL_01ba: brtrue IL_0208
+				IL_0196: ldloc.0
+				IL_0197: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited1
+				IL_019c: stloc.s 8
+				IL_019e: ldloc.s 8
+				IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+				IL_01a5: stloc.s 9
+				IL_01a7: ldloc.s 9
+				IL_01a9: brtrue IL_01f7
 
-				IL_01bf: ldloc.s 9
-				IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_01c6: stloc.s 9
-				IL_01c8: ldloc.s 9
-				IL_01ca: stloc.s 4
-				IL_01cc: ldstr "console"
-				IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01d6: stloc.s 9
-				IL_01d8: ldloc.s 9
-				IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01df: stloc.s 9
-				IL_01e1: ldloc.s 9
-				IL_01e3: ldstr "log"
-				IL_01e8: ldloc.s 4
-				IL_01ea: ldc.r8 0.0
-				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01fd: pop
-				IL_01fe: br IL_0126
+				IL_01ae: ldloc.s 8
+				IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+				IL_01b5: stloc.s 8
+				IL_01b7: ldloc.s 8
+				IL_01b9: stloc.s 4
+				IL_01bb: ldstr "console"
+				IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01c5: stloc.s 8
+				IL_01c7: ldloc.s 8
+				IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01ce: stloc.s 8
+				IL_01d0: ldloc.s 8
+				IL_01d2: ldstr "log"
+				IL_01d7: ldloc.s 4
+				IL_01d9: ldc.r8 0.0
+				IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01ec: pop
+				IL_01ed: br IL_011b
 
-				IL_0203: br IL_0222
+				IL_01f2: br IL_0211
 
-				IL_0208: ldc.i4.1
-				IL_0209: stloc.2
-				IL_020a: br IL_0222
+				IL_01f7: ldc.i4.1
+				IL_01f8: stloc.2
+				IL_01f9: br IL_0211
 
-				IL_020f: ldloc.0
-				IL_0210: ldc.i4.1
-				IL_0211: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_0216: ldloc.0
-				IL_0217: ldc.i4.0
-				IL_0218: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_021d: br IL_0222
+				IL_01fe: ldloc.0
+				IL_01ff: ldc.i4.1
+				IL_0200: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_0205: ldloc.0
+				IL_0206: ldc.i4.0
+				IL_0207: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_020c: br IL_0211
 
-				IL_0222: ldloc.2
-				IL_0223: brtrue IL_02b8
+				IL_0211: ldloc.2
+				IL_0212: brtrue IL_02a1
 
-				IL_0228: ldloc.3
-				IL_0229: brtrue IL_02b8
+				IL_0217: ldloc.3
+				IL_0218: brtrue IL_02a1
 
-				IL_022e: ldc.i4.1
-				IL_022f: stloc.3
-				IL_0230: ldloc.1
-				IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-				IL_0236: stloc.s 9
-				IL_0238: ldloc.0
-				IL_0239: ldc.i4.5
-				IL_023a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_023f: ldloc.0
-				IL_0240: ldloc.s 9
-				IL_0242: ldarg.0
-				IL_0243: ldc.i4.2
+				IL_021d: ldc.i4.1
+				IL_021e: stloc.3
+				IL_021f: ldloc.1
+				IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+				IL_0225: stloc.s 8
+				IL_0227: ldloc.0
+				IL_0228: ldc.i4.5
+				IL_0229: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_022e: ldloc.0
+				IL_022f: ldloc.s 8
+				IL_0231: ldarg.0
+				IL_0232: ldc.i4.2
+				IL_0233: ldloc.0
+				IL_0234: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+				IL_0239: ldc.i4.3
+				IL_023a: ldstr "_pendingException"
+				IL_023f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
 				IL_0244: ldloc.0
-				IL_0245: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-				IL_024a: ldc.i4.3
-				IL_024b: ldstr "_pendingException"
-				IL_0250: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-				IL_0255: ldloc.0
-				IL_0256: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-				IL_025b: dup
-				IL_025c: ldc.i4.0
-				IL_025d: ldloc.1
-				IL_025e: stelem.ref
-				IL_025f: dup
-				IL_0260: ldc.i4.1
-				IL_0261: ldloc.2
-				IL_0262: box [System.Runtime]System.Boolean
-				IL_0267: stelem.ref
-				IL_0268: dup
-				IL_0269: ldc.i4.2
-				IL_026a: ldloc.3
-				IL_026b: box [System.Runtime]System.Boolean
-				IL_0270: stelem.ref
-				IL_0271: dup
-				IL_0272: ldc.i4.3
-				IL_0273: ldloc.s 4
-				IL_0275: stelem.ref
-				IL_0276: dup
-				IL_0277: ldc.i4.4
-				IL_0278: ldloc.s 5
-				IL_027a: box [System.Runtime]System.Boolean
-				IL_027f: stelem.ref
-				IL_0280: dup
-				IL_0281: ldc.i4.5
-				IL_0282: ldloc.s 6
-				IL_0284: box [System.Runtime]System.Boolean
-				IL_0289: stelem.ref
-				IL_028a: dup
-				IL_028b: ldc.i4.6
-				IL_028c: ldloc.s 7
-				IL_028e: stelem.ref
-				IL_028f: dup
-				IL_0290: ldc.i4.7
-				IL_0291: ldloc.s 8
-				IL_0293: stelem.ref
-				IL_0294: dup
-				IL_0295: ldc.i4.8
-				IL_0296: ldloc.s 9
-				IL_0298: stelem.ref
-				IL_0299: dup
-				IL_029a: ldc.i4.s 9
-				IL_029c: ldloc.s 10
-				IL_029e: box [System.Runtime]System.Boolean
-				IL_02a3: stelem.ref
-				IL_02a4: pop
-				IL_02a5: ldloc.0
-				IL_02a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_02ab: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_02b0: ret
+				IL_0245: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+				IL_024a: dup
+				IL_024b: ldc.i4.0
+				IL_024c: ldloc.1
+				IL_024d: stelem.ref
+				IL_024e: dup
+				IL_024f: ldc.i4.1
+				IL_0250: ldloc.2
+				IL_0251: box [System.Runtime]System.Boolean
+				IL_0256: stelem.ref
+				IL_0257: dup
+				IL_0258: ldc.i4.2
+				IL_0259: ldloc.3
+				IL_025a: box [System.Runtime]System.Boolean
+				IL_025f: stelem.ref
+				IL_0260: dup
+				IL_0261: ldc.i4.3
+				IL_0262: ldloc.s 4
+				IL_0264: stelem.ref
+				IL_0265: dup
+				IL_0266: ldc.i4.4
+				IL_0267: ldloc.s 5
+				IL_0269: box [System.Runtime]System.Boolean
+				IL_026e: stelem.ref
+				IL_026f: dup
+				IL_0270: ldc.i4.5
+				IL_0271: ldloc.s 6
+				IL_0273: box [System.Runtime]System.Boolean
+				IL_0278: stelem.ref
+				IL_0279: dup
+				IL_027a: ldc.i4.6
+				IL_027b: ldloc.s 7
+				IL_027d: stelem.ref
+				IL_027e: dup
+				IL_027f: ldc.i4.7
+				IL_0280: ldloc.s 8
+				IL_0282: stelem.ref
+				IL_0283: dup
+				IL_0284: ldc.i4.8
+				IL_0285: ldloc.s 9
+				IL_0287: box [System.Runtime]System.Boolean
+				IL_028c: stelem.ref
+				IL_028d: pop
+				IL_028e: ldloc.0
+				IL_028f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0294: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_0299: ret
 
-				IL_02b1: ldloc.0
-				IL_02b2: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited2
-				IL_02b7: pop
+				IL_029a: ldloc.0
+				IL_029b: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope::_awaited2
+				IL_02a0: pop
 
-				IL_02b8: br IL_02d0
+				IL_02a1: br IL_02b9
 
-				IL_02bd: ldloc.0
-				IL_02be: ldc.i4.1
-				IL_02bf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_02c4: ldloc.0
-				IL_02c5: ldc.i4.0
-				IL_02c6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_02cb: br IL_02d0
+				IL_02a6: ldloc.0
+				IL_02a7: ldc.i4.1
+				IL_02a8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_02ad: ldloc.0
+				IL_02ae: ldc.i4.0
+				IL_02af: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_02b4: br IL_02b9
 
+				IL_02b9: ldloc.0
+				IL_02ba: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+				IL_02bf: stloc.s 5
+				IL_02c1: ldloc.s 5
+				IL_02c3: brfalse IL_02dd
+
+				IL_02c8: ldloc.0
+				IL_02c9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_02ce: stloc.s 8
 				IL_02d0: ldloc.0
-				IL_02d1: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-				IL_02d6: stloc.s 5
-				IL_02d8: ldloc.s 5
-				IL_02da: brfalse IL_02f4
+				IL_02d1: ldloc.s 8
+				IL_02d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_02d8: br IL_0350
 
-				IL_02df: ldloc.0
-				IL_02e0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_02e5: stloc.s 9
-				IL_02e7: ldloc.0
-				IL_02e8: ldloc.s 9
-				IL_02ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_02ef: br IL_0367
+				IL_02dd: ldloc.0
+				IL_02de: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+				IL_02e3: stloc.s 6
+				IL_02e5: ldloc.s 6
+				IL_02e7: brfalse IL_0324
 
+				IL_02ec: ldloc.0
+				IL_02ed: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+				IL_02f2: stloc.s 8
 				IL_02f4: ldloc.0
-				IL_02f5: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-				IL_02fa: stloc.s 6
-				IL_02fc: ldloc.s 6
-				IL_02fe: brfalse IL_033b
+				IL_02f5: ldc.i4.m1
+				IL_02f6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_02fb: ldloc.0
+				IL_02fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_0301: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+				IL_0306: ldarg.0
+				IL_0307: ldc.i4.1
+				IL_0308: newarr [System.Runtime]System.Object
+				IL_030d: dup
+				IL_030e: ldc.i4.0
+				IL_030f: ldloc.s 8
+				IL_0311: stelem.ref
+				IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+				IL_0317: pop
+				IL_0318: ldloc.0
+				IL_0319: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_031e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_0323: ret
 
-				IL_0303: ldloc.0
-				IL_0304: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-				IL_0309: stloc.s 9
-				IL_030b: ldloc.0
-				IL_030c: ldc.i4.m1
-				IL_030d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_0312: ldloc.0
-				IL_0313: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0318: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-				IL_031d: ldarg.0
-				IL_031e: ldc.i4.1
-				IL_031f: newarr [System.Runtime]System.Object
-				IL_0324: dup
-				IL_0325: ldc.i4.0
-				IL_0326: ldloc.s 9
-				IL_0328: stelem.ref
-				IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-				IL_032e: pop
-				IL_032f: ldloc.0
-				IL_0330: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_0335: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_033a: ret
+				IL_0324: ldstr "console"
+				IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_032e: stloc.s 8
+				IL_0330: ldloc.s 8
+				IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0337: stloc.s 8
+				IL_0339: ldloc.s 8
+				IL_033b: ldstr "log"
+				IL_0340: ldstr "NO_REJECT"
+				IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_034a: pop
+				IL_034b: br IL_0394
 
-				IL_033b: ldstr "console"
-				IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0345: stloc.s 9
-				IL_0347: ldloc.s 9
-				IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_034e: stloc.s 9
-				IL_0350: ldloc.s 9
-				IL_0352: ldstr "log"
-				IL_0357: ldstr "NO_REJECT"
-				IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0361: pop
-				IL_0362: br IL_03b2
+				IL_0350: ldloc.0
+				IL_0351: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0356: stloc.s 8
+				IL_0358: ldloc.0
+				IL_0359: ldc.i4.0
+				IL_035a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_035f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+				IL_0364: ldloc.s 8
+				IL_0366: stloc.s 7
+				IL_0368: ldstr "console"
+				IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0372: stloc.s 8
+				IL_0374: ldloc.s 8
+				IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_037b: stloc.s 8
+				IL_037d: ldloc.s 8
+				IL_037f: ldstr "log"
+				IL_0384: ldstr "iter-reject"
+				IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_038e: pop
+				IL_038f: br IL_0394
 
-				IL_0367: ldloc.0
-				IL_0368: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_036d: stloc.s 9
-				IL_036f: ldloc.0
-				IL_0370: ldc.i4.0
-				IL_0371: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0376: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-				IL_037b: ldloc.s 9
-				IL_037d: stloc.s 7
-				IL_037f: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17/Scope/Block_L37C16::.ctor()
-				IL_0384: stloc.s 8
-				IL_0386: ldstr "console"
-				IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0390: stloc.s 9
-				IL_0392: ldloc.s 9
-				IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0399: stloc.s 9
-				IL_039b: ldloc.s 9
-				IL_039d: ldstr "log"
-				IL_03a2: ldstr "iter-reject"
-				IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03ac: pop
-				IL_03ad: br IL_03b2
-
-				IL_03b2: ldloc.0
-				IL_03b3: ldc.i4.m1
-				IL_03b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-				IL_03b9: ldloc.0
-				IL_03ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_03bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-				IL_03c4: ldarg.0
-				IL_03c5: ldc.i4.1
-				IL_03c6: newarr [System.Runtime]System.Object
-				IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-				IL_03d0: pop
-				IL_03d1: ldloc.0
-				IL_03d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-				IL_03d7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-				IL_03dc: ret
+				IL_0394: ldloc.0
+				IL_0395: ldc.i4.m1
+				IL_0396: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+				IL_039b: ldloc.0
+				IL_039c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_03a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+				IL_03a6: ldarg.0
+				IL_03a7: ldc.i4.1
+				IL_03a8: newarr [System.Runtime]System.Object
+				IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+				IL_03b2: pop
+				IL_03b3: ldloc.0
+				IL_03b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+				IL_03b9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+				IL_03be: ret
 			} // end of method ArrowFunction_L31C17::__js_call__
 
 		} // end of class ArrowFunction_L31C17
@@ -1252,7 +1236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x310a
+				// Method begins at RVA 0x30d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1507,7 +1491,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3140
+				// Method begins at RVA 0x310e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1764,7 +1748,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3152
+					// Method begins at RVA 0x3120
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1784,7 +1768,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x315b
+					// Method begins at RVA 0x3129
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1808,7 +1792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3149
+				// Method begins at RVA 0x3117
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1834,15 +1818,14 @@
 			)
 			// Method begins at RVA 0x2abc
 			// Header size: 12
-			// Code size: 504 (0x1f8)
+			// Code size: 482 (0x1e2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14,
-				[5] object
+				[4] object
 			)
 
 			IL_0000: ldarg.0
@@ -1875,14 +1858,14 @@
 			IL_0042: brtrue IL_0053
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.5
+			IL_0048: ldc.i4.4
 			IL_0049: newarr [System.Runtime]System.Object
 			IL_004e: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0053: ldloc.0
 			IL_0054: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0059: ldc.i4.0
-			IL_005a: ble IL_0081
+			IL_005a: ble IL_0077
 
 			IL_005f: ldloc.0
 			IL_0060: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -1901,152 +1884,141 @@
 			IL_0071: dup
 			IL_0072: ldc.i4.3
 			IL_0073: ldelem.ref
-			IL_0074: castclass Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14
-			IL_0079: stloc.s 4
-			IL_007b: dup
-			IL_007c: ldc.i4.4
-			IL_007d: ldelem.ref
-			IL_007e: stloc.s 5
-			IL_0080: pop
+			IL_0074: stloc.s 4
+			IL_0076: pop
 
-			IL_0081: ldloc.0
-			IL_0082: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0087: switch (IL_0098, IL_0183, IL_0150)
+			IL_0077: ldloc.0
+			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_007d: switch (IL_008e, IL_0174, IL_0141)
 
-			IL_0098: ldarg.0
-			IL_0099: ldc.i4.1
-			IL_009a: ldelem.ref
-			IL_009b: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00a0: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-			IL_00a5: ldc.i4.0
-			IL_00a6: newarr [System.Runtime]System.Object
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_00b0: stloc.s 5
-			IL_00b2: ldloc.s 5
-			IL_00b4: stloc.1
-			IL_00b5: ldarg.0
-			IL_00b6: ldc.i4.1
-			IL_00b7: ldelem.ref
-			IL_00b8: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00bd: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c7: stloc.s 5
-			IL_00c9: ldloc.s 5
-			IL_00cb: ldstr "once"
-			IL_00d0: ldloc.1
-			IL_00d1: ldstr "ready"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00db: stloc.s 5
-			IL_00dd: ldloc.s 5
-			IL_00df: stloc.2
-			IL_00e0: ldloc.1
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e6: stloc.s 5
-			IL_00e8: ldloc.s 5
-			IL_00ea: ldstr "emit"
-			IL_00ef: ldstr "error"
-			IL_00f4: ldstr "boom"
-			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00fe: pop
-			IL_00ff: ldloc.0
-			IL_0100: ldc.i4.0
-			IL_0101: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0106: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_010b: ldloc.0
-			IL_010c: ldc.i4.2
-			IL_010d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0112: ldloc.0
-			IL_0113: ldloc.2
-			IL_0114: ldarg.0
-			IL_0115: ldc.i4.1
-			IL_0116: ldloc.0
-			IL_0117: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_011c: ldc.i4.1
-			IL_011d: ldstr "_pendingException"
-			IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0127: ldloc.0
-			IL_0128: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012d: dup
-			IL_012e: ldc.i4.0
-			IL_012f: ldloc.1
-			IL_0130: stelem.ref
-			IL_0131: dup
-			IL_0132: ldc.i4.1
-			IL_0133: ldloc.2
-			IL_0134: stelem.ref
-			IL_0135: dup
-			IL_0136: ldc.i4.2
-			IL_0137: ldloc.3
-			IL_0138: stelem.ref
-			IL_0139: dup
-			IL_013a: ldc.i4.3
-			IL_013b: ldloc.s 4
-			IL_013d: stelem.ref
-			IL_013e: dup
-			IL_013f: ldc.i4.4
-			IL_0140: ldloc.s 5
-			IL_0142: stelem.ref
-			IL_0143: pop
-			IL_0144: ldloc.0
-			IL_0145: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_014a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_014f: ret
+			IL_008e: ldarg.0
+			IL_008f: ldc.i4.1
+			IL_0090: ldelem.ref
+			IL_0091: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_0096: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
+			IL_009b: ldc.i4.0
+			IL_009c: newarr [System.Runtime]System.Object
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_00a6: stloc.s 4
+			IL_00a8: ldloc.s 4
+			IL_00aa: stloc.1
+			IL_00ab: ldarg.0
+			IL_00ac: ldc.i4.1
+			IL_00ad: ldelem.ref
+			IL_00ae: castclass Modules.Events_AsyncHelpers_On_Once/Scope
+			IL_00b3: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bd: stloc.s 4
+			IL_00bf: ldloc.s 4
+			IL_00c1: ldstr "once"
+			IL_00c6: ldloc.1
+			IL_00c7: ldstr "ready"
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d1: stloc.s 4
+			IL_00d3: ldloc.s 4
+			IL_00d5: stloc.2
+			IL_00d6: ldloc.1
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00dc: stloc.s 4
+			IL_00de: ldloc.s 4
+			IL_00e0: ldstr "emit"
+			IL_00e5: ldstr "error"
+			IL_00ea: ldstr "boom"
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00f4: pop
+			IL_00f5: ldloc.0
+			IL_00f6: ldc.i4.0
+			IL_00f7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00fc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0101: ldloc.0
+			IL_0102: ldc.i4.2
+			IL_0103: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0108: ldloc.0
+			IL_0109: ldloc.2
+			IL_010a: ldarg.0
+			IL_010b: ldc.i4.1
+			IL_010c: ldloc.0
+			IL_010d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0112: ldc.i4.1
+			IL_0113: ldstr "_pendingException"
+			IL_0118: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_011d: ldloc.0
+			IL_011e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0123: dup
+			IL_0124: ldc.i4.0
+			IL_0125: ldloc.1
+			IL_0126: stelem.ref
+			IL_0127: dup
+			IL_0128: ldc.i4.1
+			IL_0129: ldloc.2
+			IL_012a: stelem.ref
+			IL_012b: dup
+			IL_012c: ldc.i4.2
+			IL_012d: ldloc.3
+			IL_012e: stelem.ref
+			IL_012f: dup
+			IL_0130: ldc.i4.3
+			IL_0131: ldloc.s 4
+			IL_0133: stelem.ref
+			IL_0134: pop
+			IL_0135: ldloc.0
+			IL_0136: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_013b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0140: ret
 
-			IL_0150: ldloc.0
-			IL_0151: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
-			IL_0156: pop
-			IL_0157: ldstr "console"
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0161: stloc.s 5
-			IL_0163: ldloc.s 5
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016a: stloc.s 5
-			IL_016c: ldloc.s 5
-			IL_016e: ldstr "log"
-			IL_0173: ldstr "NO_REJECT"
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_017d: pop
-			IL_017e: br IL_01cd
+			IL_0141: ldloc.0
+			IL_0142: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
+			IL_0147: pop
+			IL_0148: ldstr "console"
+			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0152: stloc.s 4
+			IL_0154: ldloc.s 4
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015b: stloc.s 4
+			IL_015d: ldloc.s 4
+			IL_015f: ldstr "log"
+			IL_0164: ldstr "NO_REJECT"
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_016e: pop
+			IL_016f: br IL_01b7
 
-			IL_0183: ldloc.0
-			IL_0184: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0189: stloc.s 5
-			IL_018b: ldloc.0
-			IL_018c: ldc.i4.0
-			IL_018d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0192: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0197: ldloc.s 5
-			IL_0199: stloc.3
-			IL_019a: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope/Block_L65C14::.ctor()
-			IL_019f: stloc.s 4
-			IL_01a1: ldstr "console"
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ab: stloc.s 5
-			IL_01ad: ldloc.s 5
-			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b4: stloc.s 5
-			IL_01b6: ldloc.s 5
-			IL_01b8: ldstr "log"
-			IL_01bd: ldstr "once-reject"
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c7: pop
-			IL_01c8: br IL_01cd
+			IL_0174: ldloc.0
+			IL_0175: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_017a: stloc.s 4
+			IL_017c: ldloc.0
+			IL_017d: ldc.i4.0
+			IL_017e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0183: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0188: ldloc.s 4
+			IL_018a: stloc.3
+			IL_018b: ldstr "console"
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0195: stloc.s 4
+			IL_0197: ldloc.s 4
+			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019e: stloc.s 4
+			IL_01a0: ldloc.s 4
+			IL_01a2: ldstr "log"
+			IL_01a7: ldstr "once-reject"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b1: pop
+			IL_01b2: br IL_01b7
 
-			IL_01cd: ldloc.0
-			IL_01ce: ldc.i4.m1
-			IL_01cf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d4: ldloc.0
-			IL_01d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01df: ldarg.0
-			IL_01e0: ldc.i4.1
-			IL_01e1: newarr [System.Runtime]System.Object
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01eb: pop
-			IL_01ec: ldloc.0
-			IL_01ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01f2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f7: ret
+			IL_01b7: ldloc.0
+			IL_01b8: ldc.i4.m1
+			IL_01b9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01be: ldloc.0
+			IL_01bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01c9: ldarg.0
+			IL_01ca: ldc.i4.1
+			IL_01cb: newarr [System.Runtime]System.Object
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01d5: pop
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01dc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01e1: ret
 		} // end of method runOnceReject::__js_call__
 
 	} // end of class runOnceReject
@@ -2062,7 +2034,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3164
+				// Method begins at RVA 0x3132
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2085,7 +2057,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cc0
+			// Method begins at RVA 0x2cac
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -2139,7 +2111,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30dd
+			// Method begins at RVA 0x30ab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2332,7 +2304,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x316d
+		// Method begins at RVA 0x313b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2322
+				// Method begins at RVA 0x231a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2258
+			// Method begins at RVA 0x2250
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x232b
+				// Method begins at RVA 0x2323
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,7 +109,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2294
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -152,7 +152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2334
+				// Method begins at RVA 0x232c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22d8
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x233d
+				// Method begins at RVA 0x2335
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +237,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2346
+				// Method begins at RVA 0x233e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +255,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2319
+			// Method begins at RVA 0x2311
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -281,7 +281,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 490 (0x1ea)
+		// Code size: 483 (0x1e3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_ErrorMonitor/Scope,
@@ -292,11 +292,10 @@
 			[5] class [System.Runtime]System.Exception,
 			[6] object,
 			[7] object,
-			[8] class Modules.Events_EventEmitter_ErrorMonitor/Scope/Block_L24C12,
+			[8] object,
 			[9] object,
 			[10] object,
-			[11] object,
-			[12] object
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/Scope::.ctor()
@@ -305,8 +304,8 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "node:events"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 10
-		IL_0014: ldloc.s 10
+		IL_0012: stloc.s 9
+		IL_0014: ldloc.s 9
 		IL_0016: stloc.1
 		IL_0017: ldloc.1
 		IL_0018: ldstr "EventEmitter"
@@ -316,16 +315,16 @@
 		IL_0024: ldc.i4.0
 		IL_0025: newarr [System.Runtime]System.Object
 		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_002f: stloc.s 10
-		IL_0031: ldloc.s 10
+		IL_002f: stloc.s 9
+		IL_0031: ldloc.s 9
 		IL_0033: stloc.3
 		IL_0034: ldloc.3
 		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003a: stloc.s 10
+		IL_003a: stloc.s 9
 		IL_003c: ldloc.1
 		IL_003d: ldstr "errorMonitor"
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0047: stloc.s 11
+		IL_0047: stloc.s 10
 		IL_0049: ldnull
 		IL_004a: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
 		IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -335,16 +334,16 @@
 		IL_005c: ldc.i4.0
 		IL_005d: ldc.i4.1
 		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0063: stloc.s 12
-		IL_0065: ldloc.s 10
+		IL_0063: stloc.s 11
+		IL_0065: ldloc.s 9
 		IL_0067: ldstr "on"
-		IL_006c: ldloc.s 11
-		IL_006e: ldloc.s 12
+		IL_006c: ldloc.s 10
+		IL_006e: ldloc.s 11
 		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0075: pop
 		IL_0076: ldloc.3
 		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007c: stloc.s 12
+		IL_007c: stloc.s 11
 		IL_007e: ldnull
 		IL_007f: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
 		IL_0085: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -354,40 +353,40 @@
 		IL_0091: ldc.i4.0
 		IL_0092: ldc.i4.1
 		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0098: stloc.s 11
-		IL_009a: ldloc.s 12
+		IL_0098: stloc.s 10
+		IL_009a: ldloc.s 11
 		IL_009c: ldstr "on"
 		IL_00a1: ldstr "error"
-		IL_00a6: ldloc.s 11
+		IL_00a6: ldloc.s 10
 		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00ad: pop
 		IL_00ae: ldloc.3
 		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b4: stloc.s 11
+		IL_00b4: stloc.s 10
 		IL_00b6: ldstr "boom"
 		IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 		IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_00c5: stloc.s 12
-		IL_00c7: ldloc.s 11
+		IL_00c5: stloc.s 11
+		IL_00c7: ldloc.s 10
 		IL_00c9: ldstr "emit"
 		IL_00ce: ldstr "error"
-		IL_00d3: ldloc.s 12
+		IL_00d3: ldloc.s 11
 		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00da: pop
 		IL_00db: ldloc.2
 		IL_00dc: ldc.i4.0
 		IL_00dd: newarr [System.Runtime]System.Object
 		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_00e7: stloc.s 12
-		IL_00e9: ldloc.s 12
+		IL_00e7: stloc.s 11
+		IL_00e9: ldloc.s 11
 		IL_00eb: stloc.s 4
 		IL_00ed: ldloc.s 4
 		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f4: stloc.s 12
+		IL_00f4: stloc.s 11
 		IL_00f6: ldloc.1
 		IL_00f7: ldstr "errorMonitor"
 		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0101: stloc.s 11
+		IL_0101: stloc.s 10
 		IL_0103: ldnull
 		IL_0104: ldftn object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
 		IL_010a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
@@ -397,11 +396,11 @@
 		IL_0116: ldc.i4.0
 		IL_0117: ldc.i4.1
 		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_011d: stloc.s 10
-		IL_011f: ldloc.s 12
+		IL_011d: stloc.s 9
+		IL_011f: ldloc.s 11
 		IL_0121: ldstr "on"
-		IL_0126: ldloc.s 11
-		IL_0128: ldloc.s 10
+		IL_0126: ldloc.s 10
+		IL_0128: ldloc.s 9
 		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_012f: pop
 		.try
@@ -409,8 +408,8 @@
 			IL_0130: nop
 			IL_0131: ldloc.s 4
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0138: stloc.s 10
-			IL_013a: ldloc.s 10
+			IL_0138: stloc.s 9
+			IL_013a: ldloc.s 9
 			IL_013c: ldstr "emit"
 			IL_0141: ldstr "error"
 			IL_0146: ldstr "fatal"
@@ -418,16 +417,16 @@
 			IL_0150: pop
 			IL_0151: ldstr "console"
 			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_015b: stloc.s 10
-			IL_015d: ldloc.s 10
+			IL_015b: stloc.s 9
+			IL_015d: ldloc.s 9
 			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0164: stloc.s 10
-			IL_0166: ldloc.s 10
+			IL_0164: stloc.s 9
+			IL_0166: ldloc.s 9
 			IL_0168: ldstr "log"
 			IL_016d: ldstr "NO_THROW"
 			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0177: pop
-			IL_0178: leave IL_01e6
+			IL_0178: leave IL_01df
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -453,28 +452,26 @@
 			IL_01a9: stloc.s 6
 
 			IL_01ab: ldloc.s 6
-			IL_01ad: stloc.s 10
-			IL_01af: ldloc.s 10
+			IL_01ad: stloc.s 9
+			IL_01af: ldloc.s 9
 			IL_01b1: stloc.s 7
-			IL_01b3: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/Scope/Block_L24C12::.ctor()
-			IL_01b8: stloc.s 8
-			IL_01ba: ldstr "console"
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c4: stloc.s 10
-			IL_01c6: ldloc.s 10
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cd: stloc.s 10
-			IL_01cf: ldloc.s 10
-			IL_01d1: ldstr "log"
-			IL_01d6: ldstr "thrown"
-			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01e0: pop
-			IL_01e1: leave IL_01e6
+			IL_01b3: ldstr "console"
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01bd: stloc.s 9
+			IL_01bf: ldloc.s 9
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c6: stloc.s 9
+			IL_01c8: ldloc.s 9
+			IL_01ca: ldstr "log"
+			IL_01cf: ldstr "thrown"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01d9: pop
+			IL_01da: leave IL_01df
 		} // end handler
 
-		IL_01e6: ldnull
-		IL_01e7: stloc.s 9
-		IL_01e9: ret
+		IL_01df: ldnull
+		IL_01e0: stloc.s 8
+		IL_01e2: ret
 	} // end of method Events_EventEmitter_ErrorMonitor::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_ErrorMonitor
@@ -486,7 +483,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x234f
+		// Method begins at RVA 0x2347
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_SetMaxListeners_Validation.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_SetMaxListeners_Validation.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a5
+				// Method begins at RVA 0x2399
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ae
+				// Method begins at RVA 0x23a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b7
+				// Method begins at RVA 0x23ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c0
+				// Method begins at RVA 0x23b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x239c
+			// Method begins at RVA 0x2390
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 804 (0x324)
+		// Code size: 790 (0x316)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope,
@@ -134,15 +134,13 @@
 			[6] class [System.Runtime]System.Exception,
 			[7] object,
 			[8] object,
-			[9] class Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope/Block_L24C12,
-			[10] object,
-			[11] class [System.Runtime]System.Exception,
+			[9] object,
+			[10] class [System.Runtime]System.Exception,
+			[11] object,
 			[12] object,
 			[13] object,
-			[14] class Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope/Block_L33C12,
-			[15] object,
-			[16] object,
-			[17] object
+			[14] object,
+			[15] object
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope::.ctor()
@@ -151,8 +149,8 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "node:events"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 16
-		IL_0014: ldloc.s 16
+		IL_0012: stloc.s 14
+		IL_0014: ldloc.s 14
 		IL_0016: stloc.1
 		IL_0017: ldloc.1
 		IL_0018: ldstr "EventEmitter"
@@ -162,31 +160,31 @@
 		IL_0024: ldc.i4.0
 		IL_0025: newarr [System.Runtime]System.Object
 		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_002f: stloc.s 16
-		IL_0031: ldloc.s 16
+		IL_002f: stloc.s 14
+		IL_0031: ldloc.s 14
 		IL_0033: stloc.3
 		IL_0034: ldstr "console"
 		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_003e: stloc.s 16
-		IL_0040: ldloc.s 16
+		IL_003e: stloc.s 14
+		IL_0040: ldloc.s 14
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0047: stloc.s 16
+		IL_0047: stloc.s 14
 		IL_0049: ldloc.3
 		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.s 17
-		IL_0051: ldloc.s 17
+		IL_004f: stloc.s 15
+		IL_0051: ldloc.s 15
 		IL_0053: ldstr "getMaxListeners"
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005d: stloc.s 17
-		IL_005f: ldloc.s 16
+		IL_005d: stloc.s 15
+		IL_005f: ldloc.s 14
 		IL_0061: ldstr "log"
-		IL_0066: ldloc.s 17
+		IL_0066: ldloc.s 15
 		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_006d: pop
 		IL_006e: ldloc.3
 		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: stloc.s 17
-		IL_0076: ldloc.s 17
+		IL_0074: stloc.s 15
+		IL_0076: ldloc.s 15
 		IL_0078: ldstr "setMaxListeners"
 		IL_007d: ldc.r8 20
 		IL_0086: box [System.Runtime]System.Double
@@ -194,26 +192,26 @@
 		IL_0090: pop
 		IL_0091: ldstr "console"
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: stloc.s 17
-		IL_009d: ldloc.s 17
+		IL_009b: stloc.s 15
+		IL_009d: ldloc.s 15
 		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: stloc.s 17
+		IL_00a4: stloc.s 15
 		IL_00a6: ldloc.3
 		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 16
-		IL_00ae: ldloc.s 16
+		IL_00ac: stloc.s 14
+		IL_00ae: ldloc.s 14
 		IL_00b0: ldstr "getMaxListeners"
 		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00ba: stloc.s 16
-		IL_00bc: ldloc.s 17
+		IL_00ba: stloc.s 14
+		IL_00bc: ldloc.s 15
 		IL_00be: ldstr "log"
-		IL_00c3: ldloc.s 16
+		IL_00c3: ldloc.s 14
 		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00ca: pop
 		IL_00cb: ldloc.3
 		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d1: stloc.s 16
-		IL_00d3: ldloc.s 16
+		IL_00d1: stloc.s 14
+		IL_00d3: ldloc.s 14
 		IL_00d5: ldstr "setMaxListeners"
 		IL_00da: ldc.r8 0.0
 		IL_00e3: box [System.Runtime]System.Double
@@ -221,69 +219,69 @@
 		IL_00ed: pop
 		IL_00ee: ldstr "console"
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f8: stloc.s 16
-		IL_00fa: ldloc.s 16
+		IL_00f8: stloc.s 14
+		IL_00fa: ldloc.s 14
 		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0101: stloc.s 16
+		IL_0101: stloc.s 14
 		IL_0103: ldloc.3
 		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0109: stloc.s 17
-		IL_010b: ldloc.s 17
+		IL_0109: stloc.s 15
+		IL_010b: ldloc.s 15
 		IL_010d: ldstr "getMaxListeners"
 		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0117: stloc.s 17
-		IL_0119: ldloc.s 16
+		IL_0117: stloc.s 15
+		IL_0119: ldloc.s 14
 		IL_011b: ldstr "log"
-		IL_0120: ldloc.s 17
+		IL_0120: ldloc.s 15
 		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0127: pop
 		IL_0128: ldloc.2
 		IL_0129: ldc.i4.0
 		IL_012a: newarr [System.Runtime]System.Object
 		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0134: stloc.s 17
-		IL_0136: ldloc.s 17
+		IL_0134: stloc.s 15
+		IL_0136: ldloc.s 15
 		IL_0138: stloc.s 4
 		IL_013a: ldloc.s 4
 		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0141: stloc.s 17
-		IL_0143: ldloc.s 17
+		IL_0141: stloc.s 15
+		IL_0143: ldloc.s 15
 		IL_0145: ldstr "setMaxListeners"
 		IL_014a: ldstr "15"
 		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0154: pop
 		IL_0155: ldstr "console"
 		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015f: stloc.s 17
-		IL_0161: ldloc.s 17
+		IL_015f: stloc.s 15
+		IL_0161: ldloc.s 15
 		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0168: stloc.s 17
+		IL_0168: stloc.s 15
 		IL_016a: ldloc.s 4
 		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0171: stloc.s 16
-		IL_0173: ldloc.s 16
+		IL_0171: stloc.s 14
+		IL_0173: ldloc.s 14
 		IL_0175: ldstr "getMaxListeners"
 		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_017f: stloc.s 16
-		IL_0181: ldloc.s 17
+		IL_017f: stloc.s 14
+		IL_0181: ldloc.s 15
 		IL_0183: ldstr "log"
-		IL_0188: ldloc.s 16
+		IL_0188: ldloc.s 14
 		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_018f: pop
 		IL_0190: ldloc.2
 		IL_0191: ldc.i4.0
 		IL_0192: newarr [System.Runtime]System.Object
 		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_019c: stloc.s 16
-		IL_019e: ldloc.s 16
+		IL_019c: stloc.s 14
+		IL_019e: ldloc.s 14
 		IL_01a0: stloc.s 5
 		.try
 		{
 			IL_01a2: nop
 			IL_01a3: ldloc.s 5
 			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01aa: stloc.s 16
-			IL_01ac: ldloc.s 16
+			IL_01aa: stloc.s 14
+			IL_01ac: ldloc.s 14
 			IL_01ae: ldstr "setMaxListeners"
 			IL_01b3: ldc.r8 5
 			IL_01bc: neg
@@ -292,16 +290,16 @@
 			IL_01c7: pop
 			IL_01c8: ldstr "console"
 			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01d2: stloc.s 16
-			IL_01d4: ldloc.s 16
+			IL_01d2: stloc.s 14
+			IL_01d4: ldloc.s 14
 			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01db: stloc.s 16
-			IL_01dd: ldloc.s 16
+			IL_01db: stloc.s 14
+			IL_01dd: ldloc.s 14
 			IL_01df: ldstr "log"
 			IL_01e4: ldstr "SHOULD NOT REACH HERE"
 			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_01ee: pop
-			IL_01ef: leave IL_025d
+			IL_01ef: leave IL_0256
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -327,102 +325,98 @@
 			IL_0220: stloc.s 7
 
 			IL_0222: ldloc.s 7
-			IL_0224: stloc.s 16
-			IL_0226: ldloc.s 16
+			IL_0224: stloc.s 14
+			IL_0226: ldloc.s 14
 			IL_0228: stloc.s 8
-			IL_022a: newobj instance void Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope/Block_L24C12::.ctor()
-			IL_022f: stloc.s 9
-			IL_0231: ldstr "console"
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_023b: stloc.s 16
-			IL_023d: ldloc.s 16
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0244: stloc.s 16
-			IL_0246: ldloc.s 16
-			IL_0248: ldstr "log"
-			IL_024d: ldstr "Caught error for negative value"
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0257: pop
-			IL_0258: leave IL_025d
+			IL_022a: ldstr "console"
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0234: stloc.s 14
+			IL_0236: ldloc.s 14
+			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023d: stloc.s 14
+			IL_023f: ldloc.s 14
+			IL_0241: ldstr "log"
+			IL_0246: ldstr "Caught error for negative value"
+			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0250: pop
+			IL_0251: leave IL_0256
 		} // end handler
 
-		IL_025d: ldloc.2
-		IL_025e: ldc.i4.0
-		IL_025f: newarr [System.Runtime]System.Object
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0269: stloc.s 16
-		IL_026b: ldloc.s 16
-		IL_026d: stloc.s 10
+		IL_0256: ldloc.2
+		IL_0257: ldc.i4.0
+		IL_0258: newarr [System.Runtime]System.Object
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_0262: stloc.s 14
+		IL_0264: ldloc.s 14
+		IL_0266: stloc.s 9
 		.try
 		{
-			IL_026f: nop
-			IL_0270: ldloc.s 10
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0277: stloc.s 16
-			IL_0279: ldloc.s 16
-			IL_027b: ldstr "setMaxListeners"
-			IL_0280: ldstr "invalid"
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_028a: pop
-			IL_028b: ldstr "console"
-			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0295: stloc.s 16
-			IL_0297: ldloc.s 16
-			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029e: stloc.s 16
-			IL_02a0: ldloc.s 16
-			IL_02a2: ldstr "log"
-			IL_02a7: ldstr "SHOULD NOT REACH HERE"
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02b1: pop
-			IL_02b2: leave IL_0320
+			IL_0268: nop
+			IL_0269: ldloc.s 9
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0270: stloc.s 14
+			IL_0272: ldloc.s 14
+			IL_0274: ldstr "setMaxListeners"
+			IL_0279: ldstr "invalid"
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0283: pop
+			IL_0284: ldstr "console"
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_028e: stloc.s 14
+			IL_0290: ldloc.s 14
+			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0297: stloc.s 14
+			IL_0299: ldloc.s 14
+			IL_029b: ldstr "log"
+			IL_02a0: ldstr "SHOULD NOT REACH HERE"
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02aa: pop
+			IL_02ab: leave IL_0312
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02b7: stloc.s 11
-			IL_02b9: ldloc.s 11
-			IL_02bb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02c0: dup
-			IL_02c1: brtrue IL_02d7
+			IL_02b0: stloc.s 10
+			IL_02b2: ldloc.s 10
+			IL_02b4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02b9: dup
+			IL_02ba: brtrue IL_02d0
 
-			IL_02c6: pop
-			IL_02c7: ldloc.s 11
-			IL_02c9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02ce: dup
-			IL_02cf: brtrue IL_02e3
+			IL_02bf: pop
+			IL_02c0: ldloc.s 10
+			IL_02c2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02c7: dup
+			IL_02c8: brtrue IL_02dc
 
-			IL_02d4: pop
-			IL_02d5: rethrow
+			IL_02cd: pop
+			IL_02ce: rethrow
 
-			IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02dc: stloc.s 12
-			IL_02de: br IL_02e5
+			IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02d5: stloc.s 11
+			IL_02d7: br IL_02de
 
-			IL_02e3: stloc.s 12
+			IL_02dc: stloc.s 11
 
-			IL_02e5: ldloc.s 12
-			IL_02e7: stloc.s 16
-			IL_02e9: ldloc.s 16
-			IL_02eb: stloc.s 13
-			IL_02ed: newobj instance void Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope/Block_L33C12::.ctor()
-			IL_02f2: stloc.s 14
-			IL_02f4: ldstr "console"
-			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02fe: stloc.s 16
-			IL_0300: ldloc.s 16
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0307: stloc.s 16
-			IL_0309: ldloc.s 16
-			IL_030b: ldstr "log"
-			IL_0310: ldstr "Caught error for NaN"
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_031a: pop
-			IL_031b: leave IL_0320
+			IL_02de: ldloc.s 11
+			IL_02e0: stloc.s 14
+			IL_02e2: ldloc.s 14
+			IL_02e4: stloc.s 12
+			IL_02e6: ldstr "console"
+			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02f0: stloc.s 14
+			IL_02f2: ldloc.s 14
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f9: stloc.s 14
+			IL_02fb: ldloc.s 14
+			IL_02fd: ldstr "log"
+			IL_0302: ldstr "Caught error for NaN"
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_030c: pop
+			IL_030d: leave IL_0312
 		} // end handler
 
-		IL_0320: ldnull
-		IL_0321: stloc.s 15
-		IL_0323: ret
+		IL_0312: ldnull
+		IL_0313: stloc.s 13
+		IL_0315: ret
 	} // end of method Events_EventEmitter_SetMaxListeners_Validation::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_SetMaxListeners_Validation
@@ -434,7 +428,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23c9
+		// Method begins at RVA 0x23bd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aa6
+					// Method begins at RVA 0x2a46
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aaf
+					// Method begins at RVA 0x2a4f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ab8
+					// Method begins at RVA 0x2a58
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a9d
+				// Method begins at RVA 0x2a3d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,28 +143,26 @@
 			)
 			// Method begins at RVA 0x20e8
 			// Header size: 12
-			// Code size: 2464 (0x9a0)
+			// Code size: 2368 (0x940)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope,
 				[1] string,
 				[2] object,
 				[3] object,
-				[4] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8,
+				[4] object,
 				[5] object,
-				[6] object,
-				[7] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18,
-				[8] bool,
-				[9] bool,
-				[10] object,
-				[11] string,
-				[12] float64,
+				[6] bool,
+				[7] bool,
+				[8] object,
+				[9] string,
+				[10] float64,
+				[11] object,
+				[12] string,
 				[13] object,
-				[14] string,
+				[14] bool,
 				[15] object,
-				[16] bool,
-				[17] object,
-				[18] object
+				[16] object
 			)
 
 			IL_0000: ldarg.0
@@ -197,14 +195,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 18
+			IL_0048: ldc.i4.s 16
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_00f4
+			IL_005b: ble IL_00de
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -224,1018 +222,964 @@
 			IL_0077: dup
 			IL_0078: ldc.i4.3
 			IL_0079: ldelem.ref
-			IL_007a: castclass Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8
-			IL_007f: stloc.s 4
+			IL_007a: stloc.s 4
+			IL_007c: dup
+			IL_007d: ldc.i4.4
+			IL_007e: ldelem.ref
+			IL_007f: stloc.s 5
 			IL_0081: dup
-			IL_0082: ldc.i4.4
+			IL_0082: ldc.i4.5
 			IL_0083: ldelem.ref
-			IL_0084: stloc.s 5
-			IL_0086: dup
-			IL_0087: ldc.i4.5
-			IL_0088: ldelem.ref
+			IL_0084: unbox.any [System.Runtime]System.Boolean
 			IL_0089: stloc.s 6
 			IL_008b: dup
 			IL_008c: ldc.i4.6
 			IL_008d: ldelem.ref
-			IL_008e: castclass Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18
+			IL_008e: unbox.any [System.Runtime]System.Boolean
 			IL_0093: stloc.s 7
 			IL_0095: dup
 			IL_0096: ldc.i4.7
 			IL_0097: ldelem.ref
-			IL_0098: unbox.any [System.Runtime]System.Boolean
-			IL_009d: stloc.s 8
-			IL_009f: dup
-			IL_00a0: ldc.i4.8
-			IL_00a1: ldelem.ref
-			IL_00a2: unbox.any [System.Runtime]System.Boolean
-			IL_00a7: stloc.s 9
-			IL_00a9: dup
-			IL_00aa: ldc.i4.s 9
-			IL_00ac: ldelem.ref
+			IL_0098: stloc.s 8
+			IL_009a: dup
+			IL_009b: ldc.i4.8
+			IL_009c: ldelem.ref
+			IL_009d: castclass [System.Runtime]System.String
+			IL_00a2: stloc.s 9
+			IL_00a4: dup
+			IL_00a5: ldc.i4.s 9
+			IL_00a7: ldelem.ref
+			IL_00a8: unbox.any [System.Runtime]System.Double
 			IL_00ad: stloc.s 10
 			IL_00af: dup
 			IL_00b0: ldc.i4.s 10
 			IL_00b2: ldelem.ref
-			IL_00b3: castclass [System.Runtime]System.String
-			IL_00b8: stloc.s 11
-			IL_00ba: dup
-			IL_00bb: ldc.i4.s 11
-			IL_00bd: ldelem.ref
-			IL_00be: unbox.any [System.Runtime]System.Double
-			IL_00c3: stloc.s 12
-			IL_00c5: dup
-			IL_00c6: ldc.i4.s 12
-			IL_00c8: ldelem.ref
-			IL_00c9: stloc.s 13
-			IL_00cb: dup
-			IL_00cc: ldc.i4.s 13
-			IL_00ce: ldelem.ref
-			IL_00cf: castclass [System.Runtime]System.String
-			IL_00d4: stloc.s 14
-			IL_00d6: dup
-			IL_00d7: ldc.i4.s 14
-			IL_00d9: ldelem.ref
-			IL_00da: stloc.s 15
-			IL_00dc: dup
-			IL_00dd: ldc.i4.s 15
-			IL_00df: ldelem.ref
-			IL_00e0: unbox.any [System.Runtime]System.Boolean
-			IL_00e5: stloc.s 16
-			IL_00e7: dup
-			IL_00e8: ldc.i4.s 16
-			IL_00ea: ldelem.ref
-			IL_00eb: stloc.s 17
-			IL_00ed: dup
-			IL_00ee: ldc.i4.s 17
-			IL_00f0: ldelem.ref
-			IL_00f1: stloc.s 18
-			IL_00f3: pop
+			IL_00b3: stloc.s 11
+			IL_00b5: dup
+			IL_00b6: ldc.i4.s 11
+			IL_00b8: ldelem.ref
+			IL_00b9: castclass [System.Runtime]System.String
+			IL_00be: stloc.s 12
+			IL_00c0: dup
+			IL_00c1: ldc.i4.s 12
+			IL_00c3: ldelem.ref
+			IL_00c4: stloc.s 13
+			IL_00c6: dup
+			IL_00c7: ldc.i4.s 13
+			IL_00c9: ldelem.ref
+			IL_00ca: unbox.any [System.Runtime]System.Boolean
+			IL_00cf: stloc.s 14
+			IL_00d1: dup
+			IL_00d2: ldc.i4.s 14
+			IL_00d4: ldelem.ref
+			IL_00d5: stloc.s 15
+			IL_00d7: dup
+			IL_00d8: ldc.i4.s 15
+			IL_00da: ldelem.ref
+			IL_00db: stloc.s 16
+			IL_00dd: pop
 
-			IL_00f4: ldloc.0
-			IL_00f5: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00fa: switch (IL_0123, IL_0856, IL_08d4, IL_07d4, IL_03de, IL_04c0, IL_0599, IL_0676, IL_077c)
+			IL_00de: ldloc.0
+			IL_00df: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e4: switch (IL_010d, IL_07f6, IL_0874, IL_077b, IL_03b5, IL_048b, IL_0558, IL_0629, IL_0723)
 
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_0128: stloc.s 10
-			IL_012a: ldloc.s 10
-			IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0131: stloc.s 11
-			IL_0133: ldstr ""
-			IL_0138: ldloc.s 11
-			IL_013a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_013f: stloc.s 11
-			IL_0141: ldloc.s 11
-			IL_0143: ldstr "-"
-			IL_0148: call string [System.Runtime]System.String::Concat(string, string)
-			IL_014d: stloc.s 11
-			IL_014f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_0154: stloc.s 12
-			IL_0156: ldloc.s 12
-			IL_0158: ldc.r8 1000000000
-			IL_0161: mul
-			IL_0162: stloc.s 12
-			IL_0164: ldloc.s 12
-			IL_0166: box [System.Runtime]System.Double
-			IL_016b: stloc.s 13
-			IL_016d: ldloc.s 13
-			IL_016f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_0174: stloc.s 12
-			IL_0176: ldloc.s 12
-			IL_0178: box [System.Runtime]System.Double
-			IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0182: stloc.s 14
-			IL_0184: ldloc.s 11
-			IL_0186: ldloc.s 14
-			IL_0188: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018d: stloc.s 14
-			IL_018f: ldloc.s 14
-			IL_0191: stloc.1
-			IL_0192: ldarg.0
-			IL_0193: ldc.i4.1
-			IL_0194: ldelem.ref
-			IL_0195: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_019a: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a4: stloc.s 10
-			IL_01a6: ldarg.0
-			IL_01a7: ldc.i4.1
-			IL_01a8: ldelem.ref
-			IL_01a9: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_01ae: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b8: stloc.s 15
-			IL_01ba: ldloc.s 15
-			IL_01bc: ldstr "tmpdir"
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01c6: stloc.s 15
-			IL_01c8: ldloc.1
-			IL_01c9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ce: stloc.s 14
-			IL_01d0: ldstr "jroc-fs-append-"
-			IL_01d5: ldloc.s 14
-			IL_01d7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01dc: stloc.s 14
-			IL_01de: ldloc.s 14
-			IL_01e0: ldstr ".txt"
-			IL_01e5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ea: stloc.s 14
-			IL_01ec: ldloc.s 10
-			IL_01ee: ldstr "join"
-			IL_01f3: ldloc.s 15
-			IL_01f5: ldloc.s 14
-			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01fc: stloc.s 15
-			IL_01fe: ldloc.s 15
-			IL_0200: stloc.2
-			IL_0201: ldarg.0
-			IL_0202: ldc.i4.1
-			IL_0203: ldelem.ref
-			IL_0204: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0209: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0213: stloc.s 15
-			IL_0215: ldarg.0
-			IL_0216: ldc.i4.1
-			IL_0217: ldelem.ref
-			IL_0218: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_021d: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0227: stloc.s 10
-			IL_0229: ldloc.s 10
-			IL_022b: ldstr "tmpdir"
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0235: stloc.s 10
-			IL_0237: ldloc.1
-			IL_0238: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_023d: stloc.s 14
-			IL_023f: ldstr "jroc-fs-append-"
-			IL_0244: ldloc.s 14
-			IL_0246: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024b: stloc.s 14
-			IL_024d: ldloc.s 14
-			IL_024f: ldstr "-renamed.txt"
-			IL_0254: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0259: stloc.s 14
-			IL_025b: ldloc.s 15
-			IL_025d: ldstr "join"
-			IL_0262: ldloc.s 10
-			IL_0264: ldloc.s 14
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_026b: stloc.s 10
-			IL_026d: ldloc.s 10
-			IL_026f: stloc.3
-			IL_0270: ldloc.0
-			IL_0271: ldc.i4.0
-			IL_0272: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0277: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_027c: ldloc.0
-			IL_027d: ldc.i4.0
-			IL_027e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0283: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0288: ldloc.0
-			IL_0289: ldc.i4.0
-			IL_028a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_028f: ldloc.0
-			IL_0290: ldc.i4.0
-			IL_0291: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0296: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L12C8::.ctor()
-			IL_029b: stloc.s 4
-			IL_029d: ldarg.0
-			IL_029e: ldc.i4.1
-			IL_029f: ldelem.ref
-			IL_02a0: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_02a5: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02af: stloc.s 10
-			IL_02b1: ldloc.s 10
-			IL_02b3: ldstr "rmSync"
-			IL_02b8: ldloc.2
-			IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02be: dup
-			IL_02bf: ldstr "force"
-			IL_02c4: ldc.i4.1
-			IL_02c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02cf: pop
-			IL_02d0: ldarg.0
-			IL_02d1: ldc.i4.1
-			IL_02d2: ldelem.ref
-			IL_02d3: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_02d8: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e2: stloc.s 10
-			IL_02e4: ldloc.s 10
-			IL_02e6: ldstr "rmSync"
-			IL_02eb: ldloc.3
-			IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02f1: dup
-			IL_02f2: ldstr "force"
-			IL_02f7: ldc.i4.1
-			IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0302: pop
-			IL_0303: ldarg.0
-			IL_0304: ldc.i4.1
-			IL_0305: ldelem.ref
-			IL_0306: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_030b: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0310: ldstr "promises"
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031f: stloc.s 10
-			IL_0321: ldloc.s 10
-			IL_0323: ldstr "writeFile"
-			IL_0328: ldloc.2
-			IL_0329: ldstr "a"
-			IL_032e: ldstr "utf8"
-			IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0338: stloc.s 10
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_0112: stloc.s 8
+			IL_0114: ldloc.s 8
+			IL_0116: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_011b: stloc.s 9
+			IL_011d: ldstr ""
+			IL_0122: ldloc.s 9
+			IL_0124: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0129: stloc.s 9
+			IL_012b: ldloc.s 9
+			IL_012d: ldstr "-"
+			IL_0132: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0137: stloc.s 9
+			IL_0139: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_013e: stloc.s 10
+			IL_0140: ldloc.s 10
+			IL_0142: ldc.r8 1000000000
+			IL_014b: mul
+			IL_014c: stloc.s 10
+			IL_014e: ldloc.s 10
+			IL_0150: box [System.Runtime]System.Double
+			IL_0155: stloc.s 11
+			IL_0157: ldloc.s 11
+			IL_0159: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_015e: stloc.s 10
+			IL_0160: ldloc.s 10
+			IL_0162: box [System.Runtime]System.Double
+			IL_0167: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_016c: stloc.s 12
+			IL_016e: ldloc.s 9
+			IL_0170: ldloc.s 12
+			IL_0172: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0177: stloc.s 12
+			IL_0179: ldloc.s 12
+			IL_017b: stloc.1
+			IL_017c: ldarg.0
+			IL_017d: ldc.i4.1
+			IL_017e: ldelem.ref
+			IL_017f: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0184: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018e: stloc.s 8
+			IL_0190: ldarg.0
+			IL_0191: ldc.i4.1
+			IL_0192: ldelem.ref
+			IL_0193: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0198: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a2: stloc.s 13
+			IL_01a4: ldloc.s 13
+			IL_01a6: ldstr "tmpdir"
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01b0: stloc.s 13
+			IL_01b2: ldloc.1
+			IL_01b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b8: stloc.s 12
+			IL_01ba: ldstr "jroc-fs-append-"
+			IL_01bf: ldloc.s 12
+			IL_01c1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c6: stloc.s 12
+			IL_01c8: ldloc.s 12
+			IL_01ca: ldstr ".txt"
+			IL_01cf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d4: stloc.s 12
+			IL_01d6: ldloc.s 8
+			IL_01d8: ldstr "join"
+			IL_01dd: ldloc.s 13
+			IL_01df: ldloc.s 12
+			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01e6: stloc.s 13
+			IL_01e8: ldloc.s 13
+			IL_01ea: stloc.2
+			IL_01eb: ldarg.0
+			IL_01ec: ldc.i4.1
+			IL_01ed: ldelem.ref
+			IL_01ee: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_01f3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fd: stloc.s 13
+			IL_01ff: ldarg.0
+			IL_0200: ldc.i4.1
+			IL_0201: ldelem.ref
+			IL_0202: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0207: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0211: stloc.s 8
+			IL_0213: ldloc.s 8
+			IL_0215: ldstr "tmpdir"
+			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_021f: stloc.s 8
+			IL_0221: ldloc.1
+			IL_0222: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0227: stloc.s 12
+			IL_0229: ldstr "jroc-fs-append-"
+			IL_022e: ldloc.s 12
+			IL_0230: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0235: stloc.s 12
+			IL_0237: ldloc.s 12
+			IL_0239: ldstr "-renamed.txt"
+			IL_023e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0243: stloc.s 12
+			IL_0245: ldloc.s 13
+			IL_0247: ldstr "join"
+			IL_024c: ldloc.s 8
+			IL_024e: ldloc.s 12
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0255: stloc.s 8
+			IL_0257: ldloc.s 8
+			IL_0259: stloc.3
+			IL_025a: ldloc.0
+			IL_025b: ldc.i4.0
+			IL_025c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0261: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0266: ldloc.0
+			IL_0267: ldc.i4.0
+			IL_0268: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_026d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0272: ldloc.0
+			IL_0273: ldc.i4.0
+			IL_0274: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0279: ldloc.0
+			IL_027a: ldc.i4.0
+			IL_027b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0280: ldarg.0
+			IL_0281: ldc.i4.1
+			IL_0282: ldelem.ref
+			IL_0283: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0288: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0292: stloc.s 8
+			IL_0294: ldloc.s 8
+			IL_0296: ldstr "rmSync"
+			IL_029b: ldloc.2
+			IL_029c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a1: dup
+			IL_02a2: ldstr "force"
+			IL_02a7: ldc.i4.1
+			IL_02a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02b2: pop
+			IL_02b3: ldarg.0
+			IL_02b4: ldc.i4.1
+			IL_02b5: ldelem.ref
+			IL_02b6: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_02bb: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c5: stloc.s 8
+			IL_02c7: ldloc.s 8
+			IL_02c9: ldstr "rmSync"
+			IL_02ce: ldloc.3
+			IL_02cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02d4: dup
+			IL_02d5: ldstr "force"
+			IL_02da: ldc.i4.1
+			IL_02db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02e5: pop
+			IL_02e6: ldarg.0
+			IL_02e7: ldc.i4.1
+			IL_02e8: ldelem.ref
+			IL_02e9: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_02ee: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_02f3: ldstr "promises"
+			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0302: stloc.s 8
+			IL_0304: ldloc.s 8
+			IL_0306: ldstr "writeFile"
+			IL_030b: ldloc.2
+			IL_030c: ldstr "a"
+			IL_0311: ldstr "utf8"
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_031b: stloc.s 8
+			IL_031d: ldloc.0
+			IL_031e: ldc.i4.4
+			IL_031f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0324: ldloc.0
+			IL_0325: ldloc.s 8
+			IL_0327: ldarg.0
+			IL_0328: ldc.i4.1
+			IL_0329: ldloc.0
+			IL_032a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_032f: ldc.i4.3
+			IL_0330: ldstr "_pendingException"
+			IL_0335: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
 			IL_033a: ldloc.0
-			IL_033b: ldc.i4.4
-			IL_033c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0341: ldloc.0
-			IL_0342: ldloc.s 10
-			IL_0344: ldarg.0
+			IL_033b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0340: dup
+			IL_0341: ldc.i4.0
+			IL_0342: ldloc.1
+			IL_0343: stelem.ref
+			IL_0344: dup
 			IL_0345: ldc.i4.1
-			IL_0346: ldloc.0
-			IL_0347: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_034c: ldc.i4.3
-			IL_034d: ldstr "_pendingException"
-			IL_0352: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0357: ldloc.0
-			IL_0358: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_035d: dup
-			IL_035e: ldc.i4.0
-			IL_035f: ldloc.1
-			IL_0360: stelem.ref
-			IL_0361: dup
-			IL_0362: ldc.i4.1
-			IL_0363: ldloc.2
-			IL_0364: stelem.ref
-			IL_0365: dup
-			IL_0366: ldc.i4.2
-			IL_0367: ldloc.3
-			IL_0368: stelem.ref
-			IL_0369: dup
-			IL_036a: ldc.i4.3
-			IL_036b: ldloc.s 4
-			IL_036d: stelem.ref
-			IL_036e: dup
-			IL_036f: ldc.i4.4
-			IL_0370: ldloc.s 5
-			IL_0372: stelem.ref
-			IL_0373: dup
-			IL_0374: ldc.i4.5
-			IL_0375: ldloc.s 6
-			IL_0377: stelem.ref
-			IL_0378: dup
-			IL_0379: ldc.i4.6
-			IL_037a: ldloc.s 7
-			IL_037c: stelem.ref
-			IL_037d: dup
-			IL_037e: ldc.i4.7
-			IL_037f: ldloc.s 8
-			IL_0381: box [System.Runtime]System.Boolean
-			IL_0386: stelem.ref
-			IL_0387: dup
-			IL_0388: ldc.i4.8
-			IL_0389: ldloc.s 9
-			IL_038b: box [System.Runtime]System.Boolean
+			IL_0346: ldloc.2
+			IL_0347: stelem.ref
+			IL_0348: dup
+			IL_0349: ldc.i4.2
+			IL_034a: ldloc.3
+			IL_034b: stelem.ref
+			IL_034c: dup
+			IL_034d: ldc.i4.3
+			IL_034e: ldloc.s 4
+			IL_0350: stelem.ref
+			IL_0351: dup
+			IL_0352: ldc.i4.4
+			IL_0353: ldloc.s 5
+			IL_0355: stelem.ref
+			IL_0356: dup
+			IL_0357: ldc.i4.5
+			IL_0358: ldloc.s 6
+			IL_035a: box [System.Runtime]System.Boolean
+			IL_035f: stelem.ref
+			IL_0360: dup
+			IL_0361: ldc.i4.6
+			IL_0362: ldloc.s 7
+			IL_0364: box [System.Runtime]System.Boolean
+			IL_0369: stelem.ref
+			IL_036a: dup
+			IL_036b: ldc.i4.7
+			IL_036c: ldloc.s 8
+			IL_036e: stelem.ref
+			IL_036f: dup
+			IL_0370: ldc.i4.8
+			IL_0371: ldloc.s 9
+			IL_0373: stelem.ref
+			IL_0374: dup
+			IL_0375: ldc.i4.s 9
+			IL_0377: ldloc.s 10
+			IL_0379: box [System.Runtime]System.Double
+			IL_037e: stelem.ref
+			IL_037f: dup
+			IL_0380: ldc.i4.s 10
+			IL_0382: ldloc.s 11
+			IL_0384: stelem.ref
+			IL_0385: dup
+			IL_0386: ldc.i4.s 11
+			IL_0388: ldloc.s 12
+			IL_038a: stelem.ref
+			IL_038b: dup
+			IL_038c: ldc.i4.s 12
+			IL_038e: ldloc.s 13
 			IL_0390: stelem.ref
 			IL_0391: dup
-			IL_0392: ldc.i4.s 9
-			IL_0394: ldloc.s 10
-			IL_0396: stelem.ref
-			IL_0397: dup
-			IL_0398: ldc.i4.s 10
-			IL_039a: ldloc.s 11
-			IL_039c: stelem.ref
-			IL_039d: dup
-			IL_039e: ldc.i4.s 11
-			IL_03a0: ldloc.s 12
-			IL_03a2: box [System.Runtime]System.Double
+			IL_0392: ldc.i4.s 13
+			IL_0394: ldloc.s 14
+			IL_0396: box [System.Runtime]System.Boolean
+			IL_039b: stelem.ref
+			IL_039c: dup
+			IL_039d: ldc.i4.s 14
+			IL_039f: ldloc.s 15
+			IL_03a1: stelem.ref
+			IL_03a2: dup
+			IL_03a3: ldc.i4.s 15
+			IL_03a5: ldloc.s 16
 			IL_03a7: stelem.ref
-			IL_03a8: dup
-			IL_03a9: ldc.i4.s 12
-			IL_03ab: ldloc.s 13
-			IL_03ad: stelem.ref
-			IL_03ae: dup
-			IL_03af: ldc.i4.s 13
-			IL_03b1: ldloc.s 14
-			IL_03b3: stelem.ref
-			IL_03b4: dup
-			IL_03b5: ldc.i4.s 14
-			IL_03b7: ldloc.s 15
-			IL_03b9: stelem.ref
-			IL_03ba: dup
-			IL_03bb: ldc.i4.s 15
-			IL_03bd: ldloc.s 16
-			IL_03bf: box [System.Runtime]System.Boolean
-			IL_03c4: stelem.ref
-			IL_03c5: dup
-			IL_03c6: ldc.i4.s 16
-			IL_03c8: ldloc.s 17
-			IL_03ca: stelem.ref
-			IL_03cb: dup
-			IL_03cc: ldc.i4.s 17
-			IL_03ce: ldloc.s 18
-			IL_03d0: stelem.ref
-			IL_03d1: pop
-			IL_03d2: ldloc.0
-			IL_03d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03d8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03dd: ret
+			IL_03a8: pop
+			IL_03a9: ldloc.0
+			IL_03aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03af: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03b4: ret
 
-			IL_03de: ldloc.0
-			IL_03df: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
-			IL_03e4: pop
-			IL_03e5: ldarg.0
-			IL_03e6: ldc.i4.1
-			IL_03e7: ldelem.ref
-			IL_03e8: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_03ed: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_03f2: ldstr "promises"
-			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0401: stloc.s 10
-			IL_0403: ldloc.s 10
-			IL_0405: ldstr "appendFile"
-			IL_040a: ldloc.2
-			IL_040b: ldstr "b"
-			IL_0410: ldstr "utf8"
-			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_041a: stloc.s 10
-			IL_041c: ldloc.0
-			IL_041d: ldc.i4.5
-			IL_041e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0423: ldloc.0
-			IL_0424: ldloc.s 10
-			IL_0426: ldarg.0
-			IL_0427: ldc.i4.2
-			IL_0428: ldloc.0
-			IL_0429: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_042e: ldc.i4.3
-			IL_042f: ldstr "_pendingException"
-			IL_0434: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0439: ldloc.0
-			IL_043a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_043f: dup
-			IL_0440: ldc.i4.0
-			IL_0441: ldloc.1
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.1
-			IL_0445: ldloc.2
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.2
-			IL_0449: ldloc.3
-			IL_044a: stelem.ref
-			IL_044b: dup
-			IL_044c: ldc.i4.3
-			IL_044d: ldloc.s 4
-			IL_044f: stelem.ref
-			IL_0450: dup
-			IL_0451: ldc.i4.4
-			IL_0452: ldloc.s 5
+			IL_03b5: ldloc.0
+			IL_03b6: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03bb: pop
+			IL_03bc: ldarg.0
+			IL_03bd: ldc.i4.1
+			IL_03be: ldelem.ref
+			IL_03bf: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_03c4: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_03c9: ldstr "promises"
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d8: stloc.s 8
+			IL_03da: ldloc.s 8
+			IL_03dc: ldstr "appendFile"
+			IL_03e1: ldloc.2
+			IL_03e2: ldstr "b"
+			IL_03e7: ldstr "utf8"
+			IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_03f1: stloc.s 8
+			IL_03f3: ldloc.0
+			IL_03f4: ldc.i4.5
+			IL_03f5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03fa: ldloc.0
+			IL_03fb: ldloc.s 8
+			IL_03fd: ldarg.0
+			IL_03fe: ldc.i4.2
+			IL_03ff: ldloc.0
+			IL_0400: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0405: ldc.i4.3
+			IL_0406: ldstr "_pendingException"
+			IL_040b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0410: ldloc.0
+			IL_0411: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0416: dup
+			IL_0417: ldc.i4.0
+			IL_0418: ldloc.1
+			IL_0419: stelem.ref
+			IL_041a: dup
+			IL_041b: ldc.i4.1
+			IL_041c: ldloc.2
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.2
+			IL_0420: ldloc.3
+			IL_0421: stelem.ref
+			IL_0422: dup
+			IL_0423: ldc.i4.3
+			IL_0424: ldloc.s 4
+			IL_0426: stelem.ref
+			IL_0427: dup
+			IL_0428: ldc.i4.4
+			IL_0429: ldloc.s 5
+			IL_042b: stelem.ref
+			IL_042c: dup
+			IL_042d: ldc.i4.5
+			IL_042e: ldloc.s 6
+			IL_0430: box [System.Runtime]System.Boolean
+			IL_0435: stelem.ref
+			IL_0436: dup
+			IL_0437: ldc.i4.6
+			IL_0438: ldloc.s 7
+			IL_043a: box [System.Runtime]System.Boolean
+			IL_043f: stelem.ref
+			IL_0440: dup
+			IL_0441: ldc.i4.7
+			IL_0442: ldloc.s 8
+			IL_0444: stelem.ref
+			IL_0445: dup
+			IL_0446: ldc.i4.8
+			IL_0447: ldloc.s 9
+			IL_0449: stelem.ref
+			IL_044a: dup
+			IL_044b: ldc.i4.s 9
+			IL_044d: ldloc.s 10
+			IL_044f: box [System.Runtime]System.Double
 			IL_0454: stelem.ref
 			IL_0455: dup
-			IL_0456: ldc.i4.5
-			IL_0457: ldloc.s 6
-			IL_0459: stelem.ref
-			IL_045a: dup
-			IL_045b: ldc.i4.6
-			IL_045c: ldloc.s 7
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.7
-			IL_0461: ldloc.s 8
-			IL_0463: box [System.Runtime]System.Boolean
-			IL_0468: stelem.ref
-			IL_0469: dup
-			IL_046a: ldc.i4.8
-			IL_046b: ldloc.s 9
-			IL_046d: box [System.Runtime]System.Boolean
-			IL_0472: stelem.ref
-			IL_0473: dup
-			IL_0474: ldc.i4.s 9
-			IL_0476: ldloc.s 10
-			IL_0478: stelem.ref
-			IL_0479: dup
-			IL_047a: ldc.i4.s 10
-			IL_047c: ldloc.s 11
-			IL_047e: stelem.ref
-			IL_047f: dup
-			IL_0480: ldc.i4.s 11
-			IL_0482: ldloc.s 12
-			IL_0484: box [System.Runtime]System.Double
-			IL_0489: stelem.ref
-			IL_048a: dup
-			IL_048b: ldc.i4.s 12
-			IL_048d: ldloc.s 13
-			IL_048f: stelem.ref
-			IL_0490: dup
-			IL_0491: ldc.i4.s 13
-			IL_0493: ldloc.s 14
-			IL_0495: stelem.ref
-			IL_0496: dup
-			IL_0497: ldc.i4.s 14
-			IL_0499: ldloc.s 15
-			IL_049b: stelem.ref
-			IL_049c: dup
-			IL_049d: ldc.i4.s 15
-			IL_049f: ldloc.s 16
-			IL_04a1: box [System.Runtime]System.Boolean
-			IL_04a6: stelem.ref
-			IL_04a7: dup
-			IL_04a8: ldc.i4.s 16
-			IL_04aa: ldloc.s 17
-			IL_04ac: stelem.ref
-			IL_04ad: dup
-			IL_04ae: ldc.i4.s 17
-			IL_04b0: ldloc.s 18
-			IL_04b2: stelem.ref
-			IL_04b3: pop
-			IL_04b4: ldloc.0
-			IL_04b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04bf: ret
+			IL_0456: ldc.i4.s 10
+			IL_0458: ldloc.s 11
+			IL_045a: stelem.ref
+			IL_045b: dup
+			IL_045c: ldc.i4.s 11
+			IL_045e: ldloc.s 12
+			IL_0460: stelem.ref
+			IL_0461: dup
+			IL_0462: ldc.i4.s 12
+			IL_0464: ldloc.s 13
+			IL_0466: stelem.ref
+			IL_0467: dup
+			IL_0468: ldc.i4.s 13
+			IL_046a: ldloc.s 14
+			IL_046c: box [System.Runtime]System.Boolean
+			IL_0471: stelem.ref
+			IL_0472: dup
+			IL_0473: ldc.i4.s 14
+			IL_0475: ldloc.s 15
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.s 15
+			IL_047b: ldloc.s 16
+			IL_047d: stelem.ref
+			IL_047e: pop
+			IL_047f: ldloc.0
+			IL_0480: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0485: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_048a: ret
 
+			IL_048b: ldloc.0
+			IL_048c: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0491: pop
+			IL_0492: ldarg.0
+			IL_0493: ldc.i4.1
+			IL_0494: ldelem.ref
+			IL_0495: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_049a: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_049f: ldstr "promises"
+			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ae: stloc.s 8
+			IL_04b0: ldloc.s 8
+			IL_04b2: ldstr "rename"
+			IL_04b7: ldloc.2
+			IL_04b8: ldloc.3
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04be: stloc.s 8
 			IL_04c0: ldloc.0
-			IL_04c1: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
-			IL_04c6: pop
-			IL_04c7: ldarg.0
-			IL_04c8: ldc.i4.1
-			IL_04c9: ldelem.ref
-			IL_04ca: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_04cf: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_04d4: ldstr "promises"
-			IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04e3: stloc.s 10
-			IL_04e5: ldloc.s 10
-			IL_04e7: ldstr "rename"
-			IL_04ec: ldloc.2
+			IL_04c1: ldc.i4.6
+			IL_04c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04c7: ldloc.0
+			IL_04c8: ldloc.s 8
+			IL_04ca: ldarg.0
+			IL_04cb: ldc.i4.3
+			IL_04cc: ldloc.0
+			IL_04cd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04d2: ldc.i4.3
+			IL_04d3: ldstr "_pendingException"
+			IL_04d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_04dd: ldloc.0
+			IL_04de: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04e3: dup
+			IL_04e4: ldc.i4.0
+			IL_04e5: ldloc.1
+			IL_04e6: stelem.ref
+			IL_04e7: dup
+			IL_04e8: ldc.i4.1
+			IL_04e9: ldloc.2
+			IL_04ea: stelem.ref
+			IL_04eb: dup
+			IL_04ec: ldc.i4.2
 			IL_04ed: ldloc.3
-			IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04f3: stloc.s 10
-			IL_04f5: ldloc.0
-			IL_04f6: ldc.i4.6
-			IL_04f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04fc: ldloc.0
-			IL_04fd: ldloc.s 10
-			IL_04ff: ldarg.0
-			IL_0500: ldc.i4.3
-			IL_0501: ldloc.0
-			IL_0502: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0507: ldc.i4.3
-			IL_0508: ldstr "_pendingException"
-			IL_050d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0512: ldloc.0
-			IL_0513: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0518: dup
-			IL_0519: ldc.i4.0
-			IL_051a: ldloc.1
-			IL_051b: stelem.ref
-			IL_051c: dup
-			IL_051d: ldc.i4.1
-			IL_051e: ldloc.2
-			IL_051f: stelem.ref
-			IL_0520: dup
-			IL_0521: ldc.i4.2
-			IL_0522: ldloc.3
-			IL_0523: stelem.ref
-			IL_0524: dup
-			IL_0525: ldc.i4.3
-			IL_0526: ldloc.s 4
-			IL_0528: stelem.ref
-			IL_0529: dup
-			IL_052a: ldc.i4.4
-			IL_052b: ldloc.s 5
+			IL_04ee: stelem.ref
+			IL_04ef: dup
+			IL_04f0: ldc.i4.3
+			IL_04f1: ldloc.s 4
+			IL_04f3: stelem.ref
+			IL_04f4: dup
+			IL_04f5: ldc.i4.4
+			IL_04f6: ldloc.s 5
+			IL_04f8: stelem.ref
+			IL_04f9: dup
+			IL_04fa: ldc.i4.5
+			IL_04fb: ldloc.s 6
+			IL_04fd: box [System.Runtime]System.Boolean
+			IL_0502: stelem.ref
+			IL_0503: dup
+			IL_0504: ldc.i4.6
+			IL_0505: ldloc.s 7
+			IL_0507: box [System.Runtime]System.Boolean
+			IL_050c: stelem.ref
+			IL_050d: dup
+			IL_050e: ldc.i4.7
+			IL_050f: ldloc.s 8
+			IL_0511: stelem.ref
+			IL_0512: dup
+			IL_0513: ldc.i4.8
+			IL_0514: ldloc.s 9
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.s 9
+			IL_051a: ldloc.s 10
+			IL_051c: box [System.Runtime]System.Double
+			IL_0521: stelem.ref
+			IL_0522: dup
+			IL_0523: ldc.i4.s 10
+			IL_0525: ldloc.s 11
+			IL_0527: stelem.ref
+			IL_0528: dup
+			IL_0529: ldc.i4.s 11
+			IL_052b: ldloc.s 12
 			IL_052d: stelem.ref
 			IL_052e: dup
-			IL_052f: ldc.i4.5
-			IL_0530: ldloc.s 6
-			IL_0532: stelem.ref
-			IL_0533: dup
-			IL_0534: ldc.i4.6
-			IL_0535: ldloc.s 7
-			IL_0537: stelem.ref
-			IL_0538: dup
-			IL_0539: ldc.i4.7
-			IL_053a: ldloc.s 8
-			IL_053c: box [System.Runtime]System.Boolean
-			IL_0541: stelem.ref
-			IL_0542: dup
-			IL_0543: ldc.i4.8
-			IL_0544: ldloc.s 9
-			IL_0546: box [System.Runtime]System.Boolean
-			IL_054b: stelem.ref
-			IL_054c: dup
-			IL_054d: ldc.i4.s 9
-			IL_054f: ldloc.s 10
-			IL_0551: stelem.ref
-			IL_0552: dup
-			IL_0553: ldc.i4.s 10
-			IL_0555: ldloc.s 11
-			IL_0557: stelem.ref
-			IL_0558: dup
-			IL_0559: ldc.i4.s 11
-			IL_055b: ldloc.s 12
-			IL_055d: box [System.Runtime]System.Double
-			IL_0562: stelem.ref
-			IL_0563: dup
-			IL_0564: ldc.i4.s 12
-			IL_0566: ldloc.s 13
-			IL_0568: stelem.ref
-			IL_0569: dup
-			IL_056a: ldc.i4.s 13
-			IL_056c: ldloc.s 14
-			IL_056e: stelem.ref
-			IL_056f: dup
-			IL_0570: ldc.i4.s 14
-			IL_0572: ldloc.s 15
-			IL_0574: stelem.ref
-			IL_0575: dup
-			IL_0576: ldc.i4.s 15
-			IL_0578: ldloc.s 16
-			IL_057a: box [System.Runtime]System.Boolean
-			IL_057f: stelem.ref
-			IL_0580: dup
-			IL_0581: ldc.i4.s 16
-			IL_0583: ldloc.s 17
-			IL_0585: stelem.ref
-			IL_0586: dup
-			IL_0587: ldc.i4.s 17
-			IL_0589: ldloc.s 18
-			IL_058b: stelem.ref
-			IL_058c: pop
-			IL_058d: ldloc.0
-			IL_058e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0593: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0598: ret
+			IL_052f: ldc.i4.s 12
+			IL_0531: ldloc.s 13
+			IL_0533: stelem.ref
+			IL_0534: dup
+			IL_0535: ldc.i4.s 13
+			IL_0537: ldloc.s 14
+			IL_0539: box [System.Runtime]System.Boolean
+			IL_053e: stelem.ref
+			IL_053f: dup
+			IL_0540: ldc.i4.s 14
+			IL_0542: ldloc.s 15
+			IL_0544: stelem.ref
+			IL_0545: dup
+			IL_0546: ldc.i4.s 15
+			IL_0548: ldloc.s 16
+			IL_054a: stelem.ref
+			IL_054b: pop
+			IL_054c: ldloc.0
+			IL_054d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0552: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0557: ret
 
-			IL_0599: ldloc.0
-			IL_059a: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
-			IL_059f: pop
-			IL_05a0: ldarg.0
-			IL_05a1: ldc.i4.1
-			IL_05a2: ldelem.ref
-			IL_05a3: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_05a8: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_05ad: ldstr "promises"
-			IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05bc: stloc.s 10
-			IL_05be: ldloc.s 10
-			IL_05c0: ldstr "readFile"
-			IL_05c5: ldloc.3
-			IL_05c6: ldstr "utf8"
-			IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05d0: stloc.s 10
-			IL_05d2: ldloc.0
-			IL_05d3: ldc.i4.7
-			IL_05d4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05d9: ldloc.0
-			IL_05da: ldloc.s 10
-			IL_05dc: ldarg.0
-			IL_05dd: ldc.i4.4
-			IL_05de: ldloc.0
-			IL_05df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05e4: ldc.i4.3
-			IL_05e5: ldstr "_pendingException"
-			IL_05ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05ef: ldloc.0
-			IL_05f0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05f5: dup
-			IL_05f6: ldc.i4.0
-			IL_05f7: ldloc.1
+			IL_0558: ldloc.0
+			IL_0559: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
+			IL_055e: pop
+			IL_055f: ldarg.0
+			IL_0560: ldc.i4.1
+			IL_0561: ldelem.ref
+			IL_0562: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0567: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_056c: ldstr "promises"
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_057b: stloc.s 8
+			IL_057d: ldloc.s 8
+			IL_057f: ldstr "readFile"
+			IL_0584: ldloc.3
+			IL_0585: ldstr "utf8"
+			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_058f: stloc.s 8
+			IL_0591: ldloc.0
+			IL_0592: ldc.i4.7
+			IL_0593: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0598: ldloc.0
+			IL_0599: ldloc.s 8
+			IL_059b: ldarg.0
+			IL_059c: ldc.i4.4
+			IL_059d: ldloc.0
+			IL_059e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05a3: ldc.i4.3
+			IL_05a4: ldstr "_pendingException"
+			IL_05a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05ae: ldloc.0
+			IL_05af: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05b4: dup
+			IL_05b5: ldc.i4.0
+			IL_05b6: ldloc.1
+			IL_05b7: stelem.ref
+			IL_05b8: dup
+			IL_05b9: ldc.i4.1
+			IL_05ba: ldloc.2
+			IL_05bb: stelem.ref
+			IL_05bc: dup
+			IL_05bd: ldc.i4.2
+			IL_05be: ldloc.3
+			IL_05bf: stelem.ref
+			IL_05c0: dup
+			IL_05c1: ldc.i4.3
+			IL_05c2: ldloc.s 4
+			IL_05c4: stelem.ref
+			IL_05c5: dup
+			IL_05c6: ldc.i4.4
+			IL_05c7: ldloc.s 5
+			IL_05c9: stelem.ref
+			IL_05ca: dup
+			IL_05cb: ldc.i4.5
+			IL_05cc: ldloc.s 6
+			IL_05ce: box [System.Runtime]System.Boolean
+			IL_05d3: stelem.ref
+			IL_05d4: dup
+			IL_05d5: ldc.i4.6
+			IL_05d6: ldloc.s 7
+			IL_05d8: box [System.Runtime]System.Boolean
+			IL_05dd: stelem.ref
+			IL_05de: dup
+			IL_05df: ldc.i4.7
+			IL_05e0: ldloc.s 8
+			IL_05e2: stelem.ref
+			IL_05e3: dup
+			IL_05e4: ldc.i4.8
+			IL_05e5: ldloc.s 9
+			IL_05e7: stelem.ref
+			IL_05e8: dup
+			IL_05e9: ldc.i4.s 9
+			IL_05eb: ldloc.s 10
+			IL_05ed: box [System.Runtime]System.Double
+			IL_05f2: stelem.ref
+			IL_05f3: dup
+			IL_05f4: ldc.i4.s 10
+			IL_05f6: ldloc.s 11
 			IL_05f8: stelem.ref
 			IL_05f9: dup
-			IL_05fa: ldc.i4.1
-			IL_05fb: ldloc.2
-			IL_05fc: stelem.ref
-			IL_05fd: dup
-			IL_05fe: ldc.i4.2
-			IL_05ff: ldloc.3
-			IL_0600: stelem.ref
-			IL_0601: dup
-			IL_0602: ldc.i4.3
-			IL_0603: ldloc.s 4
-			IL_0605: stelem.ref
-			IL_0606: dup
-			IL_0607: ldc.i4.4
-			IL_0608: ldloc.s 5
-			IL_060a: stelem.ref
-			IL_060b: dup
-			IL_060c: ldc.i4.5
-			IL_060d: ldloc.s 6
+			IL_05fa: ldc.i4.s 11
+			IL_05fc: ldloc.s 12
+			IL_05fe: stelem.ref
+			IL_05ff: dup
+			IL_0600: ldc.i4.s 12
+			IL_0602: ldloc.s 13
+			IL_0604: stelem.ref
+			IL_0605: dup
+			IL_0606: ldc.i4.s 13
+			IL_0608: ldloc.s 14
+			IL_060a: box [System.Runtime]System.Boolean
 			IL_060f: stelem.ref
 			IL_0610: dup
-			IL_0611: ldc.i4.6
-			IL_0612: ldloc.s 7
-			IL_0614: stelem.ref
-			IL_0615: dup
-			IL_0616: ldc.i4.7
-			IL_0617: ldloc.s 8
-			IL_0619: box [System.Runtime]System.Boolean
-			IL_061e: stelem.ref
-			IL_061f: dup
-			IL_0620: ldc.i4.8
-			IL_0621: ldloc.s 9
-			IL_0623: box [System.Runtime]System.Boolean
-			IL_0628: stelem.ref
-			IL_0629: dup
-			IL_062a: ldc.i4.s 9
-			IL_062c: ldloc.s 10
-			IL_062e: stelem.ref
-			IL_062f: dup
-			IL_0630: ldc.i4.s 10
-			IL_0632: ldloc.s 11
-			IL_0634: stelem.ref
-			IL_0635: dup
-			IL_0636: ldc.i4.s 11
-			IL_0638: ldloc.s 12
-			IL_063a: box [System.Runtime]System.Double
-			IL_063f: stelem.ref
-			IL_0640: dup
-			IL_0641: ldc.i4.s 12
-			IL_0643: ldloc.s 13
-			IL_0645: stelem.ref
-			IL_0646: dup
-			IL_0647: ldc.i4.s 13
-			IL_0649: ldloc.s 14
-			IL_064b: stelem.ref
-			IL_064c: dup
-			IL_064d: ldc.i4.s 14
-			IL_064f: ldloc.s 15
-			IL_0651: stelem.ref
-			IL_0652: dup
-			IL_0653: ldc.i4.s 15
-			IL_0655: ldloc.s 16
-			IL_0657: box [System.Runtime]System.Boolean
-			IL_065c: stelem.ref
-			IL_065d: dup
-			IL_065e: ldc.i4.s 16
-			IL_0660: ldloc.s 17
-			IL_0662: stelem.ref
-			IL_0663: dup
-			IL_0664: ldc.i4.s 17
-			IL_0666: ldloc.s 18
-			IL_0668: stelem.ref
-			IL_0669: pop
-			IL_066a: ldloc.0
-			IL_066b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0670: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0675: ret
+			IL_0611: ldc.i4.s 14
+			IL_0613: ldloc.s 15
+			IL_0615: stelem.ref
+			IL_0616: dup
+			IL_0617: ldc.i4.s 15
+			IL_0619: ldloc.s 16
+			IL_061b: stelem.ref
+			IL_061c: pop
+			IL_061d: ldloc.0
+			IL_061e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0623: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0628: ret
 
-			IL_0676: ldloc.0
-			IL_0677: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
-			IL_067c: stloc.s 10
-			IL_067e: ldloc.s 10
-			IL_0680: stloc.s 5
-			IL_0682: ldstr "console"
-			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_068c: stloc.s 10
-			IL_068e: ldloc.s 10
-			IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0695: stloc.s 10
-			IL_0697: ldloc.s 10
-			IL_0699: ldstr "log"
-			IL_069e: ldstr "Text:"
-			IL_06a3: ldloc.s 5
-			IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_06aa: pop
-			IL_06ab: ldarg.0
-			IL_06ac: ldc.i4.1
-			IL_06ad: ldelem.ref
-			IL_06ae: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_06b3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_06b8: ldstr "promises"
-			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06c7: stloc.s 10
-			IL_06c9: ldloc.s 10
-			IL_06cb: ldstr "unlink"
-			IL_06d0: ldloc.3
-			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06d6: stloc.s 10
-			IL_06d8: ldloc.0
-			IL_06d9: ldc.i4.8
-			IL_06da: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06df: ldloc.0
-			IL_06e0: ldloc.s 10
-			IL_06e2: ldarg.0
-			IL_06e3: ldc.i4.5
-			IL_06e4: ldloc.0
-			IL_06e5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06ea: ldc.i4.3
-			IL_06eb: ldstr "_pendingException"
-			IL_06f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_06f5: ldloc.0
-			IL_06f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06fb: dup
-			IL_06fc: ldc.i4.0
-			IL_06fd: ldloc.1
+			IL_0629: ldloc.0
+			IL_062a: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
+			IL_062f: stloc.s 8
+			IL_0631: ldloc.s 8
+			IL_0633: stloc.s 4
+			IL_0635: ldstr "console"
+			IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_063f: stloc.s 8
+			IL_0641: ldloc.s 8
+			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0648: stloc.s 8
+			IL_064a: ldloc.s 8
+			IL_064c: ldstr "log"
+			IL_0651: ldstr "Text:"
+			IL_0656: ldloc.s 4
+			IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_065d: pop
+			IL_065e: ldarg.0
+			IL_065f: ldc.i4.1
+			IL_0660: ldelem.ref
+			IL_0661: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0666: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_066b: ldstr "promises"
+			IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_067a: stloc.s 8
+			IL_067c: ldloc.s 8
+			IL_067e: ldstr "unlink"
+			IL_0683: ldloc.3
+			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0689: stloc.s 8
+			IL_068b: ldloc.0
+			IL_068c: ldc.i4.8
+			IL_068d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0692: ldloc.0
+			IL_0693: ldloc.s 8
+			IL_0695: ldarg.0
+			IL_0696: ldc.i4.5
+			IL_0697: ldloc.0
+			IL_0698: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_069d: ldc.i4.3
+			IL_069e: ldstr "_pendingException"
+			IL_06a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_06a8: ldloc.0
+			IL_06a9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06ae: dup
+			IL_06af: ldc.i4.0
+			IL_06b0: ldloc.1
+			IL_06b1: stelem.ref
+			IL_06b2: dup
+			IL_06b3: ldc.i4.1
+			IL_06b4: ldloc.2
+			IL_06b5: stelem.ref
+			IL_06b6: dup
+			IL_06b7: ldc.i4.2
+			IL_06b8: ldloc.3
+			IL_06b9: stelem.ref
+			IL_06ba: dup
+			IL_06bb: ldc.i4.3
+			IL_06bc: ldloc.s 4
+			IL_06be: stelem.ref
+			IL_06bf: dup
+			IL_06c0: ldc.i4.4
+			IL_06c1: ldloc.s 5
+			IL_06c3: stelem.ref
+			IL_06c4: dup
+			IL_06c5: ldc.i4.5
+			IL_06c6: ldloc.s 6
+			IL_06c8: box [System.Runtime]System.Boolean
+			IL_06cd: stelem.ref
+			IL_06ce: dup
+			IL_06cf: ldc.i4.6
+			IL_06d0: ldloc.s 7
+			IL_06d2: box [System.Runtime]System.Boolean
+			IL_06d7: stelem.ref
+			IL_06d8: dup
+			IL_06d9: ldc.i4.7
+			IL_06da: ldloc.s 8
+			IL_06dc: stelem.ref
+			IL_06dd: dup
+			IL_06de: ldc.i4.8
+			IL_06df: ldloc.s 9
+			IL_06e1: stelem.ref
+			IL_06e2: dup
+			IL_06e3: ldc.i4.s 9
+			IL_06e5: ldloc.s 10
+			IL_06e7: box [System.Runtime]System.Double
+			IL_06ec: stelem.ref
+			IL_06ed: dup
+			IL_06ee: ldc.i4.s 10
+			IL_06f0: ldloc.s 11
+			IL_06f2: stelem.ref
+			IL_06f3: dup
+			IL_06f4: ldc.i4.s 11
+			IL_06f6: ldloc.s 12
+			IL_06f8: stelem.ref
+			IL_06f9: dup
+			IL_06fa: ldc.i4.s 12
+			IL_06fc: ldloc.s 13
 			IL_06fe: stelem.ref
 			IL_06ff: dup
-			IL_0700: ldc.i4.1
-			IL_0701: ldloc.2
-			IL_0702: stelem.ref
-			IL_0703: dup
-			IL_0704: ldc.i4.2
-			IL_0705: ldloc.3
-			IL_0706: stelem.ref
-			IL_0707: dup
-			IL_0708: ldc.i4.3
-			IL_0709: ldloc.s 4
-			IL_070b: stelem.ref
-			IL_070c: dup
-			IL_070d: ldc.i4.4
-			IL_070e: ldloc.s 5
-			IL_0710: stelem.ref
-			IL_0711: dup
-			IL_0712: ldc.i4.5
-			IL_0713: ldloc.s 6
+			IL_0700: ldc.i4.s 13
+			IL_0702: ldloc.s 14
+			IL_0704: box [System.Runtime]System.Boolean
+			IL_0709: stelem.ref
+			IL_070a: dup
+			IL_070b: ldc.i4.s 14
+			IL_070d: ldloc.s 15
+			IL_070f: stelem.ref
+			IL_0710: dup
+			IL_0711: ldc.i4.s 15
+			IL_0713: ldloc.s 16
 			IL_0715: stelem.ref
-			IL_0716: dup
-			IL_0717: ldc.i4.6
-			IL_0718: ldloc.s 7
-			IL_071a: stelem.ref
-			IL_071b: dup
-			IL_071c: ldc.i4.7
-			IL_071d: ldloc.s 8
-			IL_071f: box [System.Runtime]System.Boolean
-			IL_0724: stelem.ref
-			IL_0725: dup
-			IL_0726: ldc.i4.8
-			IL_0727: ldloc.s 9
-			IL_0729: box [System.Runtime]System.Boolean
-			IL_072e: stelem.ref
-			IL_072f: dup
-			IL_0730: ldc.i4.s 9
-			IL_0732: ldloc.s 10
-			IL_0734: stelem.ref
-			IL_0735: dup
-			IL_0736: ldc.i4.s 10
-			IL_0738: ldloc.s 11
-			IL_073a: stelem.ref
-			IL_073b: dup
-			IL_073c: ldc.i4.s 11
-			IL_073e: ldloc.s 12
-			IL_0740: box [System.Runtime]System.Double
-			IL_0745: stelem.ref
-			IL_0746: dup
-			IL_0747: ldc.i4.s 12
-			IL_0749: ldloc.s 13
-			IL_074b: stelem.ref
-			IL_074c: dup
-			IL_074d: ldc.i4.s 13
-			IL_074f: ldloc.s 14
-			IL_0751: stelem.ref
-			IL_0752: dup
-			IL_0753: ldc.i4.s 14
-			IL_0755: ldloc.s 15
-			IL_0757: stelem.ref
-			IL_0758: dup
-			IL_0759: ldc.i4.s 15
-			IL_075b: ldloc.s 16
-			IL_075d: box [System.Runtime]System.Boolean
-			IL_0762: stelem.ref
-			IL_0763: dup
-			IL_0764: ldc.i4.s 16
-			IL_0766: ldloc.s 17
-			IL_0768: stelem.ref
-			IL_0769: dup
-			IL_076a: ldc.i4.s 17
-			IL_076c: ldloc.s 18
-			IL_076e: stelem.ref
-			IL_076f: pop
-			IL_0770: ldloc.0
-			IL_0771: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0776: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_077b: ret
+			IL_0716: pop
+			IL_0717: ldloc.0
+			IL_0718: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_071d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0722: ret
 
-			IL_077c: ldloc.0
-			IL_077d: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
-			IL_0782: pop
-			IL_0783: ldstr "console"
-			IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_078d: stloc.s 10
-			IL_078f: ldloc.s 10
-			IL_0791: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0796: stloc.s 10
-			IL_0798: ldarg.0
-			IL_0799: ldc.i4.1
-			IL_079a: ldelem.ref
-			IL_079b: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_07a0: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07aa: stloc.s 15
-			IL_07ac: ldloc.s 15
-			IL_07ae: ldstr "existsSync"
-			IL_07b3: ldloc.3
-			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07b9: stloc.s 15
-			IL_07bb: ldloc.s 10
-			IL_07bd: ldstr "log"
-			IL_07c2: ldstr "ExistsAfterUnlink:"
-			IL_07c7: ldloc.s 15
-			IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_07ce: pop
-			IL_07cf: br IL_0869
+			IL_0723: ldloc.0
+			IL_0724: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
+			IL_0729: pop
+			IL_072a: ldstr "console"
+			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0734: stloc.s 8
+			IL_0736: ldloc.s 8
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_073d: stloc.s 8
+			IL_073f: ldarg.0
+			IL_0740: ldc.i4.1
+			IL_0741: ldelem.ref
+			IL_0742: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0747: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0751: stloc.s 13
+			IL_0753: ldloc.s 13
+			IL_0755: ldstr "existsSync"
+			IL_075a: ldloc.3
+			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0760: stloc.s 13
+			IL_0762: ldloc.s 8
+			IL_0764: ldstr "log"
+			IL_0769: ldstr "ExistsAfterUnlink:"
+			IL_076e: ldloc.s 13
+			IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0775: pop
+			IL_0776: br IL_0809
 
-			IL_07d4: ldloc.0
-			IL_07d5: ldc.i4.1
-			IL_07d6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07db: ldloc.0
-			IL_07dc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07e1: stloc.s 15
-			IL_07e3: ldloc.0
-			IL_07e4: ldc.i4.0
-			IL_07e5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07ef: ldloc.0
-			IL_07f0: ldc.i4.0
-			IL_07f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07f6: ldloc.s 15
-			IL_07f8: stloc.s 6
-			IL_07fa: newobj instance void Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
-			IL_07ff: stloc.s 7
-			IL_0801: ldstr "console"
-			IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_080b: stloc.s 15
-			IL_080d: ldloc.s 15
-			IL_080f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0814: stloc.s 15
-			IL_0816: ldloc.s 6
-			IL_0818: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_081d: stloc.s 16
-			IL_081f: ldloc.s 16
-			IL_0821: brfalse IL_0839
+			IL_077b: ldloc.0
+			IL_077c: ldc.i4.1
+			IL_077d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0782: ldloc.0
+			IL_0783: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0788: stloc.s 13
+			IL_078a: ldloc.0
+			IL_078b: ldc.i4.0
+			IL_078c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0791: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0796: ldloc.0
+			IL_0797: ldc.i4.0
+			IL_0798: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_079d: ldloc.s 13
+			IL_079f: stloc.s 5
+			IL_07a1: ldstr "console"
+			IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07ab: stloc.s 13
+			IL_07ad: ldloc.s 13
+			IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07b4: stloc.s 13
+			IL_07b6: ldloc.s 5
+			IL_07b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_07bd: stloc.s 14
+			IL_07bf: ldloc.s 14
+			IL_07c1: brfalse IL_07d9
 
-			IL_0826: ldloc.s 6
-			IL_0828: ldstr "message"
-			IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0832: stloc.s 18
-			IL_0834: br IL_083d
+			IL_07c6: ldloc.s 5
+			IL_07c8: ldstr "message"
+			IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d2: stloc.s 16
+			IL_07d4: br IL_07dd
 
-			IL_0839: ldloc.s 6
-			IL_083b: stloc.s 18
+			IL_07d9: ldloc.s 5
+			IL_07db: stloc.s 16
 
-			IL_083d: ldloc.s 15
-			IL_083f: ldstr "log"
-			IL_0844: ldstr "Error:"
-			IL_0849: ldloc.s 18
-			IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0850: pop
-			IL_0851: br IL_0869
+			IL_07dd: ldloc.s 13
+			IL_07df: ldstr "log"
+			IL_07e4: ldstr "Error:"
+			IL_07e9: ldloc.s 16
+			IL_07eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07f0: pop
+			IL_07f1: br IL_0809
 
-			IL_0856: ldloc.0
-			IL_0857: ldc.i4.1
-			IL_0858: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_085d: ldloc.0
-			IL_085e: ldc.i4.0
-			IL_085f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0864: br IL_0869
+			IL_07f6: ldloc.0
+			IL_07f7: ldc.i4.1
+			IL_07f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07fd: ldloc.0
+			IL_07fe: ldc.i4.0
+			IL_07ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0804: br IL_0809
 
-			IL_0869: ldarg.0
-			IL_086a: ldc.i4.1
-			IL_086b: ldelem.ref
-			IL_086c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0871: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_087b: stloc.s 15
-			IL_087d: ldloc.s 15
-			IL_087f: ldstr "rmSync"
-			IL_0884: ldloc.2
-			IL_0885: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_088a: dup
-			IL_088b: ldstr "force"
-			IL_0890: ldc.i4.1
-			IL_0891: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0896: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_089b: pop
-			IL_089c: ldarg.0
-			IL_089d: ldc.i4.1
-			IL_089e: ldelem.ref
-			IL_089f: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_08a4: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_08a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08ae: stloc.s 15
-			IL_08b0: ldloc.s 15
-			IL_08b2: ldstr "rmSync"
-			IL_08b7: ldloc.3
-			IL_08b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08bd: dup
-			IL_08be: ldstr "force"
-			IL_08c3: ldc.i4.1
-			IL_08c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_08ce: pop
-			IL_08cf: br IL_08e7
+			IL_0809: ldarg.0
+			IL_080a: ldc.i4.1
+			IL_080b: ldelem.ref
+			IL_080c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0811: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0816: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_081b: stloc.s 13
+			IL_081d: ldloc.s 13
+			IL_081f: ldstr "rmSync"
+			IL_0824: ldloc.2
+			IL_0825: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_082a: dup
+			IL_082b: ldstr "force"
+			IL_0830: ldc.i4.1
+			IL_0831: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_083b: pop
+			IL_083c: ldarg.0
+			IL_083d: ldc.i4.1
+			IL_083e: ldelem.ref
+			IL_083f: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0844: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0849: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_084e: stloc.s 13
+			IL_0850: ldloc.s 13
+			IL_0852: ldstr "rmSync"
+			IL_0857: ldloc.3
+			IL_0858: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_085d: dup
+			IL_085e: ldstr "force"
+			IL_0863: ldc.i4.1
+			IL_0864: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0869: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_086e: pop
+			IL_086f: br IL_0887
 
-			IL_08d4: ldloc.0
-			IL_08d5: ldc.i4.1
-			IL_08d6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08db: ldloc.0
-			IL_08dc: ldc.i4.0
-			IL_08dd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08e2: br IL_08e7
+			IL_0874: ldloc.0
+			IL_0875: ldc.i4.1
+			IL_0876: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_087b: ldloc.0
+			IL_087c: ldc.i4.0
+			IL_087d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0882: br IL_0887
 
-			IL_08e7: ldloc.0
-			IL_08e8: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08ed: stloc.s 8
-			IL_08ef: ldloc.s 8
-			IL_08f1: brfalse IL_092e
+			IL_0887: ldloc.0
+			IL_0888: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_088d: stloc.s 6
+			IL_088f: ldloc.s 6
+			IL_0891: brfalse IL_08ce
 
-			IL_08f6: ldloc.0
-			IL_08f7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08fc: stloc.s 15
-			IL_08fe: ldloc.0
-			IL_08ff: ldc.i4.m1
-			IL_0900: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0905: ldloc.0
-			IL_0906: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_090b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0910: ldarg.0
-			IL_0911: ldc.i4.1
-			IL_0912: newarr [System.Runtime]System.Object
-			IL_0917: dup
-			IL_0918: ldc.i4.0
-			IL_0919: ldloc.s 15
-			IL_091b: stelem.ref
-			IL_091c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0921: pop
-			IL_0922: ldloc.0
-			IL_0923: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0928: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_092d: ret
+			IL_0896: ldloc.0
+			IL_0897: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_089c: stloc.s 13
+			IL_089e: ldloc.0
+			IL_089f: ldc.i4.m1
+			IL_08a0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08a5: ldloc.0
+			IL_08a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08b0: ldarg.0
+			IL_08b1: ldc.i4.1
+			IL_08b2: newarr [System.Runtime]System.Object
+			IL_08b7: dup
+			IL_08b8: ldc.i4.0
+			IL_08b9: ldloc.s 13
+			IL_08bb: stelem.ref
+			IL_08bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08c1: pop
+			IL_08c2: ldloc.0
+			IL_08c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08cd: ret
 
-			IL_092e: ldloc.0
-			IL_092f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0934: stloc.s 9
-			IL_0936: ldloc.s 9
-			IL_0938: brfalse IL_0975
+			IL_08ce: ldloc.0
+			IL_08cf: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08d4: stloc.s 7
+			IL_08d6: ldloc.s 7
+			IL_08d8: brfalse IL_0915
 
-			IL_093d: ldloc.0
-			IL_093e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0943: stloc.s 15
-			IL_0945: ldloc.0
-			IL_0946: ldc.i4.m1
-			IL_0947: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_094c: ldloc.0
-			IL_094d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0952: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0957: ldarg.0
-			IL_0958: ldc.i4.1
-			IL_0959: newarr [System.Runtime]System.Object
-			IL_095e: dup
-			IL_095f: ldc.i4.0
-			IL_0960: ldloc.s 15
-			IL_0962: stelem.ref
-			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0968: pop
-			IL_0969: ldloc.0
-			IL_096a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_096f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0974: ret
+			IL_08dd: ldloc.0
+			IL_08de: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_08e3: stloc.s 13
+			IL_08e5: ldloc.0
+			IL_08e6: ldc.i4.m1
+			IL_08e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08ec: ldloc.0
+			IL_08ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08f7: ldarg.0
+			IL_08f8: ldc.i4.1
+			IL_08f9: newarr [System.Runtime]System.Object
+			IL_08fe: dup
+			IL_08ff: ldc.i4.0
+			IL_0900: ldloc.s 13
+			IL_0902: stelem.ref
+			IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0908: pop
+			IL_0909: ldloc.0
+			IL_090a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_090f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0914: ret
 
-			IL_0975: ldloc.0
-			IL_0976: ldc.i4.m1
-			IL_0977: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_097c: ldloc.0
-			IL_097d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0982: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0987: ldarg.0
-			IL_0988: ldc.i4.1
-			IL_0989: newarr [System.Runtime]System.Object
-			IL_098e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0993: pop
-			IL_0994: ldloc.0
-			IL_0995: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_099a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_099f: ret
+			IL_0915: ldloc.0
+			IL_0916: ldc.i4.m1
+			IL_0917: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_091c: ldloc.0
+			IL_091d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0922: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0927: ldarg.0
+			IL_0928: ldc.i4.1
+			IL_0929: newarr [System.Runtime]System.Object
+			IL_092e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0933: pop
+			IL_0934: ldloc.0
+			IL_0935: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_093a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_093f: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1257,7 +1201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a94
+			// Method begins at RVA 0x2a34
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1354,7 +1298,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2ac1
+		// Method begins at RVA 0x2a61
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d6a
+					// Method begins at RVA 0x2cf9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d73
+					// Method begins at RVA 0x2d02
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d7c
+					// Method begins at RVA 0x2d0b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -121,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d61
+				// Method begins at RVA 0x2cf0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,35 +147,33 @@
 			)
 			// Method begins at RVA 0x20e8
 			// Header size: 12
-			// Code size: 3172 (0xc64)
+			// Code size: 3059 (0xbf3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope,
 				[1] string,
 				[2] object,
-				[3] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8,
-				[4] object,
+				[3] object,
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-				[6] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
-				[11] object,
-				[12] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18,
-				[13] bool,
-				[14] bool,
-				[15] object,
-				[16] string,
-				[17] float64,
+				[11] bool,
+				[12] bool,
+				[13] object,
+				[14] string,
+				[15] float64,
+				[16] object,
+				[17] string,
 				[18] object,
-				[19] string,
-				[20] object,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-				[22] object[],
-				[23] bool,
-				[24] object,
-				[25] object
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[20] object[],
+				[21] bool,
+				[22] object,
+				[23] object
 			)
 
 			IL_0000: ldarg.0
@@ -208,14 +206,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 25
+			IL_0048: ldc.i4.s 23
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0132
+			IL_005b: ble IL_011c
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -231,11 +229,11 @@
 			IL_0073: dup
 			IL_0074: ldc.i4.2
 			IL_0075: ldelem.ref
-			IL_0076: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8
-			IL_007b: stloc.3
-			IL_007c: dup
-			IL_007d: ldc.i4.3
-			IL_007e: ldelem.ref
+			IL_0076: stloc.3
+			IL_0077: dup
+			IL_0078: ldc.i4.3
+			IL_0079: ldelem.ref
+			IL_007a: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
 			IL_007f: stloc.s 4
 			IL_0081: dup
 			IL_0082: ldc.i4.4
@@ -245,1371 +243,1309 @@
 			IL_008b: dup
 			IL_008c: ldc.i4.5
 			IL_008d: ldelem.ref
-			IL_008e: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
-			IL_0093: stloc.s 6
+			IL_008e: stloc.s 6
+			IL_0090: dup
+			IL_0091: ldc.i4.6
+			IL_0092: ldelem.ref
+			IL_0093: stloc.s 7
 			IL_0095: dup
-			IL_0096: ldc.i4.6
+			IL_0096: ldc.i4.7
 			IL_0097: ldelem.ref
-			IL_0098: stloc.s 7
+			IL_0098: stloc.s 8
 			IL_009a: dup
-			IL_009b: ldc.i4.7
+			IL_009b: ldc.i4.8
 			IL_009c: ldelem.ref
-			IL_009d: stloc.s 8
+			IL_009d: stloc.s 9
 			IL_009f: dup
-			IL_00a0: ldc.i4.8
-			IL_00a1: ldelem.ref
-			IL_00a2: stloc.s 9
-			IL_00a4: dup
-			IL_00a5: ldc.i4.s 9
-			IL_00a7: ldelem.ref
-			IL_00a8: stloc.s 10
-			IL_00aa: dup
-			IL_00ab: ldc.i4.s 10
-			IL_00ad: ldelem.ref
+			IL_00a0: ldc.i4.s 9
+			IL_00a2: ldelem.ref
+			IL_00a3: stloc.s 10
+			IL_00a5: dup
+			IL_00a6: ldc.i4.s 10
+			IL_00a8: ldelem.ref
+			IL_00a9: unbox.any [System.Runtime]System.Boolean
 			IL_00ae: stloc.s 11
 			IL_00b0: dup
 			IL_00b1: ldc.i4.s 11
 			IL_00b3: ldelem.ref
-			IL_00b4: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18
+			IL_00b4: unbox.any [System.Runtime]System.Boolean
 			IL_00b9: stloc.s 12
 			IL_00bb: dup
 			IL_00bc: ldc.i4.s 12
 			IL_00be: ldelem.ref
-			IL_00bf: unbox.any [System.Runtime]System.Boolean
-			IL_00c4: stloc.s 13
-			IL_00c6: dup
-			IL_00c7: ldc.i4.s 13
-			IL_00c9: ldelem.ref
-			IL_00ca: unbox.any [System.Runtime]System.Boolean
-			IL_00cf: stloc.s 14
-			IL_00d1: dup
-			IL_00d2: ldc.i4.s 14
-			IL_00d4: ldelem.ref
+			IL_00bf: stloc.s 13
+			IL_00c1: dup
+			IL_00c2: ldc.i4.s 13
+			IL_00c4: ldelem.ref
+			IL_00c5: castclass [System.Runtime]System.String
+			IL_00ca: stloc.s 14
+			IL_00cc: dup
+			IL_00cd: ldc.i4.s 14
+			IL_00cf: ldelem.ref
+			IL_00d0: unbox.any [System.Runtime]System.Double
 			IL_00d5: stloc.s 15
 			IL_00d7: dup
 			IL_00d8: ldc.i4.s 15
 			IL_00da: ldelem.ref
-			IL_00db: castclass [System.Runtime]System.String
-			IL_00e0: stloc.s 16
-			IL_00e2: dup
-			IL_00e3: ldc.i4.s 16
-			IL_00e5: ldelem.ref
-			IL_00e6: unbox.any [System.Runtime]System.Double
-			IL_00eb: stloc.s 17
-			IL_00ed: dup
-			IL_00ee: ldc.i4.s 17
-			IL_00f0: ldelem.ref
-			IL_00f1: stloc.s 18
-			IL_00f3: dup
-			IL_00f4: ldc.i4.s 18
-			IL_00f6: ldelem.ref
-			IL_00f7: castclass [System.Runtime]System.String
-			IL_00fc: stloc.s 19
-			IL_00fe: dup
-			IL_00ff: ldc.i4.s 19
-			IL_0101: ldelem.ref
+			IL_00db: stloc.s 16
+			IL_00dd: dup
+			IL_00de: ldc.i4.s 16
+			IL_00e0: ldelem.ref
+			IL_00e1: castclass [System.Runtime]System.String
+			IL_00e6: stloc.s 17
+			IL_00e8: dup
+			IL_00e9: ldc.i4.s 17
+			IL_00eb: ldelem.ref
+			IL_00ec: stloc.s 18
+			IL_00ee: dup
+			IL_00ef: ldc.i4.s 18
+			IL_00f1: ldelem.ref
+			IL_00f2: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_00f7: stloc.s 19
+			IL_00f9: dup
+			IL_00fa: ldc.i4.s 19
+			IL_00fc: ldelem.ref
+			IL_00fd: castclass object[]
 			IL_0102: stloc.s 20
 			IL_0104: dup
 			IL_0105: ldc.i4.s 20
 			IL_0107: ldelem.ref
-			IL_0108: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_0108: unbox.any [System.Runtime]System.Boolean
 			IL_010d: stloc.s 21
 			IL_010f: dup
 			IL_0110: ldc.i4.s 21
 			IL_0112: ldelem.ref
-			IL_0113: castclass object[]
-			IL_0118: stloc.s 22
-			IL_011a: dup
-			IL_011b: ldc.i4.s 22
-			IL_011d: ldelem.ref
-			IL_011e: unbox.any [System.Runtime]System.Boolean
-			IL_0123: stloc.s 23
-			IL_0125: dup
-			IL_0126: ldc.i4.s 23
-			IL_0128: ldelem.ref
-			IL_0129: stloc.s 24
-			IL_012b: dup
-			IL_012c: ldc.i4.s 24
-			IL_012e: ldelem.ref
-			IL_012f: stloc.s 25
-			IL_0131: pop
+			IL_0113: stloc.s 22
+			IL_0115: dup
+			IL_0116: ldc.i4.s 22
+			IL_0118: ldelem.ref
+			IL_0119: stloc.s 23
+			IL_011b: pop
 
-			IL_0132: ldloc.0
-			IL_0133: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0138: switch (IL_0165, IL_0b4d, IL_0b98, IL_0acb, IL_03ce, IL_0539, IL_066a, IL_0773, IL_0874, IL_0966)
+			IL_011c: ldloc.0
+			IL_011d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0122: switch (IL_014f, IL_0adc, IL_0b27, IL_0a61, IL_03a6, IL_0503, IL_0627, IL_0723, IL_0817, IL_08fc)
 
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_016a: stloc.s 15
-			IL_016c: ldloc.s 15
-			IL_016e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0173: stloc.s 16
-			IL_0175: ldstr ""
-			IL_017a: ldloc.s 16
-			IL_017c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0181: stloc.s 16
-			IL_0183: ldloc.s 16
-			IL_0185: ldstr "-"
-			IL_018a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018f: stloc.s 16
-			IL_0191: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_0196: stloc.s 17
-			IL_0198: ldloc.s 17
-			IL_019a: ldc.r8 1000000000
-			IL_01a3: mul
-			IL_01a4: stloc.s 17
-			IL_01a6: ldloc.s 17
-			IL_01a8: box [System.Runtime]System.Double
-			IL_01ad: stloc.s 18
-			IL_01af: ldloc.s 18
-			IL_01b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_01b6: stloc.s 17
-			IL_01b8: ldloc.s 17
-			IL_01ba: box [System.Runtime]System.Double
-			IL_01bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c4: stloc.s 19
-			IL_01c6: ldloc.s 16
-			IL_01c8: ldloc.s 19
-			IL_01ca: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01cf: stloc.s 19
-			IL_01d1: ldloc.s 19
-			IL_01d3: stloc.1
-			IL_01d4: ldarg.0
-			IL_01d5: ldc.i4.1
-			IL_01d6: ldelem.ref
-			IL_01d7: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_01dc: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e6: stloc.s 15
-			IL_01e8: ldarg.0
-			IL_01e9: ldc.i4.1
-			IL_01ea: ldelem.ref
-			IL_01eb: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_01f0: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fa: stloc.s 20
-			IL_01fc: ldloc.s 20
-			IL_01fe: ldstr "tmpdir"
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0208: stloc.s 20
-			IL_020a: ldloc.1
-			IL_020b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0210: stloc.s 19
-			IL_0212: ldstr "jroc-fs-open-position-"
-			IL_0217: ldloc.s 19
-			IL_0219: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021e: stloc.s 19
-			IL_0220: ldloc.s 19
-			IL_0222: ldstr ".txt"
-			IL_0227: call string [System.Runtime]System.String::Concat(string, string)
-			IL_022c: stloc.s 19
-			IL_022e: ldloc.s 15
-			IL_0230: ldstr "join"
-			IL_0235: ldloc.s 20
-			IL_0237: ldloc.s 19
-			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_023e: stloc.s 20
-			IL_0240: ldloc.s 20
-			IL_0242: stloc.2
-			IL_0243: ldloc.0
-			IL_0244: ldc.i4.0
-			IL_0245: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_024a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_024f: ldloc.0
-			IL_0250: ldc.i4.0
-			IL_0251: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0256: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_025b: ldloc.0
-			IL_025c: ldc.i4.0
-			IL_025d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0262: ldloc.0
-			IL_0263: ldc.i4.0
-			IL_0264: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0269: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
-			IL_026e: stloc.3
-			IL_026f: ldarg.0
-			IL_0270: ldc.i4.1
-			IL_0271: ldelem.ref
-			IL_0272: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0277: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0281: stloc.s 20
-			IL_0283: ldloc.s 20
-			IL_0285: ldstr "rmSync"
-			IL_028a: ldloc.2
-			IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0290: dup
-			IL_0291: ldstr "force"
-			IL_0296: ldc.i4.1
-			IL_0297: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02a1: pop
-			IL_02a2: ldarg.0
-			IL_02a3: ldc.i4.1
-			IL_02a4: ldelem.ref
-			IL_02a5: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_02aa: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b4: stloc.s 20
-			IL_02b6: ldloc.s 20
-			IL_02b8: ldstr "writeFileSync"
-			IL_02bd: ldloc.2
-			IL_02be: ldstr "hello"
-			IL_02c3: ldstr "utf8"
-			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_02cd: pop
-			IL_02ce: ldarg.0
-			IL_02cf: ldc.i4.1
-			IL_02d0: ldelem.ref
-			IL_02d1: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_02d6: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_02db: ldstr "promises"
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ea: stloc.s 20
-			IL_02ec: ldloc.s 20
-			IL_02ee: ldstr "open"
-			IL_02f3: ldloc.2
-			IL_02f4: ldstr "r+"
-			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02fe: stloc.s 20
-			IL_0300: ldloc.0
-			IL_0301: ldc.i4.4
-			IL_0302: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0307: ldloc.0
-			IL_0308: ldloc.s 20
-			IL_030a: ldarg.0
-			IL_030b: ldc.i4.1
-			IL_030c: ldloc.0
-			IL_030d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0312: ldc.i4.3
-			IL_0313: ldstr "_pendingException"
-			IL_0318: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_031d: ldloc.0
-			IL_031e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0323: dup
-			IL_0324: ldc.i4.0
-			IL_0325: ldloc.1
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_0154: stloc.s 13
+			IL_0156: ldloc.s 13
+			IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_015d: stloc.s 14
+			IL_015f: ldstr ""
+			IL_0164: ldloc.s 14
+			IL_0166: call string [System.Runtime]System.String::Concat(string, string)
+			IL_016b: stloc.s 14
+			IL_016d: ldloc.s 14
+			IL_016f: ldstr "-"
+			IL_0174: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0179: stloc.s 14
+			IL_017b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_0180: stloc.s 15
+			IL_0182: ldloc.s 15
+			IL_0184: ldc.r8 1000000000
+			IL_018d: mul
+			IL_018e: stloc.s 15
+			IL_0190: ldloc.s 15
+			IL_0192: box [System.Runtime]System.Double
+			IL_0197: stloc.s 16
+			IL_0199: ldloc.s 16
+			IL_019b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_01a0: stloc.s 15
+			IL_01a2: ldloc.s 15
+			IL_01a4: box [System.Runtime]System.Double
+			IL_01a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ae: stloc.s 17
+			IL_01b0: ldloc.s 14
+			IL_01b2: ldloc.s 17
+			IL_01b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b9: stloc.s 17
+			IL_01bb: ldloc.s 17
+			IL_01bd: stloc.1
+			IL_01be: ldarg.0
+			IL_01bf: ldc.i4.1
+			IL_01c0: ldelem.ref
+			IL_01c1: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01c6: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d0: stloc.s 13
+			IL_01d2: ldarg.0
+			IL_01d3: ldc.i4.1
+			IL_01d4: ldelem.ref
+			IL_01d5: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01da: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e4: stloc.s 18
+			IL_01e6: ldloc.s 18
+			IL_01e8: ldstr "tmpdir"
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01f2: stloc.s 18
+			IL_01f4: ldloc.1
+			IL_01f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01fa: stloc.s 17
+			IL_01fc: ldstr "jroc-fs-open-position-"
+			IL_0201: ldloc.s 17
+			IL_0203: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0208: stloc.s 17
+			IL_020a: ldloc.s 17
+			IL_020c: ldstr ".txt"
+			IL_0211: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0216: stloc.s 17
+			IL_0218: ldloc.s 13
+			IL_021a: ldstr "join"
+			IL_021f: ldloc.s 18
+			IL_0221: ldloc.s 17
+			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0228: stloc.s 18
+			IL_022a: ldloc.s 18
+			IL_022c: stloc.2
+			IL_022d: ldloc.0
+			IL_022e: ldc.i4.0
+			IL_022f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0234: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0239: ldloc.0
+			IL_023a: ldc.i4.0
+			IL_023b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0240: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0245: ldloc.0
+			IL_0246: ldc.i4.0
+			IL_0247: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_024c: ldloc.0
+			IL_024d: ldc.i4.0
+			IL_024e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0253: ldarg.0
+			IL_0254: ldc.i4.1
+			IL_0255: ldelem.ref
+			IL_0256: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_025b: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0265: stloc.s 18
+			IL_0267: ldloc.s 18
+			IL_0269: ldstr "rmSync"
+			IL_026e: ldloc.2
+			IL_026f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0274: dup
+			IL_0275: ldstr "force"
+			IL_027a: ldc.i4.1
+			IL_027b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0285: pop
+			IL_0286: ldarg.0
+			IL_0287: ldc.i4.1
+			IL_0288: ldelem.ref
+			IL_0289: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_028e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0298: stloc.s 18
+			IL_029a: ldloc.s 18
+			IL_029c: ldstr "writeFileSync"
+			IL_02a1: ldloc.2
+			IL_02a2: ldstr "hello"
+			IL_02a7: ldstr "utf8"
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_02b1: pop
+			IL_02b2: ldarg.0
+			IL_02b3: ldc.i4.1
+			IL_02b4: ldelem.ref
+			IL_02b5: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_02ba: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_02bf: ldstr "promises"
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ce: stloc.s 18
+			IL_02d0: ldloc.s 18
+			IL_02d2: ldstr "open"
+			IL_02d7: ldloc.2
+			IL_02d8: ldstr "r+"
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02e2: stloc.s 18
+			IL_02e4: ldloc.0
+			IL_02e5: ldc.i4.4
+			IL_02e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02eb: ldloc.0
+			IL_02ec: ldloc.s 18
+			IL_02ee: ldarg.0
+			IL_02ef: ldc.i4.1
+			IL_02f0: ldloc.0
+			IL_02f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02f6: ldc.i4.3
+			IL_02f7: ldstr "_pendingException"
+			IL_02fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0301: ldloc.0
+			IL_0302: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0307: dup
+			IL_0308: ldc.i4.0
+			IL_0309: ldloc.1
+			IL_030a: stelem.ref
+			IL_030b: dup
+			IL_030c: ldc.i4.1
+			IL_030d: ldloc.2
+			IL_030e: stelem.ref
+			IL_030f: dup
+			IL_0310: ldc.i4.2
+			IL_0311: ldloc.3
+			IL_0312: stelem.ref
+			IL_0313: dup
+			IL_0314: ldc.i4.3
+			IL_0315: ldloc.s 4
+			IL_0317: stelem.ref
+			IL_0318: dup
+			IL_0319: ldc.i4.4
+			IL_031a: ldloc.s 5
+			IL_031c: stelem.ref
+			IL_031d: dup
+			IL_031e: ldc.i4.5
+			IL_031f: ldloc.s 6
+			IL_0321: stelem.ref
+			IL_0322: dup
+			IL_0323: ldc.i4.6
+			IL_0324: ldloc.s 7
 			IL_0326: stelem.ref
 			IL_0327: dup
-			IL_0328: ldc.i4.1
-			IL_0329: ldloc.2
-			IL_032a: stelem.ref
-			IL_032b: dup
-			IL_032c: ldc.i4.2
-			IL_032d: ldloc.3
-			IL_032e: stelem.ref
-			IL_032f: dup
-			IL_0330: ldc.i4.3
-			IL_0331: ldloc.s 4
-			IL_0333: stelem.ref
-			IL_0334: dup
-			IL_0335: ldc.i4.4
-			IL_0336: ldloc.s 5
-			IL_0338: stelem.ref
-			IL_0339: dup
-			IL_033a: ldc.i4.5
-			IL_033b: ldloc.s 6
-			IL_033d: stelem.ref
-			IL_033e: dup
-			IL_033f: ldc.i4.6
-			IL_0340: ldloc.s 7
-			IL_0342: stelem.ref
-			IL_0343: dup
-			IL_0344: ldc.i4.7
-			IL_0345: ldloc.s 8
-			IL_0347: stelem.ref
-			IL_0348: dup
-			IL_0349: ldc.i4.8
-			IL_034a: ldloc.s 9
+			IL_0328: ldc.i4.7
+			IL_0329: ldloc.s 8
+			IL_032b: stelem.ref
+			IL_032c: dup
+			IL_032d: ldc.i4.8
+			IL_032e: ldloc.s 9
+			IL_0330: stelem.ref
+			IL_0331: dup
+			IL_0332: ldc.i4.s 9
+			IL_0334: ldloc.s 10
+			IL_0336: stelem.ref
+			IL_0337: dup
+			IL_0338: ldc.i4.s 10
+			IL_033a: ldloc.s 11
+			IL_033c: box [System.Runtime]System.Boolean
+			IL_0341: stelem.ref
+			IL_0342: dup
+			IL_0343: ldc.i4.s 11
+			IL_0345: ldloc.s 12
+			IL_0347: box [System.Runtime]System.Boolean
 			IL_034c: stelem.ref
 			IL_034d: dup
-			IL_034e: ldc.i4.s 9
-			IL_0350: ldloc.s 10
+			IL_034e: ldc.i4.s 12
+			IL_0350: ldloc.s 13
 			IL_0352: stelem.ref
 			IL_0353: dup
-			IL_0354: ldc.i4.s 10
-			IL_0356: ldloc.s 11
+			IL_0354: ldc.i4.s 13
+			IL_0356: ldloc.s 14
 			IL_0358: stelem.ref
 			IL_0359: dup
-			IL_035a: ldc.i4.s 11
-			IL_035c: ldloc.s 12
-			IL_035e: stelem.ref
-			IL_035f: dup
-			IL_0360: ldc.i4.s 12
-			IL_0362: ldloc.s 13
-			IL_0364: box [System.Runtime]System.Boolean
+			IL_035a: ldc.i4.s 14
+			IL_035c: ldloc.s 15
+			IL_035e: box [System.Runtime]System.Double
+			IL_0363: stelem.ref
+			IL_0364: dup
+			IL_0365: ldc.i4.s 15
+			IL_0367: ldloc.s 16
 			IL_0369: stelem.ref
 			IL_036a: dup
-			IL_036b: ldc.i4.s 13
-			IL_036d: ldloc.s 14
-			IL_036f: box [System.Runtime]System.Boolean
-			IL_0374: stelem.ref
-			IL_0375: dup
-			IL_0376: ldc.i4.s 14
-			IL_0378: ldloc.s 15
-			IL_037a: stelem.ref
-			IL_037b: dup
-			IL_037c: ldc.i4.s 15
-			IL_037e: ldloc.s 16
-			IL_0380: stelem.ref
-			IL_0381: dup
-			IL_0382: ldc.i4.s 16
-			IL_0384: ldloc.s 17
-			IL_0386: box [System.Runtime]System.Double
-			IL_038b: stelem.ref
-			IL_038c: dup
-			IL_038d: ldc.i4.s 17
-			IL_038f: ldloc.s 18
-			IL_0391: stelem.ref
-			IL_0392: dup
-			IL_0393: ldc.i4.s 18
-			IL_0395: ldloc.s 19
-			IL_0397: stelem.ref
-			IL_0398: dup
-			IL_0399: ldc.i4.s 19
-			IL_039b: ldloc.s 20
-			IL_039d: stelem.ref
-			IL_039e: dup
-			IL_039f: ldc.i4.s 20
-			IL_03a1: ldloc.s 21
-			IL_03a3: stelem.ref
-			IL_03a4: dup
-			IL_03a5: ldc.i4.s 21
-			IL_03a7: ldloc.s 22
-			IL_03a9: stelem.ref
-			IL_03aa: dup
-			IL_03ab: ldc.i4.s 22
-			IL_03ad: ldloc.s 23
-			IL_03af: box [System.Runtime]System.Boolean
-			IL_03b4: stelem.ref
-			IL_03b5: dup
-			IL_03b6: ldc.i4.s 23
-			IL_03b8: ldloc.s 24
-			IL_03ba: stelem.ref
-			IL_03bb: dup
-			IL_03bc: ldc.i4.s 24
-			IL_03be: ldloc.s 25
-			IL_03c0: stelem.ref
-			IL_03c1: pop
-			IL_03c2: ldloc.0
-			IL_03c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03cd: ret
+			IL_036b: ldc.i4.s 16
+			IL_036d: ldloc.s 17
+			IL_036f: stelem.ref
+			IL_0370: dup
+			IL_0371: ldc.i4.s 17
+			IL_0373: ldloc.s 18
+			IL_0375: stelem.ref
+			IL_0376: dup
+			IL_0377: ldc.i4.s 18
+			IL_0379: ldloc.s 19
+			IL_037b: stelem.ref
+			IL_037c: dup
+			IL_037d: ldc.i4.s 19
+			IL_037f: ldloc.s 20
+			IL_0381: stelem.ref
+			IL_0382: dup
+			IL_0383: ldc.i4.s 20
+			IL_0385: ldloc.s 21
+			IL_0387: box [System.Runtime]System.Boolean
+			IL_038c: stelem.ref
+			IL_038d: dup
+			IL_038e: ldc.i4.s 21
+			IL_0390: ldloc.s 22
+			IL_0392: stelem.ref
+			IL_0393: dup
+			IL_0394: ldc.i4.s 22
+			IL_0396: ldloc.s 23
+			IL_0398: stelem.ref
+			IL_0399: pop
+			IL_039a: ldloc.0
+			IL_039b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03a5: ret
 
-			IL_03ce: ldloc.0
-			IL_03cf: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
-			IL_03d4: stloc.s 20
-			IL_03d6: ldloc.s 20
-			IL_03d8: stloc.s 4
-			IL_03da: ldc.r8 1
-			IL_03e3: box [System.Runtime]System.Double
-			IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_03ed: stloc.s 21
-			IL_03ef: ldloc.s 21
-			IL_03f1: stloc.s 5
-			IL_03f3: ldc.r8 1
-			IL_03fc: box [System.Runtime]System.Double
-			IL_0401: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_0406: stloc.s 21
-			IL_0408: ldloc.s 21
-			IL_040a: stloc.s 6
-			IL_040c: ldloc.s 4
-			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0413: stloc.s 20
-			IL_0415: ldloc.s 5
-			IL_0417: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_041c: stloc.s 17
-			IL_041e: ldloc.s 17
-			IL_0420: box [System.Runtime]System.Double
-			IL_0425: stloc.s 18
-			IL_0427: ldc.i4.4
-			IL_0428: newarr [System.Runtime]System.Object
-			IL_042d: dup
-			IL_042e: ldc.i4.0
-			IL_042f: ldloc.s 5
-			IL_0431: stelem.ref
-			IL_0432: dup
-			IL_0433: ldc.i4.1
-			IL_0434: ldc.r8 0.0
-			IL_043d: box [System.Runtime]System.Double
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.2
-			IL_0445: ldloc.s 18
-			IL_0447: stelem.ref
-			IL_0448: dup
-			IL_0449: ldc.i4.3
-			IL_044a: ldc.r8 2
-			IL_0453: box [System.Runtime]System.Double
-			IL_0458: stelem.ref
-			IL_0459: stloc.s 22
-			IL_045b: ldloc.s 20
-			IL_045d: ldstr "read"
-			IL_0462: ldloc.s 22
-			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0469: stloc.s 20
-			IL_046b: ldloc.0
-			IL_046c: ldc.i4.5
-			IL_046d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0472: ldloc.0
-			IL_0473: ldloc.s 20
-			IL_0475: ldarg.0
-			IL_0476: ldc.i4.2
-			IL_0477: ldloc.0
-			IL_0478: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_047d: ldc.i4.3
-			IL_047e: ldstr "_pendingException"
-			IL_0483: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0488: ldloc.0
-			IL_0489: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03a6: ldloc.0
+			IL_03a7: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03ac: stloc.s 18
+			IL_03ae: ldloc.s 18
+			IL_03b0: stloc.3
+			IL_03b1: ldc.r8 1
+			IL_03ba: box [System.Runtime]System.Double
+			IL_03bf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03c4: stloc.s 19
+			IL_03c6: ldloc.s 19
+			IL_03c8: stloc.s 4
+			IL_03ca: ldc.r8 1
+			IL_03d3: box [System.Runtime]System.Double
+			IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03dd: stloc.s 19
+			IL_03df: ldloc.s 19
+			IL_03e1: stloc.s 5
+			IL_03e3: ldloc.3
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e9: stloc.s 18
+			IL_03eb: ldloc.s 4
+			IL_03ed: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_03f2: stloc.s 15
+			IL_03f4: ldloc.s 15
+			IL_03f6: box [System.Runtime]System.Double
+			IL_03fb: stloc.s 16
+			IL_03fd: ldc.i4.4
+			IL_03fe: newarr [System.Runtime]System.Object
+			IL_0403: dup
+			IL_0404: ldc.i4.0
+			IL_0405: ldloc.s 4
+			IL_0407: stelem.ref
+			IL_0408: dup
+			IL_0409: ldc.i4.1
+			IL_040a: ldc.r8 0.0
+			IL_0413: box [System.Runtime]System.Double
+			IL_0418: stelem.ref
+			IL_0419: dup
+			IL_041a: ldc.i4.2
+			IL_041b: ldloc.s 16
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.3
+			IL_0420: ldc.r8 2
+			IL_0429: box [System.Runtime]System.Double
+			IL_042e: stelem.ref
+			IL_042f: stloc.s 20
+			IL_0431: ldloc.s 18
+			IL_0433: ldstr "read"
+			IL_0438: ldloc.s 20
+			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_043f: stloc.s 18
+			IL_0441: ldloc.0
+			IL_0442: ldc.i4.5
+			IL_0443: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0448: ldloc.0
+			IL_0449: ldloc.s 18
+			IL_044b: ldarg.0
+			IL_044c: ldc.i4.2
+			IL_044d: ldloc.0
+			IL_044e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0453: ldc.i4.3
+			IL_0454: ldstr "_pendingException"
+			IL_0459: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_045e: ldloc.0
+			IL_045f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0464: dup
+			IL_0465: ldc.i4.0
+			IL_0466: ldloc.1
+			IL_0467: stelem.ref
+			IL_0468: dup
+			IL_0469: ldc.i4.1
+			IL_046a: ldloc.2
+			IL_046b: stelem.ref
+			IL_046c: dup
+			IL_046d: ldc.i4.2
+			IL_046e: ldloc.3
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.3
+			IL_0472: ldloc.s 4
+			IL_0474: stelem.ref
+			IL_0475: dup
+			IL_0476: ldc.i4.4
+			IL_0477: ldloc.s 5
+			IL_0479: stelem.ref
+			IL_047a: dup
+			IL_047b: ldc.i4.5
+			IL_047c: ldloc.s 6
+			IL_047e: stelem.ref
+			IL_047f: dup
+			IL_0480: ldc.i4.6
+			IL_0481: ldloc.s 7
+			IL_0483: stelem.ref
+			IL_0484: dup
+			IL_0485: ldc.i4.7
+			IL_0486: ldloc.s 8
+			IL_0488: stelem.ref
+			IL_0489: dup
+			IL_048a: ldc.i4.8
+			IL_048b: ldloc.s 9
+			IL_048d: stelem.ref
 			IL_048e: dup
-			IL_048f: ldc.i4.0
-			IL_0490: ldloc.1
-			IL_0491: stelem.ref
-			IL_0492: dup
-			IL_0493: ldc.i4.1
-			IL_0494: ldloc.2
-			IL_0495: stelem.ref
-			IL_0496: dup
-			IL_0497: ldc.i4.2
-			IL_0498: ldloc.3
-			IL_0499: stelem.ref
-			IL_049a: dup
-			IL_049b: ldc.i4.3
-			IL_049c: ldloc.s 4
+			IL_048f: ldc.i4.s 9
+			IL_0491: ldloc.s 10
+			IL_0493: stelem.ref
+			IL_0494: dup
+			IL_0495: ldc.i4.s 10
+			IL_0497: ldloc.s 11
+			IL_0499: box [System.Runtime]System.Boolean
 			IL_049e: stelem.ref
 			IL_049f: dup
-			IL_04a0: ldc.i4.4
-			IL_04a1: ldloc.s 5
-			IL_04a3: stelem.ref
-			IL_04a4: dup
-			IL_04a5: ldc.i4.5
-			IL_04a6: ldloc.s 6
-			IL_04a8: stelem.ref
-			IL_04a9: dup
-			IL_04aa: ldc.i4.6
-			IL_04ab: ldloc.s 7
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.7
-			IL_04b0: ldloc.s 8
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.8
-			IL_04b5: ldloc.s 9
-			IL_04b7: stelem.ref
-			IL_04b8: dup
-			IL_04b9: ldc.i4.s 9
-			IL_04bb: ldloc.s 10
-			IL_04bd: stelem.ref
-			IL_04be: dup
-			IL_04bf: ldc.i4.s 10
-			IL_04c1: ldloc.s 11
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 11
-			IL_04c7: ldloc.s 12
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 12
-			IL_04cd: ldloc.s 13
-			IL_04cf: box [System.Runtime]System.Boolean
-			IL_04d4: stelem.ref
-			IL_04d5: dup
-			IL_04d6: ldc.i4.s 13
-			IL_04d8: ldloc.s 14
-			IL_04da: box [System.Runtime]System.Boolean
-			IL_04df: stelem.ref
-			IL_04e0: dup
-			IL_04e1: ldc.i4.s 14
-			IL_04e3: ldloc.s 15
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.s 15
-			IL_04e9: ldloc.s 16
-			IL_04eb: stelem.ref
-			IL_04ec: dup
-			IL_04ed: ldc.i4.s 16
-			IL_04ef: ldloc.s 17
-			IL_04f1: box [System.Runtime]System.Double
-			IL_04f6: stelem.ref
-			IL_04f7: dup
-			IL_04f8: ldc.i4.s 17
-			IL_04fa: ldloc.s 18
-			IL_04fc: stelem.ref
-			IL_04fd: dup
-			IL_04fe: ldc.i4.s 18
-			IL_0500: ldloc.s 19
-			IL_0502: stelem.ref
-			IL_0503: dup
-			IL_0504: ldc.i4.s 19
-			IL_0506: ldloc.s 20
-			IL_0508: stelem.ref
-			IL_0509: dup
-			IL_050a: ldc.i4.s 20
-			IL_050c: ldloc.s 21
-			IL_050e: stelem.ref
-			IL_050f: dup
-			IL_0510: ldc.i4.s 21
-			IL_0512: ldloc.s 22
-			IL_0514: stelem.ref
-			IL_0515: dup
-			IL_0516: ldc.i4.s 22
-			IL_0518: ldloc.s 23
-			IL_051a: box [System.Runtime]System.Boolean
-			IL_051f: stelem.ref
-			IL_0520: dup
-			IL_0521: ldc.i4.s 23
-			IL_0523: ldloc.s 24
-			IL_0525: stelem.ref
-			IL_0526: dup
-			IL_0527: ldc.i4.s 24
-			IL_0529: ldloc.s 25
-			IL_052b: stelem.ref
-			IL_052c: pop
-			IL_052d: ldloc.0
-			IL_052e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0533: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0538: ret
+			IL_04a0: ldc.i4.s 11
+			IL_04a2: ldloc.s 12
+			IL_04a4: box [System.Runtime]System.Boolean
+			IL_04a9: stelem.ref
+			IL_04aa: dup
+			IL_04ab: ldc.i4.s 12
+			IL_04ad: ldloc.s 13
+			IL_04af: stelem.ref
+			IL_04b0: dup
+			IL_04b1: ldc.i4.s 13
+			IL_04b3: ldloc.s 14
+			IL_04b5: stelem.ref
+			IL_04b6: dup
+			IL_04b7: ldc.i4.s 14
+			IL_04b9: ldloc.s 15
+			IL_04bb: box [System.Runtime]System.Double
+			IL_04c0: stelem.ref
+			IL_04c1: dup
+			IL_04c2: ldc.i4.s 15
+			IL_04c4: ldloc.s 16
+			IL_04c6: stelem.ref
+			IL_04c7: dup
+			IL_04c8: ldc.i4.s 16
+			IL_04ca: ldloc.s 17
+			IL_04cc: stelem.ref
+			IL_04cd: dup
+			IL_04ce: ldc.i4.s 17
+			IL_04d0: ldloc.s 18
+			IL_04d2: stelem.ref
+			IL_04d3: dup
+			IL_04d4: ldc.i4.s 18
+			IL_04d6: ldloc.s 19
+			IL_04d8: stelem.ref
+			IL_04d9: dup
+			IL_04da: ldc.i4.s 19
+			IL_04dc: ldloc.s 20
+			IL_04de: stelem.ref
+			IL_04df: dup
+			IL_04e0: ldc.i4.s 20
+			IL_04e2: ldloc.s 21
+			IL_04e4: box [System.Runtime]System.Boolean
+			IL_04e9: stelem.ref
+			IL_04ea: dup
+			IL_04eb: ldc.i4.s 21
+			IL_04ed: ldloc.s 22
+			IL_04ef: stelem.ref
+			IL_04f0: dup
+			IL_04f1: ldc.i4.s 22
+			IL_04f3: ldloc.s 23
+			IL_04f5: stelem.ref
+			IL_04f6: pop
+			IL_04f7: ldloc.0
+			IL_04f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04fd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0502: ret
 
-			IL_0539: ldloc.0
-			IL_053a: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
-			IL_053f: stloc.s 20
-			IL_0541: ldloc.s 20
-			IL_0543: stloc.s 7
-			IL_0545: ldloc.s 4
-			IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_054c: stloc.s 20
-			IL_054e: ldloc.s 6
-			IL_0550: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_0555: stloc.s 17
-			IL_0557: ldloc.s 17
-			IL_0559: box [System.Runtime]System.Double
-			IL_055e: stloc.s 18
-			IL_0560: ldc.i4.4
-			IL_0561: newarr [System.Runtime]System.Object
-			IL_0566: dup
-			IL_0567: ldc.i4.0
-			IL_0568: ldloc.s 6
-			IL_056a: stelem.ref
-			IL_056b: dup
-			IL_056c: ldc.i4.1
-			IL_056d: ldc.r8 0.0
-			IL_0576: box [System.Runtime]System.Double
-			IL_057b: stelem.ref
-			IL_057c: dup
-			IL_057d: ldc.i4.2
-			IL_057e: ldloc.s 18
-			IL_0580: stelem.ref
-			IL_0581: dup
-			IL_0582: ldc.i4.3
-			IL_0583: ldc.i4.0
-			IL_0584: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0589: stelem.ref
-			IL_058a: stloc.s 22
-			IL_058c: ldloc.s 20
-			IL_058e: ldstr "read"
-			IL_0593: ldloc.s 22
-			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_059a: stloc.s 20
-			IL_059c: ldloc.0
-			IL_059d: ldc.i4.6
-			IL_059e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05a3: ldloc.0
-			IL_05a4: ldloc.s 20
-			IL_05a6: ldarg.0
-			IL_05a7: ldc.i4.3
-			IL_05a8: ldloc.0
-			IL_05a9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05ae: ldc.i4.3
-			IL_05af: ldstr "_pendingException"
-			IL_05b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05b9: ldloc.0
-			IL_05ba: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05bf: dup
-			IL_05c0: ldc.i4.0
-			IL_05c1: ldloc.1
+			IL_0503: ldloc.0
+			IL_0504: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0509: stloc.s 18
+			IL_050b: ldloc.s 18
+			IL_050d: stloc.s 6
+			IL_050f: ldloc.3
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0515: stloc.s 18
+			IL_0517: ldloc.s 5
+			IL_0519: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_051e: stloc.s 15
+			IL_0520: ldloc.s 15
+			IL_0522: box [System.Runtime]System.Double
+			IL_0527: stloc.s 16
+			IL_0529: ldc.i4.4
+			IL_052a: newarr [System.Runtime]System.Object
+			IL_052f: dup
+			IL_0530: ldc.i4.0
+			IL_0531: ldloc.s 5
+			IL_0533: stelem.ref
+			IL_0534: dup
+			IL_0535: ldc.i4.1
+			IL_0536: ldc.r8 0.0
+			IL_053f: box [System.Runtime]System.Double
+			IL_0544: stelem.ref
+			IL_0545: dup
+			IL_0546: ldc.i4.2
+			IL_0547: ldloc.s 16
+			IL_0549: stelem.ref
+			IL_054a: dup
+			IL_054b: ldc.i4.3
+			IL_054c: ldc.i4.0
+			IL_054d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0552: stelem.ref
+			IL_0553: stloc.s 20
+			IL_0555: ldloc.s 18
+			IL_0557: ldstr "read"
+			IL_055c: ldloc.s 20
+			IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0563: stloc.s 18
+			IL_0565: ldloc.0
+			IL_0566: ldc.i4.6
+			IL_0567: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_056c: ldloc.0
+			IL_056d: ldloc.s 18
+			IL_056f: ldarg.0
+			IL_0570: ldc.i4.3
+			IL_0571: ldloc.0
+			IL_0572: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0577: ldc.i4.3
+			IL_0578: ldstr "_pendingException"
+			IL_057d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0582: ldloc.0
+			IL_0583: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0588: dup
+			IL_0589: ldc.i4.0
+			IL_058a: ldloc.1
+			IL_058b: stelem.ref
+			IL_058c: dup
+			IL_058d: ldc.i4.1
+			IL_058e: ldloc.2
+			IL_058f: stelem.ref
+			IL_0590: dup
+			IL_0591: ldc.i4.2
+			IL_0592: ldloc.3
+			IL_0593: stelem.ref
+			IL_0594: dup
+			IL_0595: ldc.i4.3
+			IL_0596: ldloc.s 4
+			IL_0598: stelem.ref
+			IL_0599: dup
+			IL_059a: ldc.i4.4
+			IL_059b: ldloc.s 5
+			IL_059d: stelem.ref
+			IL_059e: dup
+			IL_059f: ldc.i4.5
+			IL_05a0: ldloc.s 6
+			IL_05a2: stelem.ref
+			IL_05a3: dup
+			IL_05a4: ldc.i4.6
+			IL_05a5: ldloc.s 7
+			IL_05a7: stelem.ref
+			IL_05a8: dup
+			IL_05a9: ldc.i4.7
+			IL_05aa: ldloc.s 8
+			IL_05ac: stelem.ref
+			IL_05ad: dup
+			IL_05ae: ldc.i4.8
+			IL_05af: ldloc.s 9
+			IL_05b1: stelem.ref
+			IL_05b2: dup
+			IL_05b3: ldc.i4.s 9
+			IL_05b5: ldloc.s 10
+			IL_05b7: stelem.ref
+			IL_05b8: dup
+			IL_05b9: ldc.i4.s 10
+			IL_05bb: ldloc.s 11
+			IL_05bd: box [System.Runtime]System.Boolean
 			IL_05c2: stelem.ref
 			IL_05c3: dup
-			IL_05c4: ldc.i4.1
-			IL_05c5: ldloc.2
-			IL_05c6: stelem.ref
-			IL_05c7: dup
-			IL_05c8: ldc.i4.2
-			IL_05c9: ldloc.3
-			IL_05ca: stelem.ref
-			IL_05cb: dup
-			IL_05cc: ldc.i4.3
-			IL_05cd: ldloc.s 4
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.4
-			IL_05d2: ldloc.s 5
-			IL_05d4: stelem.ref
-			IL_05d5: dup
-			IL_05d6: ldc.i4.5
-			IL_05d7: ldloc.s 6
+			IL_05c4: ldc.i4.s 11
+			IL_05c6: ldloc.s 12
+			IL_05c8: box [System.Runtime]System.Boolean
+			IL_05cd: stelem.ref
+			IL_05ce: dup
+			IL_05cf: ldc.i4.s 12
+			IL_05d1: ldloc.s 13
+			IL_05d3: stelem.ref
+			IL_05d4: dup
+			IL_05d5: ldc.i4.s 13
+			IL_05d7: ldloc.s 14
 			IL_05d9: stelem.ref
 			IL_05da: dup
-			IL_05db: ldc.i4.6
-			IL_05dc: ldloc.s 7
-			IL_05de: stelem.ref
-			IL_05df: dup
-			IL_05e0: ldc.i4.7
-			IL_05e1: ldloc.s 8
-			IL_05e3: stelem.ref
-			IL_05e4: dup
-			IL_05e5: ldc.i4.8
-			IL_05e6: ldloc.s 9
-			IL_05e8: stelem.ref
-			IL_05e9: dup
-			IL_05ea: ldc.i4.s 9
-			IL_05ec: ldloc.s 10
-			IL_05ee: stelem.ref
-			IL_05ef: dup
-			IL_05f0: ldc.i4.s 10
-			IL_05f2: ldloc.s 11
-			IL_05f4: stelem.ref
-			IL_05f5: dup
-			IL_05f6: ldc.i4.s 11
-			IL_05f8: ldloc.s 12
-			IL_05fa: stelem.ref
-			IL_05fb: dup
-			IL_05fc: ldc.i4.s 12
-			IL_05fe: ldloc.s 13
-			IL_0600: box [System.Runtime]System.Boolean
-			IL_0605: stelem.ref
-			IL_0606: dup
-			IL_0607: ldc.i4.s 13
-			IL_0609: ldloc.s 14
-			IL_060b: box [System.Runtime]System.Boolean
-			IL_0610: stelem.ref
-			IL_0611: dup
-			IL_0612: ldc.i4.s 14
-			IL_0614: ldloc.s 15
-			IL_0616: stelem.ref
-			IL_0617: dup
-			IL_0618: ldc.i4.s 15
-			IL_061a: ldloc.s 16
-			IL_061c: stelem.ref
-			IL_061d: dup
-			IL_061e: ldc.i4.s 16
-			IL_0620: ldloc.s 17
-			IL_0622: box [System.Runtime]System.Double
-			IL_0627: stelem.ref
-			IL_0628: dup
-			IL_0629: ldc.i4.s 17
-			IL_062b: ldloc.s 18
-			IL_062d: stelem.ref
-			IL_062e: dup
-			IL_062f: ldc.i4.s 18
-			IL_0631: ldloc.s 19
-			IL_0633: stelem.ref
-			IL_0634: dup
-			IL_0635: ldc.i4.s 19
-			IL_0637: ldloc.s 20
-			IL_0639: stelem.ref
-			IL_063a: dup
-			IL_063b: ldc.i4.s 20
-			IL_063d: ldloc.s 21
-			IL_063f: stelem.ref
-			IL_0640: dup
-			IL_0641: ldc.i4.s 21
-			IL_0643: ldloc.s 22
-			IL_0645: stelem.ref
-			IL_0646: dup
-			IL_0647: ldc.i4.s 22
-			IL_0649: ldloc.s 23
-			IL_064b: box [System.Runtime]System.Boolean
-			IL_0650: stelem.ref
-			IL_0651: dup
-			IL_0652: ldc.i4.s 23
-			IL_0654: ldloc.s 24
-			IL_0656: stelem.ref
-			IL_0657: dup
-			IL_0658: ldc.i4.s 24
-			IL_065a: ldloc.s 25
-			IL_065c: stelem.ref
-			IL_065d: pop
-			IL_065e: ldloc.0
-			IL_065f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0664: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0669: ret
+			IL_05db: ldc.i4.s 14
+			IL_05dd: ldloc.s 15
+			IL_05df: box [System.Runtime]System.Double
+			IL_05e4: stelem.ref
+			IL_05e5: dup
+			IL_05e6: ldc.i4.s 15
+			IL_05e8: ldloc.s 16
+			IL_05ea: stelem.ref
+			IL_05eb: dup
+			IL_05ec: ldc.i4.s 16
+			IL_05ee: ldloc.s 17
+			IL_05f0: stelem.ref
+			IL_05f1: dup
+			IL_05f2: ldc.i4.s 17
+			IL_05f4: ldloc.s 18
+			IL_05f6: stelem.ref
+			IL_05f7: dup
+			IL_05f8: ldc.i4.s 18
+			IL_05fa: ldloc.s 19
+			IL_05fc: stelem.ref
+			IL_05fd: dup
+			IL_05fe: ldc.i4.s 19
+			IL_0600: ldloc.s 20
+			IL_0602: stelem.ref
+			IL_0603: dup
+			IL_0604: ldc.i4.s 20
+			IL_0606: ldloc.s 21
+			IL_0608: box [System.Runtime]System.Boolean
+			IL_060d: stelem.ref
+			IL_060e: dup
+			IL_060f: ldc.i4.s 21
+			IL_0611: ldloc.s 22
+			IL_0613: stelem.ref
+			IL_0614: dup
+			IL_0615: ldc.i4.s 22
+			IL_0617: ldloc.s 23
+			IL_0619: stelem.ref
+			IL_061a: pop
+			IL_061b: ldloc.0
+			IL_061c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0621: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0626: ret
 
-			IL_066a: ldloc.0
-			IL_066b: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
-			IL_0670: stloc.s 20
-			IL_0672: ldloc.s 20
-			IL_0674: stloc.s 8
-			IL_0676: ldloc.s 4
-			IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_067d: stloc.s 20
-			IL_067f: ldloc.s 20
-			IL_0681: ldstr "write"
-			IL_0686: ldstr "X"
-			IL_068b: ldc.r8 4
-			IL_0694: box [System.Runtime]System.Double
-			IL_0699: ldstr "utf8"
-			IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_06a3: stloc.s 20
-			IL_06a5: ldloc.0
-			IL_06a6: ldc.i4.7
-			IL_06a7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06ac: ldloc.0
-			IL_06ad: ldloc.s 20
-			IL_06af: ldarg.0
-			IL_06b0: ldc.i4.4
-			IL_06b1: ldloc.0
-			IL_06b2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06b7: ldc.i4.3
-			IL_06b8: ldstr "_pendingException"
-			IL_06bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_06c2: ldloc.0
-			IL_06c3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06c8: dup
-			IL_06c9: ldc.i4.0
-			IL_06ca: ldloc.1
-			IL_06cb: stelem.ref
-			IL_06cc: dup
-			IL_06cd: ldc.i4.1
-			IL_06ce: ldloc.2
+			IL_0627: ldloc.0
+			IL_0628: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
+			IL_062d: stloc.s 18
+			IL_062f: ldloc.s 18
+			IL_0631: stloc.s 7
+			IL_0633: ldloc.3
+			IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0639: stloc.s 18
+			IL_063b: ldloc.s 18
+			IL_063d: ldstr "write"
+			IL_0642: ldstr "X"
+			IL_0647: ldc.r8 4
+			IL_0650: box [System.Runtime]System.Double
+			IL_0655: ldstr "utf8"
+			IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_065f: stloc.s 18
+			IL_0661: ldloc.0
+			IL_0662: ldc.i4.7
+			IL_0663: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0668: ldloc.0
+			IL_0669: ldloc.s 18
+			IL_066b: ldarg.0
+			IL_066c: ldc.i4.4
+			IL_066d: ldloc.0
+			IL_066e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0673: ldc.i4.3
+			IL_0674: ldstr "_pendingException"
+			IL_0679: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_067e: ldloc.0
+			IL_067f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0684: dup
+			IL_0685: ldc.i4.0
+			IL_0686: ldloc.1
+			IL_0687: stelem.ref
+			IL_0688: dup
+			IL_0689: ldc.i4.1
+			IL_068a: ldloc.2
+			IL_068b: stelem.ref
+			IL_068c: dup
+			IL_068d: ldc.i4.2
+			IL_068e: ldloc.3
+			IL_068f: stelem.ref
+			IL_0690: dup
+			IL_0691: ldc.i4.3
+			IL_0692: ldloc.s 4
+			IL_0694: stelem.ref
+			IL_0695: dup
+			IL_0696: ldc.i4.4
+			IL_0697: ldloc.s 5
+			IL_0699: stelem.ref
+			IL_069a: dup
+			IL_069b: ldc.i4.5
+			IL_069c: ldloc.s 6
+			IL_069e: stelem.ref
+			IL_069f: dup
+			IL_06a0: ldc.i4.6
+			IL_06a1: ldloc.s 7
+			IL_06a3: stelem.ref
+			IL_06a4: dup
+			IL_06a5: ldc.i4.7
+			IL_06a6: ldloc.s 8
+			IL_06a8: stelem.ref
+			IL_06a9: dup
+			IL_06aa: ldc.i4.8
+			IL_06ab: ldloc.s 9
+			IL_06ad: stelem.ref
+			IL_06ae: dup
+			IL_06af: ldc.i4.s 9
+			IL_06b1: ldloc.s 10
+			IL_06b3: stelem.ref
+			IL_06b4: dup
+			IL_06b5: ldc.i4.s 10
+			IL_06b7: ldloc.s 11
+			IL_06b9: box [System.Runtime]System.Boolean
+			IL_06be: stelem.ref
+			IL_06bf: dup
+			IL_06c0: ldc.i4.s 11
+			IL_06c2: ldloc.s 12
+			IL_06c4: box [System.Runtime]System.Boolean
+			IL_06c9: stelem.ref
+			IL_06ca: dup
+			IL_06cb: ldc.i4.s 12
+			IL_06cd: ldloc.s 13
 			IL_06cf: stelem.ref
 			IL_06d0: dup
-			IL_06d1: ldc.i4.2
-			IL_06d2: ldloc.3
-			IL_06d3: stelem.ref
-			IL_06d4: dup
-			IL_06d5: ldc.i4.3
-			IL_06d6: ldloc.s 4
-			IL_06d8: stelem.ref
-			IL_06d9: dup
-			IL_06da: ldc.i4.4
-			IL_06db: ldloc.s 5
-			IL_06dd: stelem.ref
-			IL_06de: dup
-			IL_06df: ldc.i4.5
-			IL_06e0: ldloc.s 6
-			IL_06e2: stelem.ref
-			IL_06e3: dup
-			IL_06e4: ldc.i4.6
-			IL_06e5: ldloc.s 7
-			IL_06e7: stelem.ref
-			IL_06e8: dup
-			IL_06e9: ldc.i4.7
-			IL_06ea: ldloc.s 8
+			IL_06d1: ldc.i4.s 13
+			IL_06d3: ldloc.s 14
+			IL_06d5: stelem.ref
+			IL_06d6: dup
+			IL_06d7: ldc.i4.s 14
+			IL_06d9: ldloc.s 15
+			IL_06db: box [System.Runtime]System.Double
+			IL_06e0: stelem.ref
+			IL_06e1: dup
+			IL_06e2: ldc.i4.s 15
+			IL_06e4: ldloc.s 16
+			IL_06e6: stelem.ref
+			IL_06e7: dup
+			IL_06e8: ldc.i4.s 16
+			IL_06ea: ldloc.s 17
 			IL_06ec: stelem.ref
 			IL_06ed: dup
-			IL_06ee: ldc.i4.8
-			IL_06ef: ldloc.s 9
-			IL_06f1: stelem.ref
-			IL_06f2: dup
-			IL_06f3: ldc.i4.s 9
-			IL_06f5: ldloc.s 10
-			IL_06f7: stelem.ref
-			IL_06f8: dup
-			IL_06f9: ldc.i4.s 10
-			IL_06fb: ldloc.s 11
-			IL_06fd: stelem.ref
-			IL_06fe: dup
-			IL_06ff: ldc.i4.s 11
-			IL_0701: ldloc.s 12
-			IL_0703: stelem.ref
-			IL_0704: dup
-			IL_0705: ldc.i4.s 12
-			IL_0707: ldloc.s 13
-			IL_0709: box [System.Runtime]System.Boolean
-			IL_070e: stelem.ref
-			IL_070f: dup
-			IL_0710: ldc.i4.s 13
-			IL_0712: ldloc.s 14
-			IL_0714: box [System.Runtime]System.Boolean
-			IL_0719: stelem.ref
-			IL_071a: dup
-			IL_071b: ldc.i4.s 14
-			IL_071d: ldloc.s 15
-			IL_071f: stelem.ref
-			IL_0720: dup
-			IL_0721: ldc.i4.s 15
-			IL_0723: ldloc.s 16
-			IL_0725: stelem.ref
-			IL_0726: dup
-			IL_0727: ldc.i4.s 16
-			IL_0729: ldloc.s 17
-			IL_072b: box [System.Runtime]System.Double
-			IL_0730: stelem.ref
-			IL_0731: dup
-			IL_0732: ldc.i4.s 17
-			IL_0734: ldloc.s 18
-			IL_0736: stelem.ref
-			IL_0737: dup
-			IL_0738: ldc.i4.s 18
-			IL_073a: ldloc.s 19
-			IL_073c: stelem.ref
-			IL_073d: dup
-			IL_073e: ldc.i4.s 19
-			IL_0740: ldloc.s 20
-			IL_0742: stelem.ref
-			IL_0743: dup
-			IL_0744: ldc.i4.s 20
-			IL_0746: ldloc.s 21
-			IL_0748: stelem.ref
-			IL_0749: dup
-			IL_074a: ldc.i4.s 21
-			IL_074c: ldloc.s 22
-			IL_074e: stelem.ref
-			IL_074f: dup
-			IL_0750: ldc.i4.s 22
-			IL_0752: ldloc.s 23
-			IL_0754: box [System.Runtime]System.Boolean
-			IL_0759: stelem.ref
-			IL_075a: dup
-			IL_075b: ldc.i4.s 23
-			IL_075d: ldloc.s 24
-			IL_075f: stelem.ref
-			IL_0760: dup
-			IL_0761: ldc.i4.s 24
-			IL_0763: ldloc.s 25
-			IL_0765: stelem.ref
-			IL_0766: pop
-			IL_0767: ldloc.0
-			IL_0768: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_076d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0772: ret
+			IL_06ee: ldc.i4.s 17
+			IL_06f0: ldloc.s 18
+			IL_06f2: stelem.ref
+			IL_06f3: dup
+			IL_06f4: ldc.i4.s 18
+			IL_06f6: ldloc.s 19
+			IL_06f8: stelem.ref
+			IL_06f9: dup
+			IL_06fa: ldc.i4.s 19
+			IL_06fc: ldloc.s 20
+			IL_06fe: stelem.ref
+			IL_06ff: dup
+			IL_0700: ldc.i4.s 20
+			IL_0702: ldloc.s 21
+			IL_0704: box [System.Runtime]System.Boolean
+			IL_0709: stelem.ref
+			IL_070a: dup
+			IL_070b: ldc.i4.s 21
+			IL_070d: ldloc.s 22
+			IL_070f: stelem.ref
+			IL_0710: dup
+			IL_0711: ldc.i4.s 22
+			IL_0713: ldloc.s 23
+			IL_0715: stelem.ref
+			IL_0716: pop
+			IL_0717: ldloc.0
+			IL_0718: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_071d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0722: ret
 
-			IL_0773: ldloc.0
-			IL_0774: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
-			IL_0779: stloc.s 20
-			IL_077b: ldloc.s 20
-			IL_077d: stloc.s 9
-			IL_077f: ldloc.s 4
-			IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0786: stloc.s 20
-			IL_0788: ldloc.s 20
-			IL_078a: ldstr "write"
-			IL_078f: ldstr "Y"
-			IL_0794: ldc.i4.0
-			IL_0795: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_079a: ldstr "utf8"
-			IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_07a4: stloc.s 20
-			IL_07a6: ldloc.0
-			IL_07a7: ldc.i4.8
-			IL_07a8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07ad: ldloc.0
-			IL_07ae: ldloc.s 20
-			IL_07b0: ldarg.0
-			IL_07b1: ldc.i4.5
-			IL_07b2: ldloc.0
-			IL_07b3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07b8: ldc.i4.3
-			IL_07b9: ldstr "_pendingException"
-			IL_07be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_07c3: ldloc.0
-			IL_07c4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07c9: dup
-			IL_07ca: ldc.i4.0
-			IL_07cb: ldloc.1
-			IL_07cc: stelem.ref
-			IL_07cd: dup
-			IL_07ce: ldc.i4.1
-			IL_07cf: ldloc.2
-			IL_07d0: stelem.ref
-			IL_07d1: dup
-			IL_07d2: ldc.i4.2
-			IL_07d3: ldloc.3
+			IL_0723: ldloc.0
+			IL_0724: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
+			IL_0729: stloc.s 18
+			IL_072b: ldloc.s 18
+			IL_072d: stloc.s 8
+			IL_072f: ldloc.3
+			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0735: stloc.s 18
+			IL_0737: ldloc.s 18
+			IL_0739: ldstr "write"
+			IL_073e: ldstr "Y"
+			IL_0743: ldc.i4.0
+			IL_0744: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0749: ldstr "utf8"
+			IL_074e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0753: stloc.s 18
+			IL_0755: ldloc.0
+			IL_0756: ldc.i4.8
+			IL_0757: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_075c: ldloc.0
+			IL_075d: ldloc.s 18
+			IL_075f: ldarg.0
+			IL_0760: ldc.i4.5
+			IL_0761: ldloc.0
+			IL_0762: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0767: ldc.i4.3
+			IL_0768: ldstr "_pendingException"
+			IL_076d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0772: ldloc.0
+			IL_0773: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0778: dup
+			IL_0779: ldc.i4.0
+			IL_077a: ldloc.1
+			IL_077b: stelem.ref
+			IL_077c: dup
+			IL_077d: ldc.i4.1
+			IL_077e: ldloc.2
+			IL_077f: stelem.ref
+			IL_0780: dup
+			IL_0781: ldc.i4.2
+			IL_0782: ldloc.3
+			IL_0783: stelem.ref
+			IL_0784: dup
+			IL_0785: ldc.i4.3
+			IL_0786: ldloc.s 4
+			IL_0788: stelem.ref
+			IL_0789: dup
+			IL_078a: ldc.i4.4
+			IL_078b: ldloc.s 5
+			IL_078d: stelem.ref
+			IL_078e: dup
+			IL_078f: ldc.i4.5
+			IL_0790: ldloc.s 6
+			IL_0792: stelem.ref
+			IL_0793: dup
+			IL_0794: ldc.i4.6
+			IL_0795: ldloc.s 7
+			IL_0797: stelem.ref
+			IL_0798: dup
+			IL_0799: ldc.i4.7
+			IL_079a: ldloc.s 8
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.8
+			IL_079f: ldloc.s 9
+			IL_07a1: stelem.ref
+			IL_07a2: dup
+			IL_07a3: ldc.i4.s 9
+			IL_07a5: ldloc.s 10
+			IL_07a7: stelem.ref
+			IL_07a8: dup
+			IL_07a9: ldc.i4.s 10
+			IL_07ab: ldloc.s 11
+			IL_07ad: box [System.Runtime]System.Boolean
+			IL_07b2: stelem.ref
+			IL_07b3: dup
+			IL_07b4: ldc.i4.s 11
+			IL_07b6: ldloc.s 12
+			IL_07b8: box [System.Runtime]System.Boolean
+			IL_07bd: stelem.ref
+			IL_07be: dup
+			IL_07bf: ldc.i4.s 12
+			IL_07c1: ldloc.s 13
+			IL_07c3: stelem.ref
+			IL_07c4: dup
+			IL_07c5: ldc.i4.s 13
+			IL_07c7: ldloc.s 14
+			IL_07c9: stelem.ref
+			IL_07ca: dup
+			IL_07cb: ldc.i4.s 14
+			IL_07cd: ldloc.s 15
+			IL_07cf: box [System.Runtime]System.Double
 			IL_07d4: stelem.ref
 			IL_07d5: dup
-			IL_07d6: ldc.i4.3
-			IL_07d7: ldloc.s 4
-			IL_07d9: stelem.ref
-			IL_07da: dup
-			IL_07db: ldc.i4.4
-			IL_07dc: ldloc.s 5
-			IL_07de: stelem.ref
-			IL_07df: dup
-			IL_07e0: ldc.i4.5
-			IL_07e1: ldloc.s 6
-			IL_07e3: stelem.ref
-			IL_07e4: dup
-			IL_07e5: ldc.i4.6
-			IL_07e6: ldloc.s 7
-			IL_07e8: stelem.ref
-			IL_07e9: dup
-			IL_07ea: ldc.i4.7
-			IL_07eb: ldloc.s 8
-			IL_07ed: stelem.ref
-			IL_07ee: dup
-			IL_07ef: ldc.i4.8
-			IL_07f0: ldloc.s 9
+			IL_07d6: ldc.i4.s 15
+			IL_07d8: ldloc.s 16
+			IL_07da: stelem.ref
+			IL_07db: dup
+			IL_07dc: ldc.i4.s 16
+			IL_07de: ldloc.s 17
+			IL_07e0: stelem.ref
+			IL_07e1: dup
+			IL_07e2: ldc.i4.s 17
+			IL_07e4: ldloc.s 18
+			IL_07e6: stelem.ref
+			IL_07e7: dup
+			IL_07e8: ldc.i4.s 18
+			IL_07ea: ldloc.s 19
+			IL_07ec: stelem.ref
+			IL_07ed: dup
+			IL_07ee: ldc.i4.s 19
+			IL_07f0: ldloc.s 20
 			IL_07f2: stelem.ref
 			IL_07f3: dup
-			IL_07f4: ldc.i4.s 9
-			IL_07f6: ldloc.s 10
-			IL_07f8: stelem.ref
-			IL_07f9: dup
-			IL_07fa: ldc.i4.s 10
-			IL_07fc: ldloc.s 11
-			IL_07fe: stelem.ref
-			IL_07ff: dup
-			IL_0800: ldc.i4.s 11
-			IL_0802: ldloc.s 12
-			IL_0804: stelem.ref
-			IL_0805: dup
-			IL_0806: ldc.i4.s 12
-			IL_0808: ldloc.s 13
-			IL_080a: box [System.Runtime]System.Boolean
-			IL_080f: stelem.ref
-			IL_0810: dup
-			IL_0811: ldc.i4.s 13
-			IL_0813: ldloc.s 14
-			IL_0815: box [System.Runtime]System.Boolean
-			IL_081a: stelem.ref
-			IL_081b: dup
-			IL_081c: ldc.i4.s 14
-			IL_081e: ldloc.s 15
-			IL_0820: stelem.ref
-			IL_0821: dup
-			IL_0822: ldc.i4.s 15
-			IL_0824: ldloc.s 16
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.s 16
-			IL_082a: ldloc.s 17
-			IL_082c: box [System.Runtime]System.Double
-			IL_0831: stelem.ref
-			IL_0832: dup
-			IL_0833: ldc.i4.s 17
-			IL_0835: ldloc.s 18
-			IL_0837: stelem.ref
-			IL_0838: dup
-			IL_0839: ldc.i4.s 18
-			IL_083b: ldloc.s 19
-			IL_083d: stelem.ref
-			IL_083e: dup
-			IL_083f: ldc.i4.s 19
-			IL_0841: ldloc.s 20
-			IL_0843: stelem.ref
-			IL_0844: dup
-			IL_0845: ldc.i4.s 20
-			IL_0847: ldloc.s 21
-			IL_0849: stelem.ref
-			IL_084a: dup
-			IL_084b: ldc.i4.s 21
-			IL_084d: ldloc.s 22
-			IL_084f: stelem.ref
-			IL_0850: dup
-			IL_0851: ldc.i4.s 22
-			IL_0853: ldloc.s 23
-			IL_0855: box [System.Runtime]System.Boolean
-			IL_085a: stelem.ref
-			IL_085b: dup
-			IL_085c: ldc.i4.s 23
-			IL_085e: ldloc.s 24
+			IL_07f4: ldc.i4.s 20
+			IL_07f6: ldloc.s 21
+			IL_07f8: box [System.Runtime]System.Boolean
+			IL_07fd: stelem.ref
+			IL_07fe: dup
+			IL_07ff: ldc.i4.s 21
+			IL_0801: ldloc.s 22
+			IL_0803: stelem.ref
+			IL_0804: dup
+			IL_0805: ldc.i4.s 22
+			IL_0807: ldloc.s 23
+			IL_0809: stelem.ref
+			IL_080a: pop
+			IL_080b: ldloc.0
+			IL_080c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0811: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0816: ret
+
+			IL_0817: ldloc.0
+			IL_0818: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
+			IL_081d: stloc.s 18
+			IL_081f: ldloc.s 18
+			IL_0821: stloc.s 9
+			IL_0823: ldloc.3
+			IL_0824: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0829: stloc.s 18
+			IL_082b: ldloc.s 18
+			IL_082d: ldstr "close"
+			IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0837: stloc.s 18
+			IL_0839: ldloc.0
+			IL_083a: ldc.i4.s 9
+			IL_083c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0841: ldloc.0
+			IL_0842: ldloc.s 18
+			IL_0844: ldarg.0
+			IL_0845: ldc.i4.6
+			IL_0846: ldloc.0
+			IL_0847: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_084c: ldc.i4.3
+			IL_084d: ldstr "_pendingException"
+			IL_0852: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0857: ldloc.0
+			IL_0858: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_085d: dup
+			IL_085e: ldc.i4.0
+			IL_085f: ldloc.1
 			IL_0860: stelem.ref
 			IL_0861: dup
-			IL_0862: ldc.i4.s 24
-			IL_0864: ldloc.s 25
-			IL_0866: stelem.ref
-			IL_0867: pop
-			IL_0868: ldloc.0
-			IL_0869: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_086e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0873: ret
-
-			IL_0874: ldloc.0
-			IL_0875: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
-			IL_087a: stloc.s 20
-			IL_087c: ldloc.s 20
-			IL_087e: stloc.s 10
-			IL_0880: ldloc.s 4
-			IL_0882: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0887: stloc.s 20
-			IL_0889: ldloc.s 20
-			IL_088b: ldstr "close"
-			IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0895: stloc.s 20
-			IL_0897: ldloc.0
-			IL_0898: ldc.i4.s 9
-			IL_089a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_089f: ldloc.0
-			IL_08a0: ldloc.s 20
-			IL_08a2: ldarg.0
-			IL_08a3: ldc.i4.6
-			IL_08a4: ldloc.0
-			IL_08a5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_08aa: ldc.i4.3
-			IL_08ab: ldstr "_pendingException"
-			IL_08b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_08b5: ldloc.0
-			IL_08b6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08bb: dup
-			IL_08bc: ldc.i4.0
-			IL_08bd: ldloc.1
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.1
-			IL_08c1: ldloc.2
-			IL_08c2: stelem.ref
-			IL_08c3: dup
-			IL_08c4: ldc.i4.2
-			IL_08c5: ldloc.3
-			IL_08c6: stelem.ref
-			IL_08c7: dup
-			IL_08c8: ldc.i4.3
-			IL_08c9: ldloc.s 4
+			IL_0862: ldc.i4.1
+			IL_0863: ldloc.2
+			IL_0864: stelem.ref
+			IL_0865: dup
+			IL_0866: ldc.i4.2
+			IL_0867: ldloc.3
+			IL_0868: stelem.ref
+			IL_0869: dup
+			IL_086a: ldc.i4.3
+			IL_086b: ldloc.s 4
+			IL_086d: stelem.ref
+			IL_086e: dup
+			IL_086f: ldc.i4.4
+			IL_0870: ldloc.s 5
+			IL_0872: stelem.ref
+			IL_0873: dup
+			IL_0874: ldc.i4.5
+			IL_0875: ldloc.s 6
+			IL_0877: stelem.ref
+			IL_0878: dup
+			IL_0879: ldc.i4.6
+			IL_087a: ldloc.s 7
+			IL_087c: stelem.ref
+			IL_087d: dup
+			IL_087e: ldc.i4.7
+			IL_087f: ldloc.s 8
+			IL_0881: stelem.ref
+			IL_0882: dup
+			IL_0883: ldc.i4.8
+			IL_0884: ldloc.s 9
+			IL_0886: stelem.ref
+			IL_0887: dup
+			IL_0888: ldc.i4.s 9
+			IL_088a: ldloc.s 10
+			IL_088c: stelem.ref
+			IL_088d: dup
+			IL_088e: ldc.i4.s 10
+			IL_0890: ldloc.s 11
+			IL_0892: box [System.Runtime]System.Boolean
+			IL_0897: stelem.ref
+			IL_0898: dup
+			IL_0899: ldc.i4.s 11
+			IL_089b: ldloc.s 12
+			IL_089d: box [System.Runtime]System.Boolean
+			IL_08a2: stelem.ref
+			IL_08a3: dup
+			IL_08a4: ldc.i4.s 12
+			IL_08a6: ldloc.s 13
+			IL_08a8: stelem.ref
+			IL_08a9: dup
+			IL_08aa: ldc.i4.s 13
+			IL_08ac: ldloc.s 14
+			IL_08ae: stelem.ref
+			IL_08af: dup
+			IL_08b0: ldc.i4.s 14
+			IL_08b2: ldloc.s 15
+			IL_08b4: box [System.Runtime]System.Double
+			IL_08b9: stelem.ref
+			IL_08ba: dup
+			IL_08bb: ldc.i4.s 15
+			IL_08bd: ldloc.s 16
+			IL_08bf: stelem.ref
+			IL_08c0: dup
+			IL_08c1: ldc.i4.s 16
+			IL_08c3: ldloc.s 17
+			IL_08c5: stelem.ref
+			IL_08c6: dup
+			IL_08c7: ldc.i4.s 17
+			IL_08c9: ldloc.s 18
 			IL_08cb: stelem.ref
 			IL_08cc: dup
-			IL_08cd: ldc.i4.4
-			IL_08ce: ldloc.s 5
-			IL_08d0: stelem.ref
-			IL_08d1: dup
-			IL_08d2: ldc.i4.5
-			IL_08d3: ldloc.s 6
-			IL_08d5: stelem.ref
-			IL_08d6: dup
-			IL_08d7: ldc.i4.6
-			IL_08d8: ldloc.s 7
-			IL_08da: stelem.ref
-			IL_08db: dup
-			IL_08dc: ldc.i4.7
-			IL_08dd: ldloc.s 8
-			IL_08df: stelem.ref
-			IL_08e0: dup
-			IL_08e1: ldc.i4.8
-			IL_08e2: ldloc.s 9
-			IL_08e4: stelem.ref
-			IL_08e5: dup
-			IL_08e6: ldc.i4.s 9
-			IL_08e8: ldloc.s 10
-			IL_08ea: stelem.ref
-			IL_08eb: dup
-			IL_08ec: ldc.i4.s 10
-			IL_08ee: ldloc.s 11
-			IL_08f0: stelem.ref
-			IL_08f1: dup
-			IL_08f2: ldc.i4.s 11
-			IL_08f4: ldloc.s 12
-			IL_08f6: stelem.ref
-			IL_08f7: dup
-			IL_08f8: ldc.i4.s 12
-			IL_08fa: ldloc.s 13
-			IL_08fc: box [System.Runtime]System.Boolean
-			IL_0901: stelem.ref
-			IL_0902: dup
-			IL_0903: ldc.i4.s 13
-			IL_0905: ldloc.s 14
-			IL_0907: box [System.Runtime]System.Boolean
-			IL_090c: stelem.ref
-			IL_090d: dup
-			IL_090e: ldc.i4.s 14
-			IL_0910: ldloc.s 15
-			IL_0912: stelem.ref
-			IL_0913: dup
-			IL_0914: ldc.i4.s 15
-			IL_0916: ldloc.s 16
-			IL_0918: stelem.ref
-			IL_0919: dup
-			IL_091a: ldc.i4.s 16
-			IL_091c: ldloc.s 17
-			IL_091e: box [System.Runtime]System.Double
-			IL_0923: stelem.ref
-			IL_0924: dup
-			IL_0925: ldc.i4.s 17
-			IL_0927: ldloc.s 18
-			IL_0929: stelem.ref
-			IL_092a: dup
-			IL_092b: ldc.i4.s 18
-			IL_092d: ldloc.s 19
-			IL_092f: stelem.ref
-			IL_0930: dup
-			IL_0931: ldc.i4.s 19
-			IL_0933: ldloc.s 20
-			IL_0935: stelem.ref
-			IL_0936: dup
-			IL_0937: ldc.i4.s 20
-			IL_0939: ldloc.s 21
-			IL_093b: stelem.ref
-			IL_093c: dup
-			IL_093d: ldc.i4.s 21
-			IL_093f: ldloc.s 22
-			IL_0941: stelem.ref
-			IL_0942: dup
-			IL_0943: ldc.i4.s 22
-			IL_0945: ldloc.s 23
-			IL_0947: box [System.Runtime]System.Boolean
-			IL_094c: stelem.ref
-			IL_094d: dup
-			IL_094e: ldc.i4.s 23
-			IL_0950: ldloc.s 24
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.s 24
-			IL_0956: ldloc.s 25
-			IL_0958: stelem.ref
-			IL_0959: pop
-			IL_095a: ldloc.0
-			IL_095b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0960: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0965: ret
+			IL_08cd: ldc.i4.s 18
+			IL_08cf: ldloc.s 19
+			IL_08d1: stelem.ref
+			IL_08d2: dup
+			IL_08d3: ldc.i4.s 19
+			IL_08d5: ldloc.s 20
+			IL_08d7: stelem.ref
+			IL_08d8: dup
+			IL_08d9: ldc.i4.s 20
+			IL_08db: ldloc.s 21
+			IL_08dd: box [System.Runtime]System.Boolean
+			IL_08e2: stelem.ref
+			IL_08e3: dup
+			IL_08e4: ldc.i4.s 21
+			IL_08e6: ldloc.s 22
+			IL_08e8: stelem.ref
+			IL_08e9: dup
+			IL_08ea: ldc.i4.s 22
+			IL_08ec: ldloc.s 23
+			IL_08ee: stelem.ref
+			IL_08ef: pop
+			IL_08f0: ldloc.0
+			IL_08f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08fb: ret
 
-			IL_0966: ldloc.0
-			IL_0967: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
-			IL_096c: pop
-			IL_096d: ldstr "console"
-			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0977: stloc.s 20
-			IL_0979: ldloc.s 20
-			IL_097b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0980: stloc.s 20
-			IL_0982: ldloc.s 5
-			IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0989: stloc.s 15
-			IL_098b: ldloc.s 15
-			IL_098d: ldstr "toString"
-			IL_0992: ldstr "utf8"
-			IL_0997: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_099c: stloc.s 15
-			IL_099e: ldloc.s 20
-			IL_09a0: ldstr "log"
-			IL_09a5: ldstr "ExplicitRead:"
-			IL_09aa: ldloc.s 15
-			IL_09ac: ldloc.s 7
-			IL_09ae: ldstr "bytesRead"
-			IL_09b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_09bd: pop
-			IL_09be: ldstr "console"
-			IL_09c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09c8: stloc.s 15
-			IL_09ca: ldloc.s 15
-			IL_09cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09d1: stloc.s 15
-			IL_09d3: ldloc.s 6
-			IL_09d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09da: stloc.s 20
-			IL_09dc: ldloc.s 20
-			IL_09de: ldstr "toString"
-			IL_09e3: ldstr "utf8"
-			IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_09ed: stloc.s 20
-			IL_09ef: ldloc.s 15
-			IL_09f1: ldstr "log"
-			IL_09f6: ldstr "ImplicitReadAfterExplicit:"
-			IL_09fb: ldloc.s 20
-			IL_09fd: ldloc.s 8
-			IL_09ff: ldstr "bytesRead"
-			IL_0a04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a09: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0a0e: pop
-			IL_0a0f: ldstr "console"
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a19: stloc.s 20
-			IL_0a1b: ldloc.s 20
-			IL_0a1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a22: stloc.s 20
-			IL_0a24: ldloc.s 20
-			IL_0a26: ldstr "log"
-			IL_0a2b: ldstr "ExplicitWriteBytes:"
-			IL_0a30: ldloc.s 9
-			IL_0a32: ldstr "bytesWritten"
-			IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a41: pop
-			IL_0a42: ldstr "console"
-			IL_0a47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a4c: stloc.s 20
-			IL_0a4e: ldloc.s 20
-			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a55: stloc.s 20
-			IL_0a57: ldloc.s 20
-			IL_0a59: ldstr "log"
-			IL_0a5e: ldstr "ImplicitWriteBytes:"
-			IL_0a63: ldloc.s 10
-			IL_0a65: ldstr "bytesWritten"
-			IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a74: pop
-			IL_0a75: ldstr "console"
-			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a7f: stloc.s 20
-			IL_0a81: ldloc.s 20
-			IL_0a83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a88: stloc.s 20
-			IL_0a8a: ldarg.0
-			IL_0a8b: ldc.i4.1
-			IL_0a8c: ldelem.ref
-			IL_0a8d: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0a92: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0a97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a9c: stloc.s 15
-			IL_0a9e: ldloc.s 15
-			IL_0aa0: ldstr "readFileSync"
-			IL_0aa5: ldloc.2
-			IL_0aa6: ldstr "utf8"
-			IL_0aab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0ab0: stloc.s 15
-			IL_0ab2: ldloc.s 20
-			IL_0ab4: ldstr "log"
-			IL_0ab9: ldstr "FinalText:"
-			IL_0abe: ldloc.s 15
-			IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0ac5: pop
-			IL_0ac6: br IL_0b60
+			IL_08fc: ldloc.0
+			IL_08fd: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
+			IL_0902: pop
+			IL_0903: ldstr "console"
+			IL_0908: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_090d: stloc.s 18
+			IL_090f: ldloc.s 18
+			IL_0911: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0916: stloc.s 18
+			IL_0918: ldloc.s 4
+			IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_091f: stloc.s 13
+			IL_0921: ldloc.s 13
+			IL_0923: ldstr "toString"
+			IL_0928: ldstr "utf8"
+			IL_092d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0932: stloc.s 13
+			IL_0934: ldloc.s 18
+			IL_0936: ldstr "log"
+			IL_093b: ldstr "ExplicitRead:"
+			IL_0940: ldloc.s 13
+			IL_0942: ldloc.s 6
+			IL_0944: ldstr "bytesRead"
+			IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0953: pop
+			IL_0954: ldstr "console"
+			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_095e: stloc.s 13
+			IL_0960: ldloc.s 13
+			IL_0962: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0967: stloc.s 13
+			IL_0969: ldloc.s 5
+			IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0970: stloc.s 18
+			IL_0972: ldloc.s 18
+			IL_0974: ldstr "toString"
+			IL_0979: ldstr "utf8"
+			IL_097e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0983: stloc.s 18
+			IL_0985: ldloc.s 13
+			IL_0987: ldstr "log"
+			IL_098c: ldstr "ImplicitReadAfterExplicit:"
+			IL_0991: ldloc.s 18
+			IL_0993: ldloc.s 7
+			IL_0995: ldstr "bytesRead"
+			IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_09a4: pop
+			IL_09a5: ldstr "console"
+			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09af: stloc.s 18
+			IL_09b1: ldloc.s 18
+			IL_09b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09b8: stloc.s 18
+			IL_09ba: ldloc.s 18
+			IL_09bc: ldstr "log"
+			IL_09c1: ldstr "ExplicitWriteBytes:"
+			IL_09c6: ldloc.s 8
+			IL_09c8: ldstr "bytesWritten"
+			IL_09cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_09d7: pop
+			IL_09d8: ldstr "console"
+			IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09e2: stloc.s 18
+			IL_09e4: ldloc.s 18
+			IL_09e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09eb: stloc.s 18
+			IL_09ed: ldloc.s 18
+			IL_09ef: ldstr "log"
+			IL_09f4: ldstr "ImplicitWriteBytes:"
+			IL_09f9: ldloc.s 9
+			IL_09fb: ldstr "bytesWritten"
+			IL_0a00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a05: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a0a: pop
+			IL_0a0b: ldstr "console"
+			IL_0a10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a15: stloc.s 18
+			IL_0a17: ldloc.s 18
+			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a1e: stloc.s 18
+			IL_0a20: ldarg.0
+			IL_0a21: ldc.i4.1
+			IL_0a22: ldelem.ref
+			IL_0a23: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0a28: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0a2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a32: stloc.s 13
+			IL_0a34: ldloc.s 13
+			IL_0a36: ldstr "readFileSync"
+			IL_0a3b: ldloc.2
+			IL_0a3c: ldstr "utf8"
+			IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a46: stloc.s 13
+			IL_0a48: ldloc.s 18
+			IL_0a4a: ldstr "log"
+			IL_0a4f: ldstr "FinalText:"
+			IL_0a54: ldloc.s 13
+			IL_0a56: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a5b: pop
+			IL_0a5c: br IL_0aef
 
-			IL_0acb: ldloc.0
-			IL_0acc: ldc.i4.1
-			IL_0acd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0ad2: ldloc.0
-			IL_0ad3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0ad8: stloc.s 15
-			IL_0ada: ldloc.0
-			IL_0adb: ldc.i4.0
-			IL_0adc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0ae1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0ae6: ldloc.0
-			IL_0ae7: ldc.i4.0
-			IL_0ae8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0aed: ldloc.s 15
-			IL_0aef: stloc.s 11
-			IL_0af1: newobj instance void Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope/Block_L30C18::.ctor()
-			IL_0af6: stloc.s 12
-			IL_0af8: ldstr "console"
-			IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b02: stloc.s 15
-			IL_0b04: ldloc.s 15
-			IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b0b: stloc.s 15
-			IL_0b0d: ldloc.s 11
-			IL_0b0f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0b14: stloc.s 23
-			IL_0b16: ldloc.s 23
-			IL_0b18: brfalse IL_0b30
+			IL_0a61: ldloc.0
+			IL_0a62: ldc.i4.1
+			IL_0a63: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0a68: ldloc.0
+			IL_0a69: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0a6e: stloc.s 13
+			IL_0a70: ldloc.0
+			IL_0a71: ldc.i4.0
+			IL_0a72: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0a77: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0a7c: ldloc.0
+			IL_0a7d: ldc.i4.0
+			IL_0a7e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0a83: ldloc.s 13
+			IL_0a85: stloc.s 10
+			IL_0a87: ldstr "console"
+			IL_0a8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a91: stloc.s 13
+			IL_0a93: ldloc.s 13
+			IL_0a95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a9a: stloc.s 13
+			IL_0a9c: ldloc.s 10
+			IL_0a9e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0aa3: stloc.s 21
+			IL_0aa5: ldloc.s 21
+			IL_0aa7: brfalse IL_0abf
 
-			IL_0b1d: ldloc.s 11
-			IL_0b1f: ldstr "message"
-			IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b29: stloc.s 25
-			IL_0b2b: br IL_0b34
+			IL_0aac: ldloc.s 10
+			IL_0aae: ldstr "message"
+			IL_0ab3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab8: stloc.s 23
+			IL_0aba: br IL_0ac3
 
-			IL_0b30: ldloc.s 11
-			IL_0b32: stloc.s 25
+			IL_0abf: ldloc.s 10
+			IL_0ac1: stloc.s 23
 
-			IL_0b34: ldloc.s 15
-			IL_0b36: ldstr "log"
-			IL_0b3b: ldstr "Error:"
-			IL_0b40: ldloc.s 25
-			IL_0b42: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b47: pop
-			IL_0b48: br IL_0b60
+			IL_0ac3: ldloc.s 13
+			IL_0ac5: ldstr "log"
+			IL_0aca: ldstr "Error:"
+			IL_0acf: ldloc.s 23
+			IL_0ad1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0ad6: pop
+			IL_0ad7: br IL_0aef
 
-			IL_0b4d: ldloc.0
-			IL_0b4e: ldc.i4.1
-			IL_0b4f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b54: ldloc.0
-			IL_0b55: ldc.i4.0
-			IL_0b56: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0b5b: br IL_0b60
+			IL_0adc: ldloc.0
+			IL_0add: ldc.i4.1
+			IL_0ade: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0ae3: ldloc.0
+			IL_0ae4: ldc.i4.0
+			IL_0ae5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0aea: br IL_0aef
 
-			IL_0b60: ldarg.0
-			IL_0b61: ldc.i4.1
-			IL_0b62: ldelem.ref
-			IL_0b63: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0b68: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0b6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b72: stloc.s 15
-			IL_0b74: ldloc.s 15
-			IL_0b76: ldstr "rmSync"
-			IL_0b7b: ldloc.2
-			IL_0b7c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0b81: dup
-			IL_0b82: ldstr "force"
-			IL_0b87: ldc.i4.1
-			IL_0b88: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0b8d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b92: pop
-			IL_0b93: br IL_0bab
+			IL_0aef: ldarg.0
+			IL_0af0: ldc.i4.1
+			IL_0af1: ldelem.ref
+			IL_0af2: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0af7: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0afc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b01: stloc.s 13
+			IL_0b03: ldloc.s 13
+			IL_0b05: ldstr "rmSync"
+			IL_0b0a: ldloc.2
+			IL_0b0b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0b10: dup
+			IL_0b11: ldstr "force"
+			IL_0b16: ldc.i4.1
+			IL_0b17: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b21: pop
+			IL_0b22: br IL_0b3a
 
+			IL_0b27: ldloc.0
+			IL_0b28: ldc.i4.1
+			IL_0b29: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b2e: ldloc.0
+			IL_0b2f: ldc.i4.0
+			IL_0b30: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0b35: br IL_0b3a
+
+			IL_0b3a: ldloc.0
+			IL_0b3b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b40: stloc.s 11
+			IL_0b42: ldloc.s 11
+			IL_0b44: brfalse IL_0b81
+
+			IL_0b49: ldloc.0
+			IL_0b4a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0b4f: stloc.s 13
+			IL_0b51: ldloc.0
+			IL_0b52: ldc.i4.m1
+			IL_0b53: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b58: ldloc.0
+			IL_0b59: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0b63: ldarg.0
+			IL_0b64: ldc.i4.1
+			IL_0b65: newarr [System.Runtime]System.Object
+			IL_0b6a: dup
+			IL_0b6b: ldc.i4.0
+			IL_0b6c: ldloc.s 13
+			IL_0b6e: stelem.ref
+			IL_0b6f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0b74: pop
+			IL_0b75: ldloc.0
+			IL_0b76: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b7b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0b80: ret
+
+			IL_0b81: ldloc.0
+			IL_0b82: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0b87: stloc.s 12
+			IL_0b89: ldloc.s 12
+			IL_0b8b: brfalse IL_0bc8
+
+			IL_0b90: ldloc.0
+			IL_0b91: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0b96: stloc.s 13
 			IL_0b98: ldloc.0
-			IL_0b99: ldc.i4.1
-			IL_0b9a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b99: ldc.i4.m1
+			IL_0b9a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0b9f: ldloc.0
-			IL_0ba0: ldc.i4.0
-			IL_0ba1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0ba6: br IL_0bab
-
-			IL_0bab: ldloc.0
-			IL_0bac: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0bb1: stloc.s 13
+			IL_0ba0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0baa: ldarg.0
+			IL_0bab: ldc.i4.1
+			IL_0bac: newarr [System.Runtime]System.Object
+			IL_0bb1: dup
+			IL_0bb2: ldc.i4.0
 			IL_0bb3: ldloc.s 13
-			IL_0bb5: brfalse IL_0bf2
+			IL_0bb5: stelem.ref
+			IL_0bb6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bbb: pop
+			IL_0bbc: ldloc.0
+			IL_0bbd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bc2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bc7: ret
 
-			IL_0bba: ldloc.0
-			IL_0bbb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0bc0: stloc.s 15
-			IL_0bc2: ldloc.0
-			IL_0bc3: ldc.i4.m1
-			IL_0bc4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0bc9: ldloc.0
-			IL_0bca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bcf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0bd4: ldarg.0
-			IL_0bd5: ldc.i4.1
-			IL_0bd6: newarr [System.Runtime]System.Object
-			IL_0bdb: dup
-			IL_0bdc: ldc.i4.0
-			IL_0bdd: ldloc.s 15
-			IL_0bdf: stelem.ref
-			IL_0be0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0be5: pop
-			IL_0be6: ldloc.0
-			IL_0be7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bec: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bf1: ret
-
-			IL_0bf2: ldloc.0
-			IL_0bf3: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0bf8: stloc.s 14
-			IL_0bfa: ldloc.s 14
-			IL_0bfc: brfalse IL_0c39
-
-			IL_0c01: ldloc.0
-			IL_0c02: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0c07: stloc.s 15
-			IL_0c09: ldloc.0
-			IL_0c0a: ldc.i4.m1
-			IL_0c0b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c10: ldloc.0
-			IL_0c11: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c16: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c1b: ldarg.0
-			IL_0c1c: ldc.i4.1
-			IL_0c1d: newarr [System.Runtime]System.Object
-			IL_0c22: dup
-			IL_0c23: ldc.i4.0
-			IL_0c24: ldloc.s 15
-			IL_0c26: stelem.ref
-			IL_0c27: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c2c: pop
-			IL_0c2d: ldloc.0
-			IL_0c2e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c33: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c38: ret
-
-			IL_0c39: ldloc.0
-			IL_0c3a: ldc.i4.m1
-			IL_0c3b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c40: ldloc.0
-			IL_0c41: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c46: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c4b: ldarg.0
-			IL_0c4c: ldc.i4.1
-			IL_0c4d: newarr [System.Runtime]System.Object
-			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c57: pop
-			IL_0c58: ldloc.0
-			IL_0c59: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c5e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c63: ret
+			IL_0bc8: ldloc.0
+			IL_0bc9: ldc.i4.m1
+			IL_0bca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0bcf: ldloc.0
+			IL_0bd0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bd5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bda: ldarg.0
+			IL_0bdb: ldc.i4.1
+			IL_0bdc: newarr [System.Runtime]System.Object
+			IL_0be1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0be6: pop
+			IL_0be7: ldloc.0
+			IL_0be8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bf2: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1631,7 +1567,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d58
+			// Method begins at RVA 0x2ce7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1728,7 +1664,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d85
+		// Method begins at RVA 0x2d14
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a4a
+					// Method begins at RVA 0x29f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a53
+					// Method begins at RVA 0x29fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a5c
+					// Method begins at RVA 0x2a04
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a41
+				// Method begins at RVA 0x29e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,33 +139,31 @@
 			)
 			// Method begins at RVA 0x20e8
 			// Header size: 12
-			// Code size: 2372 (0x944)
+			// Code size: 2284 (0x8ec)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope,
 				[1] string,
 				[2] object,
-				[3] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[6] object,
 				[7] object,
-				[8] object,
-				[9] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18,
-				[10] bool,
-				[11] bool,
-				[12] object,
-				[13] string,
-				[14] float64,
+				[8] bool,
+				[9] bool,
+				[10] object,
+				[11] string,
+				[12] float64,
+				[13] object,
+				[14] string,
 				[15] object,
-				[16] string,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-				[19] object[],
-				[20] bool,
-				[21] object,
-				[22] object,
-				[23] object
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[17] object[],
+				[18] bool,
+				[19] object,
+				[20] object,
+				[21] object
 			)
 
 			IL_0000: ldarg.0
@@ -198,14 +196,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 23
+			IL_0048: ldc.i4.s 21
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0121
+			IL_005b: ble IL_010b
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -221,991 +219,945 @@
 			IL_0073: dup
 			IL_0074: ldc.i4.2
 			IL_0075: ldelem.ref
-			IL_0076: castclass Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8
-			IL_007b: stloc.3
+			IL_0076: stloc.3
+			IL_0077: dup
+			IL_0078: ldc.i4.3
+			IL_0079: ldelem.ref
+			IL_007a: stloc.s 4
 			IL_007c: dup
-			IL_007d: ldc.i4.3
+			IL_007d: ldc.i4.4
 			IL_007e: ldelem.ref
-			IL_007f: stloc.s 4
-			IL_0081: dup
-			IL_0082: ldc.i4.4
-			IL_0083: ldelem.ref
+			IL_007f: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
 			IL_0084: stloc.s 5
 			IL_0086: dup
 			IL_0087: ldc.i4.5
 			IL_0088: ldelem.ref
-			IL_0089: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
-			IL_008e: stloc.s 6
+			IL_0089: stloc.s 6
+			IL_008b: dup
+			IL_008c: ldc.i4.6
+			IL_008d: ldelem.ref
+			IL_008e: stloc.s 7
 			IL_0090: dup
-			IL_0091: ldc.i4.6
+			IL_0091: ldc.i4.7
 			IL_0092: ldelem.ref
-			IL_0093: stloc.s 7
-			IL_0095: dup
-			IL_0096: ldc.i4.7
-			IL_0097: ldelem.ref
+			IL_0093: unbox.any [System.Runtime]System.Boolean
 			IL_0098: stloc.s 8
 			IL_009a: dup
 			IL_009b: ldc.i4.8
 			IL_009c: ldelem.ref
-			IL_009d: castclass Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18
+			IL_009d: unbox.any [System.Runtime]System.Boolean
 			IL_00a2: stloc.s 9
 			IL_00a4: dup
 			IL_00a5: ldc.i4.s 9
 			IL_00a7: ldelem.ref
-			IL_00a8: unbox.any [System.Runtime]System.Boolean
-			IL_00ad: stloc.s 10
-			IL_00af: dup
-			IL_00b0: ldc.i4.s 10
-			IL_00b2: ldelem.ref
-			IL_00b3: unbox.any [System.Runtime]System.Boolean
-			IL_00b8: stloc.s 11
-			IL_00ba: dup
-			IL_00bb: ldc.i4.s 11
-			IL_00bd: ldelem.ref
+			IL_00a8: stloc.s 10
+			IL_00aa: dup
+			IL_00ab: ldc.i4.s 10
+			IL_00ad: ldelem.ref
+			IL_00ae: castclass [System.Runtime]System.String
+			IL_00b3: stloc.s 11
+			IL_00b5: dup
+			IL_00b6: ldc.i4.s 11
+			IL_00b8: ldelem.ref
+			IL_00b9: unbox.any [System.Runtime]System.Double
 			IL_00be: stloc.s 12
 			IL_00c0: dup
 			IL_00c1: ldc.i4.s 12
 			IL_00c3: ldelem.ref
-			IL_00c4: castclass [System.Runtime]System.String
-			IL_00c9: stloc.s 13
-			IL_00cb: dup
-			IL_00cc: ldc.i4.s 13
-			IL_00ce: ldelem.ref
-			IL_00cf: unbox.any [System.Runtime]System.Double
-			IL_00d4: stloc.s 14
-			IL_00d6: dup
-			IL_00d7: ldc.i4.s 14
-			IL_00d9: ldelem.ref
-			IL_00da: stloc.s 15
-			IL_00dc: dup
-			IL_00dd: ldc.i4.s 15
-			IL_00df: ldelem.ref
-			IL_00e0: castclass [System.Runtime]System.String
-			IL_00e5: stloc.s 16
-			IL_00e7: dup
-			IL_00e8: ldc.i4.s 16
-			IL_00ea: ldelem.ref
+			IL_00c4: stloc.s 13
+			IL_00c6: dup
+			IL_00c7: ldc.i4.s 13
+			IL_00c9: ldelem.ref
+			IL_00ca: castclass [System.Runtime]System.String
+			IL_00cf: stloc.s 14
+			IL_00d1: dup
+			IL_00d2: ldc.i4.s 14
+			IL_00d4: ldelem.ref
+			IL_00d5: stloc.s 15
+			IL_00d7: dup
+			IL_00d8: ldc.i4.s 15
+			IL_00da: ldelem.ref
+			IL_00db: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_00e0: stloc.s 16
+			IL_00e2: dup
+			IL_00e3: ldc.i4.s 16
+			IL_00e5: ldelem.ref
+			IL_00e6: castclass object[]
 			IL_00eb: stloc.s 17
 			IL_00ed: dup
 			IL_00ee: ldc.i4.s 17
 			IL_00f0: ldelem.ref
-			IL_00f1: castclass [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			IL_00f1: unbox.any [System.Runtime]System.Boolean
 			IL_00f6: stloc.s 18
 			IL_00f8: dup
 			IL_00f9: ldc.i4.s 18
 			IL_00fb: ldelem.ref
-			IL_00fc: castclass object[]
-			IL_0101: stloc.s 19
-			IL_0103: dup
-			IL_0104: ldc.i4.s 19
-			IL_0106: ldelem.ref
-			IL_0107: unbox.any [System.Runtime]System.Boolean
-			IL_010c: stloc.s 20
-			IL_010e: dup
-			IL_010f: ldc.i4.s 20
-			IL_0111: ldelem.ref
-			IL_0112: stloc.s 21
-			IL_0114: dup
-			IL_0115: ldc.i4.s 21
-			IL_0117: ldelem.ref
-			IL_0118: stloc.s 22
-			IL_011a: dup
-			IL_011b: ldc.i4.s 22
-			IL_011d: ldelem.ref
-			IL_011e: stloc.s 23
-			IL_0120: pop
+			IL_00fc: stloc.s 19
+			IL_00fe: dup
+			IL_00ff: ldc.i4.s 19
+			IL_0101: ldelem.ref
+			IL_0102: stloc.s 20
+			IL_0104: dup
+			IL_0105: ldc.i4.s 20
+			IL_0107: ldelem.ref
+			IL_0108: stloc.s 21
+			IL_010a: pop
 
-			IL_0121: ldloc.0
-			IL_0122: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0127: switch (IL_014c, IL_082d, IL_0878, IL_07ab, IL_037d, IL_047a, IL_05c0, IL_06a5)
+			IL_010b: ldloc.0
+			IL_010c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0111: switch (IL_0136, IL_07d5, IL_0820, IL_075a, IL_0355, IL_0444, IL_057d, IL_0655)
 
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_0151: stloc.s 12
-			IL_0153: ldloc.s 12
-			IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_015a: stloc.s 13
-			IL_015c: ldstr ""
-			IL_0161: ldloc.s 13
-			IL_0163: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0168: stloc.s 13
-			IL_016a: ldloc.s 13
-			IL_016c: ldstr "-"
-			IL_0171: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0176: stloc.s 13
-			IL_0178: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_017d: stloc.s 14
-			IL_017f: ldloc.s 14
-			IL_0181: ldc.r8 1000000000
-			IL_018a: mul
-			IL_018b: stloc.s 14
-			IL_018d: ldloc.s 14
-			IL_018f: box [System.Runtime]System.Double
-			IL_0194: stloc.s 15
-			IL_0196: ldloc.s 15
-			IL_0198: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_019d: stloc.s 14
-			IL_019f: ldloc.s 14
-			IL_01a1: box [System.Runtime]System.Double
-			IL_01a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ab: stloc.s 16
-			IL_01ad: ldloc.s 13
-			IL_01af: ldloc.s 16
-			IL_01b1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b6: stloc.s 16
-			IL_01b8: ldloc.s 16
-			IL_01ba: stloc.1
-			IL_01bb: ldarg.0
-			IL_01bc: ldc.i4.1
-			IL_01bd: ldelem.ref
-			IL_01be: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01c3: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cd: stloc.s 12
-			IL_01cf: ldarg.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: ldelem.ref
-			IL_01d2: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01d7: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e1: stloc.s 17
-			IL_01e3: ldloc.s 17
-			IL_01e5: ldstr "tmpdir"
-			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01ef: stloc.s 17
-			IL_01f1: ldloc.1
-			IL_01f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f7: stloc.s 16
-			IL_01f9: ldstr "jroc-fs-open-"
-			IL_01fe: ldloc.s 16
-			IL_0200: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0205: stloc.s 16
-			IL_0207: ldloc.s 16
-			IL_0209: ldstr ".txt"
-			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0213: stloc.s 16
-			IL_0215: ldloc.s 12
-			IL_0217: ldstr "join"
-			IL_021c: ldloc.s 17
-			IL_021e: ldloc.s 16
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0225: stloc.s 17
-			IL_0227: ldloc.s 17
-			IL_0229: stloc.2
-			IL_022a: ldloc.0
-			IL_022b: ldc.i4.0
-			IL_022c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0231: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0236: ldloc.0
-			IL_0237: ldc.i4.0
-			IL_0238: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_023d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0242: ldloc.0
-			IL_0243: ldc.i4.0
-			IL_0244: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0249: ldloc.0
-			IL_024a: ldc.i4.0
-			IL_024b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0250: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L11C8::.ctor()
-			IL_0255: stloc.3
-			IL_0256: ldarg.0
-			IL_0257: ldc.i4.1
-			IL_0258: ldelem.ref
-			IL_0259: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_025e: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0268: stloc.s 17
-			IL_026a: ldloc.s 17
-			IL_026c: ldstr "rmSync"
-			IL_0271: ldloc.2
-			IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0277: dup
-			IL_0278: ldstr "force"
-			IL_027d: ldc.i4.1
-			IL_027e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0288: pop
-			IL_0289: ldarg.0
-			IL_028a: ldc.i4.1
-			IL_028b: ldelem.ref
-			IL_028c: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0291: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0296: ldstr "promises"
-			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a5: stloc.s 17
-			IL_02a7: ldloc.s 17
-			IL_02a9: ldstr "open"
-			IL_02ae: ldloc.2
-			IL_02af: ldstr "w+"
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02b9: stloc.s 17
-			IL_02bb: ldloc.0
-			IL_02bc: ldc.i4.4
-			IL_02bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02c2: ldloc.0
-			IL_02c3: ldloc.s 17
-			IL_02c5: ldarg.0
-			IL_02c6: ldc.i4.1
-			IL_02c7: ldloc.0
-			IL_02c8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02cd: ldc.i4.3
-			IL_02ce: ldstr "_pendingException"
-			IL_02d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02d8: ldloc.0
-			IL_02d9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02de: dup
-			IL_02df: ldc.i4.0
-			IL_02e0: ldloc.1
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_013b: stloc.s 10
+			IL_013d: ldloc.s 10
+			IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0144: stloc.s 11
+			IL_0146: ldstr ""
+			IL_014b: ldloc.s 11
+			IL_014d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0152: stloc.s 11
+			IL_0154: ldloc.s 11
+			IL_0156: ldstr "-"
+			IL_015b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0160: stloc.s 11
+			IL_0162: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_0167: stloc.s 12
+			IL_0169: ldloc.s 12
+			IL_016b: ldc.r8 1000000000
+			IL_0174: mul
+			IL_0175: stloc.s 12
+			IL_0177: ldloc.s 12
+			IL_0179: box [System.Runtime]System.Double
+			IL_017e: stloc.s 13
+			IL_0180: ldloc.s 13
+			IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_0187: stloc.s 12
+			IL_0189: ldloc.s 12
+			IL_018b: box [System.Runtime]System.Double
+			IL_0190: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0195: stloc.s 14
+			IL_0197: ldloc.s 11
+			IL_0199: ldloc.s 14
+			IL_019b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a0: stloc.s 14
+			IL_01a2: ldloc.s 14
+			IL_01a4: stloc.1
+			IL_01a5: ldarg.0
+			IL_01a6: ldc.i4.1
+			IL_01a7: ldelem.ref
+			IL_01a8: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01ad: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b7: stloc.s 10
+			IL_01b9: ldarg.0
+			IL_01ba: ldc.i4.1
+			IL_01bb: ldelem.ref
+			IL_01bc: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01c1: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cb: stloc.s 15
+			IL_01cd: ldloc.s 15
+			IL_01cf: ldstr "tmpdir"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01d9: stloc.s 15
+			IL_01db: ldloc.1
+			IL_01dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e1: stloc.s 14
+			IL_01e3: ldstr "jroc-fs-open-"
+			IL_01e8: ldloc.s 14
+			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ef: stloc.s 14
+			IL_01f1: ldloc.s 14
+			IL_01f3: ldstr ".txt"
+			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fd: stloc.s 14
+			IL_01ff: ldloc.s 10
+			IL_0201: ldstr "join"
+			IL_0206: ldloc.s 15
+			IL_0208: ldloc.s 14
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_020f: stloc.s 15
+			IL_0211: ldloc.s 15
+			IL_0213: stloc.2
+			IL_0214: ldloc.0
+			IL_0215: ldc.i4.0
+			IL_0216: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_021b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0220: ldloc.0
+			IL_0221: ldc.i4.0
+			IL_0222: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0227: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_022c: ldloc.0
+			IL_022d: ldc.i4.0
+			IL_022e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0233: ldloc.0
+			IL_0234: ldc.i4.0
+			IL_0235: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_023a: ldarg.0
+			IL_023b: ldc.i4.1
+			IL_023c: ldelem.ref
+			IL_023d: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0242: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024c: stloc.s 15
+			IL_024e: ldloc.s 15
+			IL_0250: ldstr "rmSync"
+			IL_0255: ldloc.2
+			IL_0256: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_025b: dup
+			IL_025c: ldstr "force"
+			IL_0261: ldc.i4.1
+			IL_0262: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_026c: pop
+			IL_026d: ldarg.0
+			IL_026e: ldc.i4.1
+			IL_026f: ldelem.ref
+			IL_0270: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0275: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_027a: ldstr "promises"
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0289: stloc.s 15
+			IL_028b: ldloc.s 15
+			IL_028d: ldstr "open"
+			IL_0292: ldloc.2
+			IL_0293: ldstr "w+"
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_029d: stloc.s 15
+			IL_029f: ldloc.0
+			IL_02a0: ldc.i4.4
+			IL_02a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02a6: ldloc.0
+			IL_02a7: ldloc.s 15
+			IL_02a9: ldarg.0
+			IL_02aa: ldc.i4.1
+			IL_02ab: ldloc.0
+			IL_02ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02b1: ldc.i4.3
+			IL_02b2: ldstr "_pendingException"
+			IL_02b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02bc: ldloc.0
+			IL_02bd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02c2: dup
+			IL_02c3: ldc.i4.0
+			IL_02c4: ldloc.1
+			IL_02c5: stelem.ref
+			IL_02c6: dup
+			IL_02c7: ldc.i4.1
+			IL_02c8: ldloc.2
+			IL_02c9: stelem.ref
+			IL_02ca: dup
+			IL_02cb: ldc.i4.2
+			IL_02cc: ldloc.3
+			IL_02cd: stelem.ref
+			IL_02ce: dup
+			IL_02cf: ldc.i4.3
+			IL_02d0: ldloc.s 4
+			IL_02d2: stelem.ref
+			IL_02d3: dup
+			IL_02d4: ldc.i4.4
+			IL_02d5: ldloc.s 5
+			IL_02d7: stelem.ref
+			IL_02d8: dup
+			IL_02d9: ldc.i4.5
+			IL_02da: ldloc.s 6
+			IL_02dc: stelem.ref
+			IL_02dd: dup
+			IL_02de: ldc.i4.6
+			IL_02df: ldloc.s 7
 			IL_02e1: stelem.ref
 			IL_02e2: dup
-			IL_02e3: ldc.i4.1
-			IL_02e4: ldloc.2
-			IL_02e5: stelem.ref
-			IL_02e6: dup
-			IL_02e7: ldc.i4.2
-			IL_02e8: ldloc.3
-			IL_02e9: stelem.ref
-			IL_02ea: dup
-			IL_02eb: ldc.i4.3
-			IL_02ec: ldloc.s 4
-			IL_02ee: stelem.ref
-			IL_02ef: dup
-			IL_02f0: ldc.i4.4
-			IL_02f1: ldloc.s 5
-			IL_02f3: stelem.ref
-			IL_02f4: dup
-			IL_02f5: ldc.i4.5
-			IL_02f6: ldloc.s 6
-			IL_02f8: stelem.ref
-			IL_02f9: dup
-			IL_02fa: ldc.i4.6
-			IL_02fb: ldloc.s 7
-			IL_02fd: stelem.ref
-			IL_02fe: dup
-			IL_02ff: ldc.i4.7
-			IL_0300: ldloc.s 8
-			IL_0302: stelem.ref
-			IL_0303: dup
-			IL_0304: ldc.i4.8
-			IL_0305: ldloc.s 9
-			IL_0307: stelem.ref
-			IL_0308: dup
-			IL_0309: ldc.i4.s 9
-			IL_030b: ldloc.s 10
-			IL_030d: box [System.Runtime]System.Boolean
+			IL_02e3: ldc.i4.7
+			IL_02e4: ldloc.s 8
+			IL_02e6: box [System.Runtime]System.Boolean
+			IL_02eb: stelem.ref
+			IL_02ec: dup
+			IL_02ed: ldc.i4.8
+			IL_02ee: ldloc.s 9
+			IL_02f0: box [System.Runtime]System.Boolean
+			IL_02f5: stelem.ref
+			IL_02f6: dup
+			IL_02f7: ldc.i4.s 9
+			IL_02f9: ldloc.s 10
+			IL_02fb: stelem.ref
+			IL_02fc: dup
+			IL_02fd: ldc.i4.s 10
+			IL_02ff: ldloc.s 11
+			IL_0301: stelem.ref
+			IL_0302: dup
+			IL_0303: ldc.i4.s 11
+			IL_0305: ldloc.s 12
+			IL_0307: box [System.Runtime]System.Double
+			IL_030c: stelem.ref
+			IL_030d: dup
+			IL_030e: ldc.i4.s 12
+			IL_0310: ldloc.s 13
 			IL_0312: stelem.ref
 			IL_0313: dup
-			IL_0314: ldc.i4.s 10
-			IL_0316: ldloc.s 11
-			IL_0318: box [System.Runtime]System.Boolean
-			IL_031d: stelem.ref
-			IL_031e: dup
-			IL_031f: ldc.i4.s 11
-			IL_0321: ldloc.s 12
-			IL_0323: stelem.ref
-			IL_0324: dup
-			IL_0325: ldc.i4.s 12
-			IL_0327: ldloc.s 13
-			IL_0329: stelem.ref
-			IL_032a: dup
-			IL_032b: ldc.i4.s 13
-			IL_032d: ldloc.s 14
-			IL_032f: box [System.Runtime]System.Double
-			IL_0334: stelem.ref
-			IL_0335: dup
-			IL_0336: ldc.i4.s 14
-			IL_0338: ldloc.s 15
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.s 15
-			IL_033e: ldloc.s 16
-			IL_0340: stelem.ref
-			IL_0341: dup
-			IL_0342: ldc.i4.s 16
-			IL_0344: ldloc.s 17
-			IL_0346: stelem.ref
-			IL_0347: dup
-			IL_0348: ldc.i4.s 17
-			IL_034a: ldloc.s 18
-			IL_034c: stelem.ref
-			IL_034d: dup
-			IL_034e: ldc.i4.s 18
-			IL_0350: ldloc.s 19
-			IL_0352: stelem.ref
-			IL_0353: dup
-			IL_0354: ldc.i4.s 19
-			IL_0356: ldloc.s 20
-			IL_0358: box [System.Runtime]System.Boolean
-			IL_035d: stelem.ref
-			IL_035e: dup
-			IL_035f: ldc.i4.s 20
-			IL_0361: ldloc.s 21
-			IL_0363: stelem.ref
-			IL_0364: dup
-			IL_0365: ldc.i4.s 21
-			IL_0367: ldloc.s 22
-			IL_0369: stelem.ref
-			IL_036a: dup
-			IL_036b: ldc.i4.s 22
-			IL_036d: ldloc.s 23
-			IL_036f: stelem.ref
-			IL_0370: pop
-			IL_0371: ldloc.0
-			IL_0372: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0377: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_037c: ret
+			IL_0314: ldc.i4.s 13
+			IL_0316: ldloc.s 14
+			IL_0318: stelem.ref
+			IL_0319: dup
+			IL_031a: ldc.i4.s 14
+			IL_031c: ldloc.s 15
+			IL_031e: stelem.ref
+			IL_031f: dup
+			IL_0320: ldc.i4.s 15
+			IL_0322: ldloc.s 16
+			IL_0324: stelem.ref
+			IL_0325: dup
+			IL_0326: ldc.i4.s 16
+			IL_0328: ldloc.s 17
+			IL_032a: stelem.ref
+			IL_032b: dup
+			IL_032c: ldc.i4.s 17
+			IL_032e: ldloc.s 18
+			IL_0330: box [System.Runtime]System.Boolean
+			IL_0335: stelem.ref
+			IL_0336: dup
+			IL_0337: ldc.i4.s 18
+			IL_0339: ldloc.s 19
+			IL_033b: stelem.ref
+			IL_033c: dup
+			IL_033d: ldc.i4.s 19
+			IL_033f: ldloc.s 20
+			IL_0341: stelem.ref
+			IL_0342: dup
+			IL_0343: ldc.i4.s 20
+			IL_0345: ldloc.s 21
+			IL_0347: stelem.ref
+			IL_0348: pop
+			IL_0349: ldloc.0
+			IL_034a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_034f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0354: ret
 
-			IL_037d: ldloc.0
-			IL_037e: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0383: stloc.s 17
-			IL_0385: ldloc.s 17
-			IL_0387: stloc.s 4
-			IL_0389: ldloc.s 4
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0390: stloc.s 17
-			IL_0392: ldloc.s 17
-			IL_0394: ldstr "write"
-			IL_0399: ldstr "hello"
-			IL_039e: ldc.r8 0.0
-			IL_03a7: box [System.Runtime]System.Double
-			IL_03ac: ldstr "utf8"
-			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_03b6: stloc.s 17
-			IL_03b8: ldloc.0
-			IL_03b9: ldc.i4.5
-			IL_03ba: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03bf: ldloc.0
-			IL_03c0: ldloc.s 17
-			IL_03c2: ldarg.0
-			IL_03c3: ldc.i4.2
-			IL_03c4: ldloc.0
-			IL_03c5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03ca: ldc.i4.3
-			IL_03cb: ldstr "_pendingException"
-			IL_03d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03d5: ldloc.0
-			IL_03d6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0355: ldloc.0
+			IL_0356: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
+			IL_035b: stloc.s 15
+			IL_035d: ldloc.s 15
+			IL_035f: stloc.3
+			IL_0360: ldloc.3
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0366: stloc.s 15
+			IL_0368: ldloc.s 15
+			IL_036a: ldstr "write"
+			IL_036f: ldstr "hello"
+			IL_0374: ldc.r8 0.0
+			IL_037d: box [System.Runtime]System.Double
+			IL_0382: ldstr "utf8"
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_038c: stloc.s 15
+			IL_038e: ldloc.0
+			IL_038f: ldc.i4.5
+			IL_0390: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0395: ldloc.0
+			IL_0396: ldloc.s 15
+			IL_0398: ldarg.0
+			IL_0399: ldc.i4.2
+			IL_039a: ldloc.0
+			IL_039b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03a0: ldc.i4.3
+			IL_03a1: ldstr "_pendingException"
+			IL_03a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03ab: ldloc.0
+			IL_03ac: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03b1: dup
+			IL_03b2: ldc.i4.0
+			IL_03b3: ldloc.1
+			IL_03b4: stelem.ref
+			IL_03b5: dup
+			IL_03b6: ldc.i4.1
+			IL_03b7: ldloc.2
+			IL_03b8: stelem.ref
+			IL_03b9: dup
+			IL_03ba: ldc.i4.2
+			IL_03bb: ldloc.3
+			IL_03bc: stelem.ref
+			IL_03bd: dup
+			IL_03be: ldc.i4.3
+			IL_03bf: ldloc.s 4
+			IL_03c1: stelem.ref
+			IL_03c2: dup
+			IL_03c3: ldc.i4.4
+			IL_03c4: ldloc.s 5
+			IL_03c6: stelem.ref
+			IL_03c7: dup
+			IL_03c8: ldc.i4.5
+			IL_03c9: ldloc.s 6
+			IL_03cb: stelem.ref
+			IL_03cc: dup
+			IL_03cd: ldc.i4.6
+			IL_03ce: ldloc.s 7
+			IL_03d0: stelem.ref
+			IL_03d1: dup
+			IL_03d2: ldc.i4.7
+			IL_03d3: ldloc.s 8
+			IL_03d5: box [System.Runtime]System.Boolean
+			IL_03da: stelem.ref
 			IL_03db: dup
-			IL_03dc: ldc.i4.0
-			IL_03dd: ldloc.1
-			IL_03de: stelem.ref
-			IL_03df: dup
-			IL_03e0: ldc.i4.1
-			IL_03e1: ldloc.2
-			IL_03e2: stelem.ref
-			IL_03e3: dup
-			IL_03e4: ldc.i4.2
-			IL_03e5: ldloc.3
-			IL_03e6: stelem.ref
-			IL_03e7: dup
-			IL_03e8: ldc.i4.3
-			IL_03e9: ldloc.s 4
-			IL_03eb: stelem.ref
-			IL_03ec: dup
-			IL_03ed: ldc.i4.4
-			IL_03ee: ldloc.s 5
+			IL_03dc: ldc.i4.8
+			IL_03dd: ldloc.s 9
+			IL_03df: box [System.Runtime]System.Boolean
+			IL_03e4: stelem.ref
+			IL_03e5: dup
+			IL_03e6: ldc.i4.s 9
+			IL_03e8: ldloc.s 10
+			IL_03ea: stelem.ref
+			IL_03eb: dup
+			IL_03ec: ldc.i4.s 10
+			IL_03ee: ldloc.s 11
 			IL_03f0: stelem.ref
 			IL_03f1: dup
-			IL_03f2: ldc.i4.5
-			IL_03f3: ldloc.s 6
-			IL_03f5: stelem.ref
-			IL_03f6: dup
-			IL_03f7: ldc.i4.6
-			IL_03f8: ldloc.s 7
-			IL_03fa: stelem.ref
-			IL_03fb: dup
-			IL_03fc: ldc.i4.7
-			IL_03fd: ldloc.s 8
-			IL_03ff: stelem.ref
-			IL_0400: dup
-			IL_0401: ldc.i4.8
-			IL_0402: ldloc.s 9
-			IL_0404: stelem.ref
-			IL_0405: dup
-			IL_0406: ldc.i4.s 9
-			IL_0408: ldloc.s 10
-			IL_040a: box [System.Runtime]System.Boolean
-			IL_040f: stelem.ref
-			IL_0410: dup
-			IL_0411: ldc.i4.s 10
-			IL_0413: ldloc.s 11
-			IL_0415: box [System.Runtime]System.Boolean
-			IL_041a: stelem.ref
-			IL_041b: dup
-			IL_041c: ldc.i4.s 11
-			IL_041e: ldloc.s 12
-			IL_0420: stelem.ref
-			IL_0421: dup
-			IL_0422: ldc.i4.s 12
-			IL_0424: ldloc.s 13
-			IL_0426: stelem.ref
-			IL_0427: dup
-			IL_0428: ldc.i4.s 13
-			IL_042a: ldloc.s 14
-			IL_042c: box [System.Runtime]System.Double
-			IL_0431: stelem.ref
-			IL_0432: dup
-			IL_0433: ldc.i4.s 14
-			IL_0435: ldloc.s 15
-			IL_0437: stelem.ref
-			IL_0438: dup
-			IL_0439: ldc.i4.s 15
-			IL_043b: ldloc.s 16
-			IL_043d: stelem.ref
-			IL_043e: dup
-			IL_043f: ldc.i4.s 16
-			IL_0441: ldloc.s 17
-			IL_0443: stelem.ref
-			IL_0444: dup
-			IL_0445: ldc.i4.s 17
-			IL_0447: ldloc.s 18
-			IL_0449: stelem.ref
-			IL_044a: dup
-			IL_044b: ldc.i4.s 18
-			IL_044d: ldloc.s 19
-			IL_044f: stelem.ref
-			IL_0450: dup
-			IL_0451: ldc.i4.s 19
-			IL_0453: ldloc.s 20
-			IL_0455: box [System.Runtime]System.Boolean
-			IL_045a: stelem.ref
-			IL_045b: dup
-			IL_045c: ldc.i4.s 20
-			IL_045e: ldloc.s 21
-			IL_0460: stelem.ref
-			IL_0461: dup
-			IL_0462: ldc.i4.s 21
-			IL_0464: ldloc.s 22
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.s 22
-			IL_046a: ldloc.s 23
-			IL_046c: stelem.ref
-			IL_046d: pop
-			IL_046e: ldloc.0
-			IL_046f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0474: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0479: ret
+			IL_03f2: ldc.i4.s 11
+			IL_03f4: ldloc.s 12
+			IL_03f6: box [System.Runtime]System.Double
+			IL_03fb: stelem.ref
+			IL_03fc: dup
+			IL_03fd: ldc.i4.s 12
+			IL_03ff: ldloc.s 13
+			IL_0401: stelem.ref
+			IL_0402: dup
+			IL_0403: ldc.i4.s 13
+			IL_0405: ldloc.s 14
+			IL_0407: stelem.ref
+			IL_0408: dup
+			IL_0409: ldc.i4.s 14
+			IL_040b: ldloc.s 15
+			IL_040d: stelem.ref
+			IL_040e: dup
+			IL_040f: ldc.i4.s 15
+			IL_0411: ldloc.s 16
+			IL_0413: stelem.ref
+			IL_0414: dup
+			IL_0415: ldc.i4.s 16
+			IL_0417: ldloc.s 17
+			IL_0419: stelem.ref
+			IL_041a: dup
+			IL_041b: ldc.i4.s 17
+			IL_041d: ldloc.s 18
+			IL_041f: box [System.Runtime]System.Boolean
+			IL_0424: stelem.ref
+			IL_0425: dup
+			IL_0426: ldc.i4.s 18
+			IL_0428: ldloc.s 19
+			IL_042a: stelem.ref
+			IL_042b: dup
+			IL_042c: ldc.i4.s 19
+			IL_042e: ldloc.s 20
+			IL_0430: stelem.ref
+			IL_0431: dup
+			IL_0432: ldc.i4.s 20
+			IL_0434: ldloc.s 21
+			IL_0436: stelem.ref
+			IL_0437: pop
+			IL_0438: ldloc.0
+			IL_0439: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_043e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0443: ret
 
-			IL_047a: ldloc.0
-			IL_047b: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0480: stloc.s 17
-			IL_0482: ldloc.s 17
-			IL_0484: stloc.s 5
-			IL_0486: ldc.r8 5
-			IL_048f: box [System.Runtime]System.Double
-			IL_0494: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_0499: stloc.s 18
-			IL_049b: ldloc.s 18
-			IL_049d: stloc.s 6
-			IL_049f: ldloc.s 4
-			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04a6: stloc.s 17
-			IL_04a8: ldloc.s 6
-			IL_04aa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_04af: stloc.s 14
-			IL_04b1: ldloc.s 14
-			IL_04b3: box [System.Runtime]System.Double
-			IL_04b8: stloc.s 15
-			IL_04ba: ldc.i4.4
-			IL_04bb: newarr [System.Runtime]System.Object
-			IL_04c0: dup
-			IL_04c1: ldc.i4.0
-			IL_04c2: ldloc.s 6
-			IL_04c4: stelem.ref
-			IL_04c5: dup
-			IL_04c6: ldc.i4.1
-			IL_04c7: ldc.r8 0.0
-			IL_04d0: box [System.Runtime]System.Double
-			IL_04d5: stelem.ref
-			IL_04d6: dup
-			IL_04d7: ldc.i4.2
-			IL_04d8: ldloc.s 15
-			IL_04da: stelem.ref
-			IL_04db: dup
-			IL_04dc: ldc.i4.3
-			IL_04dd: ldc.r8 0.0
-			IL_04e6: box [System.Runtime]System.Double
-			IL_04eb: stelem.ref
-			IL_04ec: stloc.s 19
-			IL_04ee: ldloc.s 17
-			IL_04f0: ldstr "read"
-			IL_04f5: ldloc.s 19
-			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_04fc: stloc.s 17
-			IL_04fe: ldloc.0
-			IL_04ff: ldc.i4.6
-			IL_0500: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0505: ldloc.0
-			IL_0506: ldloc.s 17
-			IL_0508: ldarg.0
-			IL_0509: ldc.i4.3
-			IL_050a: ldloc.0
-			IL_050b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0510: ldc.i4.3
-			IL_0511: ldstr "_pendingException"
-			IL_0516: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_051b: ldloc.0
-			IL_051c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0521: dup
-			IL_0522: ldc.i4.0
-			IL_0523: ldloc.1
-			IL_0524: stelem.ref
-			IL_0525: dup
-			IL_0526: ldc.i4.1
-			IL_0527: ldloc.2
-			IL_0528: stelem.ref
-			IL_0529: dup
-			IL_052a: ldc.i4.2
-			IL_052b: ldloc.3
-			IL_052c: stelem.ref
-			IL_052d: dup
-			IL_052e: ldc.i4.3
-			IL_052f: ldloc.s 4
-			IL_0531: stelem.ref
-			IL_0532: dup
-			IL_0533: ldc.i4.4
-			IL_0534: ldloc.s 5
-			IL_0536: stelem.ref
-			IL_0537: dup
-			IL_0538: ldc.i4.5
-			IL_0539: ldloc.s 6
-			IL_053b: stelem.ref
-			IL_053c: dup
-			IL_053d: ldc.i4.6
-			IL_053e: ldloc.s 7
+			IL_0444: ldloc.0
+			IL_0445: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
+			IL_044a: stloc.s 15
+			IL_044c: ldloc.s 15
+			IL_044e: stloc.s 4
+			IL_0450: ldc.r8 5
+			IL_0459: box [System.Runtime]System.Double
+			IL_045e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_0463: stloc.s 16
+			IL_0465: ldloc.s 16
+			IL_0467: stloc.s 5
+			IL_0469: ldloc.3
+			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_046f: stloc.s 15
+			IL_0471: ldloc.s 5
+			IL_0473: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_0478: stloc.s 12
+			IL_047a: ldloc.s 12
+			IL_047c: box [System.Runtime]System.Double
+			IL_0481: stloc.s 13
+			IL_0483: ldc.i4.4
+			IL_0484: newarr [System.Runtime]System.Object
+			IL_0489: dup
+			IL_048a: ldc.i4.0
+			IL_048b: ldloc.s 5
+			IL_048d: stelem.ref
+			IL_048e: dup
+			IL_048f: ldc.i4.1
+			IL_0490: ldc.r8 0.0
+			IL_0499: box [System.Runtime]System.Double
+			IL_049e: stelem.ref
+			IL_049f: dup
+			IL_04a0: ldc.i4.2
+			IL_04a1: ldloc.s 13
+			IL_04a3: stelem.ref
+			IL_04a4: dup
+			IL_04a5: ldc.i4.3
+			IL_04a6: ldc.r8 0.0
+			IL_04af: box [System.Runtime]System.Double
+			IL_04b4: stelem.ref
+			IL_04b5: stloc.s 17
+			IL_04b7: ldloc.s 15
+			IL_04b9: ldstr "read"
+			IL_04be: ldloc.s 17
+			IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_04c5: stloc.s 15
+			IL_04c7: ldloc.0
+			IL_04c8: ldc.i4.6
+			IL_04c9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04ce: ldloc.0
+			IL_04cf: ldloc.s 15
+			IL_04d1: ldarg.0
+			IL_04d2: ldc.i4.3
+			IL_04d3: ldloc.0
+			IL_04d4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04d9: ldc.i4.3
+			IL_04da: ldstr "_pendingException"
+			IL_04df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_04e4: ldloc.0
+			IL_04e5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04ea: dup
+			IL_04eb: ldc.i4.0
+			IL_04ec: ldloc.1
+			IL_04ed: stelem.ref
+			IL_04ee: dup
+			IL_04ef: ldc.i4.1
+			IL_04f0: ldloc.2
+			IL_04f1: stelem.ref
+			IL_04f2: dup
+			IL_04f3: ldc.i4.2
+			IL_04f4: ldloc.3
+			IL_04f5: stelem.ref
+			IL_04f6: dup
+			IL_04f7: ldc.i4.3
+			IL_04f8: ldloc.s 4
+			IL_04fa: stelem.ref
+			IL_04fb: dup
+			IL_04fc: ldc.i4.4
+			IL_04fd: ldloc.s 5
+			IL_04ff: stelem.ref
+			IL_0500: dup
+			IL_0501: ldc.i4.5
+			IL_0502: ldloc.s 6
+			IL_0504: stelem.ref
+			IL_0505: dup
+			IL_0506: ldc.i4.6
+			IL_0507: ldloc.s 7
+			IL_0509: stelem.ref
+			IL_050a: dup
+			IL_050b: ldc.i4.7
+			IL_050c: ldloc.s 8
+			IL_050e: box [System.Runtime]System.Boolean
+			IL_0513: stelem.ref
+			IL_0514: dup
+			IL_0515: ldc.i4.8
+			IL_0516: ldloc.s 9
+			IL_0518: box [System.Runtime]System.Boolean
+			IL_051d: stelem.ref
+			IL_051e: dup
+			IL_051f: ldc.i4.s 9
+			IL_0521: ldloc.s 10
+			IL_0523: stelem.ref
+			IL_0524: dup
+			IL_0525: ldc.i4.s 10
+			IL_0527: ldloc.s 11
+			IL_0529: stelem.ref
+			IL_052a: dup
+			IL_052b: ldc.i4.s 11
+			IL_052d: ldloc.s 12
+			IL_052f: box [System.Runtime]System.Double
+			IL_0534: stelem.ref
+			IL_0535: dup
+			IL_0536: ldc.i4.s 12
+			IL_0538: ldloc.s 13
+			IL_053a: stelem.ref
+			IL_053b: dup
+			IL_053c: ldc.i4.s 13
+			IL_053e: ldloc.s 14
 			IL_0540: stelem.ref
 			IL_0541: dup
-			IL_0542: ldc.i4.7
-			IL_0543: ldloc.s 8
-			IL_0545: stelem.ref
-			IL_0546: dup
-			IL_0547: ldc.i4.8
-			IL_0548: ldloc.s 9
-			IL_054a: stelem.ref
-			IL_054b: dup
-			IL_054c: ldc.i4.s 9
-			IL_054e: ldloc.s 10
-			IL_0550: box [System.Runtime]System.Boolean
-			IL_0555: stelem.ref
-			IL_0556: dup
-			IL_0557: ldc.i4.s 10
-			IL_0559: ldloc.s 11
-			IL_055b: box [System.Runtime]System.Boolean
-			IL_0560: stelem.ref
-			IL_0561: dup
-			IL_0562: ldc.i4.s 11
-			IL_0564: ldloc.s 12
-			IL_0566: stelem.ref
-			IL_0567: dup
-			IL_0568: ldc.i4.s 12
-			IL_056a: ldloc.s 13
-			IL_056c: stelem.ref
-			IL_056d: dup
-			IL_056e: ldc.i4.s 13
-			IL_0570: ldloc.s 14
-			IL_0572: box [System.Runtime]System.Double
-			IL_0577: stelem.ref
-			IL_0578: dup
-			IL_0579: ldc.i4.s 14
-			IL_057b: ldloc.s 15
-			IL_057d: stelem.ref
-			IL_057e: dup
-			IL_057f: ldc.i4.s 15
-			IL_0581: ldloc.s 16
-			IL_0583: stelem.ref
-			IL_0584: dup
-			IL_0585: ldc.i4.s 16
-			IL_0587: ldloc.s 17
-			IL_0589: stelem.ref
-			IL_058a: dup
-			IL_058b: ldc.i4.s 17
-			IL_058d: ldloc.s 18
-			IL_058f: stelem.ref
-			IL_0590: dup
-			IL_0591: ldc.i4.s 18
-			IL_0593: ldloc.s 19
-			IL_0595: stelem.ref
-			IL_0596: dup
-			IL_0597: ldc.i4.s 19
-			IL_0599: ldloc.s 20
-			IL_059b: box [System.Runtime]System.Boolean
-			IL_05a0: stelem.ref
-			IL_05a1: dup
-			IL_05a2: ldc.i4.s 20
-			IL_05a4: ldloc.s 21
-			IL_05a6: stelem.ref
-			IL_05a7: dup
-			IL_05a8: ldc.i4.s 21
-			IL_05aa: ldloc.s 22
-			IL_05ac: stelem.ref
-			IL_05ad: dup
-			IL_05ae: ldc.i4.s 22
-			IL_05b0: ldloc.s 23
-			IL_05b2: stelem.ref
-			IL_05b3: pop
-			IL_05b4: ldloc.0
-			IL_05b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05bf: ret
+			IL_0542: ldc.i4.s 14
+			IL_0544: ldloc.s 15
+			IL_0546: stelem.ref
+			IL_0547: dup
+			IL_0548: ldc.i4.s 15
+			IL_054a: ldloc.s 16
+			IL_054c: stelem.ref
+			IL_054d: dup
+			IL_054e: ldc.i4.s 16
+			IL_0550: ldloc.s 17
+			IL_0552: stelem.ref
+			IL_0553: dup
+			IL_0554: ldc.i4.s 17
+			IL_0556: ldloc.s 18
+			IL_0558: box [System.Runtime]System.Boolean
+			IL_055d: stelem.ref
+			IL_055e: dup
+			IL_055f: ldc.i4.s 18
+			IL_0561: ldloc.s 19
+			IL_0563: stelem.ref
+			IL_0564: dup
+			IL_0565: ldc.i4.s 19
+			IL_0567: ldloc.s 20
+			IL_0569: stelem.ref
+			IL_056a: dup
+			IL_056b: ldc.i4.s 20
+			IL_056d: ldloc.s 21
+			IL_056f: stelem.ref
+			IL_0570: pop
+			IL_0571: ldloc.0
+			IL_0572: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0577: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_057c: ret
 
-			IL_05c0: ldloc.0
-			IL_05c1: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
-			IL_05c6: stloc.s 17
-			IL_05c8: ldloc.s 17
-			IL_05ca: stloc.s 7
-			IL_05cc: ldloc.s 4
-			IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05d3: stloc.s 17
-			IL_05d5: ldloc.s 17
-			IL_05d7: ldstr "close"
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05e1: stloc.s 17
-			IL_05e3: ldloc.0
-			IL_05e4: ldc.i4.7
-			IL_05e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05ea: ldloc.0
-			IL_05eb: ldloc.s 17
-			IL_05ed: ldarg.0
-			IL_05ee: ldc.i4.4
-			IL_05ef: ldloc.0
-			IL_05f0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05f5: ldc.i4.3
-			IL_05f6: ldstr "_pendingException"
-			IL_05fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0600: ldloc.0
-			IL_0601: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0606: dup
-			IL_0607: ldc.i4.0
-			IL_0608: ldloc.1
-			IL_0609: stelem.ref
-			IL_060a: dup
-			IL_060b: ldc.i4.1
-			IL_060c: ldloc.2
-			IL_060d: stelem.ref
-			IL_060e: dup
-			IL_060f: ldc.i4.2
-			IL_0610: ldloc.3
-			IL_0611: stelem.ref
-			IL_0612: dup
-			IL_0613: ldc.i4.3
-			IL_0614: ldloc.s 4
-			IL_0616: stelem.ref
-			IL_0617: dup
-			IL_0618: ldc.i4.4
-			IL_0619: ldloc.s 5
-			IL_061b: stelem.ref
-			IL_061c: dup
-			IL_061d: ldc.i4.5
-			IL_061e: ldloc.s 6
-			IL_0620: stelem.ref
-			IL_0621: dup
-			IL_0622: ldc.i4.6
-			IL_0623: ldloc.s 7
-			IL_0625: stelem.ref
-			IL_0626: dup
-			IL_0627: ldc.i4.7
-			IL_0628: ldloc.s 8
+			IL_057d: ldloc.0
+			IL_057e: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0583: stloc.s 15
+			IL_0585: ldloc.s 15
+			IL_0587: stloc.s 6
+			IL_0589: ldloc.3
+			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_058f: stloc.s 15
+			IL_0591: ldloc.s 15
+			IL_0593: ldstr "close"
+			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_059d: stloc.s 15
+			IL_059f: ldloc.0
+			IL_05a0: ldc.i4.7
+			IL_05a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05a6: ldloc.0
+			IL_05a7: ldloc.s 15
+			IL_05a9: ldarg.0
+			IL_05aa: ldc.i4.4
+			IL_05ab: ldloc.0
+			IL_05ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05b1: ldc.i4.3
+			IL_05b2: ldstr "_pendingException"
+			IL_05b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05bc: ldloc.0
+			IL_05bd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05c2: dup
+			IL_05c3: ldc.i4.0
+			IL_05c4: ldloc.1
+			IL_05c5: stelem.ref
+			IL_05c6: dup
+			IL_05c7: ldc.i4.1
+			IL_05c8: ldloc.2
+			IL_05c9: stelem.ref
+			IL_05ca: dup
+			IL_05cb: ldc.i4.2
+			IL_05cc: ldloc.3
+			IL_05cd: stelem.ref
+			IL_05ce: dup
+			IL_05cf: ldc.i4.3
+			IL_05d0: ldloc.s 4
+			IL_05d2: stelem.ref
+			IL_05d3: dup
+			IL_05d4: ldc.i4.4
+			IL_05d5: ldloc.s 5
+			IL_05d7: stelem.ref
+			IL_05d8: dup
+			IL_05d9: ldc.i4.5
+			IL_05da: ldloc.s 6
+			IL_05dc: stelem.ref
+			IL_05dd: dup
+			IL_05de: ldc.i4.6
+			IL_05df: ldloc.s 7
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.7
+			IL_05e4: ldloc.s 8
+			IL_05e6: box [System.Runtime]System.Boolean
+			IL_05eb: stelem.ref
+			IL_05ec: dup
+			IL_05ed: ldc.i4.8
+			IL_05ee: ldloc.s 9
+			IL_05f0: box [System.Runtime]System.Boolean
+			IL_05f5: stelem.ref
+			IL_05f6: dup
+			IL_05f7: ldc.i4.s 9
+			IL_05f9: ldloc.s 10
+			IL_05fb: stelem.ref
+			IL_05fc: dup
+			IL_05fd: ldc.i4.s 10
+			IL_05ff: ldloc.s 11
+			IL_0601: stelem.ref
+			IL_0602: dup
+			IL_0603: ldc.i4.s 11
+			IL_0605: ldloc.s 12
+			IL_0607: box [System.Runtime]System.Double
+			IL_060c: stelem.ref
+			IL_060d: dup
+			IL_060e: ldc.i4.s 12
+			IL_0610: ldloc.s 13
+			IL_0612: stelem.ref
+			IL_0613: dup
+			IL_0614: ldc.i4.s 13
+			IL_0616: ldloc.s 14
+			IL_0618: stelem.ref
+			IL_0619: dup
+			IL_061a: ldc.i4.s 14
+			IL_061c: ldloc.s 15
+			IL_061e: stelem.ref
+			IL_061f: dup
+			IL_0620: ldc.i4.s 15
+			IL_0622: ldloc.s 16
+			IL_0624: stelem.ref
+			IL_0625: dup
+			IL_0626: ldc.i4.s 16
+			IL_0628: ldloc.s 17
 			IL_062a: stelem.ref
 			IL_062b: dup
-			IL_062c: ldc.i4.8
-			IL_062d: ldloc.s 9
-			IL_062f: stelem.ref
-			IL_0630: dup
-			IL_0631: ldc.i4.s 9
-			IL_0633: ldloc.s 10
-			IL_0635: box [System.Runtime]System.Boolean
-			IL_063a: stelem.ref
-			IL_063b: dup
-			IL_063c: ldc.i4.s 10
-			IL_063e: ldloc.s 11
-			IL_0640: box [System.Runtime]System.Boolean
-			IL_0645: stelem.ref
-			IL_0646: dup
-			IL_0647: ldc.i4.s 11
-			IL_0649: ldloc.s 12
-			IL_064b: stelem.ref
-			IL_064c: dup
-			IL_064d: ldc.i4.s 12
-			IL_064f: ldloc.s 13
-			IL_0651: stelem.ref
-			IL_0652: dup
-			IL_0653: ldc.i4.s 13
-			IL_0655: ldloc.s 14
-			IL_0657: box [System.Runtime]System.Double
-			IL_065c: stelem.ref
-			IL_065d: dup
-			IL_065e: ldc.i4.s 14
-			IL_0660: ldloc.s 15
-			IL_0662: stelem.ref
-			IL_0663: dup
-			IL_0664: ldc.i4.s 15
-			IL_0666: ldloc.s 16
-			IL_0668: stelem.ref
-			IL_0669: dup
-			IL_066a: ldc.i4.s 16
-			IL_066c: ldloc.s 17
-			IL_066e: stelem.ref
-			IL_066f: dup
-			IL_0670: ldc.i4.s 17
-			IL_0672: ldloc.s 18
-			IL_0674: stelem.ref
-			IL_0675: dup
-			IL_0676: ldc.i4.s 18
-			IL_0678: ldloc.s 19
-			IL_067a: stelem.ref
-			IL_067b: dup
-			IL_067c: ldc.i4.s 19
-			IL_067e: ldloc.s 20
-			IL_0680: box [System.Runtime]System.Boolean
-			IL_0685: stelem.ref
-			IL_0686: dup
-			IL_0687: ldc.i4.s 20
-			IL_0689: ldloc.s 21
-			IL_068b: stelem.ref
-			IL_068c: dup
-			IL_068d: ldc.i4.s 21
-			IL_068f: ldloc.s 22
-			IL_0691: stelem.ref
-			IL_0692: dup
-			IL_0693: ldc.i4.s 22
-			IL_0695: ldloc.s 23
-			IL_0697: stelem.ref
-			IL_0698: pop
-			IL_0699: ldloc.0
-			IL_069a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_069f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06a4: ret
+			IL_062c: ldc.i4.s 17
+			IL_062e: ldloc.s 18
+			IL_0630: box [System.Runtime]System.Boolean
+			IL_0635: stelem.ref
+			IL_0636: dup
+			IL_0637: ldc.i4.s 18
+			IL_0639: ldloc.s 19
+			IL_063b: stelem.ref
+			IL_063c: dup
+			IL_063d: ldc.i4.s 19
+			IL_063f: ldloc.s 20
+			IL_0641: stelem.ref
+			IL_0642: dup
+			IL_0643: ldc.i4.s 20
+			IL_0645: ldloc.s 21
+			IL_0647: stelem.ref
+			IL_0648: pop
+			IL_0649: ldloc.0
+			IL_064a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_064f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0654: ret
 
-			IL_06a5: ldloc.0
-			IL_06a6: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
-			IL_06ab: pop
-			IL_06ac: ldstr "console"
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06b6: stloc.s 17
-			IL_06b8: ldloc.s 17
-			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06bf: stloc.s 17
-			IL_06c1: ldloc.s 4
-			IL_06c3: ldstr "fd"
-			IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06cd: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_06d2: ldstr "number"
-			IL_06d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_06dc: stloc.s 20
-			IL_06de: ldloc.s 20
-			IL_06e0: box [System.Runtime]System.Boolean
-			IL_06e5: stloc.s 21
-			IL_06e7: ldloc.s 17
-			IL_06e9: ldstr "log"
-			IL_06ee: ldstr "FDIsNumber:"
-			IL_06f3: ldloc.s 21
-			IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_06fa: pop
-			IL_06fb: ldstr "console"
-			IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0705: stloc.s 17
-			IL_0707: ldloc.s 17
-			IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_070e: stloc.s 17
-			IL_0710: ldloc.s 17
-			IL_0712: ldstr "log"
-			IL_0717: ldstr "BytesWritten:"
-			IL_071c: ldloc.s 5
-			IL_071e: ldstr "bytesWritten"
-			IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_072d: pop
-			IL_072e: ldstr "console"
-			IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0738: stloc.s 17
-			IL_073a: ldloc.s 17
-			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0741: stloc.s 17
-			IL_0743: ldloc.s 17
-			IL_0745: ldstr "log"
-			IL_074a: ldstr "BytesRead:"
-			IL_074f: ldloc.s 7
-			IL_0751: ldstr "bytesRead"
-			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0760: pop
-			IL_0761: ldstr "console"
-			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_076b: stloc.s 17
-			IL_076d: ldloc.s 17
-			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0774: stloc.s 17
-			IL_0776: ldloc.s 6
-			IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_077d: stloc.s 12
-			IL_077f: ldloc.s 12
-			IL_0781: ldstr "toString"
-			IL_0786: ldstr "utf8"
-			IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0790: stloc.s 12
-			IL_0792: ldloc.s 17
-			IL_0794: ldstr "log"
-			IL_0799: ldstr "BufferText:"
-			IL_079e: ldloc.s 12
-			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_07a5: pop
-			IL_07a6: br IL_0840
+			IL_0655: ldloc.0
+			IL_0656: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
+			IL_065b: pop
+			IL_065c: ldstr "console"
+			IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0666: stloc.s 15
+			IL_0668: ldloc.s 15
+			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_066f: stloc.s 15
+			IL_0671: ldloc.3
+			IL_0672: ldstr "fd"
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_067c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0681: ldstr "number"
+			IL_0686: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_068b: stloc.s 18
+			IL_068d: ldloc.s 18
+			IL_068f: box [System.Runtime]System.Boolean
+			IL_0694: stloc.s 19
+			IL_0696: ldloc.s 15
+			IL_0698: ldstr "log"
+			IL_069d: ldstr "FDIsNumber:"
+			IL_06a2: ldloc.s 19
+			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06a9: pop
+			IL_06aa: ldstr "console"
+			IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06b4: stloc.s 15
+			IL_06b6: ldloc.s 15
+			IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06bd: stloc.s 15
+			IL_06bf: ldloc.s 15
+			IL_06c1: ldstr "log"
+			IL_06c6: ldstr "BytesWritten:"
+			IL_06cb: ldloc.s 4
+			IL_06cd: ldstr "bytesWritten"
+			IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_06dc: pop
+			IL_06dd: ldstr "console"
+			IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06e7: stloc.s 15
+			IL_06e9: ldloc.s 15
+			IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06f0: stloc.s 15
+			IL_06f2: ldloc.s 15
+			IL_06f4: ldstr "log"
+			IL_06f9: ldstr "BytesRead:"
+			IL_06fe: ldloc.s 6
+			IL_0700: ldstr "bytesRead"
+			IL_0705: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_070f: pop
+			IL_0710: ldstr "console"
+			IL_0715: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_071a: stloc.s 15
+			IL_071c: ldloc.s 15
+			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0723: stloc.s 15
+			IL_0725: ldloc.s 5
+			IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_072c: stloc.s 10
+			IL_072e: ldloc.s 10
+			IL_0730: ldstr "toString"
+			IL_0735: ldstr "utf8"
+			IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_073f: stloc.s 10
+			IL_0741: ldloc.s 15
+			IL_0743: ldstr "log"
+			IL_0748: ldstr "BufferText:"
+			IL_074d: ldloc.s 10
+			IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0754: pop
+			IL_0755: br IL_07e8
 
-			IL_07ab: ldloc.0
-			IL_07ac: ldc.i4.1
-			IL_07ad: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07b2: ldloc.0
-			IL_07b3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07b8: stloc.s 12
-			IL_07ba: ldloc.0
-			IL_07bb: ldc.i4.0
-			IL_07bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07c1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07c6: ldloc.0
-			IL_07c7: ldc.i4.0
-			IL_07c8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07cd: ldloc.s 12
-			IL_07cf: stloc.s 8
-			IL_07d1: newobj instance void Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope/Block_L25C18::.ctor()
-			IL_07d6: stloc.s 9
-			IL_07d8: ldstr "console"
-			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07e2: stloc.s 12
-			IL_07e4: ldloc.s 12
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07eb: stloc.s 12
-			IL_07ed: ldloc.s 8
-			IL_07ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07f4: stloc.s 20
-			IL_07f6: ldloc.s 20
-			IL_07f8: brfalse IL_0810
+			IL_075a: ldloc.0
+			IL_075b: ldc.i4.1
+			IL_075c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0761: ldloc.0
+			IL_0762: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0767: stloc.s 10
+			IL_0769: ldloc.0
+			IL_076a: ldc.i4.0
+			IL_076b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0770: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0775: ldloc.0
+			IL_0776: ldc.i4.0
+			IL_0777: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_077c: ldloc.s 10
+			IL_077e: stloc.s 7
+			IL_0780: ldstr "console"
+			IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_078a: stloc.s 10
+			IL_078c: ldloc.s 10
+			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0793: stloc.s 10
+			IL_0795: ldloc.s 7
+			IL_0797: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_079c: stloc.s 18
+			IL_079e: ldloc.s 18
+			IL_07a0: brfalse IL_07b8
 
-			IL_07fd: ldloc.s 8
-			IL_07ff: ldstr "message"
-			IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0809: stloc.s 23
-			IL_080b: br IL_0814
+			IL_07a5: ldloc.s 7
+			IL_07a7: ldstr "message"
+			IL_07ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07b1: stloc.s 21
+			IL_07b3: br IL_07bc
 
-			IL_0810: ldloc.s 8
-			IL_0812: stloc.s 23
+			IL_07b8: ldloc.s 7
+			IL_07ba: stloc.s 21
 
-			IL_0814: ldloc.s 12
-			IL_0816: ldstr "log"
-			IL_081b: ldstr "Error:"
-			IL_0820: ldloc.s 23
-			IL_0822: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0827: pop
-			IL_0828: br IL_0840
+			IL_07bc: ldloc.s 10
+			IL_07be: ldstr "log"
+			IL_07c3: ldstr "Error:"
+			IL_07c8: ldloc.s 21
+			IL_07ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_07cf: pop
+			IL_07d0: br IL_07e8
 
-			IL_082d: ldloc.0
-			IL_082e: ldc.i4.1
-			IL_082f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0834: ldloc.0
-			IL_0835: ldc.i4.0
-			IL_0836: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_083b: br IL_0840
+			IL_07d5: ldloc.0
+			IL_07d6: ldc.i4.1
+			IL_07d7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07dc: ldloc.0
+			IL_07dd: ldc.i4.0
+			IL_07de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_07e3: br IL_07e8
 
-			IL_0840: ldarg.0
-			IL_0841: ldc.i4.1
-			IL_0842: ldelem.ref
-			IL_0843: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0848: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_084d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0852: stloc.s 12
-			IL_0854: ldloc.s 12
-			IL_0856: ldstr "rmSync"
-			IL_085b: ldloc.2
-			IL_085c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0861: dup
-			IL_0862: ldstr "force"
-			IL_0867: ldc.i4.1
-			IL_0868: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0872: pop
-			IL_0873: br IL_088b
+			IL_07e8: ldarg.0
+			IL_07e9: ldc.i4.1
+			IL_07ea: ldelem.ref
+			IL_07eb: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_07f0: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07fa: stloc.s 10
+			IL_07fc: ldloc.s 10
+			IL_07fe: ldstr "rmSync"
+			IL_0803: ldloc.2
+			IL_0804: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0809: dup
+			IL_080a: ldstr "force"
+			IL_080f: ldc.i4.1
+			IL_0810: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0815: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_081a: pop
+			IL_081b: br IL_0833
 
-			IL_0878: ldloc.0
-			IL_0879: ldc.i4.1
-			IL_087a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_087f: ldloc.0
-			IL_0880: ldc.i4.0
-			IL_0881: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0886: br IL_088b
+			IL_0820: ldloc.0
+			IL_0821: ldc.i4.1
+			IL_0822: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0827: ldloc.0
+			IL_0828: ldc.i4.0
+			IL_0829: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_082e: br IL_0833
 
-			IL_088b: ldloc.0
-			IL_088c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0891: stloc.s 10
-			IL_0893: ldloc.s 10
-			IL_0895: brfalse IL_08d2
+			IL_0833: ldloc.0
+			IL_0834: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0839: stloc.s 8
+			IL_083b: ldloc.s 8
+			IL_083d: brfalse IL_087a
 
-			IL_089a: ldloc.0
-			IL_089b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08a0: stloc.s 12
-			IL_08a2: ldloc.0
-			IL_08a3: ldc.i4.m1
-			IL_08a4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08a9: ldloc.0
-			IL_08aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_08b4: ldarg.0
-			IL_08b5: ldc.i4.1
-			IL_08b6: newarr [System.Runtime]System.Object
-			IL_08bb: dup
-			IL_08bc: ldc.i4.0
-			IL_08bd: ldloc.s 12
-			IL_08bf: stelem.ref
-			IL_08c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08c5: pop
-			IL_08c6: ldloc.0
-			IL_08c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08d1: ret
+			IL_0842: ldloc.0
+			IL_0843: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0848: stloc.s 10
+			IL_084a: ldloc.0
+			IL_084b: ldc.i4.m1
+			IL_084c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0851: ldloc.0
+			IL_0852: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0857: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_085c: ldarg.0
+			IL_085d: ldc.i4.1
+			IL_085e: newarr [System.Runtime]System.Object
+			IL_0863: dup
+			IL_0864: ldc.i4.0
+			IL_0865: ldloc.s 10
+			IL_0867: stelem.ref
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_086d: pop
+			IL_086e: ldloc.0
+			IL_086f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0874: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0879: ret
 
-			IL_08d2: ldloc.0
-			IL_08d3: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08d8: stloc.s 11
-			IL_08da: ldloc.s 11
-			IL_08dc: brfalse IL_0919
+			IL_087a: ldloc.0
+			IL_087b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0880: stloc.s 9
+			IL_0882: ldloc.s 9
+			IL_0884: brfalse IL_08c1
 
-			IL_08e1: ldloc.0
-			IL_08e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_08e7: stloc.s 12
-			IL_08e9: ldloc.0
-			IL_08ea: ldc.i4.m1
-			IL_08eb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08f0: ldloc.0
-			IL_08f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_08fb: ldarg.0
-			IL_08fc: ldc.i4.1
-			IL_08fd: newarr [System.Runtime]System.Object
-			IL_0902: dup
-			IL_0903: ldc.i4.0
-			IL_0904: ldloc.s 12
-			IL_0906: stelem.ref
-			IL_0907: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_090c: pop
-			IL_090d: ldloc.0
-			IL_090e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0913: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0918: ret
+			IL_0889: ldloc.0
+			IL_088a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_088f: stloc.s 10
+			IL_0891: ldloc.0
+			IL_0892: ldc.i4.m1
+			IL_0893: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0898: ldloc.0
+			IL_0899: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_089e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08a3: ldarg.0
+			IL_08a4: ldc.i4.1
+			IL_08a5: newarr [System.Runtime]System.Object
+			IL_08aa: dup
+			IL_08ab: ldc.i4.0
+			IL_08ac: ldloc.s 10
+			IL_08ae: stelem.ref
+			IL_08af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08b4: pop
+			IL_08b5: ldloc.0
+			IL_08b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08c0: ret
 
-			IL_0919: ldloc.0
-			IL_091a: ldc.i4.m1
-			IL_091b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0920: ldloc.0
-			IL_0921: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0926: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_092b: ldarg.0
-			IL_092c: ldc.i4.1
-			IL_092d: newarr [System.Runtime]System.Object
-			IL_0932: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0937: pop
-			IL_0938: ldloc.0
-			IL_0939: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_093e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0943: ret
+			IL_08c1: ldloc.0
+			IL_08c2: ldc.i4.m1
+			IL_08c3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08c8: ldloc.0
+			IL_08c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08d3: ldarg.0
+			IL_08d4: ldc.i4.1
+			IL_08d5: newarr [System.Runtime]System.Object
+			IL_08da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08df: pop
+			IL_08e0: ldloc.0
+			IL_08e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08eb: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1227,7 +1179,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a38
+			// Method begins at RVA 0x29e0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1324,7 +1276,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a65
+		// Method begins at RVA 0x2a0d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x283e
+						// Method begins at RVA 0x2826
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2847
+						// Method begins at RVA 0x282f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2835
+					// Method begins at RVA 0x281d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2850
+					// Method begins at RVA 0x2838
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282c
+				// Method begins at RVA 0x2814
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20e8
 			// Header size: 12
-			// Code size: 1839 (0x72f)
+			// Code size: 1815 (0x717)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope,
@@ -163,19 +163,18 @@
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22,
+				[7] bool,
 				[8] bool,
-				[9] bool,
-				[10] object,
-				[11] string,
-				[12] float64,
-				[13] object,
-				[14] string,
-				[15] object,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[17] bool,
-				[18] object,
-				[19] object
+				[9] object,
+				[10] string,
+				[11] float64,
+				[12] object,
+				[13] string,
+				[14] object,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[16] bool,
+				[17] object,
+				[18] object
 			)
 
 			IL_0000: ldarg.0
@@ -208,14 +207,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 19
+			IL_0048: ldc.i4.s 18
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_00fa
+			IL_005b: ble IL_00ef
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -247,7 +246,7 @@
 			IL_0086: dup
 			IL_0087: ldc.i4.6
 			IL_0088: ldelem.ref
-			IL_0089: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22
+			IL_0089: unbox.any [System.Runtime]System.Boolean
 			IL_008e: stloc.s 7
 			IL_0090: dup
 			IL_0091: ldc.i4.7
@@ -257,629 +256,618 @@
 			IL_009a: dup
 			IL_009b: ldc.i4.8
 			IL_009c: ldelem.ref
-			IL_009d: unbox.any [System.Runtime]System.Boolean
-			IL_00a2: stloc.s 9
-			IL_00a4: dup
-			IL_00a5: ldc.i4.s 9
-			IL_00a7: ldelem.ref
+			IL_009d: stloc.s 9
+			IL_009f: dup
+			IL_00a0: ldc.i4.s 9
+			IL_00a2: ldelem.ref
+			IL_00a3: castclass [System.Runtime]System.String
 			IL_00a8: stloc.s 10
 			IL_00aa: dup
 			IL_00ab: ldc.i4.s 10
 			IL_00ad: ldelem.ref
-			IL_00ae: castclass [System.Runtime]System.String
+			IL_00ae: unbox.any [System.Runtime]System.Double
 			IL_00b3: stloc.s 11
 			IL_00b5: dup
 			IL_00b6: ldc.i4.s 11
 			IL_00b8: ldelem.ref
-			IL_00b9: unbox.any [System.Runtime]System.Double
-			IL_00be: stloc.s 12
-			IL_00c0: dup
-			IL_00c1: ldc.i4.s 12
-			IL_00c3: ldelem.ref
+			IL_00b9: stloc.s 12
+			IL_00bb: dup
+			IL_00bc: ldc.i4.s 12
+			IL_00be: ldelem.ref
+			IL_00bf: castclass [System.Runtime]System.String
 			IL_00c4: stloc.s 13
 			IL_00c6: dup
 			IL_00c7: ldc.i4.s 13
 			IL_00c9: ldelem.ref
-			IL_00ca: castclass [System.Runtime]System.String
-			IL_00cf: stloc.s 14
-			IL_00d1: dup
-			IL_00d2: ldc.i4.s 14
-			IL_00d4: ldelem.ref
+			IL_00ca: stloc.s 14
+			IL_00cc: dup
+			IL_00cd: ldc.i4.s 14
+			IL_00cf: ldelem.ref
+			IL_00d0: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			IL_00d5: stloc.s 15
 			IL_00d7: dup
 			IL_00d8: ldc.i4.s 15
 			IL_00da: ldelem.ref
-			IL_00db: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			IL_00db: unbox.any [System.Runtime]System.Boolean
 			IL_00e0: stloc.s 16
 			IL_00e2: dup
 			IL_00e3: ldc.i4.s 16
 			IL_00e5: ldelem.ref
-			IL_00e6: unbox.any [System.Runtime]System.Boolean
-			IL_00eb: stloc.s 17
-			IL_00ed: dup
-			IL_00ee: ldc.i4.s 17
-			IL_00f0: ldelem.ref
-			IL_00f1: stloc.s 18
-			IL_00f3: dup
-			IL_00f4: ldc.i4.s 18
-			IL_00f6: ldelem.ref
-			IL_00f7: stloc.s 19
-			IL_00f9: pop
+			IL_00e6: stloc.s 17
+			IL_00e8: dup
+			IL_00e9: ldc.i4.s 17
+			IL_00eb: ldelem.ref
+			IL_00ec: stloc.s 18
+			IL_00ee: pop
 
-			IL_00fa: ldloc.0
-			IL_00fb: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0100: switch (IL_0119, IL_060c, IL_0663, IL_0483, IL_044b)
+			IL_00ef: ldloc.0
+			IL_00f0: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00f5: switch (IL_010e, IL_05f4, IL_064b, IL_0472, IL_043a)
 
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_011e: stloc.s 10
-			IL_0120: ldloc.s 10
-			IL_0122: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0127: stloc.s 11
-			IL_0129: ldstr ""
-			IL_012e: ldloc.s 11
-			IL_0130: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0135: stloc.s 11
-			IL_0137: ldloc.s 11
-			IL_0139: ldstr "-"
-			IL_013e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0143: stloc.s 11
-			IL_0145: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_014a: stloc.s 12
-			IL_014c: ldloc.s 12
-			IL_014e: ldc.r8 1000000000
-			IL_0157: mul
-			IL_0158: stloc.s 12
-			IL_015a: ldloc.s 12
-			IL_015c: box [System.Runtime]System.Double
-			IL_0161: stloc.s 13
-			IL_0163: ldloc.s 13
-			IL_0165: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-			IL_016a: stloc.s 12
-			IL_016c: ldloc.s 12
-			IL_016e: box [System.Runtime]System.Double
-			IL_0173: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0178: stloc.s 14
-			IL_017a: ldloc.s 11
-			IL_017c: ldloc.s 14
-			IL_017e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0183: stloc.s 14
-			IL_0185: ldloc.s 14
-			IL_0187: stloc.1
-			IL_0188: ldarg.0
-			IL_0189: ldc.i4.1
-			IL_018a: ldelem.ref
-			IL_018b: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0190: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_019a: stloc.s 10
-			IL_019c: ldarg.0
-			IL_019d: ldc.i4.1
-			IL_019e: ldelem.ref
-			IL_019f: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01a4: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ae: stloc.s 15
-			IL_01b0: ldloc.s 15
-			IL_01b2: ldstr "tmpdir"
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01bc: stloc.s 15
-			IL_01be: ldloc.1
-			IL_01bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c4: stloc.s 14
-			IL_01c6: ldstr "jroc-fs-rename-existing-dir-"
-			IL_01cb: ldloc.s 14
-			IL_01cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d2: stloc.s 14
-			IL_01d4: ldloc.s 10
-			IL_01d6: ldstr "join"
-			IL_01db: ldloc.s 15
-			IL_01dd: ldloc.s 14
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01e4: stloc.s 15
-			IL_01e6: ldloc.s 15
-			IL_01e8: stloc.2
-			IL_01e9: ldarg.0
-			IL_01ea: ldc.i4.1
-			IL_01eb: ldelem.ref
-			IL_01ec: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01f1: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fb: stloc.s 15
-			IL_01fd: ldloc.s 15
-			IL_01ff: ldstr "join"
-			IL_0204: ldloc.2
-			IL_0205: ldstr "source"
-			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_020f: stloc.s 15
-			IL_0211: ldloc.s 15
-			IL_0213: stloc.3
-			IL_0214: ldarg.0
-			IL_0215: ldc.i4.1
-			IL_0216: ldelem.ref
-			IL_0217: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_021c: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0226: stloc.s 15
-			IL_0228: ldloc.s 15
-			IL_022a: ldstr "join"
-			IL_022f: ldloc.2
-			IL_0230: ldstr "destination"
-			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_023a: stloc.s 15
-			IL_023c: ldloc.s 15
-			IL_023e: stloc.s 4
-			IL_0240: ldarg.0
-			IL_0241: ldc.i4.1
-			IL_0242: ldelem.ref
-			IL_0243: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0248: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0252: stloc.s 15
-			IL_0254: ldloc.s 15
-			IL_0256: ldstr "join"
-			IL_025b: ldloc.s 4
-			IL_025d: ldstr "keep.txt"
-			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0267: stloc.s 15
-			IL_0269: ldloc.s 15
-			IL_026b: stloc.s 5
-			IL_026d: ldloc.0
-			IL_026e: ldc.i4.0
-			IL_026f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0274: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0279: ldloc.0
-			IL_027a: ldc.i4.0
-			IL_027b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0280: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0285: ldloc.0
-			IL_0286: ldc.i4.0
-			IL_0287: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_028c: ldloc.0
-			IL_028d: ldc.i4.0
-			IL_028e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0293: ldarg.0
-			IL_0294: ldc.i4.1
-			IL_0295: ldelem.ref
-			IL_0296: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_029b: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a5: stloc.s 15
-			IL_02a7: ldloc.s 15
-			IL_02a9: ldstr "rmSync"
-			IL_02ae: ldloc.2
-			IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02b4: dup
-			IL_02b5: ldstr "recursive"
-			IL_02ba: ldc.i4.1
-			IL_02bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02c0: dup
-			IL_02c1: ldstr "force"
-			IL_02c6: ldc.i4.1
-			IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02d1: pop
-			IL_02d2: ldarg.0
-			IL_02d3: ldc.i4.1
-			IL_02d4: ldelem.ref
-			IL_02d5: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02da: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e4: stloc.s 15
-			IL_02e6: ldloc.s 15
-			IL_02e8: ldstr "mkdirSync"
-			IL_02ed: ldloc.3
-			IL_02ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02f3: dup
-			IL_02f4: ldstr "recursive"
-			IL_02f9: ldc.i4.1
-			IL_02fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0304: pop
-			IL_0305: ldarg.0
-			IL_0306: ldc.i4.1
-			IL_0307: ldelem.ref
-			IL_0308: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_030d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0317: stloc.s 15
-			IL_0319: ldloc.s 15
-			IL_031b: ldstr "mkdirSync"
-			IL_0320: ldloc.s 4
-			IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0327: dup
-			IL_0328: ldstr "recursive"
-			IL_032d: ldc.i4.1
-			IL_032e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0338: pop
-			IL_0339: ldarg.0
-			IL_033a: ldc.i4.1
-			IL_033b: ldelem.ref
-			IL_033c: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0341: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_034b: stloc.s 15
-			IL_034d: ldloc.s 15
-			IL_034f: ldstr "writeFileSync"
-			IL_0354: ldloc.s 5
-			IL_0356: ldstr "keep"
-			IL_035b: ldstr "utf8"
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0365: pop
-			IL_0366: ldloc.0
-			IL_0367: ldc.i4.0
-			IL_0368: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_036d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0372: ldarg.0
-			IL_0373: ldc.i4.1
-			IL_0374: ldelem.ref
-			IL_0375: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_037a: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_037f: ldstr "promises"
-			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_038e: stloc.s 15
-			IL_0390: ldloc.s 15
-			IL_0392: ldstr "rename"
-			IL_0397: ldloc.3
-			IL_0398: ldloc.s 4
-			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_039f: stloc.s 15
-			IL_03a1: ldloc.0
-			IL_03a2: ldc.i4.4
-			IL_03a3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03a8: ldloc.0
-			IL_03a9: ldloc.s 15
-			IL_03ab: ldarg.0
-			IL_03ac: ldc.i4.1
-			IL_03ad: ldloc.0
-			IL_03ae: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03b3: ldc.i4.3
-			IL_03b4: ldstr "_pendingException"
-			IL_03b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03be: ldloc.0
-			IL_03bf: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03c4: dup
-			IL_03c5: ldc.i4.0
-			IL_03c6: ldloc.1
-			IL_03c7: stelem.ref
-			IL_03c8: dup
-			IL_03c9: ldc.i4.1
-			IL_03ca: ldloc.2
-			IL_03cb: stelem.ref
-			IL_03cc: dup
-			IL_03cd: ldc.i4.2
-			IL_03ce: ldloc.3
-			IL_03cf: stelem.ref
-			IL_03d0: dup
-			IL_03d1: ldc.i4.3
-			IL_03d2: ldloc.s 4
-			IL_03d4: stelem.ref
-			IL_03d5: dup
-			IL_03d6: ldc.i4.4
-			IL_03d7: ldloc.s 5
-			IL_03d9: stelem.ref
-			IL_03da: dup
-			IL_03db: ldc.i4.5
-			IL_03dc: ldloc.s 6
-			IL_03de: stelem.ref
-			IL_03df: dup
-			IL_03e0: ldc.i4.6
-			IL_03e1: ldloc.s 7
-			IL_03e3: stelem.ref
-			IL_03e4: dup
-			IL_03e5: ldc.i4.7
-			IL_03e6: ldloc.s 8
-			IL_03e8: box [System.Runtime]System.Boolean
-			IL_03ed: stelem.ref
-			IL_03ee: dup
-			IL_03ef: ldc.i4.8
-			IL_03f0: ldloc.s 9
-			IL_03f2: box [System.Runtime]System.Boolean
-			IL_03f7: stelem.ref
-			IL_03f8: dup
-			IL_03f9: ldc.i4.s 9
-			IL_03fb: ldloc.s 10
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_0113: stloc.s 9
+			IL_0115: ldloc.s 9
+			IL_0117: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_011c: stloc.s 10
+			IL_011e: ldstr ""
+			IL_0123: ldloc.s 10
+			IL_0125: call string [System.Runtime]System.String::Concat(string, string)
+			IL_012a: stloc.s 10
+			IL_012c: ldloc.s 10
+			IL_012e: ldstr "-"
+			IL_0133: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0138: stloc.s 10
+			IL_013a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_013f: stloc.s 11
+			IL_0141: ldloc.s 11
+			IL_0143: ldc.r8 1000000000
+			IL_014c: mul
+			IL_014d: stloc.s 11
+			IL_014f: ldloc.s 11
+			IL_0151: box [System.Runtime]System.Double
+			IL_0156: stloc.s 12
+			IL_0158: ldloc.s 12
+			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+			IL_015f: stloc.s 11
+			IL_0161: ldloc.s 11
+			IL_0163: box [System.Runtime]System.Double
+			IL_0168: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_016d: stloc.s 13
+			IL_016f: ldloc.s 10
+			IL_0171: ldloc.s 13
+			IL_0173: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0178: stloc.s 13
+			IL_017a: ldloc.s 13
+			IL_017c: stloc.1
+			IL_017d: ldarg.0
+			IL_017e: ldc.i4.1
+			IL_017f: ldelem.ref
+			IL_0180: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0185: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018f: stloc.s 9
+			IL_0191: ldarg.0
+			IL_0192: ldc.i4.1
+			IL_0193: ldelem.ref
+			IL_0194: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0199: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a3: stloc.s 14
+			IL_01a5: ldloc.s 14
+			IL_01a7: ldstr "tmpdir"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01b1: stloc.s 14
+			IL_01b3: ldloc.1
+			IL_01b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b9: stloc.s 13
+			IL_01bb: ldstr "jroc-fs-rename-existing-dir-"
+			IL_01c0: ldloc.s 13
+			IL_01c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c7: stloc.s 13
+			IL_01c9: ldloc.s 9
+			IL_01cb: ldstr "join"
+			IL_01d0: ldloc.s 14
+			IL_01d2: ldloc.s 13
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01d9: stloc.s 14
+			IL_01db: ldloc.s 14
+			IL_01dd: stloc.2
+			IL_01de: ldarg.0
+			IL_01df: ldc.i4.1
+			IL_01e0: ldelem.ref
+			IL_01e1: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01e6: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f0: stloc.s 14
+			IL_01f2: ldloc.s 14
+			IL_01f4: ldstr "join"
+			IL_01f9: ldloc.2
+			IL_01fa: ldstr "source"
+			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0204: stloc.s 14
+			IL_0206: ldloc.s 14
+			IL_0208: stloc.3
+			IL_0209: ldarg.0
+			IL_020a: ldc.i4.1
+			IL_020b: ldelem.ref
+			IL_020c: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0211: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021b: stloc.s 14
+			IL_021d: ldloc.s 14
+			IL_021f: ldstr "join"
+			IL_0224: ldloc.2
+			IL_0225: ldstr "destination"
+			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_022f: stloc.s 14
+			IL_0231: ldloc.s 14
+			IL_0233: stloc.s 4
+			IL_0235: ldarg.0
+			IL_0236: ldc.i4.1
+			IL_0237: ldelem.ref
+			IL_0238: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_023d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0247: stloc.s 14
+			IL_0249: ldloc.s 14
+			IL_024b: ldstr "join"
+			IL_0250: ldloc.s 4
+			IL_0252: ldstr "keep.txt"
+			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_025c: stloc.s 14
+			IL_025e: ldloc.s 14
+			IL_0260: stloc.s 5
+			IL_0262: ldloc.0
+			IL_0263: ldc.i4.0
+			IL_0264: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0269: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_026e: ldloc.0
+			IL_026f: ldc.i4.0
+			IL_0270: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0275: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_027a: ldloc.0
+			IL_027b: ldc.i4.0
+			IL_027c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0281: ldloc.0
+			IL_0282: ldc.i4.0
+			IL_0283: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0288: ldarg.0
+			IL_0289: ldc.i4.1
+			IL_028a: ldelem.ref
+			IL_028b: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0290: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_029a: stloc.s 14
+			IL_029c: ldloc.s 14
+			IL_029e: ldstr "rmSync"
+			IL_02a3: ldloc.2
+			IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a9: dup
+			IL_02aa: ldstr "recursive"
+			IL_02af: ldc.i4.1
+			IL_02b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02b5: dup
+			IL_02b6: ldstr "force"
+			IL_02bb: ldc.i4.1
+			IL_02bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02c6: pop
+			IL_02c7: ldarg.0
+			IL_02c8: ldc.i4.1
+			IL_02c9: ldelem.ref
+			IL_02ca: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02cf: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d9: stloc.s 14
+			IL_02db: ldloc.s 14
+			IL_02dd: ldstr "mkdirSync"
+			IL_02e2: ldloc.3
+			IL_02e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02e8: dup
+			IL_02e9: ldstr "recursive"
+			IL_02ee: ldc.i4.1
+			IL_02ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02f9: pop
+			IL_02fa: ldarg.0
+			IL_02fb: ldc.i4.1
+			IL_02fc: ldelem.ref
+			IL_02fd: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0302: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_030c: stloc.s 14
+			IL_030e: ldloc.s 14
+			IL_0310: ldstr "mkdirSync"
+			IL_0315: ldloc.s 4
+			IL_0317: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_031c: dup
+			IL_031d: ldstr "recursive"
+			IL_0322: ldc.i4.1
+			IL_0323: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_032d: pop
+			IL_032e: ldarg.0
+			IL_032f: ldc.i4.1
+			IL_0330: ldelem.ref
+			IL_0331: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0336: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0340: stloc.s 14
+			IL_0342: ldloc.s 14
+			IL_0344: ldstr "writeFileSync"
+			IL_0349: ldloc.s 5
+			IL_034b: ldstr "keep"
+			IL_0350: ldstr "utf8"
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_035a: pop
+			IL_035b: ldloc.0
+			IL_035c: ldc.i4.0
+			IL_035d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0362: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0367: ldarg.0
+			IL_0368: ldc.i4.1
+			IL_0369: ldelem.ref
+			IL_036a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_036f: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0374: ldstr "promises"
+			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0383: stloc.s 14
+			IL_0385: ldloc.s 14
+			IL_0387: ldstr "rename"
+			IL_038c: ldloc.3
+			IL_038d: ldloc.s 4
+			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0394: stloc.s 14
+			IL_0396: ldloc.0
+			IL_0397: ldc.i4.4
+			IL_0398: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_039d: ldloc.0
+			IL_039e: ldloc.s 14
+			IL_03a0: ldarg.0
+			IL_03a1: ldc.i4.1
+			IL_03a2: ldloc.0
+			IL_03a3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03a8: ldc.i4.3
+			IL_03a9: ldstr "_pendingException"
+			IL_03ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03b3: ldloc.0
+			IL_03b4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03b9: dup
+			IL_03ba: ldc.i4.0
+			IL_03bb: ldloc.1
+			IL_03bc: stelem.ref
+			IL_03bd: dup
+			IL_03be: ldc.i4.1
+			IL_03bf: ldloc.2
+			IL_03c0: stelem.ref
+			IL_03c1: dup
+			IL_03c2: ldc.i4.2
+			IL_03c3: ldloc.3
+			IL_03c4: stelem.ref
+			IL_03c5: dup
+			IL_03c6: ldc.i4.3
+			IL_03c7: ldloc.s 4
+			IL_03c9: stelem.ref
+			IL_03ca: dup
+			IL_03cb: ldc.i4.4
+			IL_03cc: ldloc.s 5
+			IL_03ce: stelem.ref
+			IL_03cf: dup
+			IL_03d0: ldc.i4.5
+			IL_03d1: ldloc.s 6
+			IL_03d3: stelem.ref
+			IL_03d4: dup
+			IL_03d5: ldc.i4.6
+			IL_03d6: ldloc.s 7
+			IL_03d8: box [System.Runtime]System.Boolean
+			IL_03dd: stelem.ref
+			IL_03de: dup
+			IL_03df: ldc.i4.7
+			IL_03e0: ldloc.s 8
+			IL_03e2: box [System.Runtime]System.Boolean
+			IL_03e7: stelem.ref
+			IL_03e8: dup
+			IL_03e9: ldc.i4.8
+			IL_03ea: ldloc.s 9
+			IL_03ec: stelem.ref
+			IL_03ed: dup
+			IL_03ee: ldc.i4.s 9
+			IL_03f0: ldloc.s 10
+			IL_03f2: stelem.ref
+			IL_03f3: dup
+			IL_03f4: ldc.i4.s 10
+			IL_03f6: ldloc.s 11
+			IL_03f8: box [System.Runtime]System.Double
 			IL_03fd: stelem.ref
 			IL_03fe: dup
-			IL_03ff: ldc.i4.s 10
-			IL_0401: ldloc.s 11
+			IL_03ff: ldc.i4.s 11
+			IL_0401: ldloc.s 12
 			IL_0403: stelem.ref
 			IL_0404: dup
-			IL_0405: ldc.i4.s 11
-			IL_0407: ldloc.s 12
-			IL_0409: box [System.Runtime]System.Double
-			IL_040e: stelem.ref
-			IL_040f: dup
-			IL_0410: ldc.i4.s 12
-			IL_0412: ldloc.s 13
-			IL_0414: stelem.ref
-			IL_0415: dup
-			IL_0416: ldc.i4.s 13
-			IL_0418: ldloc.s 14
-			IL_041a: stelem.ref
-			IL_041b: dup
-			IL_041c: ldc.i4.s 14
-			IL_041e: ldloc.s 15
+			IL_0405: ldc.i4.s 12
+			IL_0407: ldloc.s 13
+			IL_0409: stelem.ref
+			IL_040a: dup
+			IL_040b: ldc.i4.s 13
+			IL_040d: ldloc.s 14
+			IL_040f: stelem.ref
+			IL_0410: dup
+			IL_0411: ldc.i4.s 14
+			IL_0413: ldloc.s 15
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.s 15
+			IL_0419: ldloc.s 16
+			IL_041b: box [System.Runtime]System.Boolean
 			IL_0420: stelem.ref
 			IL_0421: dup
-			IL_0422: ldc.i4.s 15
-			IL_0424: ldloc.s 16
+			IL_0422: ldc.i4.s 16
+			IL_0424: ldloc.s 17
 			IL_0426: stelem.ref
 			IL_0427: dup
-			IL_0428: ldc.i4.s 16
-			IL_042a: ldloc.s 17
-			IL_042c: box [System.Runtime]System.Boolean
-			IL_0431: stelem.ref
-			IL_0432: dup
-			IL_0433: ldc.i4.s 17
-			IL_0435: ldloc.s 18
-			IL_0437: stelem.ref
-			IL_0438: dup
-			IL_0439: ldc.i4.s 18
-			IL_043b: ldloc.s 19
-			IL_043d: stelem.ref
-			IL_043e: pop
-			IL_043f: ldloc.0
-			IL_0440: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0445: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_044a: ret
+			IL_0428: ldc.i4.s 17
+			IL_042a: ldloc.s 18
+			IL_042c: stelem.ref
+			IL_042d: pop
+			IL_042e: ldloc.0
+			IL_042f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0434: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0439: ret
 
-			IL_044b: ldloc.0
-			IL_044c: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0451: pop
-			IL_0452: ldstr "console"
-			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_045c: stloc.s 15
-			IL_045e: ldloc.s 15
-			IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0465: stloc.s 15
-			IL_0467: ldloc.s 15
-			IL_0469: ldstr "log"
-			IL_046e: ldstr "RenameResult:"
-			IL_0473: ldstr "success"
-			IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_047d: pop
-			IL_047e: br IL_0521
+			IL_043a: ldloc.0
+			IL_043b: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
+			IL_0440: pop
+			IL_0441: ldstr "console"
+			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_044b: stloc.s 14
+			IL_044d: ldloc.s 14
+			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0454: stloc.s 14
+			IL_0456: ldloc.s 14
+			IL_0458: ldstr "log"
+			IL_045d: ldstr "RenameResult:"
+			IL_0462: ldstr "success"
+			IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_046c: pop
+			IL_046d: br IL_0509
 
-			IL_0483: ldloc.0
-			IL_0484: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0489: stloc.s 15
-			IL_048b: ldloc.0
-			IL_048c: ldc.i4.0
-			IL_048d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0492: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0497: ldloc.s 15
-			IL_0499: stloc.s 6
-			IL_049b: newobj instance void Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope/Block_L14C8/Block_L23C22::.ctor()
-			IL_04a0: stloc.s 7
-			IL_04a2: ldstr "console"
-			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04ac: stloc.s 15
-			IL_04ae: ldloc.s 15
-			IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04b5: stloc.s 15
-			IL_04b7: ldstr "^EPERM: "
-			IL_04bc: ldstr ""
-			IL_04c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_04c6: stloc.s 16
-			IL_04c8: ldloc.s 16
-			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04cf: stloc.s 10
-			IL_04d1: ldloc.s 6
-			IL_04d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04d8: stloc.s 17
-			IL_04da: ldloc.s 17
-			IL_04dc: brfalse IL_04f4
+			IL_0472: ldloc.0
+			IL_0473: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0478: stloc.s 14
+			IL_047a: ldloc.0
+			IL_047b: ldc.i4.0
+			IL_047c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0481: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0486: ldloc.s 14
+			IL_0488: stloc.s 6
+			IL_048a: ldstr "console"
+			IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0494: stloc.s 14
+			IL_0496: ldloc.s 14
+			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_049d: stloc.s 14
+			IL_049f: ldstr "^EPERM: "
+			IL_04a4: ldstr ""
+			IL_04a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_04ae: stloc.s 15
+			IL_04b0: ldloc.s 15
+			IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04b7: stloc.s 9
+			IL_04b9: ldloc.s 6
+			IL_04bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04c0: stloc.s 16
+			IL_04c2: ldloc.s 16
+			IL_04c4: brfalse IL_04dc
 
-			IL_04e1: ldloc.s 6
-			IL_04e3: ldstr "message"
-			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ed: stloc.s 19
-			IL_04ef: br IL_04f8
+			IL_04c9: ldloc.s 6
+			IL_04cb: ldstr "message"
+			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d5: stloc.s 18
+			IL_04d7: br IL_04e0
 
-			IL_04f4: ldloc.s 6
-			IL_04f6: stloc.s 19
+			IL_04dc: ldloc.s 6
+			IL_04de: stloc.s 18
 
-			IL_04f8: ldloc.s 10
-			IL_04fa: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_04ff: ldloc.s 19
-			IL_0501: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0506: stloc.s 10
-			IL_0508: ldloc.s 15
-			IL_050a: ldstr "log"
-			IL_050f: ldstr "RenameStartsWithEPERM:"
-			IL_0514: ldloc.s 10
-			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_051b: pop
-			IL_051c: br IL_0521
+			IL_04e0: ldloc.s 9
+			IL_04e2: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			IL_04e7: ldloc.s 18
+			IL_04e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04ee: stloc.s 9
+			IL_04f0: ldloc.s 14
+			IL_04f2: ldstr "log"
+			IL_04f7: ldstr "RenameStartsWithEPERM:"
+			IL_04fc: ldloc.s 9
+			IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0503: pop
+			IL_0504: br IL_0509
 
-			IL_0521: ldstr "console"
-			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_052b: stloc.s 10
-			IL_052d: ldloc.s 10
-			IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0534: stloc.s 10
-			IL_0536: ldarg.0
-			IL_0537: ldc.i4.1
-			IL_0538: ldelem.ref
-			IL_0539: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_053e: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0548: stloc.s 15
-			IL_054a: ldloc.s 15
-			IL_054c: ldstr "existsSync"
-			IL_0551: ldloc.3
-			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0557: stloc.s 15
-			IL_0559: ldloc.s 10
-			IL_055b: ldstr "log"
-			IL_0560: ldstr "SourceExists:"
-			IL_0565: ldloc.s 15
-			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_056c: pop
-			IL_056d: ldstr "console"
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0577: stloc.s 15
-			IL_0579: ldloc.s 15
-			IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0580: stloc.s 15
-			IL_0582: ldarg.0
-			IL_0583: ldc.i4.1
-			IL_0584: ldelem.ref
-			IL_0585: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_058a: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0594: stloc.s 10
-			IL_0596: ldloc.s 10
-			IL_0598: ldstr "existsSync"
-			IL_059d: ldloc.s 4
-			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05a4: stloc.s 10
-			IL_05a6: ldloc.s 15
-			IL_05a8: ldstr "log"
-			IL_05ad: ldstr "DestinationExists:"
-			IL_05b2: ldloc.s 10
-			IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05b9: pop
-			IL_05ba: ldstr "console"
-			IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05c4: stloc.s 10
-			IL_05c6: ldloc.s 10
-			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05cd: stloc.s 10
-			IL_05cf: ldarg.0
-			IL_05d0: ldc.i4.1
-			IL_05d1: ldelem.ref
-			IL_05d2: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_05d7: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05e1: stloc.s 15
-			IL_05e3: ldloc.s 15
-			IL_05e5: ldstr "existsSync"
-			IL_05ea: ldloc.s 5
-			IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05f1: stloc.s 15
-			IL_05f3: ldloc.s 10
-			IL_05f5: ldstr "log"
-			IL_05fa: ldstr "SentinelExists:"
-			IL_05ff: ldloc.s 15
-			IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0606: pop
-			IL_0607: br IL_061f
+			IL_0509: ldstr "console"
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0513: stloc.s 9
+			IL_0515: ldloc.s 9
+			IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_051c: stloc.s 9
+			IL_051e: ldarg.0
+			IL_051f: ldc.i4.1
+			IL_0520: ldelem.ref
+			IL_0521: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0526: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0530: stloc.s 14
+			IL_0532: ldloc.s 14
+			IL_0534: ldstr "existsSync"
+			IL_0539: ldloc.3
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_053f: stloc.s 14
+			IL_0541: ldloc.s 9
+			IL_0543: ldstr "log"
+			IL_0548: ldstr "SourceExists:"
+			IL_054d: ldloc.s 14
+			IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0554: pop
+			IL_0555: ldstr "console"
+			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_055f: stloc.s 14
+			IL_0561: ldloc.s 14
+			IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0568: stloc.s 14
+			IL_056a: ldarg.0
+			IL_056b: ldc.i4.1
+			IL_056c: ldelem.ref
+			IL_056d: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0572: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_057c: stloc.s 9
+			IL_057e: ldloc.s 9
+			IL_0580: ldstr "existsSync"
+			IL_0585: ldloc.s 4
+			IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_058c: stloc.s 9
+			IL_058e: ldloc.s 14
+			IL_0590: ldstr "log"
+			IL_0595: ldstr "DestinationExists:"
+			IL_059a: ldloc.s 9
+			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05a1: pop
+			IL_05a2: ldstr "console"
+			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05ac: stloc.s 9
+			IL_05ae: ldloc.s 9
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b5: stloc.s 9
+			IL_05b7: ldarg.0
+			IL_05b8: ldc.i4.1
+			IL_05b9: ldelem.ref
+			IL_05ba: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05bf: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c9: stloc.s 14
+			IL_05cb: ldloc.s 14
+			IL_05cd: ldstr "existsSync"
+			IL_05d2: ldloc.s 5
+			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05d9: stloc.s 14
+			IL_05db: ldloc.s 9
+			IL_05dd: ldstr "log"
+			IL_05e2: ldstr "SentinelExists:"
+			IL_05e7: ldloc.s 14
+			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05ee: pop
+			IL_05ef: br IL_0607
 
-			IL_060c: ldloc.0
-			IL_060d: ldc.i4.1
-			IL_060e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0613: ldloc.0
-			IL_0614: ldc.i4.0
-			IL_0615: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_061a: br IL_061f
+			IL_05f4: ldloc.0
+			IL_05f5: ldc.i4.1
+			IL_05f6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05fb: ldloc.0
+			IL_05fc: ldc.i4.0
+			IL_05fd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0602: br IL_0607
 
-			IL_061f: ldarg.0
-			IL_0620: ldc.i4.1
-			IL_0621: ldelem.ref
-			IL_0622: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0627: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0631: stloc.s 15
-			IL_0633: ldloc.s 15
-			IL_0635: ldstr "rmSync"
-			IL_063a: ldloc.2
-			IL_063b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0640: dup
-			IL_0641: ldstr "recursive"
-			IL_0646: ldc.i4.1
-			IL_0647: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_064c: dup
-			IL_064d: ldstr "force"
-			IL_0652: ldc.i4.1
-			IL_0653: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_065d: pop
-			IL_065e: br IL_0676
+			IL_0607: ldarg.0
+			IL_0608: ldc.i4.1
+			IL_0609: ldelem.ref
+			IL_060a: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_060f: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0619: stloc.s 14
+			IL_061b: ldloc.s 14
+			IL_061d: ldstr "rmSync"
+			IL_0622: ldloc.2
+			IL_0623: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0628: dup
+			IL_0629: ldstr "recursive"
+			IL_062e: ldc.i4.1
+			IL_062f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0634: dup
+			IL_0635: ldstr "force"
+			IL_063a: ldc.i4.1
+			IL_063b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0645: pop
+			IL_0646: br IL_065e
 
-			IL_0663: ldloc.0
-			IL_0664: ldc.i4.1
-			IL_0665: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_066a: ldloc.0
-			IL_066b: ldc.i4.0
-			IL_066c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0671: br IL_0676
+			IL_064b: ldloc.0
+			IL_064c: ldc.i4.1
+			IL_064d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0652: ldloc.0
+			IL_0653: ldc.i4.0
+			IL_0654: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0659: br IL_065e
 
-			IL_0676: ldloc.0
-			IL_0677: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_067c: stloc.s 8
-			IL_067e: ldloc.s 8
-			IL_0680: brfalse IL_06bd
+			IL_065e: ldloc.0
+			IL_065f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0664: stloc.s 7
+			IL_0666: ldloc.s 7
+			IL_0668: brfalse IL_06a5
 
-			IL_0685: ldloc.0
-			IL_0686: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_068b: stloc.s 15
-			IL_068d: ldloc.0
-			IL_068e: ldc.i4.m1
-			IL_068f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0694: ldloc.0
-			IL_0695: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_069a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_069f: ldarg.0
-			IL_06a0: ldc.i4.1
-			IL_06a1: newarr [System.Runtime]System.Object
-			IL_06a6: dup
-			IL_06a7: ldc.i4.0
-			IL_06a8: ldloc.s 15
-			IL_06aa: stelem.ref
-			IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06b0: pop
-			IL_06b1: ldloc.0
-			IL_06b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06b7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06bc: ret
+			IL_066d: ldloc.0
+			IL_066e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0673: stloc.s 14
+			IL_0675: ldloc.0
+			IL_0676: ldc.i4.m1
+			IL_0677: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_067c: ldloc.0
+			IL_067d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0682: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0687: ldarg.0
+			IL_0688: ldc.i4.1
+			IL_0689: newarr [System.Runtime]System.Object
+			IL_068e: dup
+			IL_068f: ldc.i4.0
+			IL_0690: ldloc.s 14
+			IL_0692: stelem.ref
+			IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0698: pop
+			IL_0699: ldloc.0
+			IL_069a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_069f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06a4: ret
 
-			IL_06bd: ldloc.0
-			IL_06be: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_06c3: stloc.s 9
-			IL_06c5: ldloc.s 9
-			IL_06c7: brfalse IL_0704
+			IL_06a5: ldloc.0
+			IL_06a6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_06ab: stloc.s 8
+			IL_06ad: ldloc.s 8
+			IL_06af: brfalse IL_06ec
 
-			IL_06cc: ldloc.0
-			IL_06cd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_06d2: stloc.s 15
-			IL_06d4: ldloc.0
-			IL_06d5: ldc.i4.m1
-			IL_06d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06db: ldloc.0
-			IL_06dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06e6: ldarg.0
-			IL_06e7: ldc.i4.1
-			IL_06e8: newarr [System.Runtime]System.Object
-			IL_06ed: dup
-			IL_06ee: ldc.i4.0
-			IL_06ef: ldloc.s 15
-			IL_06f1: stelem.ref
-			IL_06f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06f7: pop
-			IL_06f8: ldloc.0
-			IL_06f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06fe: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0703: ret
+			IL_06b4: ldloc.0
+			IL_06b5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_06ba: stloc.s 14
+			IL_06bc: ldloc.0
+			IL_06bd: ldc.i4.m1
+			IL_06be: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06c3: ldloc.0
+			IL_06c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06ce: ldarg.0
+			IL_06cf: ldc.i4.1
+			IL_06d0: newarr [System.Runtime]System.Object
+			IL_06d5: dup
+			IL_06d6: ldc.i4.0
+			IL_06d7: ldloc.s 14
+			IL_06d9: stelem.ref
+			IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06df: pop
+			IL_06e0: ldloc.0
+			IL_06e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06eb: ret
 
-			IL_0704: ldloc.0
-			IL_0705: ldc.i4.m1
-			IL_0706: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06ec: ldloc.0
+			IL_06ed: ldc.i4.m1
+			IL_06ee: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06f3: ldloc.0
+			IL_06f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06fe: ldarg.0
+			IL_06ff: ldc.i4.1
+			IL_0700: newarr [System.Runtime]System.Object
+			IL_0705: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_070a: pop
 			IL_070b: ldloc.0
 			IL_070c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0711: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0716: ldarg.0
-			IL_0717: ldc.i4.1
-			IL_0718: newarr [System.Runtime]System.Object
-			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0722: pop
-			IL_0723: ldloc.0
-			IL_0724: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0729: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_072e: ret
+			IL_0711: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0716: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -901,7 +889,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2823
+			// Method begins at RVA 0x280b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -998,7 +986,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2859
+		// Method begins at RVA 0x2841
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_StatSync_RichMetadata.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_StatSync_RichMetadata.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x267d
+				// Method begins at RVA 0x2679
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2686
+				// Method begins at RVA 0x2682
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2674
+			// Method begins at RVA 0x2670
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1532 (0x5fc)
+		// Code size: 1526 (0x5f6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_StatSync_RichMetadata/Scope,
@@ -92,20 +92,19 @@
 			[4] string,
 			[5] object,
 			[6] object,
-			[7] class Modules.FS_StatSync_RichMetadata/Scope/Block_L16C4,
+			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
-			[11] object,
-			[12] string,
-			[13] float64,
-			[14] object,
-			[15] string,
-			[16] object,
-			[17] bool,
+			[11] string,
+			[12] float64,
+			[13] object,
+			[14] string,
+			[15] object,
+			[16] bool,
+			[17] object,
 			[18] object,
-			[19] object,
-			[20] object
+			[19] object
 		)
 
 		IL_0000: newobj instance void Modules.FS_StatSync_RichMetadata/Scope::.ctor()
@@ -114,114 +113,114 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "fs"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 11
-		IL_0014: ldloc.s 11
+		IL_0012: stloc.s 10
+		IL_0014: ldloc.s 10
 		IL_0016: stloc.1
 		IL_0017: ldarg.1
 		IL_0018: ldstr "path"
 		IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0022: stloc.s 11
-		IL_0024: ldloc.s 11
+		IL_0022: stloc.s 10
+		IL_0024: ldloc.s 10
 		IL_0026: stloc.2
 		IL_0027: ldarg.1
 		IL_0028: ldstr "os"
 		IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0032: stloc.s 11
-		IL_0034: ldloc.s 11
+		IL_0032: stloc.s 10
+		IL_0034: ldloc.s 10
 		IL_0036: stloc.3
 		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-		IL_003c: stloc.s 11
-		IL_003e: ldloc.s 11
+		IL_003c: stloc.s 10
+		IL_003e: ldloc.s 10
 		IL_0040: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0045: stloc.s 12
+		IL_0045: stloc.s 11
 		IL_0047: ldstr ""
-		IL_004c: ldloc.s 12
+		IL_004c: ldloc.s 11
 		IL_004e: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0053: stloc.s 12
-		IL_0055: ldloc.s 12
+		IL_0053: stloc.s 11
+		IL_0055: ldloc.s 11
 		IL_0057: ldstr "-"
 		IL_005c: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0061: stloc.s 12
+		IL_0061: stloc.s 11
 		IL_0063: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-		IL_0068: stloc.s 13
-		IL_006a: ldloc.s 13
+		IL_0068: stloc.s 12
+		IL_006a: ldloc.s 12
 		IL_006c: ldc.r8 1000000000
 		IL_0075: mul
-		IL_0076: stloc.s 13
-		IL_0078: ldloc.s 13
+		IL_0076: stloc.s 12
+		IL_0078: ldloc.s 12
 		IL_007a: box [System.Runtime]System.Double
-		IL_007f: stloc.s 14
-		IL_0081: ldloc.s 14
+		IL_007f: stloc.s 13
+		IL_0081: ldloc.s 13
 		IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-		IL_0088: stloc.s 13
-		IL_008a: ldloc.s 13
+		IL_0088: stloc.s 12
+		IL_008a: ldloc.s 12
 		IL_008c: box [System.Runtime]System.Double
 		IL_0091: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0096: stloc.s 15
-		IL_0098: ldloc.s 12
-		IL_009a: ldloc.s 15
+		IL_0096: stloc.s 14
+		IL_0098: ldloc.s 11
+		IL_009a: ldloc.s 14
 		IL_009c: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00a1: stloc.s 15
-		IL_00a3: ldloc.s 15
+		IL_00a1: stloc.s 14
+		IL_00a3: ldloc.s 14
 		IL_00a5: stloc.s 4
 		IL_00a7: ldloc.2
 		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ad: stloc.s 11
+		IL_00ad: stloc.s 10
 		IL_00af: ldloc.3
 		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b5: stloc.s 16
-		IL_00b7: ldloc.s 16
+		IL_00b5: stloc.s 15
+		IL_00b7: ldloc.s 15
 		IL_00b9: ldstr "tmpdir"
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00c3: stloc.s 16
+		IL_00c3: stloc.s 15
 		IL_00c5: ldloc.s 4
 		IL_00c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00cc: stloc.s 15
+		IL_00cc: stloc.s 14
 		IL_00ce: ldstr "jroc-fs-stat-sync-"
-		IL_00d3: ldloc.s 15
+		IL_00d3: ldloc.s 14
 		IL_00d5: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00da: stloc.s 15
-		IL_00dc: ldloc.s 15
+		IL_00da: stloc.s 14
+		IL_00dc: ldloc.s 14
 		IL_00de: ldstr ".txt"
 		IL_00e3: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00e8: stloc.s 15
-		IL_00ea: ldloc.s 11
+		IL_00e8: stloc.s 14
+		IL_00ea: ldloc.s 10
 		IL_00ec: ldstr "join"
-		IL_00f1: ldloc.s 16
-		IL_00f3: ldloc.s 15
+		IL_00f1: ldloc.s 15
+		IL_00f3: ldloc.s 14
 		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00fa: stloc.s 16
-		IL_00fc: ldloc.s 16
+		IL_00fa: stloc.s 15
+		IL_00fc: ldloc.s 15
 		IL_00fe: stloc.s 5
 		IL_0100: ldloc.2
 		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0106: stloc.s 16
+		IL_0106: stloc.s 15
 		IL_0108: ldloc.3
 		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: stloc.s 11
-		IL_0110: ldloc.s 11
+		IL_010e: stloc.s 10
+		IL_0110: ldloc.s 10
 		IL_0112: ldstr "tmpdir"
 		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_011c: stloc.s 11
+		IL_011c: stloc.s 10
 		IL_011e: ldloc.s 4
 		IL_0120: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0125: stloc.s 15
+		IL_0125: stloc.s 14
 		IL_0127: ldstr "jroc-fs-stat-sync-dir-"
-		IL_012c: ldloc.s 15
+		IL_012c: ldloc.s 14
 		IL_012e: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0133: stloc.s 15
-		IL_0135: ldloc.s 16
+		IL_0133: stloc.s 14
+		IL_0135: ldloc.s 15
 		IL_0137: ldstr "join"
-		IL_013c: ldloc.s 11
-		IL_013e: ldloc.s 15
+		IL_013c: ldloc.s 10
+		IL_013e: ldloc.s 14
 		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0145: stloc.s 11
-		IL_0147: ldloc.s 11
+		IL_0145: stloc.s 10
+		IL_0147: ldloc.s 10
 		IL_0149: stloc.s 6
 		IL_014b: ldloc.1
 		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: stloc.s 11
-		IL_0153: ldloc.s 11
+		IL_0151: stloc.s 10
+		IL_0153: ldloc.s 10
 		IL_0155: ldstr "rmSync"
 		IL_015a: ldloc.s 5
 		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -233,8 +232,8 @@
 		IL_0172: pop
 		IL_0173: ldloc.1
 		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0179: stloc.s 11
-		IL_017b: ldloc.s 11
+		IL_0179: stloc.s 10
+		IL_017b: ldloc.s 10
 		IL_017d: ldstr "rmSync"
 		IL_0182: ldloc.s 6
 		IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -250,8 +249,8 @@
 		IL_01a6: pop
 		IL_01a7: ldloc.1
 		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ad: stloc.s 11
-		IL_01af: ldloc.s 11
+		IL_01ad: stloc.s 10
+		IL_01af: ldloc.s 10
 		IL_01b1: ldstr "writeFileSync"
 		IL_01b6: ldloc.s 5
 		IL_01b8: ldstr "hello"
@@ -260,8 +259,8 @@
 		IL_01c7: pop
 		IL_01c8: ldloc.1
 		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ce: stloc.s 11
-		IL_01d0: ldloc.s 11
+		IL_01ce: stloc.s 10
+		IL_01d0: ldloc.s 10
 		IL_01d2: ldstr "mkdirSync"
 		IL_01d7: ldloc.s 6
 		IL_01d9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -273,323 +272,322 @@
 		IL_01ef: pop
 		.try
 		{
-			IL_01f0: newobj instance void Modules.FS_StatSync_RichMetadata/Scope/Block_L16C4::.ctor()
-			IL_01f5: stloc.s 7
-			IL_01f7: ldloc.1
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fd: stloc.s 11
-			IL_01ff: ldloc.s 11
-			IL_0201: ldstr "statSync"
-			IL_0206: ldloc.s 5
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_020d: stloc.s 11
-			IL_020f: ldloc.s 11
-			IL_0211: stloc.s 8
-			IL_0213: ldloc.1
-			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0219: stloc.s 11
-			IL_021b: ldloc.s 11
-			IL_021d: ldstr "statSync"
-			IL_0222: ldloc.s 6
-			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0229: stloc.s 11
-			IL_022b: ldloc.s 11
-			IL_022d: stloc.s 9
-			IL_022f: ldstr "console"
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0239: stloc.s 11
-			IL_023b: ldloc.s 11
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0242: stloc.s 11
-			IL_0244: ldloc.s 11
-			IL_0246: ldstr "log"
-			IL_024b: ldstr "FileSize:"
-			IL_0250: ldloc.s 8
-			IL_0252: ldstr "size"
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0261: pop
-			IL_0262: ldstr "console"
-			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_026c: stloc.s 11
-			IL_026e: ldloc.s 11
-			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0275: stloc.s 11
-			IL_0277: ldloc.s 8
-			IL_0279: ldstr "mode"
-			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0283: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0288: conv.i4
-			IL_0289: ldc.r8 32768
-			IL_0292: conv.i4
-			IL_0293: and
-			IL_0294: conv.r8
-			IL_0295: stloc.s 13
-			IL_0297: ldloc.s 13
-			IL_0299: ldc.r8 32768
-			IL_02a2: ceq
-			IL_02a4: stloc.s 17
-			IL_02a6: ldloc.s 17
-			IL_02a8: box [System.Runtime]System.Boolean
-			IL_02ad: stloc.s 18
-			IL_02af: ldloc.s 11
-			IL_02b1: ldstr "log"
-			IL_02b6: ldstr "FileModeHasRegularBit:"
-			IL_02bb: ldloc.s 18
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02c2: pop
-			IL_02c3: ldstr "console"
-			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02cd: stloc.s 11
-			IL_02cf: ldloc.s 11
-			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d6: stloc.s 11
-			IL_02d8: ldloc.s 8
-			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02df: stloc.s 16
-			IL_02e1: ldloc.s 16
-			IL_02e3: ldstr "isFile"
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02ed: stloc.s 16
-			IL_02ef: ldloc.s 11
-			IL_02f1: ldstr "log"
-			IL_02f6: ldstr "FileIsFile:"
-			IL_02fb: ldloc.s 16
-			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0302: pop
-			IL_0303: ldstr "console"
-			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_030d: stloc.s 16
-			IL_030f: ldloc.s 16
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0316: stloc.s 16
-			IL_0318: ldloc.s 8
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_031f: stloc.s 11
-			IL_0321: ldloc.s 11
-			IL_0323: ldstr "isDirectory"
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_032d: stloc.s 11
-			IL_032f: ldloc.s 16
-			IL_0331: ldstr "log"
-			IL_0336: ldstr "FileIsDirectory:"
-			IL_033b: ldloc.s 11
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0342: pop
-			IL_0343: ldstr "console"
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_034d: stloc.s 11
-			IL_034f: ldloc.s 11
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0356: stloc.s 11
-			IL_0358: ldloc.s 8
-			IL_035a: ldstr "mtimeMs"
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0364: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0369: ldstr "number"
-			IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0373: stloc.s 17
-			IL_0375: ldloc.s 17
-			IL_0377: box [System.Runtime]System.Boolean
-			IL_037c: stloc.s 18
-			IL_037e: ldloc.s 18
-			IL_0380: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0385: stloc.s 17
-			IL_0387: ldloc.s 17
-			IL_0389: brfalse IL_03b6
+			IL_01f0: nop
+			IL_01f1: ldloc.1
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f7: stloc.s 10
+			IL_01f9: ldloc.s 10
+			IL_01fb: ldstr "statSync"
+			IL_0200: ldloc.s 5
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0207: stloc.s 10
+			IL_0209: ldloc.s 10
+			IL_020b: stloc.s 7
+			IL_020d: ldloc.1
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0213: stloc.s 10
+			IL_0215: ldloc.s 10
+			IL_0217: ldstr "statSync"
+			IL_021c: ldloc.s 6
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0223: stloc.s 10
+			IL_0225: ldloc.s 10
+			IL_0227: stloc.s 8
+			IL_0229: ldstr "console"
+			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0233: stloc.s 10
+			IL_0235: ldloc.s 10
+			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023c: stloc.s 10
+			IL_023e: ldloc.s 10
+			IL_0240: ldstr "log"
+			IL_0245: ldstr "FileSize:"
+			IL_024a: ldloc.s 7
+			IL_024c: ldstr "size"
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_025b: pop
+			IL_025c: ldstr "console"
+			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0266: stloc.s 10
+			IL_0268: ldloc.s 10
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_026f: stloc.s 10
+			IL_0271: ldloc.s 7
+			IL_0273: ldstr "mode"
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0282: conv.i4
+			IL_0283: ldc.r8 32768
+			IL_028c: conv.i4
+			IL_028d: and
+			IL_028e: conv.r8
+			IL_028f: stloc.s 12
+			IL_0291: ldloc.s 12
+			IL_0293: ldc.r8 32768
+			IL_029c: ceq
+			IL_029e: stloc.s 16
+			IL_02a0: ldloc.s 16
+			IL_02a2: box [System.Runtime]System.Boolean
+			IL_02a7: stloc.s 17
+			IL_02a9: ldloc.s 10
+			IL_02ab: ldstr "log"
+			IL_02b0: ldstr "FileModeHasRegularBit:"
+			IL_02b5: ldloc.s 17
+			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02bc: pop
+			IL_02bd: ldstr "console"
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02c7: stloc.s 10
+			IL_02c9: ldloc.s 10
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d0: stloc.s 10
+			IL_02d2: ldloc.s 7
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d9: stloc.s 15
+			IL_02db: ldloc.s 15
+			IL_02dd: ldstr "isFile"
+			IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_02e7: stloc.s 15
+			IL_02e9: ldloc.s 10
+			IL_02eb: ldstr "log"
+			IL_02f0: ldstr "FileIsFile:"
+			IL_02f5: ldloc.s 15
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02fc: pop
+			IL_02fd: ldstr "console"
+			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0307: stloc.s 15
+			IL_0309: ldloc.s 15
+			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0310: stloc.s 15
+			IL_0312: ldloc.s 7
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0319: stloc.s 10
+			IL_031b: ldloc.s 10
+			IL_031d: ldstr "isDirectory"
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0327: stloc.s 10
+			IL_0329: ldloc.s 15
+			IL_032b: ldstr "log"
+			IL_0330: ldstr "FileIsDirectory:"
+			IL_0335: ldloc.s 10
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_033c: pop
+			IL_033d: ldstr "console"
+			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0347: stloc.s 10
+			IL_0349: ldloc.s 10
+			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0350: stloc.s 10
+			IL_0352: ldloc.s 7
+			IL_0354: ldstr "mtimeMs"
+			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_035e: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0363: ldstr "number"
+			IL_0368: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_036d: stloc.s 16
+			IL_036f: ldloc.s 16
+			IL_0371: box [System.Runtime]System.Boolean
+			IL_0376: stloc.s 17
+			IL_0378: ldloc.s 17
+			IL_037a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_037f: stloc.s 16
+			IL_0381: ldloc.s 16
+			IL_0383: brfalse IL_03b0
 
-			IL_038e: ldloc.s 8
-			IL_0390: ldstr "mtimeMs"
-			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_039a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_039f: ldc.r8 0.0
-			IL_03a8: cgt
-			IL_03aa: box [System.Runtime]System.Boolean
-			IL_03af: stloc.s 20
-			IL_03b1: br IL_03ba
+			IL_0388: ldloc.s 7
+			IL_038a: ldstr "mtimeMs"
+			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0394: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0399: ldc.r8 0.0
+			IL_03a2: cgt
+			IL_03a4: box [System.Runtime]System.Boolean
+			IL_03a9: stloc.s 19
+			IL_03ab: br IL_03b4
 
-			IL_03b6: ldloc.s 18
-			IL_03b8: stloc.s 20
+			IL_03b0: ldloc.s 17
+			IL_03b2: stloc.s 19
 
-			IL_03ba: ldloc.s 11
-			IL_03bc: ldstr "log"
-			IL_03c1: ldstr "FileHasMtimeMs:"
-			IL_03c6: ldloc.s 20
-			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03cd: pop
-			IL_03ce: ldstr "console"
-			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03d8: stloc.s 11
-			IL_03da: ldloc.s 11
-			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03e1: stloc.s 11
-			IL_03e3: ldloc.s 8
-			IL_03e5: ldstr "mtime"
-			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f4: stloc.s 16
-			IL_03f6: ldloc.s 16
-			IL_03f8: ldstr "toISOString"
-			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0402: stloc.s 16
-			IL_0404: ldloc.s 16
-			IL_0406: ldstr "length"
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0410: stloc.s 16
-			IL_0412: ldloc.s 11
-			IL_0414: ldstr "log"
-			IL_0419: ldstr "FileMtimeIsoLength:"
-			IL_041e: ldloc.s 16
-			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0425: pop
-			IL_0426: ldstr "console"
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0430: stloc.s 16
-			IL_0432: ldloc.s 16
-			IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0439: stloc.s 16
-			IL_043b: ldloc.s 8
-			IL_043d: ldstr "birthtimeMs"
-			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0447: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_044c: ldstr "number"
-			IL_0451: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0456: stloc.s 17
-			IL_0458: ldloc.s 17
-			IL_045a: box [System.Runtime]System.Boolean
-			IL_045f: stloc.s 18
-			IL_0461: ldloc.s 16
-			IL_0463: ldstr "log"
-			IL_0468: ldstr "FileBirthtimeMatchesType:"
-			IL_046d: ldloc.s 18
-			IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0474: pop
-			IL_0475: ldstr "console"
-			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_047f: stloc.s 16
-			IL_0481: ldloc.s 16
-			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0488: stloc.s 16
-			IL_048a: ldloc.s 8
-			IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0491: stloc.s 11
-			IL_0493: ldloc.s 11
-			IL_0495: ldstr "isSymbolicLink"
-			IL_049a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_049f: stloc.s 11
-			IL_04a1: ldloc.s 16
-			IL_04a3: ldstr "log"
-			IL_04a8: ldstr "FileIsSymbolicLink:"
-			IL_04ad: ldloc.s 11
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04b4: pop
-			IL_04b5: ldstr "console"
-			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04bf: stloc.s 11
-			IL_04c1: ldloc.s 11
-			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04c8: stloc.s 11
-			IL_04ca: ldloc.s 9
-			IL_04cc: ldstr "mode"
-			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04d6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_04db: conv.i4
-			IL_04dc: ldc.r8 16384
-			IL_04e5: conv.i4
-			IL_04e6: and
-			IL_04e7: conv.r8
-			IL_04e8: stloc.s 13
-			IL_04ea: ldloc.s 13
-			IL_04ec: ldc.r8 16384
-			IL_04f5: ceq
-			IL_04f7: stloc.s 17
-			IL_04f9: ldloc.s 17
-			IL_04fb: box [System.Runtime]System.Boolean
-			IL_0500: stloc.s 18
-			IL_0502: ldloc.s 11
-			IL_0504: ldstr "log"
-			IL_0509: ldstr "DirModeHasDirectoryBit:"
-			IL_050e: ldloc.s 18
-			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0515: pop
-			IL_0516: ldstr "console"
-			IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0520: stloc.s 11
-			IL_0522: ldloc.s 11
-			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0529: stloc.s 11
-			IL_052b: ldloc.s 9
-			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0532: stloc.s 16
-			IL_0534: ldloc.s 16
-			IL_0536: ldstr "isDirectory"
-			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0540: stloc.s 16
-			IL_0542: ldloc.s 11
-			IL_0544: ldstr "log"
-			IL_0549: ldstr "DirIsDirectory:"
-			IL_054e: ldloc.s 16
-			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0555: pop
-			IL_0556: ldstr "console"
-			IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0560: stloc.s 16
-			IL_0562: ldloc.s 16
-			IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0569: stloc.s 16
-			IL_056b: ldloc.s 9
-			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0572: stloc.s 11
-			IL_0574: ldloc.s 11
-			IL_0576: ldstr "isFile"
-			IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0580: stloc.s 11
-			IL_0582: ldloc.s 16
-			IL_0584: ldstr "log"
-			IL_0589: ldstr "DirIsFile:"
-			IL_058e: ldloc.s 11
-			IL_0590: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0595: pop
-			IL_0596: leave IL_05f8
+			IL_03b4: ldloc.s 10
+			IL_03b6: ldstr "log"
+			IL_03bb: ldstr "FileHasMtimeMs:"
+			IL_03c0: ldloc.s 19
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03c7: pop
+			IL_03c8: ldstr "console"
+			IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03d2: stloc.s 10
+			IL_03d4: ldloc.s 10
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03db: stloc.s 10
+			IL_03dd: ldloc.s 7
+			IL_03df: ldstr "mtime"
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ee: stloc.s 15
+			IL_03f0: ldloc.s 15
+			IL_03f2: ldstr "toISOString"
+			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03fc: stloc.s 15
+			IL_03fe: ldloc.s 15
+			IL_0400: ldstr "length"
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040a: stloc.s 15
+			IL_040c: ldloc.s 10
+			IL_040e: ldstr "log"
+			IL_0413: ldstr "FileMtimeIsoLength:"
+			IL_0418: ldloc.s 15
+			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_041f: pop
+			IL_0420: ldstr "console"
+			IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_042a: stloc.s 15
+			IL_042c: ldloc.s 15
+			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0433: stloc.s 15
+			IL_0435: ldloc.s 7
+			IL_0437: ldstr "birthtimeMs"
+			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0441: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0446: ldstr "number"
+			IL_044b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0450: stloc.s 16
+			IL_0452: ldloc.s 16
+			IL_0454: box [System.Runtime]System.Boolean
+			IL_0459: stloc.s 17
+			IL_045b: ldloc.s 15
+			IL_045d: ldstr "log"
+			IL_0462: ldstr "FileBirthtimeMatchesType:"
+			IL_0467: ldloc.s 17
+			IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_046e: pop
+			IL_046f: ldstr "console"
+			IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0479: stloc.s 15
+			IL_047b: ldloc.s 15
+			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0482: stloc.s 15
+			IL_0484: ldloc.s 7
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_048b: stloc.s 10
+			IL_048d: ldloc.s 10
+			IL_048f: ldstr "isSymbolicLink"
+			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0499: stloc.s 10
+			IL_049b: ldloc.s 15
+			IL_049d: ldstr "log"
+			IL_04a2: ldstr "FileIsSymbolicLink:"
+			IL_04a7: ldloc.s 10
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04ae: pop
+			IL_04af: ldstr "console"
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04b9: stloc.s 10
+			IL_04bb: ldloc.s 10
+			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04c2: stloc.s 10
+			IL_04c4: ldloc.s 8
+			IL_04c6: ldstr "mode"
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_04d5: conv.i4
+			IL_04d6: ldc.r8 16384
+			IL_04df: conv.i4
+			IL_04e0: and
+			IL_04e1: conv.r8
+			IL_04e2: stloc.s 12
+			IL_04e4: ldloc.s 12
+			IL_04e6: ldc.r8 16384
+			IL_04ef: ceq
+			IL_04f1: stloc.s 16
+			IL_04f3: ldloc.s 16
+			IL_04f5: box [System.Runtime]System.Boolean
+			IL_04fa: stloc.s 17
+			IL_04fc: ldloc.s 10
+			IL_04fe: ldstr "log"
+			IL_0503: ldstr "DirModeHasDirectoryBit:"
+			IL_0508: ldloc.s 17
+			IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_050f: pop
+			IL_0510: ldstr "console"
+			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_051a: stloc.s 10
+			IL_051c: ldloc.s 10
+			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0523: stloc.s 10
+			IL_0525: ldloc.s 8
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_052c: stloc.s 15
+			IL_052e: ldloc.s 15
+			IL_0530: ldstr "isDirectory"
+			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_053a: stloc.s 15
+			IL_053c: ldloc.s 10
+			IL_053e: ldstr "log"
+			IL_0543: ldstr "DirIsDirectory:"
+			IL_0548: ldloc.s 15
+			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_054f: pop
+			IL_0550: ldstr "console"
+			IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_055a: stloc.s 15
+			IL_055c: ldloc.s 15
+			IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0563: stloc.s 15
+			IL_0565: ldloc.s 8
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_056c: stloc.s 10
+			IL_056e: ldloc.s 10
+			IL_0570: ldstr "isFile"
+			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_057a: stloc.s 10
+			IL_057c: ldloc.s 15
+			IL_057e: ldstr "log"
+			IL_0583: ldstr "DirIsFile:"
+			IL_0588: ldloc.s 10
+			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_058f: pop
+			IL_0590: leave IL_05f2
 		} // end .try
 		finally
 		{
-			IL_059b: ldloc.1
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a1: stloc.s 11
-			IL_05a3: ldloc.s 11
-			IL_05a5: ldstr "rmSync"
-			IL_05aa: ldloc.s 5
-			IL_05ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05b1: dup
-			IL_05b2: ldstr "force"
-			IL_05b7: ldc.i4.1
-			IL_05b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05c2: pop
-			IL_05c3: ldloc.1
-			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c9: stloc.s 11
-			IL_05cb: ldloc.s 11
-			IL_05cd: ldstr "rmSync"
-			IL_05d2: ldloc.s 6
-			IL_05d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05d9: dup
-			IL_05da: ldstr "force"
-			IL_05df: ldc.i4.1
-			IL_05e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05e5: dup
-			IL_05e6: ldstr "recursive"
-			IL_05eb: ldc.i4.1
-			IL_05ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_05f6: pop
-			IL_05f7: endfinally
+			IL_0595: ldloc.1
+			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_059b: stloc.s 10
+			IL_059d: ldloc.s 10
+			IL_059f: ldstr "rmSync"
+			IL_05a4: ldloc.s 5
+			IL_05a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05ab: dup
+			IL_05ac: ldstr "force"
+			IL_05b1: ldc.i4.1
+			IL_05b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05bc: pop
+			IL_05bd: ldloc.1
+			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c3: stloc.s 10
+			IL_05c5: ldloc.s 10
+			IL_05c7: ldstr "rmSync"
+			IL_05cc: ldloc.s 6
+			IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05d3: dup
+			IL_05d4: ldstr "force"
+			IL_05d9: ldc.i4.1
+			IL_05da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05df: dup
+			IL_05e0: ldstr "recursive"
+			IL_05e5: ldc.i4.1
+			IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_05f0: pop
+			IL_05f1: endfinally
 		} // end handler
 
-		IL_05f8: ldnull
-		IL_05f9: stloc.s 10
-		IL_05fb: ret
+		IL_05f2: ldnull
+		IL_05f3: stloc.s 9
+		IL_05f5: ret
 	} // end of method FS_StatSync_RichMetadata::__js_module_init__
 
 } // end of class Modules.FS_StatSync_RichMetadata
@@ -601,7 +599,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x268f
+		// Method begins at RVA 0x268b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x246e
+					// Method begins at RVA 0x2466
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2477
+					// Method begins at RVA 0x246f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2465
+				// Method begins at RVA 0x245d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2480
+				// Method begins at RVA 0x2478
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2454
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,7 +124,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 971 (0x3cb)
+		// Code size: 964 (0x3c4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope,
@@ -138,15 +138,14 @@
 			[8] class [System.Runtime]System.Exception,
 			[9] object,
 			[10] object,
-			[11] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4/Block_L28C16,
+			[11] object,
 			[12] object,
-			[13] object,
-			[14] string,
-			[15] float64,
-			[16] object,
-			[17] string,
-			[18] object,
-			[19] object
+			[13] string,
+			[14] float64,
+			[15] object,
+			[16] string,
+			[17] object,
+			[18] object
 		)
 
 		IL_0000: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope::.ctor()
@@ -155,107 +154,107 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "fs"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 13
-		IL_0014: ldloc.s 13
+		IL_0012: stloc.s 12
+		IL_0014: ldloc.s 12
 		IL_0016: stloc.1
 		IL_0017: ldarg.1
 		IL_0018: ldstr "path"
 		IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0022: stloc.s 13
-		IL_0024: ldloc.s 13
+		IL_0022: stloc.s 12
+		IL_0024: ldloc.s 12
 		IL_0026: stloc.2
 		IL_0027: ldarg.1
 		IL_0028: ldstr "os"
 		IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0032: stloc.s 13
-		IL_0034: ldloc.s 13
+		IL_0032: stloc.s 12
+		IL_0034: ldloc.s 12
 		IL_0036: stloc.3
 		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-		IL_003c: stloc.s 13
-		IL_003e: ldloc.s 13
+		IL_003c: stloc.s 12
+		IL_003e: ldloc.s 12
 		IL_0040: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0045: stloc.s 14
+		IL_0045: stloc.s 13
 		IL_0047: ldstr ""
-		IL_004c: ldloc.s 14
+		IL_004c: ldloc.s 13
 		IL_004e: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0053: stloc.s 14
-		IL_0055: ldloc.s 14
+		IL_0053: stloc.s 13
+		IL_0055: ldloc.s 13
 		IL_0057: ldstr "-"
 		IL_005c: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0061: stloc.s 14
+		IL_0061: stloc.s 13
 		IL_0063: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-		IL_0068: stloc.s 15
-		IL_006a: ldloc.s 15
+		IL_0068: stloc.s 14
+		IL_006a: ldloc.s 14
 		IL_006c: ldc.r8 1000000000
 		IL_0075: mul
-		IL_0076: stloc.s 15
-		IL_0078: ldloc.s 15
+		IL_0076: stloc.s 14
+		IL_0078: ldloc.s 14
 		IL_007a: box [System.Runtime]System.Double
-		IL_007f: stloc.s 16
-		IL_0081: ldloc.s 16
+		IL_007f: stloc.s 15
+		IL_0081: ldloc.s 15
 		IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-		IL_0088: stloc.s 15
-		IL_008a: ldloc.s 15
+		IL_0088: stloc.s 14
+		IL_008a: ldloc.s 14
 		IL_008c: box [System.Runtime]System.Double
 		IL_0091: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0096: stloc.s 17
-		IL_0098: ldloc.s 14
-		IL_009a: ldloc.s 17
+		IL_0096: stloc.s 16
+		IL_0098: ldloc.s 13
+		IL_009a: ldloc.s 16
 		IL_009c: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00a1: stloc.s 17
-		IL_00a3: ldloc.s 17
+		IL_00a1: stloc.s 16
+		IL_00a3: ldloc.s 16
 		IL_00a5: stloc.s 4
 		IL_00a7: ldloc.2
 		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ad: stloc.s 13
+		IL_00ad: stloc.s 12
 		IL_00af: ldloc.3
 		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b5: stloc.s 18
-		IL_00b7: ldloc.s 18
+		IL_00b5: stloc.s 17
+		IL_00b7: ldloc.s 17
 		IL_00b9: ldstr "tmpdir"
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00c3: stloc.s 18
+		IL_00c3: stloc.s 17
 		IL_00c5: ldloc.s 4
 		IL_00c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00cc: stloc.s 17
+		IL_00cc: stloc.s 16
 		IL_00ce: ldstr "jroc-release-cleanup-"
-		IL_00d3: ldloc.s 17
+		IL_00d3: ldloc.s 16
 		IL_00d5: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00da: stloc.s 17
-		IL_00dc: ldloc.s 13
+		IL_00da: stloc.s 16
+		IL_00dc: ldloc.s 12
 		IL_00de: ldstr "join"
-		IL_00e3: ldloc.s 18
-		IL_00e5: ldloc.s 17
+		IL_00e3: ldloc.s 17
+		IL_00e5: ldloc.s 16
 		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_00ec: stloc.s 18
-		IL_00ee: ldloc.s 18
+		IL_00ec: stloc.s 17
+		IL_00ee: ldloc.s 17
 		IL_00f0: stloc.s 5
 		IL_00f2: ldloc.2
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: stloc.s 18
-		IL_00fa: ldloc.s 18
+		IL_00f8: stloc.s 17
+		IL_00fa: ldloc.s 17
 		IL_00fc: ldstr "join"
 		IL_0101: ldloc.s 5
 		IL_0103: ldstr "pr-body.md"
 		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_010d: stloc.s 18
-		IL_010f: ldloc.s 18
+		IL_010d: stloc.s 17
+		IL_010f: ldloc.s 17
 		IL_0111: stloc.s 6
 		IL_0113: ldloc.2
 		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0119: stloc.s 18
-		IL_011b: ldloc.s 18
+		IL_0119: stloc.s 17
+		IL_011b: ldloc.s 17
 		IL_011d: ldstr "join"
 		IL_0122: ldloc.s 5
 		IL_0124: ldstr "release-notes.md"
 		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_012e: stloc.s 18
-		IL_0130: ldloc.s 18
+		IL_012e: stloc.s 17
+		IL_0130: ldloc.s 17
 		IL_0132: stloc.s 7
 		IL_0134: ldloc.1
 		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: stloc.s 18
-		IL_013c: ldloc.s 18
+		IL_013a: stloc.s 17
+		IL_013c: ldloc.s 17
 		IL_013e: ldstr "rmSync"
 		IL_0143: ldloc.s 5
 		IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -271,8 +270,8 @@
 		IL_0167: pop
 		IL_0168: ldloc.1
 		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: stloc.s 18
-		IL_0170: ldloc.s 18
+		IL_016e: stloc.s 17
+		IL_0170: ldloc.s 17
 		IL_0172: ldstr "mkdirSync"
 		IL_0177: ldloc.s 5
 		IL_0179: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -287,8 +286,8 @@
 			IL_0190: nop
 			IL_0191: ldloc.1
 			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0197: stloc.s 18
-			IL_0199: ldloc.s 18
+			IL_0197: stloc.s 17
+			IL_0199: ldloc.s 17
 			IL_019b: ldstr "writeFileSync"
 			IL_01a0: ldloc.s 6
 			IL_01a2: ldstr "Patch release body"
@@ -297,8 +296,8 @@
 			IL_01b1: pop
 			IL_01b2: ldloc.1
 			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b8: stloc.s 18
-			IL_01ba: ldloc.s 18
+			IL_01b8: stloc.s 17
+			IL_01ba: ldloc.s 17
 			IL_01bc: ldstr "writeFileSync"
 			IL_01c1: ldloc.s 7
 			IL_01c3: ldstr "# Release notes"
@@ -307,76 +306,76 @@
 			IL_01d2: pop
 			IL_01d3: ldstr "console"
 			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01dd: stloc.s 18
-			IL_01df: ldloc.s 18
+			IL_01dd: stloc.s 17
+			IL_01df: ldloc.s 17
 			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e6: stloc.s 18
+			IL_01e6: stloc.s 17
 			IL_01e8: ldloc.1
 			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 13
-			IL_01f0: ldloc.s 13
+			IL_01ee: stloc.s 12
+			IL_01f0: ldloc.s 12
 			IL_01f2: ldstr "existsSync"
 			IL_01f7: ldloc.s 6
 			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01fe: stloc.s 13
+			IL_01fe: stloc.s 12
 			IL_0200: ldloc.1
 			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0206: stloc.s 19
-			IL_0208: ldloc.s 19
+			IL_0206: stloc.s 18
+			IL_0208: ldloc.s 18
 			IL_020a: ldstr "existsSync"
 			IL_020f: ldloc.s 7
 			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0216: stloc.s 19
-			IL_0218: ldloc.s 18
+			IL_0216: stloc.s 18
+			IL_0218: ldloc.s 17
 			IL_021a: ldstr "log"
 			IL_021f: ldstr "Before:"
-			IL_0224: ldloc.s 13
-			IL_0226: ldloc.s 19
+			IL_0224: ldloc.s 12
+			IL_0226: ldloc.s 18
 			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 			IL_022d: pop
 			IL_022e: ldloc.1
 			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0234: stloc.s 19
-			IL_0236: ldloc.s 19
+			IL_0234: stloc.s 18
+			IL_0236: ldloc.s 18
 			IL_0238: ldstr "unlinkSync"
 			IL_023d: ldloc.s 6
 			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0244: pop
 			IL_0245: ldloc.1
 			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_024b: stloc.s 19
-			IL_024d: ldloc.s 19
+			IL_024b: stloc.s 18
+			IL_024d: ldloc.s 18
 			IL_024f: ldstr "unlinkSync"
 			IL_0254: ldloc.s 7
 			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_025b: pop
 			IL_025c: ldstr "console"
 			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0266: stloc.s 19
-			IL_0268: ldloc.s 19
+			IL_0266: stloc.s 18
+			IL_0268: ldloc.s 18
 			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026f: stloc.s 19
+			IL_026f: stloc.s 18
 			IL_0271: ldloc.1
 			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0277: stloc.s 13
-			IL_0279: ldloc.s 13
+			IL_0277: stloc.s 12
+			IL_0279: ldloc.s 12
 			IL_027b: ldstr "existsSync"
 			IL_0280: ldloc.s 6
 			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0287: stloc.s 13
+			IL_0287: stloc.s 12
 			IL_0289: ldloc.1
 			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_028f: stloc.s 18
-			IL_0291: ldloc.s 18
+			IL_028f: stloc.s 17
+			IL_0291: ldloc.s 17
 			IL_0293: ldstr "existsSync"
 			IL_0298: ldloc.s 7
 			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_029f: stloc.s 18
-			IL_02a1: ldloc.s 19
+			IL_029f: stloc.s 17
+			IL_02a1: ldloc.s 18
 			IL_02a3: ldstr "log"
 			IL_02a8: ldstr "After:"
-			IL_02ad: ldloc.s 13
-			IL_02af: ldloc.s 18
+			IL_02ad: ldloc.s 12
+			IL_02af: ldloc.s 17
 			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 			IL_02b6: pop
 			.try
@@ -384,13 +383,13 @@
 				IL_02b7: nop
 				IL_02b8: ldloc.1
 				IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02be: stloc.s 18
-				IL_02c0: ldloc.s 18
+				IL_02be: stloc.s 17
+				IL_02c0: ldloc.s 17
 				IL_02c2: ldstr "unlinkSync"
 				IL_02c7: ldloc.s 6
 				IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 				IL_02ce: pop
-				IL_02cf: leave IL_038d
+				IL_02cf: leave IL_0386
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -416,74 +415,72 @@
 				IL_0300: stloc.s 9
 
 				IL_0302: ldloc.s 9
-				IL_0304: stloc.s 18
-				IL_0306: ldloc.s 18
+				IL_0304: stloc.s 17
+				IL_0306: ldloc.s 17
 				IL_0308: stloc.s 10
-				IL_030a: newobj instance void Modules.FS_UnlinkSync_ReleaseCleanup/Scope/Block_L15C4/Block_L28C16::.ctor()
-				IL_030f: stloc.s 11
-				IL_0311: ldstr "console"
-				IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_031b: stloc.s 18
-				IL_031d: ldloc.s 18
-				IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0324: stloc.s 18
-				IL_0326: ldloc.s 10
-				IL_0328: ldstr "message"
-				IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0337: stloc.s 13
-				IL_0339: ldloc.s 13
-				IL_033b: ldstr "includes"
-				IL_0340: ldstr "ENOENT:"
-				IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_034a: stloc.s 13
-				IL_034c: ldloc.s 10
-				IL_034e: ldstr "message"
-				IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_035d: stloc.s 19
-				IL_035f: ldloc.s 19
-				IL_0361: ldstr "includes"
-				IL_0366: ldstr "pr-body.md"
-				IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0370: stloc.s 19
-				IL_0372: ldloc.s 18
-				IL_0374: ldstr "log"
-				IL_0379: ldstr "MissingError:"
-				IL_037e: ldloc.s 13
-				IL_0380: ldloc.s 19
-				IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_0387: pop
-				IL_0388: leave IL_038d
+				IL_030a: ldstr "console"
+				IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0314: stloc.s 17
+				IL_0316: ldloc.s 17
+				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_031d: stloc.s 17
+				IL_031f: ldloc.s 10
+				IL_0321: ldstr "message"
+				IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0330: stloc.s 12
+				IL_0332: ldloc.s 12
+				IL_0334: ldstr "includes"
+				IL_0339: ldstr "ENOENT:"
+				IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0343: stloc.s 12
+				IL_0345: ldloc.s 10
+				IL_0347: ldstr "message"
+				IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0356: stloc.s 18
+				IL_0358: ldloc.s 18
+				IL_035a: ldstr "includes"
+				IL_035f: ldstr "pr-body.md"
+				IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0369: stloc.s 18
+				IL_036b: ldloc.s 17
+				IL_036d: ldstr "log"
+				IL_0372: ldstr "MissingError:"
+				IL_0377: ldloc.s 12
+				IL_0379: ldloc.s 18
+				IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0380: pop
+				IL_0381: leave IL_0386
 			} // end handler
 
-			IL_038d: leave IL_03c7
+			IL_0386: leave IL_03c0
 		} // end .try
 		finally
 		{
-			IL_0392: ldloc.1
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0398: stloc.s 19
-			IL_039a: ldloc.s 19
-			IL_039c: ldstr "rmSync"
-			IL_03a1: ldloc.s 5
-			IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03a8: dup
-			IL_03a9: ldstr "recursive"
-			IL_03ae: ldc.i4.1
-			IL_03af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03b4: dup
-			IL_03b5: ldstr "force"
-			IL_03ba: ldc.i4.1
-			IL_03bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03c5: pop
-			IL_03c6: endfinally
+			IL_038b: ldloc.1
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0391: stloc.s 18
+			IL_0393: ldloc.s 18
+			IL_0395: ldstr "rmSync"
+			IL_039a: ldloc.s 5
+			IL_039c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03a1: dup
+			IL_03a2: ldstr "recursive"
+			IL_03a7: ldc.i4.1
+			IL_03a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03ad: dup
+			IL_03ae: ldstr "force"
+			IL_03b3: ldc.i4.1
+			IL_03b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03be: pop
+			IL_03bf: endfinally
 		} // end handler
 
-		IL_03c7: ldnull
-		IL_03c8: stloc.s 12
-		IL_03ca: ret
+		IL_03c0: ldnull
+		IL_03c1: stloc.s 11
+		IL_03c3: ret
 	} // end of method FS_UnlinkSync_ReleaseCleanup::__js_module_init__
 
 } // end of class Modules.FS_UnlinkSync_ReleaseCleanup
@@ -495,7 +492,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2489
+		// Method begins at RVA 0x2481
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Unsupported_Connect_Fails_Clearly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e1
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ea
+				// Method begins at RVA 0x21de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,22 +82,20 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 364 (0x16c)
+		// Code size: 349 (0x15d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope,
 			[1] object,
-			[2] class Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope/Block_L5C4,
-			[3] object,
-			[4] class [System.Runtime]System.Exception,
+			[2] object,
+			[3] class [System.Runtime]System.Exception,
+			[4] object,
 			[5] object,
 			[6] object,
-			[7] class Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope/Block_L15C14,
-			[8] object,
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[11] object,
-			[12] object
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope::.ctor()
@@ -106,123 +104,120 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "node:http"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 9
-		IL_0014: ldloc.s 9
+		IL_0012: stloc.s 7
+		IL_0014: ldloc.s 7
 		IL_0016: stloc.1
 		.try
 		{
-			IL_0017: newobj instance void Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope/Block_L5C4::.ctor()
-			IL_001c: stloc.2
-			IL_001d: ldloc.1
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0023: stloc.s 9
-			IL_0025: ldloc.s 9
-			IL_0027: ldstr "request"
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "host"
-			IL_0037: ldstr "127.0.0.1"
-			IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0041: dup
-			IL_0042: ldstr "port"
-			IL_0047: ldc.r8 80
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0055: dup
-			IL_0056: ldstr "path"
-			IL_005b: ldstr "/tunnel"
-			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0065: dup
-			IL_0066: ldstr "method"
-			IL_006b: ldstr "CONNECT"
-			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007a: stloc.s 9
-			IL_007c: ldloc.s 9
-			IL_007e: stloc.3
-			IL_007f: ldloc.3
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0085: stloc.s 9
-			IL_0087: ldloc.s 9
-			IL_0089: ldstr "end"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0093: pop
-			IL_0094: ldstr "console"
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009e: stloc.s 9
-			IL_00a0: ldloc.s 9
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a7: stloc.s 9
-			IL_00a9: ldloc.s 9
-			IL_00ab: ldstr "log"
-			IL_00b0: ldstr "unexpected"
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ba: pop
-			IL_00bb: leave IL_0168
+			IL_0017: nop
+			IL_0018: ldloc.1
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001e: stloc.s 7
+			IL_0020: ldloc.s 7
+			IL_0022: ldstr "request"
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_002c: dup
+			IL_002d: ldstr "host"
+			IL_0032: ldstr "127.0.0.1"
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003c: dup
+			IL_003d: ldstr "port"
+			IL_0042: ldc.r8 80
+			IL_004b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0050: dup
+			IL_0051: ldstr "path"
+			IL_0056: ldstr "/tunnel"
+			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0060: dup
+			IL_0061: ldstr "method"
+			IL_0066: ldstr "CONNECT"
+			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0075: stloc.s 7
+			IL_0077: ldloc.s 7
+			IL_0079: stloc.2
+			IL_007a: ldloc.2
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0080: stloc.s 7
+			IL_0082: ldloc.s 7
+			IL_0084: ldstr "end"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_008e: pop
+			IL_008f: ldstr "console"
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0099: stloc.s 7
+			IL_009b: ldloc.s 7
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a2: stloc.s 7
+			IL_00a4: ldloc.s 7
+			IL_00a6: ldstr "log"
+			IL_00ab: ldstr "unexpected"
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b5: pop
+			IL_00b6: leave IL_0159
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00c0: stloc.s 4
-			IL_00c2: ldloc.s 4
-			IL_00c4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00c9: dup
-			IL_00ca: brtrue IL_00e0
+			IL_00bb: stloc.3
+			IL_00bc: ldloc.3
+			IL_00bd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00c2: dup
+			IL_00c3: brtrue IL_00d8
 
-			IL_00cf: pop
-			IL_00d0: ldloc.s 4
-			IL_00d2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00d7: dup
-			IL_00d8: brtrue IL_00ec
+			IL_00c8: pop
+			IL_00c9: ldloc.3
+			IL_00ca: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00cf: dup
+			IL_00d0: brtrue IL_00e4
 
-			IL_00dd: pop
-			IL_00de: rethrow
+			IL_00d5: pop
+			IL_00d6: rethrow
 
-			IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00e5: stloc.s 5
-			IL_00e7: br IL_00ee
+			IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00dd: stloc.s 4
+			IL_00df: br IL_00e6
 
+			IL_00e4: stloc.s 4
+
+			IL_00e6: ldloc.s 4
+			IL_00e8: stloc.s 7
+			IL_00ea: ldloc.s 7
 			IL_00ec: stloc.s 5
-
-			IL_00ee: ldloc.s 5
-			IL_00f0: stloc.s 9
-			IL_00f2: ldloc.s 9
-			IL_00f4: stloc.s 6
-			IL_00f6: newobj instance void Modules.Http_Request_Unsupported_Connect_Fails_Clearly/Scope/Block_L15C14::.ctor()
-			IL_00fb: stloc.s 7
-			IL_00fd: ldstr "console"
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0107: stloc.s 9
-			IL_0109: ldloc.s 9
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.s 9
-			IL_0112: ldstr "CONNECT requests are not supported"
-			IL_0117: ldstr ""
-			IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0121: stloc.s 10
-			IL_0123: ldloc.s 10
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012a: stloc.s 11
-			IL_012c: ldloc.s 11
-			IL_012e: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_0133: ldloc.s 6
-			IL_0135: ldstr "message"
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0144: stloc.s 11
-			IL_0146: ldstr "connect unsupported:"
-			IL_014b: ldloc.s 11
-			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0152: stloc.s 12
-			IL_0154: ldloc.s 9
-			IL_0156: ldstr "log"
-			IL_015b: ldloc.s 12
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0162: pop
-			IL_0163: leave IL_0168
+			IL_00ee: ldstr "console"
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f8: stloc.s 7
+			IL_00fa: ldloc.s 7
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0101: stloc.s 7
+			IL_0103: ldstr "CONNECT requests are not supported"
+			IL_0108: ldstr ""
+			IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0112: stloc.s 8
+			IL_0114: ldloc.s 8
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011b: stloc.s 9
+			IL_011d: ldloc.s 9
+			IL_011f: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			IL_0124: ldloc.s 5
+			IL_0126: ldstr "message"
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_0135: stloc.s 9
+			IL_0137: ldstr "connect unsupported:"
+			IL_013c: ldloc.s 9
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0143: stloc.s 10
+			IL_0145: ldloc.s 7
+			IL_0147: ldstr "log"
+			IL_014c: ldloc.s 10
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0153: pop
+			IL_0154: leave IL_0159
 		} // end handler
 
-		IL_0168: ldnull
-		IL_0169: stloc.s 8
-		IL_016b: ret
+		IL_0159: ldnull
+		IL_015a: stloc.s 6
+		IL_015c: ret
 	} // end of method Http_Request_Unsupported_Connect_Fails_Clearly::__js_module_init__
 
 } // end of class Modules.Http_Request_Unsupported_Connect_Fails_Clearly
@@ -234,7 +229,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f3
+		// Method begins at RVA 0x21e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2211
+				// Method begins at RVA 0x2209
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221a
+				// Method begins at RVA 0x2212
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x2200
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 339 (0x153)
+		// Code size: 332 (0x14c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly/Scope,
@@ -92,11 +92,10 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly/Scope/Block_L9C16,
+			[7] object,
 			[8] object,
-			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[11] object
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly/Scope::.ctor()
@@ -105,30 +104,30 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "node:tls"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 9
-		IL_0014: ldloc.s 9
+		IL_0012: stloc.s 8
+		IL_0014: ldloc.s 8
 		IL_0016: stloc.1
 		IL_0017: ldarg.1
 		IL_0018: ldstr "./Tls_TestCertificates"
 		IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0022: stloc.s 9
-		IL_0024: ldloc.s 9
+		IL_0022: stloc.s 8
+		IL_0024: ldloc.s 8
 		IL_0026: brfalse IL_0037
 
-		IL_002b: ldloc.s 9
+		IL_002b: ldloc.s 8
 		IL_002d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_0032: brfalse IL_0048
 
-		IL_0037: ldloc.s 9
+		IL_0037: ldloc.s 8
 		IL_0039: ldstr ""
 		IL_003e: ldstr "certPem"
 		IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0048: ldloc.s 9
+		IL_0048: ldloc.s 8
 		IL_004a: ldstr "certPem"
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0054: stloc.2
-		IL_0055: ldloc.s 9
+		IL_0055: ldloc.s 8
 		IL_0057: ldstr "keyPem"
 		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0061: stloc.3
@@ -137,7 +136,7 @@
 			IL_0062: nop
 			IL_0063: ldloc.1
 			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0069: stloc.s 9
+			IL_0069: stloc.s 8
 			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0070: dup
 			IL_0071: ldstr "key"
@@ -151,24 +150,24 @@
 			IL_0089: ldstr "requestCert"
 			IL_008e: ldc.i4.1
 			IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0094: stloc.s 10
-			IL_0096: ldloc.s 9
+			IL_0094: stloc.s 9
+			IL_0096: ldloc.s 8
 			IL_0098: ldstr "createServer"
-			IL_009d: ldloc.s 10
+			IL_009d: ldloc.s 9
 			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00a4: pop
 			IL_00a5: ldstr "console"
 			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00af: stloc.s 9
-			IL_00b1: ldloc.s 9
+			IL_00af: stloc.s 8
+			IL_00b1: ldloc.s 8
 			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b8: stloc.s 9
-			IL_00ba: ldloc.s 9
+			IL_00b8: stloc.s 8
+			IL_00ba: ldloc.s 8
 			IL_00bc: ldstr "log"
 			IL_00c1: ldstr "unexpected success"
 			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00cb: pop
-			IL_00cc: leave IL_014f
+			IL_00cc: leave IL_0148
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -194,34 +193,32 @@
 			IL_00fd: stloc.s 5
 
 			IL_00ff: ldloc.s 5
-			IL_0101: stloc.s 9
-			IL_0103: ldloc.s 9
+			IL_0101: stloc.s 8
+			IL_0103: ldloc.s 8
 			IL_0105: stloc.s 6
-			IL_0107: newobj instance void Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly/Scope/Block_L9C16::.ctor()
-			IL_010c: stloc.s 7
-			IL_010e: ldstr "console"
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0118: stloc.s 9
-			IL_011a: ldloc.s 9
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0121: stloc.s 9
-			IL_0123: ldstr "message:"
-			IL_0128: ldloc.s 6
-			IL_012a: ldstr "message"
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0139: stloc.s 11
-			IL_013b: ldloc.s 9
-			IL_013d: ldstr "log"
-			IL_0142: ldloc.s 11
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0149: pop
-			IL_014a: leave IL_014f
+			IL_0107: ldstr "console"
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0111: stloc.s 8
+			IL_0113: ldloc.s 8
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011a: stloc.s 8
+			IL_011c: ldstr "message:"
+			IL_0121: ldloc.s 6
+			IL_0123: ldstr "message"
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0132: stloc.s 10
+			IL_0134: ldloc.s 8
+			IL_0136: ldstr "log"
+			IL_013b: ldloc.s 10
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0142: pop
+			IL_0143: leave IL_0148
 		} // end handler
 
-		IL_014f: ldnull
-		IL_0150: stloc.s 8
-		IL_0152: ret
+		IL_0148: ldnull
+		IL_0149: stloc.s 7
+		IL_014b: ret
 	} // end of method Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly::__js_module_init__
 
 } // end of class Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly
@@ -237,7 +234,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2223
+			// Method begins at RVA 0x221b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -261,7 +258,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21c0
+		// Method begins at RVA 0x21b8
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 8
@@ -301,7 +298,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222c
+		// Method begins at RVA 0x2224
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2682
+				// Method begins at RVA 0x267a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,7 +112,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a8
+						// Method begins at RVA 0x26a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26b1
+						// Method begins at RVA 0x26a9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -150,7 +150,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x269f
+					// Method begins at RVA 0x2697
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -176,19 +176,18 @@
 				)
 				// Method begins at RVA 0x2330
 				// Header size: 12
-				// Code size: 425 (0x1a9)
+				// Code size: 417 (0x1a1)
 				.maxstack 8
 				.locals init (
 					[0] class [System.Runtime]System.Exception,
 					[1] object,
 					[2] object,
-					[3] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L24C18,
+					[3] object,
 					[4] object,
 					[5] object,
-					[6] object,
-					[7] bool,
-					[8] object,
-					[9] object
+					[6] bool,
+					[7] object,
+					[8] object
 				)
 
 				IL_0000: ldarg.0
@@ -198,16 +197,16 @@
 				IL_0008: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0017: stloc.s 5
-				IL_0019: ldloc.s 5
+				IL_0017: stloc.s 4
+				IL_0019: ldloc.s 4
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.s 5
-				IL_0022: ldloc.s 5
+				IL_0020: stloc.s 4
+				IL_0022: ldloc.s 4
 				IL_0024: ldstr "setKeepAlive"
 				IL_0029: ldc.i4.1
 				IL_002a: box [System.Runtime]System.Boolean
 				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0034: stloc.s 5
+				IL_0034: stloc.s 4
 				IL_0036: ldarg.0
 				IL_0037: ldc.i4.1
 				IL_0038: ldelem.ref
@@ -215,23 +214,23 @@
 				IL_003e: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
 				IL_0043: ldstr "Cannot access 'client' before initialization"
 				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_004d: stloc.s 6
-				IL_004f: ldloc.s 5
-				IL_0051: ldloc.s 6
+				IL_004d: stloc.s 5
+				IL_004f: ldloc.s 4
+				IL_0051: ldloc.s 5
 				IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0058: stloc.s 7
-				IL_005a: ldloc.s 7
+				IL_0058: stloc.s 6
+				IL_005a: ldloc.s 6
 				IL_005c: box [System.Runtime]System.Boolean
-				IL_0061: stloc.s 8
+				IL_0061: stloc.s 7
 				IL_0063: ldstr "client keepalive same:"
-				IL_0068: ldloc.s 8
+				IL_0068: ldloc.s 7
 				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_006f: stloc.s 9
+				IL_006f: stloc.s 8
 				IL_0071: ldarg.0
 				IL_0072: ldc.i4.0
 				IL_0073: ldelem.ref
 				IL_0074: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0079: ldloc.s 9
+				IL_0079: ldloc.s 8
 				IL_007b: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
 				IL_0080: ldarg.0
 				IL_0081: ldc.i4.1
@@ -240,14 +239,14 @@
 				IL_0088: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
 				IL_008d: ldstr "Cannot access 'client' before initialization"
 				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0097: stloc.s 6
-				IL_0099: ldloc.s 6
+				IL_0097: stloc.s 5
+				IL_0099: ldloc.s 5
 				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a0: stloc.s 6
-				IL_00a2: ldloc.s 6
+				IL_00a0: stloc.s 5
+				IL_00a2: ldloc.s 5
 				IL_00a4: ldstr "setNoDelay"
 				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_00ae: stloc.s 6
+				IL_00ae: stloc.s 5
 				IL_00b0: ldarg.0
 				IL_00b1: ldc.i4.1
 				IL_00b2: ldelem.ref
@@ -255,23 +254,23 @@
 				IL_00b8: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
 				IL_00bd: ldstr "Cannot access 'client' before initialization"
 				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00c7: stloc.s 5
-				IL_00c9: ldloc.s 6
-				IL_00cb: ldloc.s 5
+				IL_00c7: stloc.s 4
+				IL_00c9: ldloc.s 5
+				IL_00cb: ldloc.s 4
 				IL_00cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00d2: stloc.s 7
-				IL_00d4: ldloc.s 7
+				IL_00d2: stloc.s 6
+				IL_00d4: ldloc.s 6
 				IL_00d6: box [System.Runtime]System.Boolean
-				IL_00db: stloc.s 8
+				IL_00db: stloc.s 7
 				IL_00dd: ldstr "client nodelay same:"
-				IL_00e2: ldloc.s 8
+				IL_00e2: ldloc.s 7
 				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00e9: stloc.s 9
+				IL_00e9: stloc.s 8
 				IL_00eb: ldarg.0
 				IL_00ec: ldc.i4.0
 				IL_00ed: ldelem.ref
 				IL_00ee: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_00f3: ldloc.s 9
+				IL_00f3: ldloc.s 8
 				IL_00f5: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
 				.try
 				{
@@ -283,11 +282,11 @@
 					IL_0103: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
 					IL_0108: ldstr "Cannot access 'client' before initialization"
 					IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0112: stloc.s 5
-					IL_0114: ldloc.s 5
+					IL_0112: stloc.s 4
+					IL_0114: ldloc.s 4
 					IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_011b: stloc.s 5
-					IL_011d: ldloc.s 5
+					IL_011b: stloc.s 4
+					IL_011d: ldloc.s 4
 					IL_011f: ldstr "setKeepAlive"
 					IL_0124: ldc.i4.1
 					IL_0125: box [System.Runtime]System.Boolean
@@ -295,7 +294,7 @@
 					IL_0133: box [System.Runtime]System.Double
 					IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 					IL_013d: pop
-					IL_013e: leave IL_01a3
+					IL_013e: leave IL_019d
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
@@ -321,30 +320,28 @@
 					IL_016b: stloc.1
 
 					IL_016c: ldloc.1
-					IL_016d: stloc.s 5
-					IL_016f: ldloc.s 5
+					IL_016d: stloc.s 4
+					IL_016f: ldloc.s 4
 					IL_0171: stloc.2
-					IL_0172: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/Scope/Block_L24C18::.ctor()
-					IL_0177: stloc.3
-					IL_0178: ldstr "client keepalive delay:"
-					IL_017d: ldloc.2
-					IL_017e: ldstr "message"
-					IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_018d: stloc.s 9
-					IL_018f: ldarg.0
-					IL_0190: ldc.i4.0
-					IL_0191: ldelem.ref
-					IL_0192: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-					IL_0197: ldloc.s 9
-					IL_0199: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
-					IL_019e: leave IL_01a3
+					IL_0172: ldstr "client keepalive delay:"
+					IL_0177: ldloc.2
+					IL_0178: ldstr "message"
+					IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0187: stloc.s 8
+					IL_0189: ldarg.0
+					IL_018a: ldc.i4.0
+					IL_018b: ldelem.ref
+					IL_018c: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+					IL_0191: ldloc.s 8
+					IL_0193: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
+					IL_0198: leave IL_019d
 				} // end handler
 
-				IL_01a3: ldnull
-				IL_01a4: stloc.s 4
-				IL_01a6: ldloc.s 4
-				IL_01a8: ret
+				IL_019d: ldnull
+				IL_019e: stloc.3
+				IL_019f: ldloc.3
+				IL_01a0: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -360,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26ba
+					// Method begins at RVA 0x26b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -385,7 +382,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24f8
+				// Method begins at RVA 0x24f0
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -424,7 +421,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26cc
+						// Method begins at RVA 0x26c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -447,7 +444,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2648
+					// Method begins at RVA 0x2640
 					// Header size: 12
 					// Code size: 37 (0x25)
 					.maxstack 8
@@ -479,7 +476,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c3
+					// Method begins at RVA 0x26bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -503,7 +500,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2520
+				// Method begins at RVA 0x2518
 				// Header size: 12
 				// Code size: 282 (0x11a)
 				.maxstack 8
@@ -632,7 +629,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268b
+				// Method begins at RVA 0x2683
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -846,7 +843,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2679
+			// Method begins at RVA 0x2671
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -982,7 +979,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26d5
+		// Method begins at RVA 0x26cd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_PerformanceNow_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_PerformanceNow_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2249
+				// Method begins at RVA 0x2245
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2252
+				// Method begins at RVA 0x224e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225b
+				// Method begins at RVA 0x2257
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2240
+			// Method begins at RVA 0x223c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 468 (0x1d4)
+		// Code size: 461 (0x1cd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.PerfHooks_PerformanceNow_Basic/Scope,
@@ -115,14 +115,13 @@
 			[7] class [System.Runtime]System.Exception,
 			[8] object,
 			[9] object,
-			[10] class Modules.PerfHooks_PerformanceNow_Basic/Scope/Block_L18C12,
-			[11] float64,
+			[10] float64,
+			[11] object,
 			[12] object,
-			[13] object,
-			[14] float64,
-			[15] bool,
-			[16] float64,
-			[17] object
+			[13] float64,
+			[14] bool,
+			[15] float64,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.PerfHooks_PerformanceNow_Basic/Scope::.ctor()
@@ -131,31 +130,31 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "perf_hooks"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 13
-		IL_0014: ldloc.s 13
+		IL_0012: stloc.s 12
+		IL_0014: ldloc.s 12
 		IL_0016: brfalse IL_0027
 
-		IL_001b: ldloc.s 13
+		IL_001b: ldloc.s 12
 		IL_001d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_0022: brfalse IL_0038
 
-		IL_0027: ldloc.s 13
+		IL_0027: ldloc.s 12
 		IL_0029: ldstr ""
 		IL_002e: ldstr "performance"
 		IL_0033: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0038: ldloc.s 13
+		IL_0038: ldloc.s 12
 		IL_003a: ldstr "performance"
 		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0044: stloc.1
 		IL_0045: ldloc.1
 		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004b: stloc.s 13
-		IL_004d: ldloc.s 13
+		IL_004b: stloc.s 12
+		IL_004d: ldloc.s 12
 		IL_004f: ldstr "now"
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0059: stloc.s 13
-		IL_005b: ldloc.s 13
+		IL_0059: stloc.s 12
+		IL_005b: ldloc.s 12
 		IL_005d: stloc.2
 		IL_005e: ldc.r8 0.0
 		IL_0067: stloc.3
@@ -163,39 +162,39 @@
 		IL_0071: stloc.s 4
 		// loop start (head: IL_0073)
 			IL_0073: ldloc.s 4
-			IL_0075: stloc.s 14
-			IL_0077: ldloc.s 14
+			IL_0075: stloc.s 13
+			IL_0077: ldloc.s 13
 			IL_0079: ldc.r8 10000
 			IL_0082: clt
 			IL_0084: brfalse IL_00b1
 
 			IL_0089: ldloc.3
-			IL_008a: stloc.s 14
-			IL_008c: ldloc.s 14
+			IL_008a: stloc.s 13
+			IL_008c: ldloc.s 13
 			IL_008e: ldloc.s 4
 			IL_0090: add
-			IL_0091: stloc.s 14
-			IL_0093: ldloc.s 14
+			IL_0091: stloc.s 13
+			IL_0093: ldloc.s 13
 			IL_0095: stloc.3
 			IL_0096: ldloc.s 4
-			IL_0098: stloc.s 14
-			IL_009a: ldloc.s 14
+			IL_0098: stloc.s 13
+			IL_009a: ldloc.s 13
 			IL_009c: ldc.r8 1
 			IL_00a5: add
-			IL_00a6: stloc.s 14
-			IL_00a8: ldloc.s 14
+			IL_00a6: stloc.s 13
+			IL_00a8: ldloc.s 13
 			IL_00aa: stloc.s 4
 			IL_00ac: br IL_0073
 		// end loop
 
 		IL_00b1: ldloc.1
 		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b7: stloc.s 13
-		IL_00b9: ldloc.s 13
+		IL_00b7: stloc.s 12
+		IL_00b9: ldloc.s 12
 		IL_00bb: ldstr "now"
 		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00c5: stloc.s 13
-		IL_00c7: ldloc.s 13
+		IL_00c5: stloc.s 12
+		IL_00c7: ldloc.s 12
 		IL_00c9: stloc.s 5
 		IL_00cb: ldc.i4.1
 		IL_00cc: stloc.s 6
@@ -204,12 +203,12 @@
 			IL_00ce: nop
 			IL_00cf: ldloc.1
 			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d5: stloc.s 13
-			IL_00d7: ldloc.s 13
+			IL_00d5: stloc.s 12
+			IL_00d7: ldloc.s 12
 			IL_00d9: ldstr "now"
 			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 			IL_00e3: pop
-			IL_00e4: leave IL_0132
+			IL_00e4: leave IL_012b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -235,75 +234,73 @@
 			IL_0115: stloc.s 8
 
 			IL_0117: ldloc.s 8
-			IL_0119: stloc.s 13
-			IL_011b: ldloc.s 13
+			IL_0119: stloc.s 12
+			IL_011b: ldloc.s 12
 			IL_011d: stloc.s 9
-			IL_011f: newobj instance void Modules.PerfHooks_PerformanceNow_Basic/Scope/Block_L18C12::.ctor()
-			IL_0124: stloc.s 10
-			IL_0126: ldc.i4.0
-			IL_0127: stloc.s 15
-			IL_0129: ldloc.s 15
-			IL_012b: stloc.s 6
-			IL_012d: leave IL_0132
+			IL_011f: ldc.i4.0
+			IL_0120: stloc.s 14
+			IL_0122: ldloc.s 14
+			IL_0124: stloc.s 6
+			IL_0126: leave IL_012b
 		} // end handler
 
-		IL_0132: ldloc.s 5
-		IL_0134: stloc.s 13
-		IL_0136: ldloc.s 13
-		IL_0138: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_013d: stloc.s 14
-		IL_013f: ldloc.2
-		IL_0140: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0145: stloc.s 16
-		IL_0147: ldloc.s 14
-		IL_0149: ldloc.s 16
-		IL_014b: sub
-		IL_014c: stloc.s 16
-		IL_014e: ldloc.s 16
-		IL_0150: stloc.s 11
-		IL_0152: ldstr "console"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015c: stloc.s 13
-		IL_015e: ldloc.s 13
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0165: stloc.s 13
-		IL_0167: ldloc.s 6
-		IL_0169: box [System.Runtime]System.Boolean
-		IL_016e: stloc.s 17
-		IL_0170: ldloc.s 13
-		IL_0172: ldstr "log"
-		IL_0177: ldstr "hasNow="
-		IL_017c: ldloc.s 17
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0183: pop
-		IL_0184: ldstr "console"
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018e: stloc.s 13
-		IL_0190: ldloc.s 13
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0197: stloc.s 13
-		IL_0199: ldloc.s 11
-		IL_019b: stloc.s 16
-		IL_019d: ldloc.s 16
-		IL_019f: ldc.r8 0.0
-		IL_01a8: clt
-		IL_01aa: stloc.s 15
-		IL_01ac: ldloc.s 15
-		IL_01ae: ldc.i4.0
-		IL_01af: ceq
-		IL_01b1: stloc.s 15
-		IL_01b3: ldloc.s 15
-		IL_01b5: box [System.Runtime]System.Boolean
-		IL_01ba: stloc.s 17
-		IL_01bc: ldloc.s 13
-		IL_01be: ldstr "log"
-		IL_01c3: ldstr "elapsedMsNonNegative="
-		IL_01c8: ldloc.s 17
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01cf: pop
-		IL_01d0: ldnull
-		IL_01d1: stloc.s 12
-		IL_01d3: ret
+		IL_012b: ldloc.s 5
+		IL_012d: stloc.s 12
+		IL_012f: ldloc.s 12
+		IL_0131: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0136: stloc.s 13
+		IL_0138: ldloc.2
+		IL_0139: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_013e: stloc.s 15
+		IL_0140: ldloc.s 13
+		IL_0142: ldloc.s 15
+		IL_0144: sub
+		IL_0145: stloc.s 15
+		IL_0147: ldloc.s 15
+		IL_0149: stloc.s 10
+		IL_014b: ldstr "console"
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0155: stloc.s 12
+		IL_0157: ldloc.s 12
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015e: stloc.s 12
+		IL_0160: ldloc.s 6
+		IL_0162: box [System.Runtime]System.Boolean
+		IL_0167: stloc.s 16
+		IL_0169: ldloc.s 12
+		IL_016b: ldstr "log"
+		IL_0170: ldstr "hasNow="
+		IL_0175: ldloc.s 16
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_017c: pop
+		IL_017d: ldstr "console"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0187: stloc.s 12
+		IL_0189: ldloc.s 12
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0190: stloc.s 12
+		IL_0192: ldloc.s 10
+		IL_0194: stloc.s 15
+		IL_0196: ldloc.s 15
+		IL_0198: ldc.r8 0.0
+		IL_01a1: clt
+		IL_01a3: stloc.s 14
+		IL_01a5: ldloc.s 14
+		IL_01a7: ldc.i4.0
+		IL_01a8: ceq
+		IL_01aa: stloc.s 14
+		IL_01ac: ldloc.s 14
+		IL_01ae: box [System.Runtime]System.Boolean
+		IL_01b3: stloc.s 16
+		IL_01b5: ldloc.s 12
+		IL_01b7: ldstr "log"
+		IL_01bc: ldstr "elapsedMsNonNegative="
+		IL_01c1: ldloc.s 16
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01c8: pop
+		IL_01c9: ldnull
+		IL_01ca: stloc.s 11
+		IL_01cc: ret
 	} // end of method PerfHooks_PerformanceNow_Basic::__js_module_init__
 
 } // end of class Modules.PerfHooks_PerformanceNow_Basic
@@ -315,7 +312,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2264
+		// Method begins at RVA 0x2260
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad7
+					// Method begins at RVA 0x2a43
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2abc
+				// Method begins at RVA 0x2a28
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ace
+				// Method begins at RVA 0x2a3a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae0
+				// Method begins at RVA 0x2a4c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -228,7 +228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2afb
+					// Method begins at RVA 0x2a67
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -251,7 +251,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2abf
+				// Method begins at RVA 0x2a2b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -273,7 +273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b16
+					// Method begins at RVA 0x2a82
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -296,7 +296,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ac2
+				// Method begins at RVA 0x2a2e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -333,7 +333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2af2
+					// Method begins at RVA 0x2a5e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b04
+					// Method begins at RVA 0x2a70
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b0d
+					// Method begins at RVA 0x2a79
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -393,7 +393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b1f
+					// Method begins at RVA 0x2a8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -413,7 +413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b28
+					// Method begins at RVA 0x2a94
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -433,7 +433,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b31
+					// Method begins at RVA 0x2a9d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -453,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b3a
+					// Method begins at RVA 0x2aa6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -473,7 +473,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b43
+					// Method begins at RVA 0x2aaf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -501,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae9
+				// Method begins at RVA 0x2a55
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -527,33 +527,28 @@
 			)
 			// Method begins at RVA 0x21d8
 			// Header size: 12
-			// Code size: 2235 (0x8bb)
+			// Code size: 2085 (0x825)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
 				[1] class [System.Runtime]System.Exception,
 				[2] object,
 				[3] object,
-				[4] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18,
-				[5] class [System.Runtime]System.Exception,
+				[4] class [System.Runtime]System.Exception,
+				[5] object,
 				[6] object,
 				[7] object,
-				[8] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18,
+				[8] object,
 				[9] object,
-				[10] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18,
-				[11] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6,
+				[10] object,
+				[11] object,
 				[12] object,
 				[13] object,
-				[14] object,
-				[15] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18,
+				[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[15] object,
 				[16] object,
 				[17] object,
-				[18] object,
-				[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[20] object,
-				[21] object,
-				[22] object,
-				[23] object[]
+				[18] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -586,14 +581,14 @@
 			IL_0042: brtrue IL_0054
 
 			IL_0047: ldloc.0
-			IL_0048: ldc.i4.s 23
+			IL_0048: ldc.i4.s 18
 			IL_004a: newarr [System.Runtime]System.Object
 			IL_004f: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0054: ldloc.0
 			IL_0055: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_005a: ldc.i4.0
-			IL_005b: ble IL_0112
+			IL_005b: ble IL_00db
 
 			IL_0060: ldloc.0
 			IL_0061: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -613,881 +608,806 @@
 			IL_0077: dup
 			IL_0078: ldc.i4.3
 			IL_0079: ldelem.ref
-			IL_007a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18
+			IL_007a: castclass [System.Runtime]System.Exception
 			IL_007f: stloc.s 4
 			IL_0081: dup
 			IL_0082: ldc.i4.4
 			IL_0083: ldelem.ref
-			IL_0084: castclass [System.Runtime]System.Exception
-			IL_0089: stloc.s 5
+			IL_0084: stloc.s 5
+			IL_0086: dup
+			IL_0087: ldc.i4.5
+			IL_0088: ldelem.ref
+			IL_0089: stloc.s 6
 			IL_008b: dup
-			IL_008c: ldc.i4.5
+			IL_008c: ldc.i4.6
 			IL_008d: ldelem.ref
-			IL_008e: stloc.s 6
+			IL_008e: stloc.s 7
 			IL_0090: dup
-			IL_0091: ldc.i4.6
+			IL_0091: ldc.i4.7
 			IL_0092: ldelem.ref
-			IL_0093: stloc.s 7
+			IL_0093: stloc.s 8
 			IL_0095: dup
-			IL_0096: ldc.i4.7
+			IL_0096: ldc.i4.8
 			IL_0097: ldelem.ref
-			IL_0098: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18
-			IL_009d: stloc.s 8
-			IL_009f: dup
-			IL_00a0: ldc.i4.8
-			IL_00a1: ldelem.ref
-			IL_00a2: stloc.s 9
-			IL_00a4: dup
-			IL_00a5: ldc.i4.s 9
-			IL_00a7: ldelem.ref
-			IL_00a8: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18
-			IL_00ad: stloc.s 10
-			IL_00af: dup
-			IL_00b0: ldc.i4.s 10
-			IL_00b2: ldelem.ref
-			IL_00b3: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6
-			IL_00b8: stloc.s 11
-			IL_00ba: dup
-			IL_00bb: ldc.i4.s 11
-			IL_00bd: ldelem.ref
-			IL_00be: stloc.s 12
-			IL_00c0: dup
-			IL_00c1: ldc.i4.s 12
-			IL_00c3: ldelem.ref
-			IL_00c4: stloc.s 13
-			IL_00c6: dup
-			IL_00c7: ldc.i4.s 13
-			IL_00c9: ldelem.ref
-			IL_00ca: stloc.s 14
-			IL_00cc: dup
-			IL_00cd: ldc.i4.s 14
-			IL_00cf: ldelem.ref
-			IL_00d0: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18
-			IL_00d5: stloc.s 15
-			IL_00d7: dup
-			IL_00d8: ldc.i4.s 15
-			IL_00da: ldelem.ref
-			IL_00db: stloc.s 16
-			IL_00dd: dup
-			IL_00de: ldc.i4.s 16
-			IL_00e0: ldelem.ref
-			IL_00e1: stloc.s 17
-			IL_00e3: dup
-			IL_00e4: ldc.i4.s 17
-			IL_00e6: ldelem.ref
-			IL_00e7: stloc.s 18
-			IL_00e9: dup
-			IL_00ea: ldc.i4.s 18
-			IL_00ec: ldelem.ref
-			IL_00ed: castclass [JavaScriptRuntime]JavaScriptRuntime.JsObject
-			IL_00f2: stloc.s 19
-			IL_00f4: dup
-			IL_00f5: ldc.i4.s 19
-			IL_00f7: ldelem.ref
-			IL_00f8: stloc.s 20
-			IL_00fa: dup
-			IL_00fb: ldc.i4.s 20
-			IL_00fd: ldelem.ref
-			IL_00fe: stloc.s 21
-			IL_0100: dup
-			IL_0101: ldc.i4.s 21
-			IL_0103: ldelem.ref
-			IL_0104: stloc.s 22
-			IL_0106: dup
-			IL_0107: ldc.i4.s 22
-			IL_0109: ldelem.ref
-			IL_010a: castclass object[]
-			IL_010f: stloc.s 23
-			IL_0111: pop
+			IL_0098: stloc.s 9
+			IL_009a: dup
+			IL_009b: ldc.i4.s 9
+			IL_009d: ldelem.ref
+			IL_009e: stloc.s 10
+			IL_00a0: dup
+			IL_00a1: ldc.i4.s 10
+			IL_00a3: ldelem.ref
+			IL_00a4: stloc.s 11
+			IL_00a6: dup
+			IL_00a7: ldc.i4.s 11
+			IL_00a9: ldelem.ref
+			IL_00aa: stloc.s 12
+			IL_00ac: dup
+			IL_00ad: ldc.i4.s 12
+			IL_00af: ldelem.ref
+			IL_00b0: stloc.s 13
+			IL_00b2: dup
+			IL_00b3: ldc.i4.s 13
+			IL_00b5: ldelem.ref
+			IL_00b6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			IL_00bb: stloc.s 14
+			IL_00bd: dup
+			IL_00be: ldc.i4.s 14
+			IL_00c0: ldelem.ref
+			IL_00c1: stloc.s 15
+			IL_00c3: dup
+			IL_00c4: ldc.i4.s 15
+			IL_00c6: ldelem.ref
+			IL_00c7: stloc.s 16
+			IL_00c9: dup
+			IL_00ca: ldc.i4.s 16
+			IL_00cc: ldelem.ref
+			IL_00cd: stloc.s 17
+			IL_00cf: dup
+			IL_00d0: ldc.i4.s 17
+			IL_00d2: ldelem.ref
+			IL_00d3: castclass object[]
+			IL_00d8: stloc.s 18
+			IL_00da: pop
 
-			IL_0112: ldloc.0
-			IL_0113: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0118: switch (IL_0131, IL_0593, IL_0560, IL_07d7, IL_07a4)
+			IL_00db: ldloc.0
+			IL_00dc: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e1: switch (IL_00fa, IL_0530, IL_04fd, IL_0748, IL_0715)
 			.try
 			{
-				IL_0131: nop
-				IL_0132: ldarg.0
-				IL_0133: ldc.i4.1
-				IL_0134: ldelem.ref
-				IL_0135: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_013a: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0144: stloc.s 17
-				IL_0146: ldarg.0
-				IL_0147: ldc.i4.1
-				IL_0148: ldelem.ref
-				IL_0149: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_014e: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_0153: ldc.i4.1
-				IL_0154: newarr [System.Runtime]System.Object
-				IL_0159: dup
+				IL_00fa: nop
+				IL_00fb: ldarg.0
+				IL_00fc: ldc.i4.1
+				IL_00fd: ldelem.ref
+				IL_00fe: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0103: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_010d: stloc.s 12
+				IL_010f: ldarg.0
+				IL_0110: ldc.i4.1
+				IL_0111: ldelem.ref
+				IL_0112: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0117: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_011c: ldc.i4.1
+				IL_011d: newarr [System.Runtime]System.Object
+				IL_0122: dup
+				IL_0123: ldc.i4.0
+				IL_0124: ldarg.0
+				IL_0125: ldc.i4.1
+				IL_0126: ldelem.ref
+				IL_0127: stelem.ref
+				IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_012d: stloc.s 13
+				IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0134: dup
+				IL_0135: ldstr "signal"
+				IL_013a: ldc.i4.0
+				IL_013b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0140: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0145: stloc.s 14
+				IL_0147: ldnull
+				IL_0148: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+				IL_014e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0153: ldc.i4.0
+				IL_0154: conv.r8
+				IL_0155: ldstr ""
 				IL_015a: ldc.i4.0
-				IL_015b: ldarg.0
-				IL_015c: ldc.i4.1
-				IL_015d: ldelem.ref
-				IL_015e: stelem.ref
-				IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0164: stloc.s 18
-				IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_016b: dup
-				IL_016c: ldstr "signal"
-				IL_0171: ldc.i4.0
-				IL_0172: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_017c: stloc.s 19
-				IL_017e: ldnull
-				IL_017f: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-				IL_0185: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_018a: ldc.i4.0
-				IL_018b: conv.r8
-				IL_018c: ldstr ""
-				IL_0191: ldc.i4.0
-				IL_0192: ldc.i4.1
-				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0198: stloc.s 20
-				IL_019a: ldloc.s 17
-				IL_019c: ldstr "finished"
-				IL_01a1: ldloc.s 18
-				IL_01a3: ldloc.s 19
-				IL_01a5: ldloc.s 20
-				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_01ac: pop
-				IL_01ad: ldstr "console"
-				IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01b7: stloc.s 20
-				IL_01b9: ldloc.s 20
-				IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01c0: stloc.s 20
-				IL_01c2: ldloc.s 20
-				IL_01c4: ldstr "log"
-				IL_01c9: ldstr "callback-finished:ok"
-				IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01d3: pop
-				IL_01d4: leave IL_029e
+				IL_015b: ldc.i4.1
+				IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_0161: stloc.s 15
+				IL_0163: ldloc.s 12
+				IL_0165: ldstr "finished"
+				IL_016a: ldloc.s 13
+				IL_016c: ldloc.s 14
+				IL_016e: ldloc.s 15
+				IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_0175: pop
+				IL_0176: ldstr "console"
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0180: stloc.s 15
+				IL_0182: ldloc.s 15
+				IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0189: stloc.s 15
+				IL_018b: ldloc.s 15
+				IL_018d: ldstr "log"
+				IL_0192: ldstr "callback-finished:ok"
+				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_019c: pop
+				IL_019d: leave IL_0260
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_01d9: stloc.1
-				IL_01da: ldloc.1
-				IL_01db: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_01e0: dup
-				IL_01e1: brtrue IL_01f6
+				IL_01a2: stloc.1
+				IL_01a3: ldloc.1
+				IL_01a4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_01a9: dup
+				IL_01aa: brtrue IL_01bf
 
-				IL_01e6: pop
-				IL_01e7: ldloc.1
-				IL_01e8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_01ed: dup
-				IL_01ee: brtrue IL_0201
+				IL_01af: pop
+				IL_01b0: ldloc.1
+				IL_01b1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_01b6: dup
+				IL_01b7: brtrue IL_01ca
 
-				IL_01f3: pop
-				IL_01f4: rethrow
+				IL_01bc: pop
+				IL_01bd: rethrow
 
-				IL_01f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_01fb: stloc.2
-				IL_01fc: br IL_0202
+				IL_01bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_01c4: stloc.2
+				IL_01c5: br IL_01cb
 
-				IL_0201: stloc.2
+				IL_01ca: stloc.2
 
-				IL_0202: ldloc.2
-				IL_0203: stloc.s 20
-				IL_0205: ldloc.s 20
-				IL_0207: stloc.3
-				IL_0208: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
-				IL_020d: stloc.s 4
-				IL_020f: ldstr "console"
-				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0219: stloc.s 20
-				IL_021b: ldloc.s 20
-				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0222: stloc.s 20
-				IL_0224: ldstr "callback-finished:"
-				IL_0229: ldloc.3
-				IL_022a: ldstr "name"
-				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0239: stloc.s 21
-				IL_023b: ldloc.s 21
-				IL_023d: ldstr ":"
-				IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0247: stloc.s 21
-				IL_0249: ldloc.s 21
-				IL_024b: ldloc.3
-				IL_024c: ldstr "code"
-				IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_025b: stloc.s 21
-				IL_025d: ldloc.s 20
-				IL_025f: ldstr "log"
-				IL_0264: ldloc.s 21
-				IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_026b: pop
-				IL_026c: ldstr "console"
-				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0276: stloc.s 20
-				IL_0278: ldloc.s 20
-				IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_027f: stloc.s 20
-				IL_0281: ldloc.s 20
-				IL_0283: ldstr "log"
-				IL_0288: ldloc.3
-				IL_0289: ldstr "message"
-				IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0298: pop
-				IL_0299: leave IL_029e
+				IL_01cb: ldloc.2
+				IL_01cc: stloc.s 15
+				IL_01ce: ldloc.s 15
+				IL_01d0: stloc.3
+				IL_01d1: ldstr "console"
+				IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01db: stloc.s 15
+				IL_01dd: ldloc.s 15
+				IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01e4: stloc.s 15
+				IL_01e6: ldstr "callback-finished:"
+				IL_01eb: ldloc.3
+				IL_01ec: ldstr "name"
+				IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01fb: stloc.s 16
+				IL_01fd: ldloc.s 16
+				IL_01ff: ldstr ":"
+				IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0209: stloc.s 16
+				IL_020b: ldloc.s 16
+				IL_020d: ldloc.3
+				IL_020e: ldstr "code"
+				IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_021d: stloc.s 16
+				IL_021f: ldloc.s 15
+				IL_0221: ldstr "log"
+				IL_0226: ldloc.s 16
+				IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_022d: pop
+				IL_022e: ldstr "console"
+				IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0238: stloc.s 15
+				IL_023a: ldloc.s 15
+				IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0241: stloc.s 15
+				IL_0243: ldloc.s 15
+				IL_0245: ldstr "log"
+				IL_024a: ldloc.3
+				IL_024b: ldstr "message"
+				IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_025a: pop
+				IL_025b: leave IL_0260
 			} // end handler
 			.try
 			{
-				IL_029e: nop
-				IL_029f: ldarg.0
-				IL_02a0: ldc.i4.1
-				IL_02a1: ldelem.ref
-				IL_02a2: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02a7: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02b1: stloc.s 20
-				IL_02b3: ldarg.0
-				IL_02b4: ldc.i4.1
-				IL_02b5: ldelem.ref
-				IL_02b6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02bb: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-				IL_02c0: ldc.i4.1
-				IL_02c1: newarr [System.Runtime]System.Object
-				IL_02c6: dup
-				IL_02c7: ldc.i4.0
-				IL_02c8: ldarg.0
-				IL_02c9: ldc.i4.1
-				IL_02ca: ldelem.ref
-				IL_02cb: stelem.ref
-				IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_02d1: stloc.s 18
-				IL_02d3: ldarg.0
-				IL_02d4: ldc.i4.1
-				IL_02d5: ldelem.ref
-				IL_02d6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02db: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_0260: nop
+				IL_0261: ldarg.0
+				IL_0262: ldc.i4.1
+				IL_0263: ldelem.ref
+				IL_0264: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0269: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0273: stloc.s 15
+				IL_0275: ldarg.0
+				IL_0276: ldc.i4.1
+				IL_0277: ldelem.ref
+				IL_0278: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_027d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+				IL_0282: ldc.i4.1
+				IL_0283: newarr [System.Runtime]System.Object
+				IL_0288: dup
+				IL_0289: ldc.i4.0
+				IL_028a: ldarg.0
+				IL_028b: ldc.i4.1
+				IL_028c: ldelem.ref
+				IL_028d: stelem.ref
+				IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0293: stloc.s 13
+				IL_0295: ldarg.0
+				IL_0296: ldc.i4.1
+				IL_0297: ldelem.ref
+				IL_0298: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_029d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_02a2: ldc.i4.1
+				IL_02a3: newarr [System.Runtime]System.Object
+				IL_02a8: dup
+				IL_02a9: ldc.i4.0
+				IL_02aa: ldarg.0
+				IL_02ab: ldc.i4.1
+				IL_02ac: ldelem.ref
+				IL_02ad: stelem.ref
+				IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_02b3: stloc.s 12
+				IL_02b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02ba: dup
+				IL_02bb: ldstr "signal"
+				IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_02ca: stloc.s 14
+				IL_02cc: ldnull
+				IL_02cd: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+				IL_02d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_02d8: ldc.i4.0
+				IL_02d9: conv.r8
+				IL_02da: ldstr ""
+				IL_02df: ldc.i4.0
 				IL_02e0: ldc.i4.1
-				IL_02e1: newarr [System.Runtime]System.Object
-				IL_02e6: dup
-				IL_02e7: ldc.i4.0
-				IL_02e8: ldarg.0
-				IL_02e9: ldc.i4.1
-				IL_02ea: ldelem.ref
-				IL_02eb: stelem.ref
-				IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_02f1: stloc.s 17
-				IL_02f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_02e6: stloc.s 17
+				IL_02e8: ldc.i4.4
+				IL_02e9: newarr [System.Runtime]System.Object
+				IL_02ee: dup
+				IL_02ef: ldc.i4.0
+				IL_02f0: ldloc.s 13
+				IL_02f2: stelem.ref
+				IL_02f3: dup
+				IL_02f4: ldc.i4.1
+				IL_02f5: ldloc.s 12
+				IL_02f7: stelem.ref
 				IL_02f8: dup
-				IL_02f9: ldstr "signal"
-				IL_02fe: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0303: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0308: stloc.s 19
-				IL_030a: ldnull
-				IL_030b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-				IL_0311: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0316: ldc.i4.0
-				IL_0317: conv.r8
-				IL_0318: ldstr ""
-				IL_031d: ldc.i4.0
-				IL_031e: ldc.i4.1
-				IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0324: stloc.s 22
-				IL_0326: ldc.i4.4
-				IL_0327: newarr [System.Runtime]System.Object
-				IL_032c: dup
-				IL_032d: ldc.i4.0
-				IL_032e: ldloc.s 18
-				IL_0330: stelem.ref
-				IL_0331: dup
-				IL_0332: ldc.i4.1
-				IL_0333: ldloc.s 17
-				IL_0335: stelem.ref
-				IL_0336: dup
-				IL_0337: ldc.i4.2
-				IL_0338: ldloc.s 19
-				IL_033a: stelem.ref
-				IL_033b: dup
-				IL_033c: ldc.i4.3
-				IL_033d: ldloc.s 22
-				IL_033f: stelem.ref
-				IL_0340: stloc.s 23
-				IL_0342: ldloc.s 20
-				IL_0344: ldstr "pipeline"
-				IL_0349: ldloc.s 23
-				IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0350: pop
-				IL_0351: ldstr "console"
-				IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_035b: stloc.s 20
-				IL_035d: ldloc.s 20
-				IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0364: stloc.s 20
-				IL_0366: ldloc.s 20
-				IL_0368: ldstr "log"
-				IL_036d: ldstr "callback-pipeline:ok"
-				IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0377: pop
-				IL_0378: leave IL_044c
+				IL_02f9: ldc.i4.2
+				IL_02fa: ldloc.s 14
+				IL_02fc: stelem.ref
+				IL_02fd: dup
+				IL_02fe: ldc.i4.3
+				IL_02ff: ldloc.s 17
+				IL_0301: stelem.ref
+				IL_0302: stloc.s 18
+				IL_0304: ldloc.s 15
+				IL_0306: ldstr "pipeline"
+				IL_030b: ldloc.s 18
+				IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0312: pop
+				IL_0313: ldstr "console"
+				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_031d: stloc.s 15
+				IL_031f: ldloc.s 15
+				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0326: stloc.s 15
+				IL_0328: ldloc.s 15
+				IL_032a: ldstr "log"
+				IL_032f: ldstr "callback-pipeline:ok"
+				IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0339: pop
+				IL_033a: leave IL_0407
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_037d: stloc.s 5
-				IL_037f: ldloc.s 5
-				IL_0381: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0386: dup
-				IL_0387: brtrue IL_039d
+				IL_033f: stloc.s 4
+				IL_0341: ldloc.s 4
+				IL_0343: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0348: dup
+				IL_0349: brtrue IL_035f
 
-				IL_038c: pop
-				IL_038d: ldloc.s 5
-				IL_038f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0394: dup
-				IL_0395: brtrue IL_03a9
+				IL_034e: pop
+				IL_034f: ldloc.s 4
+				IL_0351: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0356: dup
+				IL_0357: brtrue IL_036b
 
-				IL_039a: pop
-				IL_039b: rethrow
+				IL_035c: pop
+				IL_035d: rethrow
 
-				IL_039d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_03a2: stloc.s 6
-				IL_03a4: br IL_03ab
+				IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0364: stloc.s 5
+				IL_0366: br IL_036d
 
-				IL_03a9: stloc.s 6
+				IL_036b: stloc.s 5
 
-				IL_03ab: ldloc.s 6
-				IL_03ad: stloc.s 20
-				IL_03af: ldloc.s 20
-				IL_03b1: stloc.s 7
-				IL_03b3: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
-				IL_03b8: stloc.s 8
-				IL_03ba: ldstr "console"
-				IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_03c4: stloc.s 20
-				IL_03c6: ldloc.s 20
-				IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03cd: stloc.s 20
-				IL_03cf: ldstr "callback-pipeline:"
-				IL_03d4: ldloc.s 7
-				IL_03d6: ldstr "name"
-				IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03e5: stloc.s 21
-				IL_03e7: ldloc.s 21
-				IL_03e9: ldstr ":"
-				IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03f3: stloc.s 21
-				IL_03f5: ldloc.s 21
-				IL_03f7: ldloc.s 7
-				IL_03f9: ldstr "code"
-				IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0408: stloc.s 21
-				IL_040a: ldloc.s 20
-				IL_040c: ldstr "log"
-				IL_0411: ldloc.s 21
-				IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0418: pop
-				IL_0419: ldstr "console"
-				IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0423: stloc.s 20
-				IL_0425: ldloc.s 20
-				IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_042c: stloc.s 20
-				IL_042e: ldloc.s 20
-				IL_0430: ldstr "log"
-				IL_0435: ldloc.s 7
-				IL_0437: ldstr "message"
-				IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0446: pop
-				IL_0447: leave IL_044c
+				IL_036d: ldloc.s 5
+				IL_036f: stloc.s 15
+				IL_0371: ldloc.s 15
+				IL_0373: stloc.s 6
+				IL_0375: ldstr "console"
+				IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_037f: stloc.s 15
+				IL_0381: ldloc.s 15
+				IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0388: stloc.s 15
+				IL_038a: ldstr "callback-pipeline:"
+				IL_038f: ldloc.s 6
+				IL_0391: ldstr "name"
+				IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03a0: stloc.s 16
+				IL_03a2: ldloc.s 16
+				IL_03a4: ldstr ":"
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03ae: stloc.s 16
+				IL_03b0: ldloc.s 16
+				IL_03b2: ldloc.s 6
+				IL_03b4: ldstr "code"
+				IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03c3: stloc.s 16
+				IL_03c5: ldloc.s 15
+				IL_03c7: ldstr "log"
+				IL_03cc: ldloc.s 16
+				IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_03d3: pop
+				IL_03d4: ldstr "console"
+				IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_03de: stloc.s 15
+				IL_03e0: ldloc.s 15
+				IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03e7: stloc.s 15
+				IL_03e9: ldloc.s 15
+				IL_03eb: ldstr "log"
+				IL_03f0: ldloc.s 6
+				IL_03f2: ldstr "message"
+				IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0401: pop
+				IL_0402: leave IL_0407
 			} // end handler
 
-			IL_044c: ldloc.0
-			IL_044d: ldc.i4.0
-			IL_044e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0453: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0458: ldarg.0
-			IL_0459: ldc.i4.1
-			IL_045a: ldelem.ref
-			IL_045b: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0460: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_046a: stloc.s 20
-			IL_046c: ldarg.0
-			IL_046d: ldc.i4.1
-			IL_046e: ldelem.ref
-			IL_046f: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0474: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_0479: ldc.i4.1
-			IL_047a: newarr [System.Runtime]System.Object
-			IL_047f: dup
-			IL_0480: ldc.i4.0
-			IL_0481: ldarg.0
-			IL_0482: ldc.i4.1
-			IL_0483: ldelem.ref
-			IL_0484: stelem.ref
-			IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_048a: stloc.s 22
-			IL_048c: ldloc.s 20
-			IL_048e: ldstr "finished"
-			IL_0493: ldloc.s 22
-			IL_0495: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_049a: dup
-			IL_049b: ldstr "signal"
-			IL_04a0: ldc.i4.0
-			IL_04a1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04b0: stloc.s 22
-			IL_04b2: ldloc.0
-			IL_04b3: ldc.i4.2
-			IL_04b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04b9: ldloc.0
-			IL_04ba: ldloc.s 22
-			IL_04bc: ldarg.0
-			IL_04bd: ldc.i4.1
-			IL_04be: ldloc.0
-			IL_04bf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04c4: ldc.i4.1
-			IL_04c5: ldstr "_pendingException"
-			IL_04ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04cf: ldloc.0
-			IL_04d0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04d5: dup
-			IL_04d6: ldc.i4.0
-			IL_04d7: ldloc.1
-			IL_04d8: stelem.ref
-			IL_04d9: dup
-			IL_04da: ldc.i4.1
-			IL_04db: ldloc.2
-			IL_04dc: stelem.ref
-			IL_04dd: dup
-			IL_04de: ldc.i4.2
-			IL_04df: ldloc.3
-			IL_04e0: stelem.ref
-			IL_04e1: dup
-			IL_04e2: ldc.i4.3
-			IL_04e3: ldloc.s 4
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.4
-			IL_04e8: ldloc.s 5
-			IL_04ea: stelem.ref
-			IL_04eb: dup
-			IL_04ec: ldc.i4.5
-			IL_04ed: ldloc.s 6
+			IL_0407: ldloc.0
+			IL_0408: ldc.i4.0
+			IL_0409: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_040e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0413: ldarg.0
+			IL_0414: ldc.i4.1
+			IL_0415: ldelem.ref
+			IL_0416: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_041b: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0425: stloc.s 15
+			IL_0427: ldarg.0
+			IL_0428: ldc.i4.1
+			IL_0429: ldelem.ref
+			IL_042a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_042f: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_0434: ldc.i4.1
+			IL_0435: newarr [System.Runtime]System.Object
+			IL_043a: dup
+			IL_043b: ldc.i4.0
+			IL_043c: ldarg.0
+			IL_043d: ldc.i4.1
+			IL_043e: ldelem.ref
+			IL_043f: stelem.ref
+			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0445: stloc.s 17
+			IL_0447: ldloc.s 15
+			IL_0449: ldstr "finished"
+			IL_044e: ldloc.s 17
+			IL_0450: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0455: dup
+			IL_0456: ldstr "signal"
+			IL_045b: ldc.i4.0
+			IL_045c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0461: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_046b: stloc.s 17
+			IL_046d: ldloc.0
+			IL_046e: ldc.i4.2
+			IL_046f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0474: ldloc.0
+			IL_0475: ldloc.s 17
+			IL_0477: ldarg.0
+			IL_0478: ldc.i4.1
+			IL_0479: ldloc.0
+			IL_047a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_047f: ldc.i4.1
+			IL_0480: ldstr "_pendingException"
+			IL_0485: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_048a: ldloc.0
+			IL_048b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0490: dup
+			IL_0491: ldc.i4.0
+			IL_0492: ldloc.1
+			IL_0493: stelem.ref
+			IL_0494: dup
+			IL_0495: ldc.i4.1
+			IL_0496: ldloc.2
+			IL_0497: stelem.ref
+			IL_0498: dup
+			IL_0499: ldc.i4.2
+			IL_049a: ldloc.3
+			IL_049b: stelem.ref
+			IL_049c: dup
+			IL_049d: ldc.i4.3
+			IL_049e: ldloc.s 4
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.4
+			IL_04a3: ldloc.s 5
+			IL_04a5: stelem.ref
+			IL_04a6: dup
+			IL_04a7: ldc.i4.5
+			IL_04a8: ldloc.s 6
+			IL_04aa: stelem.ref
+			IL_04ab: dup
+			IL_04ac: ldc.i4.6
+			IL_04ad: ldloc.s 7
+			IL_04af: stelem.ref
+			IL_04b0: dup
+			IL_04b1: ldc.i4.7
+			IL_04b2: ldloc.s 8
+			IL_04b4: stelem.ref
+			IL_04b5: dup
+			IL_04b6: ldc.i4.8
+			IL_04b7: ldloc.s 9
+			IL_04b9: stelem.ref
+			IL_04ba: dup
+			IL_04bb: ldc.i4.s 9
+			IL_04bd: ldloc.s 10
+			IL_04bf: stelem.ref
+			IL_04c0: dup
+			IL_04c1: ldc.i4.s 10
+			IL_04c3: ldloc.s 11
+			IL_04c5: stelem.ref
+			IL_04c6: dup
+			IL_04c7: ldc.i4.s 11
+			IL_04c9: ldloc.s 12
+			IL_04cb: stelem.ref
+			IL_04cc: dup
+			IL_04cd: ldc.i4.s 12
+			IL_04cf: ldloc.s 13
+			IL_04d1: stelem.ref
+			IL_04d2: dup
+			IL_04d3: ldc.i4.s 13
+			IL_04d5: ldloc.s 14
+			IL_04d7: stelem.ref
+			IL_04d8: dup
+			IL_04d9: ldc.i4.s 14
+			IL_04db: ldloc.s 15
+			IL_04dd: stelem.ref
+			IL_04de: dup
+			IL_04df: ldc.i4.s 15
+			IL_04e1: ldloc.s 16
+			IL_04e3: stelem.ref
+			IL_04e4: dup
+			IL_04e5: ldc.i4.s 16
+			IL_04e7: ldloc.s 17
+			IL_04e9: stelem.ref
+			IL_04ea: dup
+			IL_04eb: ldc.i4.s 17
+			IL_04ed: ldloc.s 18
 			IL_04ef: stelem.ref
-			IL_04f0: dup
-			IL_04f1: ldc.i4.6
-			IL_04f2: ldloc.s 7
-			IL_04f4: stelem.ref
-			IL_04f5: dup
-			IL_04f6: ldc.i4.7
-			IL_04f7: ldloc.s 8
-			IL_04f9: stelem.ref
-			IL_04fa: dup
-			IL_04fb: ldc.i4.8
-			IL_04fc: ldloc.s 9
-			IL_04fe: stelem.ref
-			IL_04ff: dup
-			IL_0500: ldc.i4.s 9
-			IL_0502: ldloc.s 10
-			IL_0504: stelem.ref
-			IL_0505: dup
-			IL_0506: ldc.i4.s 10
-			IL_0508: ldloc.s 11
-			IL_050a: stelem.ref
-			IL_050b: dup
-			IL_050c: ldc.i4.s 11
-			IL_050e: ldloc.s 12
-			IL_0510: stelem.ref
-			IL_0511: dup
-			IL_0512: ldc.i4.s 12
-			IL_0514: ldloc.s 13
-			IL_0516: stelem.ref
-			IL_0517: dup
-			IL_0518: ldc.i4.s 13
-			IL_051a: ldloc.s 14
-			IL_051c: stelem.ref
-			IL_051d: dup
-			IL_051e: ldc.i4.s 14
-			IL_0520: ldloc.s 15
-			IL_0522: stelem.ref
-			IL_0523: dup
-			IL_0524: ldc.i4.s 15
-			IL_0526: ldloc.s 16
-			IL_0528: stelem.ref
-			IL_0529: dup
-			IL_052a: ldc.i4.s 16
-			IL_052c: ldloc.s 17
-			IL_052e: stelem.ref
-			IL_052f: dup
-			IL_0530: ldc.i4.s 17
-			IL_0532: ldloc.s 18
-			IL_0534: stelem.ref
-			IL_0535: dup
-			IL_0536: ldc.i4.s 18
-			IL_0538: ldloc.s 19
-			IL_053a: stelem.ref
-			IL_053b: dup
-			IL_053c: ldc.i4.s 19
-			IL_053e: ldloc.s 20
-			IL_0540: stelem.ref
-			IL_0541: dup
-			IL_0542: ldc.i4.s 20
-			IL_0544: ldloc.s 21
-			IL_0546: stelem.ref
-			IL_0547: dup
-			IL_0548: ldc.i4.s 21
-			IL_054a: ldloc.s 22
-			IL_054c: stelem.ref
-			IL_054d: dup
-			IL_054e: ldc.i4.s 22
-			IL_0550: ldloc.s 23
-			IL_0552: stelem.ref
-			IL_0553: pop
-			IL_0554: ldloc.0
-			IL_0555: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_055a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_055f: ret
+			IL_04f0: pop
+			IL_04f1: ldloc.0
+			IL_04f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04f7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04fc: ret
 
-			IL_0560: ldloc.0
-			IL_0561: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
-			IL_0566: pop
-			IL_0567: ldstr "console"
-			IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0571: stloc.s 22
-			IL_0573: ldloc.s 22
-			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_057a: stloc.s 22
-			IL_057c: ldloc.s 22
-			IL_057e: ldstr "log"
-			IL_0583: ldstr "promise-finished:ok"
-			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_058d: pop
-			IL_058e: br IL_0644
+			IL_04fd: ldloc.0
+			IL_04fe: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_0503: pop
+			IL_0504: ldstr "console"
+			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_050e: stloc.s 17
+			IL_0510: ldloc.s 17
+			IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0517: stloc.s 17
+			IL_0519: ldloc.s 17
+			IL_051b: ldstr "log"
+			IL_0520: ldstr "promise-finished:ok"
+			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_052a: pop
+			IL_052b: br IL_05da
 
-			IL_0593: ldloc.0
-			IL_0594: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0599: stloc.s 22
-			IL_059b: ldloc.0
-			IL_059c: ldc.i4.0
-			IL_059d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_05a7: ldloc.s 22
-			IL_05a9: stloc.s 9
-			IL_05ab: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
-			IL_05b0: stloc.s 10
-			IL_05b2: ldstr "console"
-			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05bc: stloc.s 22
-			IL_05be: ldloc.s 22
-			IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c5: stloc.s 22
-			IL_05c7: ldstr "promise-finished:"
-			IL_05cc: ldloc.s 9
-			IL_05ce: ldstr "name"
-			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05dd: stloc.s 21
-			IL_05df: ldloc.s 21
-			IL_05e1: ldstr ":"
-			IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05eb: stloc.s 21
-			IL_05ed: ldloc.s 21
-			IL_05ef: ldloc.s 9
-			IL_05f1: ldstr "code"
-			IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0600: stloc.s 21
-			IL_0602: ldloc.s 22
-			IL_0604: ldstr "log"
-			IL_0609: ldloc.s 21
-			IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0610: pop
-			IL_0611: ldstr "console"
-			IL_0616: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_061b: stloc.s 22
-			IL_061d: ldloc.s 22
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0624: stloc.s 22
-			IL_0626: ldloc.s 22
-			IL_0628: ldstr "log"
-			IL_062d: ldloc.s 9
-			IL_062f: ldstr "message"
-			IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_063e: pop
-			IL_063f: br IL_0644
+			IL_0530: ldloc.0
+			IL_0531: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0536: stloc.s 17
+			IL_0538: ldloc.0
+			IL_0539: ldc.i4.0
+			IL_053a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_053f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0544: ldloc.s 17
+			IL_0546: stloc.s 7
+			IL_0548: ldstr "console"
+			IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0552: stloc.s 17
+			IL_0554: ldloc.s 17
+			IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_055b: stloc.s 17
+			IL_055d: ldstr "promise-finished:"
+			IL_0562: ldloc.s 7
+			IL_0564: ldstr "name"
+			IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0573: stloc.s 16
+			IL_0575: ldloc.s 16
+			IL_0577: ldstr ":"
+			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0581: stloc.s 16
+			IL_0583: ldloc.s 16
+			IL_0585: ldloc.s 7
+			IL_0587: ldstr "code"
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0596: stloc.s 16
+			IL_0598: ldloc.s 17
+			IL_059a: ldstr "log"
+			IL_059f: ldloc.s 16
+			IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05a6: pop
+			IL_05a7: ldstr "console"
+			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05b1: stloc.s 17
+			IL_05b3: ldloc.s 17
+			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05ba: stloc.s 17
+			IL_05bc: ldloc.s 17
+			IL_05be: ldstr "log"
+			IL_05c3: ldloc.s 7
+			IL_05c5: ldstr "message"
+			IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05d4: pop
+			IL_05d5: br IL_05da
 
-			IL_0644: ldloc.0
-			IL_0645: ldc.i4.0
-			IL_0646: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_064b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0650: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
-			IL_0655: stloc.s 11
-			IL_0657: ldarg.0
-			IL_0658: ldc.i4.1
-			IL_0659: ldelem.ref
-			IL_065a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_065f: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-			IL_0664: ldc.i4.1
-			IL_0665: newarr [System.Runtime]System.Object
-			IL_066a: dup
-			IL_066b: ldc.i4.0
-			IL_066c: ldarg.0
-			IL_066d: ldc.i4.1
-			IL_066e: ldelem.ref
-			IL_066f: stelem.ref
-			IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0675: stloc.s 22
-			IL_0677: ldloc.s 22
-			IL_0679: stloc.s 12
-			IL_067b: ldarg.0
-			IL_067c: ldc.i4.1
-			IL_067d: ldelem.ref
-			IL_067e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0683: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_068d: stloc.s 22
+			IL_05da: ldloc.0
+			IL_05db: ldc.i4.0
+			IL_05dc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05e1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05e6: ldarg.0
+			IL_05e7: ldc.i4.1
+			IL_05e8: ldelem.ref
+			IL_05e9: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_05ee: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+			IL_05f3: ldc.i4.1
+			IL_05f4: newarr [System.Runtime]System.Object
+			IL_05f9: dup
+			IL_05fa: ldc.i4.0
+			IL_05fb: ldarg.0
+			IL_05fc: ldc.i4.1
+			IL_05fd: ldelem.ref
+			IL_05fe: stelem.ref
+			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0604: stloc.s 17
+			IL_0606: ldloc.s 17
+			IL_0608: stloc.s 8
+			IL_060a: ldarg.0
+			IL_060b: ldc.i4.1
+			IL_060c: ldelem.ref
+			IL_060d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0612: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_061c: stloc.s 17
+			IL_061e: ldarg.0
+			IL_061f: ldc.i4.1
+			IL_0620: ldelem.ref
+			IL_0621: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0626: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_062b: ldc.i4.1
+			IL_062c: newarr [System.Runtime]System.Object
+			IL_0631: dup
+			IL_0632: ldc.i4.0
+			IL_0633: ldarg.0
+			IL_0634: ldc.i4.1
+			IL_0635: ldelem.ref
+			IL_0636: stelem.ref
+			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_063c: stloc.s 15
+			IL_063e: ldloc.s 17
+			IL_0640: ldstr "pipeline"
+			IL_0645: ldloc.s 8
+			IL_0647: ldloc.s 15
+			IL_0649: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_064e: dup
+			IL_064f: ldstr "signal"
+			IL_0654: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0659: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0663: stloc.s 15
+			IL_0665: ldloc.s 15
+			IL_0667: stloc.s 9
+			IL_0669: ldloc.s 8
+			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0670: stloc.s 15
+			IL_0672: ldloc.s 15
+			IL_0674: ldstr "push"
+			IL_0679: ldc.i4.0
+			IL_067a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0684: pop
+			IL_0685: ldloc.0
+			IL_0686: ldc.i4.4
+			IL_0687: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_068c: ldloc.0
+			IL_068d: ldloc.s 9
 			IL_068f: ldarg.0
-			IL_0690: ldc.i4.1
-			IL_0691: ldelem.ref
-			IL_0692: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0697: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_069c: ldc.i4.1
-			IL_069d: newarr [System.Runtime]System.Object
-			IL_06a2: dup
-			IL_06a3: ldc.i4.0
-			IL_06a4: ldarg.0
-			IL_06a5: ldc.i4.1
-			IL_06a6: ldelem.ref
-			IL_06a7: stelem.ref
-			IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_06ad: stloc.s 20
-			IL_06af: ldloc.s 22
-			IL_06b1: ldstr "pipeline"
-			IL_06b6: ldloc.s 12
-			IL_06b8: ldloc.s 20
-			IL_06ba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06bf: dup
-			IL_06c0: ldstr "signal"
-			IL_06c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_06d4: stloc.s 20
-			IL_06d6: ldloc.s 20
-			IL_06d8: stloc.s 13
-			IL_06da: ldloc.s 12
-			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06e1: stloc.s 20
-			IL_06e3: ldloc.s 20
-			IL_06e5: ldstr "push"
-			IL_06ea: ldc.i4.0
-			IL_06eb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06f5: pop
-			IL_06f6: ldloc.0
-			IL_06f7: ldc.i4.4
-			IL_06f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06fd: ldloc.0
-			IL_06fe: ldloc.s 13
-			IL_0700: ldarg.0
-			IL_0701: ldc.i4.2
-			IL_0702: ldloc.0
-			IL_0703: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0708: ldc.i4.3
-			IL_0709: ldstr "_pendingException"
-			IL_070e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0713: ldloc.0
-			IL_0714: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0719: dup
-			IL_071a: ldc.i4.0
-			IL_071b: ldloc.1
-			IL_071c: stelem.ref
-			IL_071d: dup
-			IL_071e: ldc.i4.1
-			IL_071f: ldloc.2
-			IL_0720: stelem.ref
-			IL_0721: dup
-			IL_0722: ldc.i4.2
-			IL_0723: ldloc.3
-			IL_0724: stelem.ref
-			IL_0725: dup
-			IL_0726: ldc.i4.3
-			IL_0727: ldloc.s 4
-			IL_0729: stelem.ref
-			IL_072a: dup
-			IL_072b: ldc.i4.4
-			IL_072c: ldloc.s 5
-			IL_072e: stelem.ref
-			IL_072f: dup
-			IL_0730: ldc.i4.5
-			IL_0731: ldloc.s 6
-			IL_0733: stelem.ref
-			IL_0734: dup
-			IL_0735: ldc.i4.6
-			IL_0736: ldloc.s 7
-			IL_0738: stelem.ref
-			IL_0739: dup
-			IL_073a: ldc.i4.7
-			IL_073b: ldloc.s 8
-			IL_073d: stelem.ref
-			IL_073e: dup
-			IL_073f: ldc.i4.8
-			IL_0740: ldloc.s 9
-			IL_0742: stelem.ref
-			IL_0743: dup
-			IL_0744: ldc.i4.s 9
-			IL_0746: ldloc.s 10
-			IL_0748: stelem.ref
-			IL_0749: dup
-			IL_074a: ldc.i4.s 10
-			IL_074c: ldloc.s 11
-			IL_074e: stelem.ref
-			IL_074f: dup
-			IL_0750: ldc.i4.s 11
-			IL_0752: ldloc.s 12
-			IL_0754: stelem.ref
-			IL_0755: dup
-			IL_0756: ldc.i4.s 12
-			IL_0758: ldloc.s 13
-			IL_075a: stelem.ref
-			IL_075b: dup
-			IL_075c: ldc.i4.s 13
-			IL_075e: ldloc.s 14
-			IL_0760: stelem.ref
-			IL_0761: dup
-			IL_0762: ldc.i4.s 14
-			IL_0764: ldloc.s 15
-			IL_0766: stelem.ref
-			IL_0767: dup
-			IL_0768: ldc.i4.s 15
-			IL_076a: ldloc.s 16
-			IL_076c: stelem.ref
-			IL_076d: dup
-			IL_076e: ldc.i4.s 16
-			IL_0770: ldloc.s 17
-			IL_0772: stelem.ref
-			IL_0773: dup
-			IL_0774: ldc.i4.s 17
-			IL_0776: ldloc.s 18
-			IL_0778: stelem.ref
-			IL_0779: dup
-			IL_077a: ldc.i4.s 18
-			IL_077c: ldloc.s 19
-			IL_077e: stelem.ref
-			IL_077f: dup
-			IL_0780: ldc.i4.s 19
-			IL_0782: ldloc.s 20
-			IL_0784: stelem.ref
-			IL_0785: dup
-			IL_0786: ldc.i4.s 20
-			IL_0788: ldloc.s 21
-			IL_078a: stelem.ref
-			IL_078b: dup
-			IL_078c: ldc.i4.s 21
-			IL_078e: ldloc.s 22
-			IL_0790: stelem.ref
-			IL_0791: dup
-			IL_0792: ldc.i4.s 22
-			IL_0794: ldloc.s 23
-			IL_0796: stelem.ref
-			IL_0797: pop
-			IL_0798: ldloc.0
-			IL_0799: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_079e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07a3: ret
+			IL_0690: ldc.i4.2
+			IL_0691: ldloc.0
+			IL_0692: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0697: ldc.i4.3
+			IL_0698: ldstr "_pendingException"
+			IL_069d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_06a2: ldloc.0
+			IL_06a3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06a8: dup
+			IL_06a9: ldc.i4.0
+			IL_06aa: ldloc.1
+			IL_06ab: stelem.ref
+			IL_06ac: dup
+			IL_06ad: ldc.i4.1
+			IL_06ae: ldloc.2
+			IL_06af: stelem.ref
+			IL_06b0: dup
+			IL_06b1: ldc.i4.2
+			IL_06b2: ldloc.3
+			IL_06b3: stelem.ref
+			IL_06b4: dup
+			IL_06b5: ldc.i4.3
+			IL_06b6: ldloc.s 4
+			IL_06b8: stelem.ref
+			IL_06b9: dup
+			IL_06ba: ldc.i4.4
+			IL_06bb: ldloc.s 5
+			IL_06bd: stelem.ref
+			IL_06be: dup
+			IL_06bf: ldc.i4.5
+			IL_06c0: ldloc.s 6
+			IL_06c2: stelem.ref
+			IL_06c3: dup
+			IL_06c4: ldc.i4.6
+			IL_06c5: ldloc.s 7
+			IL_06c7: stelem.ref
+			IL_06c8: dup
+			IL_06c9: ldc.i4.7
+			IL_06ca: ldloc.s 8
+			IL_06cc: stelem.ref
+			IL_06cd: dup
+			IL_06ce: ldc.i4.8
+			IL_06cf: ldloc.s 9
+			IL_06d1: stelem.ref
+			IL_06d2: dup
+			IL_06d3: ldc.i4.s 9
+			IL_06d5: ldloc.s 10
+			IL_06d7: stelem.ref
+			IL_06d8: dup
+			IL_06d9: ldc.i4.s 10
+			IL_06db: ldloc.s 11
+			IL_06dd: stelem.ref
+			IL_06de: dup
+			IL_06df: ldc.i4.s 11
+			IL_06e1: ldloc.s 12
+			IL_06e3: stelem.ref
+			IL_06e4: dup
+			IL_06e5: ldc.i4.s 12
+			IL_06e7: ldloc.s 13
+			IL_06e9: stelem.ref
+			IL_06ea: dup
+			IL_06eb: ldc.i4.s 13
+			IL_06ed: ldloc.s 14
+			IL_06ef: stelem.ref
+			IL_06f0: dup
+			IL_06f1: ldc.i4.s 14
+			IL_06f3: ldloc.s 15
+			IL_06f5: stelem.ref
+			IL_06f6: dup
+			IL_06f7: ldc.i4.s 15
+			IL_06f9: ldloc.s 16
+			IL_06fb: stelem.ref
+			IL_06fc: dup
+			IL_06fd: ldc.i4.s 16
+			IL_06ff: ldloc.s 17
+			IL_0701: stelem.ref
+			IL_0702: dup
+			IL_0703: ldc.i4.s 17
+			IL_0705: ldloc.s 18
+			IL_0707: stelem.ref
+			IL_0708: pop
+			IL_0709: ldloc.0
+			IL_070a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_070f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0714: ret
 
-			IL_07a4: ldloc.0
-			IL_07a5: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_07aa: pop
-			IL_07ab: ldstr "console"
-			IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07b5: stloc.s 20
-			IL_07b7: ldloc.s 20
-			IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07be: stloc.s 20
-			IL_07c0: ldloc.s 20
-			IL_07c2: ldstr "log"
-			IL_07c7: ldstr "promise-pipeline:ok"
-			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_07d1: pop
-			IL_07d2: br IL_0888
+			IL_0715: ldloc.0
+			IL_0716: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_071b: pop
+			IL_071c: ldstr "console"
+			IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0726: stloc.s 15
+			IL_0728: ldloc.s 15
+			IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_072f: stloc.s 15
+			IL_0731: ldloc.s 15
+			IL_0733: ldstr "log"
+			IL_0738: ldstr "promise-pipeline:ok"
+			IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0742: pop
+			IL_0743: br IL_07f2
 
-			IL_07d7: ldloc.0
-			IL_07d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07dd: stloc.s 20
-			IL_07df: ldloc.0
-			IL_07e0: ldc.i4.0
-			IL_07e1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07e6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07eb: ldloc.s 20
-			IL_07ed: stloc.s 14
-			IL_07ef: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
-			IL_07f4: stloc.s 15
-			IL_07f6: ldstr "console"
-			IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0800: stloc.s 20
-			IL_0802: ldloc.s 20
-			IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0809: stloc.s 20
-			IL_080b: ldstr "promise-pipeline:"
-			IL_0810: ldloc.s 14
-			IL_0812: ldstr "name"
-			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0821: stloc.s 21
-			IL_0823: ldloc.s 21
-			IL_0825: ldstr ":"
-			IL_082a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_082f: stloc.s 21
-			IL_0831: ldloc.s 21
-			IL_0833: ldloc.s 14
-			IL_0835: ldstr "code"
-			IL_083a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_083f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0844: stloc.s 21
-			IL_0846: ldloc.s 20
-			IL_0848: ldstr "log"
-			IL_084d: ldloc.s 21
-			IL_084f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0854: pop
-			IL_0855: ldstr "console"
-			IL_085a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_085f: stloc.s 20
-			IL_0861: ldloc.s 20
-			IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0868: stloc.s 20
-			IL_086a: ldloc.s 20
-			IL_086c: ldstr "log"
-			IL_0871: ldloc.s 14
-			IL_0873: ldstr "message"
-			IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_087d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0882: pop
-			IL_0883: br IL_0888
+			IL_0748: ldloc.0
+			IL_0749: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_074e: stloc.s 15
+			IL_0750: ldloc.0
+			IL_0751: ldc.i4.0
+			IL_0752: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0757: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_075c: ldloc.s 15
+			IL_075e: stloc.s 10
+			IL_0760: ldstr "console"
+			IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_076a: stloc.s 15
+			IL_076c: ldloc.s 15
+			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0773: stloc.s 15
+			IL_0775: ldstr "promise-pipeline:"
+			IL_077a: ldloc.s 10
+			IL_077c: ldstr "name"
+			IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0786: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_078b: stloc.s 16
+			IL_078d: ldloc.s 16
+			IL_078f: ldstr ":"
+			IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0799: stloc.s 16
+			IL_079b: ldloc.s 16
+			IL_079d: ldloc.s 10
+			IL_079f: ldstr "code"
+			IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07ae: stloc.s 16
+			IL_07b0: ldloc.s 15
+			IL_07b2: ldstr "log"
+			IL_07b7: ldloc.s 16
+			IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07be: pop
+			IL_07bf: ldstr "console"
+			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07c9: stloc.s 15
+			IL_07cb: ldloc.s 15
+			IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07d2: stloc.s 15
+			IL_07d4: ldloc.s 15
+			IL_07d6: ldstr "log"
+			IL_07db: ldloc.s 10
+			IL_07dd: ldstr "message"
+			IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_07ec: pop
+			IL_07ed: br IL_07f2
 
-			IL_0888: ldnull
-			IL_0889: stloc.s 16
-			IL_088b: ldloc.0
-			IL_088c: ldc.i4.m1
-			IL_088d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0892: ldloc.0
-			IL_0893: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0898: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_089d: ldarg.0
-			IL_089e: ldc.i4.1
-			IL_089f: newarr [System.Runtime]System.Object
-			IL_08a4: dup
-			IL_08a5: ldc.i4.0
-			IL_08a6: ldloc.s 16
-			IL_08a8: stelem.ref
-			IL_08a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08ae: pop
-			IL_08af: ldloc.0
-			IL_08b0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08b5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08ba: ret
+			IL_07f2: ldnull
+			IL_07f3: stloc.s 11
+			IL_07f5: ldloc.0
+			IL_07f6: ldc.i4.m1
+			IL_07f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07fc: ldloc.0
+			IL_07fd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0802: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0807: ldarg.0
+			IL_0808: ldc.i4.1
+			IL_0809: newarr [System.Runtime]System.Object
+			IL_080e: dup
+			IL_080f: ldc.i4.0
+			IL_0810: ldloc.s 11
+			IL_0812: stelem.ref
+			IL_0813: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0818: pop
+			IL_0819: ldloc.0
+			IL_081a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_081f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0824: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1517,7 +1437,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ac5
+			// Method begins at RVA 0x2a31
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1646,7 +1566,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b4c
+		// Method begins at RVA 0x2ab8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246a
+				// Method begins at RVA 0x2466
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2473
+				// Method begins at RVA 0x246f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247c
+				// Method begins at RVA 0x2478
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,7 +223,52 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x248e
+					// Method begins at RVA 0x248a
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 00 00 00 00 00 00
+				)
+				// Method begins at RVA 0x2424
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ret
+			} // end of method FunctionExpression_signal::__js_call__
+
+		} // end of class FunctionExpression_signal
+
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C11
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2493
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -247,51 +292,6 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Method begins at RVA 0x2428
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldnull
-				IL_0001: ret
-			} // end of method FunctionExpression_signal::__js_call__
-
-		} // end of class FunctionExpression_signal
-
-		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C11
-			extends [System.Runtime]System.Object
-		{
-			// Nested Types
-			.class nested public auto ansi beforefieldinit Scope
-				extends [System.Runtime]System.Object
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Method begins at RVA 0x2497
-					// Header size: 1
-					// Code size: 8 (0x8)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-					IL_0006: nop
-					IL_0007: ret
-				} // end of method Scope::.ctor
-
-			} // end of class Scope
-
-
-			// Methods
-			.method public hidebysig static 
-				object __js_call__ (
-					object newTarget
-				) cil managed 
-			{
-				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-					01 00 00 00 00 00 00 00
-				)
-				// Method begins at RVA 0x242c
 				// Header size: 12
 				// Code size: 41 (0x29)
 				.maxstack 8
@@ -335,7 +335,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24a0
+					// Method begins at RVA 0x249c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -355,7 +355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24a9
+					// Method begins at RVA 0x24a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2485
+				// Method begins at RVA 0x2481
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -401,7 +401,7 @@
 			)
 			// Method begins at RVA 0x2288
 			// Header size: 12
-			// Code size: 388 (0x184)
+			// Code size: 381 (0x17d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope,
@@ -409,10 +409,9 @@
 				[2] class [System.Runtime]System.Exception,
 				[3] object,
 				[4] object,
-				[5] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope/Block_L40C20,
+				[5] object,
 				[6] object,
-				[7] object,
-				[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope::.ctor()
@@ -426,14 +425,14 @@
 			IL_0019: ldc.i4.0
 			IL_001a: ldc.i4.1
 			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0020: stloc.s 7
+			IL_0020: stloc.s 6
 			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0027: dup
 			IL_0028: ldstr "addEventListener"
-			IL_002d: ldloc.s 7
+			IL_002d: ldloc.s 6
 			IL_002f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0034: stloc.s 8
-			IL_0036: ldloc.s 8
+			IL_0034: stloc.s 7
+			IL_0036: ldloc.s 7
 			IL_0038: stloc.1
 			IL_0039: ldnull
 			IL_003a: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
@@ -444,16 +443,16 @@
 			IL_004c: ldc.i4.0
 			IL_004d: ldc.i4.1
 			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0053: stloc.s 7
+			IL_0053: stloc.s 6
 			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_005a: dup
 			IL_005b: ldstr "get"
-			IL_0060: ldloc.s 7
+			IL_0060: ldloc.s 6
 			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0067: stloc.s 8
+			IL_0067: stloc.s 7
 			IL_0069: ldloc.1
 			IL_006a: ldstr "aborted"
-			IL_006f: ldloc.s 8
+			IL_006f: ldloc.s 7
 			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0076: pop
 			.try
@@ -462,33 +461,33 @@
 				IL_0078: ldarg.0
 				IL_0079: ldfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
 				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0083: stloc.s 7
+				IL_0083: stloc.s 6
 				IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_008a: dup
 				IL_008b: ldstr "signal"
 				IL_0090: ldloc.1
 				IL_0091: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0096: stloc.s 8
-				IL_0098: ldloc.s 7
+				IL_0096: stloc.s 7
+				IL_0098: ldloc.s 6
 				IL_009a: ldstr "setTimeout"
 				IL_009f: ldc.r8 0.0
 				IL_00a8: box [System.Runtime]System.Double
 				IL_00ad: ldstr "value"
-				IL_00b2: ldloc.s 8
+				IL_00b2: ldloc.s 7
 				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 				IL_00b9: pop
 				IL_00ba: ldstr "console"
 				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00c4: stloc.s 7
-				IL_00c6: ldloc.s 7
+				IL_00c4: stloc.s 6
+				IL_00c6: ldloc.s 6
 				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00cd: stloc.s 7
-				IL_00cf: ldloc.s 7
+				IL_00cd: stloc.s 6
+				IL_00cf: ldloc.s 6
 				IL_00d1: ldstr "log"
 				IL_00d6: ldstr "aborted-getter-no-throw"
 				IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 				IL_00e0: pop
-				IL_00e1: leave IL_017e
+				IL_00e1: leave IL_0177
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -514,44 +513,42 @@
 				IL_010e: stloc.3
 
 				IL_010f: ldloc.3
-				IL_0110: stloc.s 7
-				IL_0112: ldloc.s 7
+				IL_0110: stloc.s 6
+				IL_0112: ldloc.s 6
 				IL_0114: stloc.s 4
-				IL_0116: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope/Block_L40C20::.ctor()
-				IL_011b: stloc.s 5
-				IL_011d: ldstr "console"
-				IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0127: stloc.s 7
-				IL_0129: ldloc.s 7
-				IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0130: stloc.s 7
-				IL_0132: ldloc.s 7
-				IL_0134: ldstr "log"
-				IL_0139: ldloc.s 4
-				IL_013b: ldstr "name"
-				IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_014a: pop
-				IL_014b: ldstr "console"
-				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0155: stloc.s 7
-				IL_0157: ldloc.s 7
-				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_015e: stloc.s 7
-				IL_0160: ldloc.s 7
-				IL_0162: ldstr "log"
-				IL_0167: ldloc.s 4
-				IL_0169: ldstr "message"
-				IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0178: pop
-				IL_0179: leave IL_017e
+				IL_0116: ldstr "console"
+				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0120: stloc.s 6
+				IL_0122: ldloc.s 6
+				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0129: stloc.s 6
+				IL_012b: ldloc.s 6
+				IL_012d: ldstr "log"
+				IL_0132: ldloc.s 4
+				IL_0134: ldstr "name"
+				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0143: pop
+				IL_0144: ldstr "console"
+				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_014e: stloc.s 6
+				IL_0150: ldloc.s 6
+				IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0157: stloc.s 6
+				IL_0159: ldloc.s 6
+				IL_015b: ldstr "log"
+				IL_0160: ldloc.s 4
+				IL_0162: ldstr "message"
+				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0171: pop
+				IL_0172: leave IL_0177
 			} // end handler
 
-			IL_017e: ldnull
-			IL_017f: stloc.s 6
-			IL_0181: ldloc.s 6
-			IL_0183: ret
+			IL_0177: ldnull
+			IL_0178: stloc.s 5
+			IL_017a: ldloc.s 5
+			IL_017c: ret
 		} // end of method FunctionExpression_L24C8::__js_call__
 
 	} // end of class FunctionExpression_L24C8
@@ -571,7 +568,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2461
+			// Method begins at RVA 0x245d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -743,7 +740,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24b2
+		// Method begins at RVA 0x24ae
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Global_Url_And_SearchParams.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Global_Url_And_SearchParams.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c0d
+				// Method begins at RVA 0x2bfd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c16
+				// Method begins at RVA 0x2c06
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c1f
+				// Method begins at RVA 0x2c0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c28
+				// Method begins at RVA 0x2c18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2c04
+			// Method begins at RVA 0x2bf4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2954 (0xb8a)
+		// Code size: 2940 (0xb7c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Global_Url_And_SearchParams/Scope,
@@ -136,20 +136,18 @@
 			[8] class [System.Runtime]System.Exception,
 			[9] object,
 			[10] object,
-			[11] class Modules.Global_Url_And_SearchParams/Scope/Block_L44C16,
-			[12] object,
-			[13] class [System.Runtime]System.Exception,
+			[11] object,
+			[12] class [System.Runtime]System.Exception,
+			[13] object,
 			[14] object,
 			[15] object,
-			[16] class Modules.Global_Url_And_SearchParams/Scope/Block_L52C16,
+			[16] object,
 			[17] object,
-			[18] object,
+			[18] bool,
 			[19] object,
-			[20] bool,
-			[21] object,
-			[22] object,
-			[23] object[],
-			[24] object
+			[20] object,
+			[21] object[],
+			[22] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -172,8 +170,8 @@
 		IL_0051: nop
 		IL_0052: ldstr "URL"
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005c: stloc.s 18
-		IL_005e: ldloc.s 18
+		IL_005c: stloc.s 16
+		IL_005e: ldloc.s 16
 		IL_0060: ldc.i4.1
 		IL_0061: newarr [System.Runtime]System.Object
 		IL_0066: dup
@@ -181,16 +179,16 @@
 		IL_0068: ldstr "https://example.com/docs?q=1#frag"
 		IL_006d: stelem.ref
 		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_0073: stloc.s 18
-		IL_0075: ldloc.s 18
+		IL_0073: stloc.s 16
+		IL_0075: ldloc.s 16
 		IL_0077: stloc.1
 		IL_0078: ldstr "console"
 		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0082: stloc.s 18
-		IL_0084: ldloc.s 18
+		IL_0082: stloc.s 16
+		IL_0084: ldloc.s 16
 		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008b: stloc.s 18
-		IL_008d: ldloc.s 18
+		IL_008b: stloc.s 16
+		IL_008d: ldloc.s 16
 		IL_008f: ldstr "log"
 		IL_0094: ldstr "href:"
 		IL_0099: ldloc.1
@@ -200,68 +198,68 @@
 		IL_00a9: pop
 		IL_00aa: ldstr "console"
 		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b4: stloc.s 18
-		IL_00b6: ldloc.s 18
+		IL_00b4: stloc.s 16
+		IL_00b6: ldloc.s 16
 		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bd: stloc.s 18
+		IL_00bd: stloc.s 16
 		IL_00bf: ldloc.1
 		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c5: stloc.s 19
-		IL_00c7: ldloc.s 19
+		IL_00c5: stloc.s 17
+		IL_00c7: ldloc.s 17
 		IL_00c9: ldstr "toString"
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00d3: stloc.s 19
-		IL_00d5: ldloc.s 18
+		IL_00d3: stloc.s 17
+		IL_00d5: ldloc.s 16
 		IL_00d7: ldstr "log"
 		IL_00dc: ldstr "href string:"
-		IL_00e1: ldloc.s 19
+		IL_00e1: ldloc.s 17
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00e8: pop
 		IL_00e9: ldstr "console"
 		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: stloc.s 19
-		IL_00f5: ldloc.s 19
+		IL_00f3: stloc.s 17
+		IL_00f5: ldloc.s 17
 		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fc: stloc.s 19
+		IL_00fc: stloc.s 17
 		IL_00fe: ldloc.1
 		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0104: stloc.s 18
-		IL_0106: ldloc.s 18
+		IL_0104: stloc.s 16
+		IL_0106: ldloc.s 16
 		IL_0108: ldstr "toJSON"
 		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0112: stloc.s 18
-		IL_0114: ldloc.s 19
+		IL_0112: stloc.s 16
+		IL_0114: ldloc.s 17
 		IL_0116: ldstr "log"
 		IL_011b: ldstr "href json:"
-		IL_0120: ldloc.s 18
+		IL_0120: ldloc.s 16
 		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0127: pop
 		IL_0128: ldstr "console"
 		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0132: stloc.s 18
-		IL_0134: ldloc.s 18
+		IL_0132: stloc.s 16
+		IL_0134: ldloc.s 16
 		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013b: stloc.s 18
+		IL_013b: stloc.s 16
 		IL_013d: ldloc.1
 		IL_013e: ldstr "searchParams"
 		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014d: stloc.s 19
-		IL_014f: ldloc.s 19
+		IL_014d: stloc.s 17
+		IL_014f: ldloc.s 17
 		IL_0151: ldstr "get"
 		IL_0156: ldstr "q"
 		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0160: stloc.s 19
-		IL_0162: ldloc.s 18
+		IL_0160: stloc.s 17
+		IL_0162: ldloc.s 16
 		IL_0164: ldstr "log"
 		IL_0169: ldstr "search q:"
-		IL_016e: ldloc.s 19
+		IL_016e: ldloc.s 17
 		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0175: pop
 		IL_0176: ldstr "URL"
 		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0180: stloc.s 19
-		IL_0182: ldloc.s 19
+		IL_0180: stloc.s 17
+		IL_0182: ldloc.s 17
 		IL_0184: ldc.i4.2
 		IL_0185: newarr [System.Runtime]System.Object
 		IL_018a: dup
@@ -273,16 +271,16 @@
 		IL_0194: ldstr "https://example.com/docs/start/"
 		IL_0199: stelem.ref
 		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_019f: stloc.s 19
-		IL_01a1: ldloc.s 19
+		IL_019f: stloc.s 17
+		IL_01a1: ldloc.s 17
 		IL_01a3: stloc.2
 		IL_01a4: ldstr "console"
 		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ae: stloc.s 19
-		IL_01b0: ldloc.s 19
+		IL_01ae: stloc.s 17
+		IL_01b0: ldloc.s 17
 		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b7: stloc.s 19
-		IL_01b9: ldloc.s 19
+		IL_01b7: stloc.s 17
+		IL_01b9: ldloc.s 17
 		IL_01bb: ldstr "log"
 		IL_01c0: ldstr "based href:"
 		IL_01c5: ldloc.2
@@ -292,8 +290,8 @@
 		IL_01d5: pop
 		IL_01d6: ldstr "URLSearchParams"
 		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e0: stloc.s 19
-		IL_01e2: ldloc.s 19
+		IL_01e0: stloc.s 17
+		IL_01e2: ldloc.s 17
 		IL_01e4: ldc.i4.1
 		IL_01e5: newarr [System.Runtime]System.Object
 		IL_01ea: dup
@@ -301,302 +299,302 @@
 		IL_01ec: ldstr "a=1&a=2"
 		IL_01f1: stelem.ref
 		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_01f7: stloc.s 19
-		IL_01f9: ldloc.s 19
+		IL_01f7: stloc.s 17
+		IL_01f9: ldloc.s 17
 		IL_01fb: stloc.3
 		IL_01fc: ldstr "console"
 		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0206: stloc.s 19
-		IL_0208: ldloc.s 19
+		IL_0206: stloc.s 17
+		IL_0208: ldloc.s 17
 		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020f: stloc.s 19
+		IL_020f: stloc.s 17
 		IL_0211: ldloc.3
 		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0217: stloc.s 18
-		IL_0219: ldloc.s 18
+		IL_0217: stloc.s 16
+		IL_0219: ldloc.s 16
 		IL_021b: ldstr "getAll"
 		IL_0220: ldstr "a"
 		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_022a: stloc.s 18
-		IL_022c: ldloc.s 18
+		IL_022a: stloc.s 16
+		IL_022c: ldloc.s 16
 		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0233: stloc.s 18
-		IL_0235: ldloc.s 18
+		IL_0233: stloc.s 16
+		IL_0235: ldloc.s 16
 		IL_0237: ldstr "join"
 		IL_023c: ldstr "|"
 		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0246: stloc.s 18
-		IL_0248: ldloc.s 19
+		IL_0246: stloc.s 16
+		IL_0248: ldloc.s 17
 		IL_024a: ldstr "log"
 		IL_024f: ldstr "params a:"
-		IL_0254: ldloc.s 18
+		IL_0254: ldloc.s 16
 		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_025b: pop
 		IL_025c: ldstr "console"
 		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0266: stloc.s 18
-		IL_0268: ldloc.s 18
+		IL_0266: stloc.s 16
+		IL_0268: ldloc.s 16
 		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026f: stloc.s 18
+		IL_026f: stloc.s 16
 		IL_0271: ldloc.3
 		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0277: stloc.s 19
-		IL_0279: ldloc.s 19
+		IL_0277: stloc.s 17
+		IL_0279: ldloc.s 17
 		IL_027b: ldstr "toString"
 		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0285: stloc.s 19
-		IL_0287: ldloc.s 18
+		IL_0285: stloc.s 17
+		IL_0287: ldloc.s 16
 		IL_0289: ldstr "log"
 		IL_028e: ldstr "params string:"
-		IL_0293: ldloc.s 19
+		IL_0293: ldloc.s 17
 		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_029a: pop
 		IL_029b: ldarg.1
 		IL_029c: ldstr "url"
 		IL_02a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_02a6: stloc.s 19
-		IL_02a8: ldloc.s 19
+		IL_02a6: stloc.s 17
+		IL_02a8: ldloc.s 17
 		IL_02aa: stloc.s 4
 		IL_02ac: ldstr "console"
 		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02b6: stloc.s 19
-		IL_02b8: ldloc.s 19
+		IL_02b6: stloc.s 17
+		IL_02b8: ldloc.s 17
 		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bf: stloc.s 19
+		IL_02bf: stloc.s 17
 		IL_02c1: ldstr "globalThis"
 		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cb: stloc.s 18
-		IL_02cd: ldloc.s 18
+		IL_02cb: stloc.s 16
+		IL_02cd: ldloc.s 16
 		IL_02cf: ldstr "URL"
 		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d9: stloc.s 18
-		IL_02db: ldloc.s 18
+		IL_02d9: stloc.s 16
+		IL_02db: ldloc.s 16
 		IL_02dd: ldloc.s 4
 		IL_02df: ldstr "URL"
 		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_02e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02ee: stloc.s 20
-		IL_02f0: ldloc.s 20
+		IL_02ee: stloc.s 18
+		IL_02f0: ldloc.s 18
 		IL_02f2: box [System.Runtime]System.Boolean
-		IL_02f7: stloc.s 21
-		IL_02f9: ldloc.s 19
+		IL_02f7: stloc.s 19
+		IL_02f9: ldloc.s 17
 		IL_02fb: ldstr "log"
 		IL_0300: ldstr "same URL:"
-		IL_0305: ldloc.s 21
+		IL_0305: ldloc.s 19
 		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_030c: pop
 		IL_030d: ldstr "console"
 		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0317: stloc.s 19
-		IL_0319: ldloc.s 19
+		IL_0317: stloc.s 17
+		IL_0319: ldloc.s 17
 		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0320: stloc.s 19
+		IL_0320: stloc.s 17
 		IL_0322: ldstr "globalThis"
 		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_032c: stloc.s 18
-		IL_032e: ldloc.s 18
+		IL_032c: stloc.s 16
+		IL_032e: ldloc.s 16
 		IL_0330: ldstr "URLSearchParams"
 		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_033a: stloc.s 18
-		IL_033c: ldloc.s 18
+		IL_033a: stloc.s 16
+		IL_033c: ldloc.s 16
 		IL_033e: ldloc.s 4
 		IL_0340: ldstr "URLSearchParams"
 		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_034a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_034f: stloc.s 20
-		IL_0351: ldloc.s 20
+		IL_034f: stloc.s 18
+		IL_0351: ldloc.s 18
 		IL_0353: box [System.Runtime]System.Boolean
-		IL_0358: stloc.s 21
-		IL_035a: ldloc.s 19
+		IL_0358: stloc.s 19
+		IL_035a: ldloc.s 17
 		IL_035c: ldstr "log"
 		IL_0361: ldstr "same params:"
-		IL_0366: ldloc.s 21
+		IL_0366: ldloc.s 19
 		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_036d: pop
 		IL_036e: ldstr "console"
 		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0378: stloc.s 19
-		IL_037a: ldloc.s 19
+		IL_0378: stloc.s 17
+		IL_037a: ldloc.s 17
 		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0381: stloc.s 19
+		IL_0381: stloc.s 17
 		IL_0383: ldstr "URL"
 		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_038d: stloc.s 18
+		IL_038d: stloc.s 16
 		IL_038f: ldstr "Function"
 		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0399: stloc.s 22
-		IL_039b: ldloc.s 18
-		IL_039d: ldloc.s 22
+		IL_0399: stloc.s 20
+		IL_039b: ldloc.s 16
+		IL_039d: ldloc.s 20
 		IL_039f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_03a4: stloc.s 20
-		IL_03a6: ldloc.s 20
+		IL_03a4: stloc.s 18
+		IL_03a6: ldloc.s 18
 		IL_03a8: box [System.Runtime]System.Boolean
-		IL_03ad: stloc.s 21
-		IL_03af: ldloc.s 19
+		IL_03ad: stloc.s 19
+		IL_03af: ldloc.s 17
 		IL_03b1: ldstr "log"
 		IL_03b6: ldstr "url fn:"
-		IL_03bb: ldloc.s 21
+		IL_03bb: ldloc.s 19
 		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_03c2: pop
 		IL_03c3: ldstr "console"
 		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03cd: stloc.s 19
-		IL_03cf: ldloc.s 19
+		IL_03cd: stloc.s 17
+		IL_03cf: ldloc.s 17
 		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d6: stloc.s 19
+		IL_03d6: stloc.s 17
 		IL_03d8: ldstr "URL"
 		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e2: stloc.s 22
-		IL_03e4: ldloc.s 22
+		IL_03e2: stloc.s 20
+		IL_03e4: ldloc.s 20
 		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_03eb: stloc.s 22
+		IL_03eb: stloc.s 20
 		IL_03ed: ldstr "Function"
 		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03f7: stloc.s 18
-		IL_03f9: ldloc.s 18
+		IL_03f7: stloc.s 16
+		IL_03f9: ldloc.s 16
 		IL_03fb: ldstr "prototype"
 		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0405: stloc.s 18
-		IL_0407: ldloc.s 22
-		IL_0409: ldloc.s 18
+		IL_0405: stloc.s 16
+		IL_0407: ldloc.s 20
+		IL_0409: ldloc.s 16
 		IL_040b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0410: stloc.s 20
-		IL_0412: ldloc.s 20
+		IL_0410: stloc.s 18
+		IL_0412: ldloc.s 18
 		IL_0414: box [System.Runtime]System.Boolean
-		IL_0419: stloc.s 21
-		IL_041b: ldloc.s 19
+		IL_0419: stloc.s 19
+		IL_041b: ldloc.s 17
 		IL_041d: ldstr "log"
 		IL_0422: ldstr "url proto:"
-		IL_0427: ldloc.s 21
+		IL_0427: ldloc.s 19
 		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_042e: pop
 		IL_042f: ldstr "console"
 		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0439: stloc.s 19
-		IL_043b: ldloc.s 19
+		IL_0439: stloc.s 17
+		IL_043b: ldloc.s 17
 		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0442: stloc.s 19
+		IL_0442: stloc.s 17
 		IL_0444: ldstr "URL"
 		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_044e: stloc.s 18
-		IL_0450: ldloc.s 18
+		IL_044e: stloc.s 16
+		IL_0450: ldloc.s 16
 		IL_0452: ldstr "prototype"
 		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_045c: stloc.s 18
-		IL_045e: ldloc.s 18
+		IL_045c: stloc.s 16
+		IL_045e: ldloc.s 16
 		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0465: stloc.s 18
+		IL_0465: stloc.s 16
 		IL_0467: ldstr "Object"
 		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0471: stloc.s 22
-		IL_0473: ldloc.s 22
+		IL_0471: stloc.s 20
+		IL_0473: ldloc.s 20
 		IL_0475: ldstr "prototype"
 		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_047f: stloc.s 22
-		IL_0481: ldloc.s 18
-		IL_0483: ldloc.s 22
+		IL_047f: stloc.s 20
+		IL_0481: ldloc.s 16
+		IL_0483: ldloc.s 20
 		IL_0485: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_048a: stloc.s 20
-		IL_048c: ldloc.s 20
+		IL_048a: stloc.s 18
+		IL_048c: ldloc.s 18
 		IL_048e: box [System.Runtime]System.Boolean
-		IL_0493: stloc.s 21
-		IL_0495: ldloc.s 19
+		IL_0493: stloc.s 19
+		IL_0495: ldloc.s 17
 		IL_0497: ldstr "log"
 		IL_049c: ldstr "url proto parent:"
-		IL_04a1: ldloc.s 21
+		IL_04a1: ldloc.s 19
 		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_04a8: pop
 		IL_04a9: ldstr "console"
 		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04b3: stloc.s 19
-		IL_04b5: ldloc.s 19
+		IL_04b3: stloc.s 17
+		IL_04b5: ldloc.s 17
 		IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04bc: stloc.s 19
+		IL_04bc: stloc.s 17
 		IL_04be: ldloc.1
 		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_04c4: stloc.s 22
+		IL_04c4: stloc.s 20
 		IL_04c6: ldstr "URL"
 		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04d0: stloc.s 18
-		IL_04d2: ldloc.s 18
+		IL_04d0: stloc.s 16
+		IL_04d2: ldloc.s 16
 		IL_04d4: ldstr "prototype"
 		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04de: stloc.s 18
-		IL_04e0: ldloc.s 22
-		IL_04e2: ldloc.s 18
+		IL_04de: stloc.s 16
+		IL_04e0: ldloc.s 20
+		IL_04e2: ldloc.s 16
 		IL_04e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04e9: stloc.s 20
-		IL_04eb: ldloc.s 20
+		IL_04e9: stloc.s 18
+		IL_04eb: ldloc.s 18
 		IL_04ed: box [System.Runtime]System.Boolean
-		IL_04f2: stloc.s 21
-		IL_04f4: ldloc.s 19
+		IL_04f2: stloc.s 19
+		IL_04f4: ldloc.s 17
 		IL_04f6: ldstr "log"
 		IL_04fb: ldstr "url instance proto:"
-		IL_0500: ldloc.s 21
+		IL_0500: ldloc.s 19
 		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0507: pop
 		IL_0508: ldstr "console"
 		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0512: stloc.s 19
-		IL_0514: ldloc.s 19
+		IL_0512: stloc.s 17
+		IL_0514: ldloc.s 17
 		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_051b: stloc.s 19
+		IL_051b: stloc.s 17
 		IL_051d: ldloc.1
 		IL_051e: ldstr "constructor"
 		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0528: stloc.s 18
+		IL_0528: stloc.s 16
 		IL_052a: ldstr "URL"
 		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0534: stloc.s 22
-		IL_0536: ldloc.s 18
-		IL_0538: ldloc.s 22
+		IL_0534: stloc.s 20
+		IL_0536: ldloc.s 16
+		IL_0538: ldloc.s 20
 		IL_053a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_053f: stloc.s 20
-		IL_0541: ldloc.s 20
+		IL_053f: stloc.s 18
+		IL_0541: ldloc.s 18
 		IL_0543: box [System.Runtime]System.Boolean
-		IL_0548: stloc.s 21
-		IL_054a: ldloc.s 19
+		IL_0548: stloc.s 19
+		IL_054a: ldloc.s 17
 		IL_054c: ldstr "log"
 		IL_0551: ldstr "url instance ctor:"
-		IL_0556: ldloc.s 21
+		IL_0556: ldloc.s 19
 		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_055d: pop
 		IL_055e: ldstr "console"
 		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0568: stloc.s 19
-		IL_056a: ldloc.s 19
+		IL_0568: stloc.s 17
+		IL_056a: ldloc.s 17
 		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0571: stloc.s 19
+		IL_0571: stloc.s 17
 		IL_0573: ldloc.1
-		IL_0574: stloc.s 22
+		IL_0574: stloc.s 20
 		IL_0576: ldstr "URL"
 		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0580: stloc.s 18
-		IL_0582: ldloc.s 22
-		IL_0584: ldloc.s 18
+		IL_0580: stloc.s 16
+		IL_0582: ldloc.s 20
+		IL_0584: ldloc.s 16
 		IL_0586: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_058b: stloc.s 20
-		IL_058d: ldloc.s 20
+		IL_058b: stloc.s 18
+		IL_058d: ldloc.s 18
 		IL_058f: box [System.Runtime]System.Boolean
-		IL_0594: stloc.s 21
-		IL_0596: ldloc.s 19
+		IL_0594: stloc.s 19
+		IL_0596: ldloc.s 17
 		IL_0598: ldstr "log"
 		IL_059d: ldstr "url instanceof:"
-		IL_05a2: ldloc.s 21
+		IL_05a2: ldloc.s 19
 		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_05a9: pop
 		IL_05aa: ldstr "URL"
 		IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05b4: stloc.s 19
-		IL_05b6: ldloc.s 19
+		IL_05b4: stloc.s 17
+		IL_05b6: ldloc.s 17
 		IL_05b8: ldstr "prototype"
 		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_05c2: stloc.s 19
-		IL_05c4: ldloc.s 19
+		IL_05c2: stloc.s 17
+		IL_05c4: ldloc.s 17
 		IL_05c6: stloc.s 5
 		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_05cd: stloc.s 19
-		IL_05cf: ldloc.s 19
+		IL_05cd: stloc.s 17
+		IL_05cf: ldloc.s 17
 		IL_05d1: ldstr "urlPrototypeDescriptor"
 		IL_05d6: ldloc.s 5
 		IL_05d8: ldc.i4.0
@@ -604,11 +602,11 @@
 		IL_05de: pop
 		IL_05df: ldstr "console"
 		IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05e9: stloc.s 19
-		IL_05eb: ldloc.s 19
+		IL_05e9: stloc.s 17
+		IL_05eb: ldloc.s 17
 		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05f2: stloc.s 19
-		IL_05f4: ldloc.s 19
+		IL_05f2: stloc.s 17
+		IL_05f4: ldloc.s 17
 		IL_05f6: ldstr "log"
 		IL_05fb: ldstr "url descriptor writable:"
 		IL_0600: ldloc.s 5
@@ -618,11 +616,11 @@
 		IL_0611: pop
 		IL_0612: ldstr "console"
 		IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_061c: stloc.s 19
-		IL_061e: ldloc.s 19
+		IL_061c: stloc.s 17
+		IL_061e: ldloc.s 17
 		IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0625: stloc.s 19
-		IL_0627: ldloc.s 19
+		IL_0625: stloc.s 17
+		IL_0627: ldloc.s 17
 		IL_0629: ldstr "log"
 		IL_062e: ldstr "url descriptor enumerable:"
 		IL_0633: ldloc.s 5
@@ -632,11 +630,11 @@
 		IL_0644: pop
 		IL_0645: ldstr "console"
 		IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_064f: stloc.s 19
-		IL_0651: ldloc.s 19
+		IL_064f: stloc.s 17
+		IL_0651: ldloc.s 17
 		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0658: stloc.s 19
-		IL_065a: ldloc.s 19
+		IL_0658: stloc.s 17
+		IL_065a: ldloc.s 17
 		IL_065c: ldstr "log"
 		IL_0661: ldstr "url descriptor configurable:"
 		IL_0666: ldloc.s 5
@@ -646,188 +644,188 @@
 		IL_0677: pop
 		IL_0678: ldstr "console"
 		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0682: stloc.s 19
-		IL_0684: ldloc.s 19
+		IL_0682: stloc.s 17
+		IL_0684: ldloc.s 17
 		IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_068b: stloc.s 19
+		IL_068b: stloc.s 17
 		IL_068d: ldstr "URLSearchParams"
 		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0697: stloc.s 18
+		IL_0697: stloc.s 16
 		IL_0699: ldstr "Function"
 		IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06a3: stloc.s 22
-		IL_06a5: ldloc.s 18
-		IL_06a7: ldloc.s 22
+		IL_06a3: stloc.s 20
+		IL_06a5: ldloc.s 16
+		IL_06a7: ldloc.s 20
 		IL_06a9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_06ae: stloc.s 20
-		IL_06b0: ldloc.s 20
+		IL_06ae: stloc.s 18
+		IL_06b0: ldloc.s 18
 		IL_06b2: box [System.Runtime]System.Boolean
-		IL_06b7: stloc.s 21
-		IL_06b9: ldloc.s 19
+		IL_06b7: stloc.s 19
+		IL_06b9: ldloc.s 17
 		IL_06bb: ldstr "log"
 		IL_06c0: ldstr "params fn:"
-		IL_06c5: ldloc.s 21
+		IL_06c5: ldloc.s 19
 		IL_06c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_06cc: pop
 		IL_06cd: ldstr "console"
 		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06d7: stloc.s 19
-		IL_06d9: ldloc.s 19
+		IL_06d7: stloc.s 17
+		IL_06d9: ldloc.s 17
 		IL_06db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06e0: stloc.s 19
+		IL_06e0: stloc.s 17
 		IL_06e2: ldstr "URLSearchParams"
 		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06ec: stloc.s 22
-		IL_06ee: ldloc.s 22
+		IL_06ec: stloc.s 20
+		IL_06ee: ldloc.s 20
 		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_06f5: stloc.s 22
+		IL_06f5: stloc.s 20
 		IL_06f7: ldstr "Function"
 		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0701: stloc.s 18
-		IL_0703: ldloc.s 18
+		IL_0701: stloc.s 16
+		IL_0703: ldloc.s 16
 		IL_0705: ldstr "prototype"
 		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_070f: stloc.s 18
-		IL_0711: ldloc.s 22
-		IL_0713: ldloc.s 18
+		IL_070f: stloc.s 16
+		IL_0711: ldloc.s 20
+		IL_0713: ldloc.s 16
 		IL_0715: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_071a: stloc.s 20
-		IL_071c: ldloc.s 20
+		IL_071a: stloc.s 18
+		IL_071c: ldloc.s 18
 		IL_071e: box [System.Runtime]System.Boolean
-		IL_0723: stloc.s 21
-		IL_0725: ldloc.s 19
+		IL_0723: stloc.s 19
+		IL_0725: ldloc.s 17
 		IL_0727: ldstr "log"
 		IL_072c: ldstr "params proto:"
-		IL_0731: ldloc.s 21
+		IL_0731: ldloc.s 19
 		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0738: pop
 		IL_0739: ldstr "console"
 		IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0743: stloc.s 19
-		IL_0745: ldloc.s 19
+		IL_0743: stloc.s 17
+		IL_0745: ldloc.s 17
 		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_074c: stloc.s 19
+		IL_074c: stloc.s 17
 		IL_074e: ldstr "URLSearchParams"
 		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0758: stloc.s 18
-		IL_075a: ldloc.s 18
+		IL_0758: stloc.s 16
+		IL_075a: ldloc.s 16
 		IL_075c: ldstr "prototype"
 		IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0766: stloc.s 18
-		IL_0768: ldloc.s 18
+		IL_0766: stloc.s 16
+		IL_0768: ldloc.s 16
 		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_076f: stloc.s 18
+		IL_076f: stloc.s 16
 		IL_0771: ldstr "Object"
 		IL_0776: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_077b: stloc.s 22
-		IL_077d: ldloc.s 22
+		IL_077b: stloc.s 20
+		IL_077d: ldloc.s 20
 		IL_077f: ldstr "prototype"
 		IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0789: stloc.s 22
-		IL_078b: ldloc.s 18
-		IL_078d: ldloc.s 22
+		IL_0789: stloc.s 20
+		IL_078b: ldloc.s 16
+		IL_078d: ldloc.s 20
 		IL_078f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0794: stloc.s 20
-		IL_0796: ldloc.s 20
+		IL_0794: stloc.s 18
+		IL_0796: ldloc.s 18
 		IL_0798: box [System.Runtime]System.Boolean
-		IL_079d: stloc.s 21
-		IL_079f: ldloc.s 19
+		IL_079d: stloc.s 19
+		IL_079f: ldloc.s 17
 		IL_07a1: ldstr "log"
 		IL_07a6: ldstr "params proto parent:"
-		IL_07ab: ldloc.s 21
+		IL_07ab: ldloc.s 19
 		IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_07b2: pop
 		IL_07b3: ldstr "console"
 		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07bd: stloc.s 19
-		IL_07bf: ldloc.s 19
+		IL_07bd: stloc.s 17
+		IL_07bf: ldloc.s 17
 		IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07c6: stloc.s 19
+		IL_07c6: stloc.s 17
 		IL_07c8: ldloc.3
 		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_07ce: stloc.s 22
+		IL_07ce: stloc.s 20
 		IL_07d0: ldstr "URLSearchParams"
 		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07da: stloc.s 18
-		IL_07dc: ldloc.s 18
+		IL_07da: stloc.s 16
+		IL_07dc: ldloc.s 16
 		IL_07de: ldstr "prototype"
 		IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07e8: stloc.s 18
-		IL_07ea: ldloc.s 22
-		IL_07ec: ldloc.s 18
+		IL_07e8: stloc.s 16
+		IL_07ea: ldloc.s 20
+		IL_07ec: ldloc.s 16
 		IL_07ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_07f3: stloc.s 20
-		IL_07f5: ldloc.s 20
+		IL_07f3: stloc.s 18
+		IL_07f5: ldloc.s 18
 		IL_07f7: box [System.Runtime]System.Boolean
-		IL_07fc: stloc.s 21
-		IL_07fe: ldloc.s 19
+		IL_07fc: stloc.s 19
+		IL_07fe: ldloc.s 17
 		IL_0800: ldstr "log"
 		IL_0805: ldstr "params instance proto:"
-		IL_080a: ldloc.s 21
+		IL_080a: ldloc.s 19
 		IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0811: pop
 		IL_0812: ldstr "console"
 		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_081c: stloc.s 19
-		IL_081e: ldloc.s 19
+		IL_081c: stloc.s 17
+		IL_081e: ldloc.s 17
 		IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0825: stloc.s 19
+		IL_0825: stloc.s 17
 		IL_0827: ldloc.3
 		IL_0828: ldstr "constructor"
 		IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0832: stloc.s 18
+		IL_0832: stloc.s 16
 		IL_0834: ldstr "URLSearchParams"
 		IL_0839: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_083e: stloc.s 22
-		IL_0840: ldloc.s 18
-		IL_0842: ldloc.s 22
+		IL_083e: stloc.s 20
+		IL_0840: ldloc.s 16
+		IL_0842: ldloc.s 20
 		IL_0844: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0849: stloc.s 20
-		IL_084b: ldloc.s 20
+		IL_0849: stloc.s 18
+		IL_084b: ldloc.s 18
 		IL_084d: box [System.Runtime]System.Boolean
-		IL_0852: stloc.s 21
-		IL_0854: ldloc.s 19
+		IL_0852: stloc.s 19
+		IL_0854: ldloc.s 17
 		IL_0856: ldstr "log"
 		IL_085b: ldstr "params instance ctor:"
-		IL_0860: ldloc.s 21
+		IL_0860: ldloc.s 19
 		IL_0862: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0867: pop
 		IL_0868: ldstr "console"
 		IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0872: stloc.s 19
-		IL_0874: ldloc.s 19
+		IL_0872: stloc.s 17
+		IL_0874: ldloc.s 17
 		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_087b: stloc.s 19
+		IL_087b: stloc.s 17
 		IL_087d: ldloc.3
-		IL_087e: stloc.s 22
+		IL_087e: stloc.s 20
 		IL_0880: ldstr "URLSearchParams"
 		IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_088a: stloc.s 18
-		IL_088c: ldloc.s 22
-		IL_088e: ldloc.s 18
+		IL_088a: stloc.s 16
+		IL_088c: ldloc.s 20
+		IL_088e: ldloc.s 16
 		IL_0890: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0895: stloc.s 20
-		IL_0897: ldloc.s 20
+		IL_0895: stloc.s 18
+		IL_0897: ldloc.s 18
 		IL_0899: box [System.Runtime]System.Boolean
-		IL_089e: stloc.s 21
-		IL_08a0: ldloc.s 19
+		IL_089e: stloc.s 19
+		IL_08a0: ldloc.s 17
 		IL_08a2: ldstr "log"
 		IL_08a7: ldstr "params instanceof:"
-		IL_08ac: ldloc.s 21
+		IL_08ac: ldloc.s 19
 		IL_08ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_08b3: pop
 		IL_08b4: ldstr "URLSearchParams"
 		IL_08b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08be: stloc.s 19
-		IL_08c0: ldloc.s 19
+		IL_08be: stloc.s 17
+		IL_08c0: ldloc.s 17
 		IL_08c2: ldstr "prototype"
 		IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_08cc: stloc.s 19
-		IL_08ce: ldloc.s 19
+		IL_08cc: stloc.s 17
+		IL_08ce: ldloc.s 17
 		IL_08d0: stloc.s 6
 		IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_08d7: stloc.s 19
-		IL_08d9: ldloc.s 19
+		IL_08d7: stloc.s 17
+		IL_08d9: ldloc.s 17
 		IL_08db: ldstr "paramsPrototypeDescriptor"
 		IL_08e0: ldloc.s 6
 		IL_08e2: ldc.i4.0
@@ -835,11 +833,11 @@
 		IL_08e8: pop
 		IL_08e9: ldstr "console"
 		IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08f3: stloc.s 19
-		IL_08f5: ldloc.s 19
+		IL_08f3: stloc.s 17
+		IL_08f5: ldloc.s 17
 		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08fc: stloc.s 19
-		IL_08fe: ldloc.s 19
+		IL_08fc: stloc.s 17
+		IL_08fe: ldloc.s 17
 		IL_0900: ldstr "log"
 		IL_0905: ldstr "params descriptor writable:"
 		IL_090a: ldloc.s 6
@@ -849,11 +847,11 @@
 		IL_091b: pop
 		IL_091c: ldstr "console"
 		IL_0921: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0926: stloc.s 19
-		IL_0928: ldloc.s 19
+		IL_0926: stloc.s 17
+		IL_0928: ldloc.s 17
 		IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_092f: stloc.s 19
-		IL_0931: ldloc.s 19
+		IL_092f: stloc.s 17
+		IL_0931: ldloc.s 17
 		IL_0933: ldstr "log"
 		IL_0938: ldstr "params descriptor enumerable:"
 		IL_093d: ldloc.s 6
@@ -863,11 +861,11 @@
 		IL_094e: pop
 		IL_094f: ldstr "console"
 		IL_0954: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0959: stloc.s 19
-		IL_095b: ldloc.s 19
+		IL_0959: stloc.s 17
+		IL_095b: ldloc.s 17
 		IL_095d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0962: stloc.s 19
-		IL_0964: ldloc.s 19
+		IL_0962: stloc.s 17
+		IL_0964: ldloc.s 17
 		IL_0966: ldstr "log"
 		IL_096b: ldstr "params descriptor configurable:"
 		IL_0970: ldloc.s 6
@@ -880,36 +878,36 @@
 			IL_0982: nop
 			IL_0983: ldstr "URL"
 			IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_098d: stloc.s 19
-			IL_098f: ldloc.s 19
+			IL_098d: stloc.s 17
+			IL_098f: ldloc.s 17
 			IL_0991: stloc.s 7
 			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_0998: stloc.s 19
-			IL_099a: ldloc.s 19
+			IL_0998: stloc.s 17
+			IL_099a: ldloc.s 17
 			IL_099c: ldstr "urlCtor"
 			IL_09a1: ldloc.s 7
 			IL_09a3: ldc.i4.0
 			IL_09a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
 			IL_09a9: pop
 			IL_09aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_09af: stloc.s 23
+			IL_09af: stloc.s 21
 			IL_09b1: ldloc.s 7
-			IL_09b3: ldloc.s 23
+			IL_09b3: ldloc.s 21
 			IL_09b5: ldstr "https://example.com/"
 			IL_09ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_09bf: pop
 			IL_09c0: ldstr "console"
 			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09ca: stloc.s 19
-			IL_09cc: ldloc.s 19
+			IL_09ca: stloc.s 17
+			IL_09cc: ldloc.s 17
 			IL_09ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09d3: stloc.s 19
-			IL_09d5: ldloc.s 19
+			IL_09d3: stloc.s 17
+			IL_09d5: ldloc.s 17
 			IL_09d7: ldstr "log"
 			IL_09dc: ldstr "url call: no-throw"
 			IL_09e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_09e6: pop
-			IL_09e7: leave IL_0a84
+			IL_09e7: leave IL_0a7d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -935,132 +933,128 @@
 			IL_0a18: stloc.s 9
 
 			IL_0a1a: ldloc.s 9
-			IL_0a1c: stloc.s 19
-			IL_0a1e: ldloc.s 19
+			IL_0a1c: stloc.s 17
+			IL_0a1e: ldloc.s 17
 			IL_0a20: stloc.s 10
-			IL_0a22: newobj instance void Modules.Global_Url_And_SearchParams/Scope/Block_L44C16::.ctor()
-			IL_0a27: stloc.s 11
-			IL_0a29: ldstr "console"
-			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a33: stloc.s 19
-			IL_0a35: ldloc.s 19
-			IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a3c: stloc.s 19
-			IL_0a3e: ldloc.s 10
-			IL_0a40: ldstr "name"
-			IL_0a45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a4a: ldstr ": "
-			IL_0a4f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a54: stloc.s 24
-			IL_0a56: ldloc.s 24
-			IL_0a58: ldloc.s 10
-			IL_0a5a: ldstr "message"
-			IL_0a5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a64: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a69: stloc.s 24
-			IL_0a6b: ldloc.s 19
-			IL_0a6d: ldstr "log"
-			IL_0a72: ldstr "url call:"
-			IL_0a77: ldloc.s 24
-			IL_0a79: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a7e: pop
-			IL_0a7f: leave IL_0a84
+			IL_0a22: ldstr "console"
+			IL_0a27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a2c: stloc.s 17
+			IL_0a2e: ldloc.s 17
+			IL_0a30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a35: stloc.s 17
+			IL_0a37: ldloc.s 10
+			IL_0a39: ldstr "name"
+			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a43: ldstr ": "
+			IL_0a48: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a4d: stloc.s 22
+			IL_0a4f: ldloc.s 22
+			IL_0a51: ldloc.s 10
+			IL_0a53: ldstr "message"
+			IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a5d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a62: stloc.s 22
+			IL_0a64: ldloc.s 17
+			IL_0a66: ldstr "log"
+			IL_0a6b: ldstr "url call:"
+			IL_0a70: ldloc.s 22
+			IL_0a72: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a77: pop
+			IL_0a78: leave IL_0a7d
 		} // end handler
 		.try
 		{
-			IL_0a84: nop
-			IL_0a85: ldstr "URLSearchParams"
-			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a8f: stloc.s 19
-			IL_0a91: ldloc.s 19
-			IL_0a93: stloc.s 12
-			IL_0a95: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_0a9a: stloc.s 19
-			IL_0a9c: ldloc.s 19
-			IL_0a9e: ldstr "paramsCtor"
-			IL_0aa3: ldloc.s 12
-			IL_0aa5: ldc.i4.0
-			IL_0aa6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_0aab: pop
-			IL_0aac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0ab1: stloc.s 23
-			IL_0ab3: ldloc.s 12
-			IL_0ab5: ldloc.s 23
-			IL_0ab7: ldstr "a=1"
-			IL_0abc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0ac1: pop
-			IL_0ac2: ldstr "console"
-			IL_0ac7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0acc: stloc.s 19
-			IL_0ace: ldloc.s 19
-			IL_0ad0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ad5: stloc.s 19
-			IL_0ad7: ldloc.s 19
-			IL_0ad9: ldstr "log"
-			IL_0ade: ldstr "params call: no-throw"
-			IL_0ae3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0ae8: pop
-			IL_0ae9: leave IL_0b86
+			IL_0a7d: nop
+			IL_0a7e: ldstr "URLSearchParams"
+			IL_0a83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a88: stloc.s 17
+			IL_0a8a: ldloc.s 17
+			IL_0a8c: stloc.s 11
+			IL_0a8e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_0a93: stloc.s 17
+			IL_0a95: ldloc.s 17
+			IL_0a97: ldstr "paramsCtor"
+			IL_0a9c: ldloc.s 11
+			IL_0a9e: ldc.i4.0
+			IL_0a9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_0aa4: pop
+			IL_0aa5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0aaa: stloc.s 21
+			IL_0aac: ldloc.s 11
+			IL_0aae: ldloc.s 21
+			IL_0ab0: ldstr "a=1"
+			IL_0ab5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0aba: pop
+			IL_0abb: ldstr "console"
+			IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ac5: stloc.s 17
+			IL_0ac7: ldloc.s 17
+			IL_0ac9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ace: stloc.s 17
+			IL_0ad0: ldloc.s 17
+			IL_0ad2: ldstr "log"
+			IL_0ad7: ldstr "params call: no-throw"
+			IL_0adc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0ae1: pop
+			IL_0ae2: leave IL_0b78
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0aee: stloc.s 13
-			IL_0af0: ldloc.s 13
-			IL_0af2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0af7: dup
-			IL_0af8: brtrue IL_0b0e
+			IL_0ae7: stloc.s 12
+			IL_0ae9: ldloc.s 12
+			IL_0aeb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0af0: dup
+			IL_0af1: brtrue IL_0b07
 
-			IL_0afd: pop
-			IL_0afe: ldloc.s 13
-			IL_0b00: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b05: dup
-			IL_0b06: brtrue IL_0b1a
+			IL_0af6: pop
+			IL_0af7: ldloc.s 12
+			IL_0af9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0afe: dup
+			IL_0aff: brtrue IL_0b13
 
-			IL_0b0b: pop
-			IL_0b0c: rethrow
+			IL_0b04: pop
+			IL_0b05: rethrow
 
-			IL_0b0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b13: stloc.s 14
-			IL_0b15: br IL_0b1c
+			IL_0b07: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b0c: stloc.s 13
+			IL_0b0e: br IL_0b15
 
-			IL_0b1a: stloc.s 14
+			IL_0b13: stloc.s 13
 
-			IL_0b1c: ldloc.s 14
-			IL_0b1e: stloc.s 19
-			IL_0b20: ldloc.s 19
-			IL_0b22: stloc.s 15
-			IL_0b24: newobj instance void Modules.Global_Url_And_SearchParams/Scope/Block_L52C16::.ctor()
-			IL_0b29: stloc.s 16
-			IL_0b2b: ldstr "console"
-			IL_0b30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b35: stloc.s 19
-			IL_0b37: ldloc.s 19
-			IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b3e: stloc.s 19
-			IL_0b40: ldloc.s 15
-			IL_0b42: ldstr "name"
-			IL_0b47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b4c: ldstr ": "
-			IL_0b51: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b56: stloc.s 24
-			IL_0b58: ldloc.s 24
-			IL_0b5a: ldloc.s 15
-			IL_0b5c: ldstr "message"
-			IL_0b61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b66: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b6b: stloc.s 24
-			IL_0b6d: ldloc.s 19
-			IL_0b6f: ldstr "log"
-			IL_0b74: ldstr "params call:"
-			IL_0b79: ldloc.s 24
-			IL_0b7b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b80: pop
-			IL_0b81: leave IL_0b86
+			IL_0b15: ldloc.s 13
+			IL_0b17: stloc.s 17
+			IL_0b19: ldloc.s 17
+			IL_0b1b: stloc.s 14
+			IL_0b1d: ldstr "console"
+			IL_0b22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b27: stloc.s 17
+			IL_0b29: ldloc.s 17
+			IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b30: stloc.s 17
+			IL_0b32: ldloc.s 14
+			IL_0b34: ldstr "name"
+			IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b3e: ldstr ": "
+			IL_0b43: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b48: stloc.s 22
+			IL_0b4a: ldloc.s 22
+			IL_0b4c: ldloc.s 14
+			IL_0b4e: ldstr "message"
+			IL_0b53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b58: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b5d: stloc.s 22
+			IL_0b5f: ldloc.s 17
+			IL_0b61: ldstr "log"
+			IL_0b66: ldstr "params call:"
+			IL_0b6b: ldloc.s 22
+			IL_0b6d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b72: pop
+			IL_0b73: leave IL_0b78
 		} // end handler
 
-		IL_0b86: ldnull
-		IL_0b87: stloc.s 17
-		IL_0b89: ret
+		IL_0b78: ldnull
+		IL_0b79: stloc.s 15
+		IL_0b7b: ret
 	} // end of method Global_Url_And_SearchParams::__js_module_init__
 
 } // end of class Modules.Global_Url_And_SearchParams
@@ -1072,7 +1066,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2c31
+		// Method begins at RVA 0x2c21
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_Invalid_With_Base_Throws.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_Invalid_With_Base_Throws.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bd
+				// Method begins at RVA 0x21b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c6
+				// Method begins at RVA 0x21c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x21b0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 328 (0x148)
+		// Code size: 321 (0x141)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Url_Invalid_With_Base_Throws/Scope,
@@ -90,9 +90,8 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Require_Url_Invalid_With_Base_Throws/Scope/Block_L8C16,
-			[6] object,
-			[7] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Url_Invalid_With_Base_Throws/Scope::.ctor()
@@ -101,8 +100,8 @@
 		IL_0007: ldarg.1
 		IL_0008: ldstr "url"
 		IL_000d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0012: stloc.s 7
-		IL_0014: ldloc.s 7
+		IL_0012: stloc.s 6
+		IL_0014: ldloc.s 6
 		IL_0016: stloc.1
 		.try
 		{
@@ -110,8 +109,8 @@
 			IL_0018: ldloc.1
 			IL_0019: ldstr "URL"
 			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0023: stloc.s 7
-			IL_0025: ldloc.s 7
+			IL_0023: stloc.s 6
+			IL_0025: ldloc.s 6
 			IL_0027: ldc.i4.2
 			IL_0028: newarr [System.Runtime]System.Object
 			IL_002d: dup
@@ -126,18 +125,18 @@
 			IL_0042: pop
 			IL_0043: ldstr "console"
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 7
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 6
 			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.s 7
-			IL_0058: ldloc.s 7
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 6
 			IL_005a: ldstr "log"
 			IL_005f: ldstr "threw:"
 			IL_0064: ldc.i4.0
 			IL_0065: box [System.Runtime]System.Boolean
 			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_006f: pop
-			IL_0070: leave IL_0144
+			IL_0070: leave IL_013d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -163,58 +162,56 @@
 			IL_009d: stloc.3
 
 			IL_009e: ldloc.3
-			IL_009f: stloc.s 7
-			IL_00a1: ldloc.s 7
+			IL_009f: stloc.s 6
+			IL_00a1: ldloc.s 6
 			IL_00a3: stloc.s 4
-			IL_00a5: newobj instance void Modules.Require_Url_Invalid_With_Base_Throws/Scope/Block_L8C16::.ctor()
-			IL_00aa: stloc.s 5
-			IL_00ac: ldstr "console"
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bf: stloc.s 7
-			IL_00c1: ldloc.s 7
-			IL_00c3: ldstr "log"
-			IL_00c8: ldstr "threw:"
-			IL_00cd: ldc.i4.1
-			IL_00ce: box [System.Runtime]System.Boolean
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00d8: pop
-			IL_00d9: ldstr "console"
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e3: stloc.s 7
-			IL_00e5: ldloc.s 7
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ec: stloc.s 7
-			IL_00ee: ldloc.s 7
-			IL_00f0: ldstr "log"
-			IL_00f5: ldstr "name:"
-			IL_00fa: ldloc.s 4
-			IL_00fc: ldstr "name"
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_010b: pop
-			IL_010c: ldstr "console"
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0116: stloc.s 7
-			IL_0118: ldloc.s 7
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011f: stloc.s 7
-			IL_0121: ldloc.s 7
-			IL_0123: ldstr "log"
-			IL_0128: ldstr "message:"
-			IL_012d: ldloc.s 4
-			IL_012f: ldstr "message"
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_013e: pop
-			IL_013f: leave IL_0144
+			IL_00a5: ldstr "console"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00af: stloc.s 6
+			IL_00b1: ldloc.s 6
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.s 6
+			IL_00ba: ldloc.s 6
+			IL_00bc: ldstr "log"
+			IL_00c1: ldstr "threw:"
+			IL_00c6: ldc.i4.1
+			IL_00c7: box [System.Runtime]System.Boolean
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00d1: pop
+			IL_00d2: ldstr "console"
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00dc: stloc.s 6
+			IL_00de: ldloc.s 6
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.s 6
+			IL_00e9: ldstr "log"
+			IL_00ee: ldstr "name:"
+			IL_00f3: ldloc.s 4
+			IL_00f5: ldstr "name"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0104: pop
+			IL_0105: ldstr "console"
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_010f: stloc.s 6
+			IL_0111: ldloc.s 6
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0118: stloc.s 6
+			IL_011a: ldloc.s 6
+			IL_011c: ldstr "log"
+			IL_0121: ldstr "message:"
+			IL_0126: ldloc.s 4
+			IL_0128: ldstr "message"
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0137: pop
+			IL_0138: leave IL_013d
 		} // end handler
 
-		IL_0144: ldnull
-		IL_0145: stloc.s 6
-		IL_0147: ret
+		IL_013d: ldnull
+		IL_013e: stloc.s 5
+		IL_0140: ret
 	} // end of method Require_Url_Invalid_With_Base_Throws::__js_module_init__
 
 } // end of class Modules.Require_Url_Invalid_With_Base_Throws
@@ -226,7 +223,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21cf
+		// Method begins at RVA 0x21cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x281e
+					// Method begins at RVA 0x280e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2827
+					// Method begins at RVA 0x2817
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2815
+				// Method begins at RVA 0x2805
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,18 +85,17 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2548
+			// Method begins at RVA 0x2540
 			// Header size: 12
-			// Code size: 312 (0x138)
+			// Code size: 304 (0x130)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
 				[1] object,
 				[2] object,
-				[3] class Modules.Require_Zlib_ErrorPaths/logError/Scope/Block_L9C18,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			.try
@@ -108,22 +107,22 @@
 				IL_000c: pop
 				IL_000d: ldstr "console"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0017: stloc.s 5
-				IL_0019: ldloc.s 5
+				IL_0017: stloc.s 4
+				IL_0019: ldloc.s 4
 				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0020: stloc.s 5
+				IL_0020: stloc.s 4
 				IL_0022: ldarg.1
 				IL_0023: ldstr " threw:"
 				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_002d: stloc.s 6
-				IL_002f: ldloc.s 5
+				IL_002d: stloc.s 5
+				IL_002f: ldloc.s 4
 				IL_0031: ldstr "log"
-				IL_0036: ldloc.s 6
+				IL_0036: ldloc.s 5
 				IL_0038: ldc.i4.0
 				IL_0039: box [System.Runtime]System.Boolean
 				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 				IL_0043: pop
-				IL_0044: leave IL_0132
+				IL_0044: leave IL_012c
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -149,71 +148,69 @@
 				IL_0071: stloc.1
 
 				IL_0072: ldloc.1
-				IL_0073: stloc.s 5
-				IL_0075: ldloc.s 5
+				IL_0073: stloc.s 4
+				IL_0075: ldloc.s 4
 				IL_0077: stloc.2
-				IL_0078: newobj instance void Modules.Require_Zlib_ErrorPaths/logError/Scope/Block_L9C18::.ctor()
-				IL_007d: stloc.3
-				IL_007e: ldstr "console"
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0088: stloc.s 5
-				IL_008a: ldloc.s 5
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0091: stloc.s 5
-				IL_0093: ldarg.1
-				IL_0094: ldstr " threw:"
-				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_009e: stloc.s 6
-				IL_00a0: ldloc.s 5
-				IL_00a2: ldstr "log"
-				IL_00a7: ldloc.s 6
-				IL_00a9: ldc.i4.1
-				IL_00aa: box [System.Runtime]System.Boolean
-				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00b4: pop
-				IL_00b5: ldstr "console"
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00bf: stloc.s 5
-				IL_00c1: ldloc.s 5
-				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c8: stloc.s 5
-				IL_00ca: ldarg.1
-				IL_00cb: ldstr " name:"
-				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00d5: stloc.s 6
-				IL_00d7: ldloc.s 5
-				IL_00d9: ldstr "log"
-				IL_00de: ldloc.s 6
-				IL_00e0: ldloc.2
-				IL_00e1: ldstr "name"
-				IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_00f0: pop
-				IL_00f1: ldstr "console"
-				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00fb: stloc.s 5
-				IL_00fd: ldloc.s 5
-				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0104: stloc.s 5
-				IL_0106: ldarg.1
-				IL_0107: ldstr " message:"
-				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0111: stloc.s 6
-				IL_0113: ldloc.s 5
-				IL_0115: ldstr "log"
-				IL_011a: ldloc.s 6
-				IL_011c: ldloc.2
-				IL_011d: ldstr "message"
-				IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_012c: pop
-				IL_012d: leave IL_0132
+				IL_0078: ldstr "console"
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0082: stloc.s 4
+				IL_0084: ldloc.s 4
+				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008b: stloc.s 4
+				IL_008d: ldarg.1
+				IL_008e: ldstr " threw:"
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0098: stloc.s 5
+				IL_009a: ldloc.s 4
+				IL_009c: ldstr "log"
+				IL_00a1: ldloc.s 5
+				IL_00a3: ldc.i4.1
+				IL_00a4: box [System.Runtime]System.Boolean
+				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00ae: pop
+				IL_00af: ldstr "console"
+				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00b9: stloc.s 4
+				IL_00bb: ldloc.s 4
+				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c2: stloc.s 4
+				IL_00c4: ldarg.1
+				IL_00c5: ldstr " name:"
+				IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00cf: stloc.s 5
+				IL_00d1: ldloc.s 4
+				IL_00d3: ldstr "log"
+				IL_00d8: ldloc.s 5
+				IL_00da: ldloc.2
+				IL_00db: ldstr "name"
+				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_00ea: pop
+				IL_00eb: ldstr "console"
+				IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00f5: stloc.s 4
+				IL_00f7: ldloc.s 4
+				IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00fe: stloc.s 4
+				IL_0100: ldarg.1
+				IL_0101: ldstr " message:"
+				IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_010b: stloc.s 5
+				IL_010d: ldloc.s 4
+				IL_010f: ldstr "log"
+				IL_0114: ldloc.s 5
+				IL_0116: ldloc.2
+				IL_0117: ldstr "message"
+				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0126: pop
+				IL_0127: leave IL_012c
 			} // end handler
 
-			IL_0132: ldnull
-			IL_0133: stloc.s 4
-			IL_0135: ldloc.s 4
-			IL_0137: ret
+			IL_012c: ldnull
+			IL_012d: stloc.3
+			IL_012e: ldloc.3
+			IL_012f: ret
 		} // end of method logError::__js_call__
 
 	} // end of class logError
@@ -229,7 +226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2830
+				// Method begins at RVA 0x2820
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +252,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x269c
+			// Method begins at RVA 0x268c
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -294,7 +291,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2839
+				// Method begins at RVA 0x2829
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -320,7 +317,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x26e0
+			// Method begins at RVA 0x26d0
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -369,7 +366,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2842
+				// Method begins at RVA 0x2832
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -395,7 +392,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2740
+			// Method begins at RVA 0x2730
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -434,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x284b
+				// Method begins at RVA 0x283b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -460,7 +457,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2784
+			// Method begins at RVA 0x2774
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -499,7 +496,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2854
+				// Method begins at RVA 0x2844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -525,7 +522,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x27c8
+			// Method begins at RVA 0x27b8
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -569,7 +566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285d
+				// Method begins at RVA 0x284d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -589,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2866
+				// Method begins at RVA 0x2856
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -611,7 +608,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x280c
+			// Method begins at RVA 0x27fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -637,7 +634,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1231 (0x4cf)
+		// Code size: 1224 (0x4c8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
@@ -645,17 +642,16 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Require_Zlib_ErrorPaths/Scope/Block_L34C16,
+			[5] object,
 			[6] object,
 			[7] object,
 			[8] object,
-			[9] object,
-			[10] object[],
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[12] bool,
+			[9] object[],
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[11] bool,
+			[12] object,
 			[13] object,
-			[14] object,
-			[15] object
+			[14] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope::.ctor()
@@ -669,33 +665,33 @@
 		IL_0019: ldc.i4.0
 		IL_001a: ldc.i4.1
 		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0020: stloc.s 7
-		IL_0022: ldloc.s 7
+		IL_0020: stloc.s 6
+		IL_0022: ldloc.s 6
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldarg.1
 		IL_0027: ldstr "node:zlib"
 		IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0031: stloc.s 7
+		IL_0031: stloc.s 6
 		IL_0033: ldloc.0
-		IL_0034: ldloc.s 7
+		IL_0034: ldloc.s 6
 		IL_0036: stfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_003b: nop
 		IL_003c: ldstr "console"
 		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0046: stloc.s 7
-		IL_0048: ldloc.s 7
+		IL_0046: stloc.s 6
+		IL_0048: ldloc.s 6
 		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.s 7
+		IL_004f: stloc.s 6
 		IL_0051: ldloc.0
 		IL_0052: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005c: stloc.s 8
+		IL_005c: stloc.s 7
 		IL_005e: ldloc.0
 		IL_005f: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: stloc.s 9
-		IL_006b: ldloc.s 9
+		IL_0069: stloc.s 8
+		IL_006b: ldloc.s 8
 		IL_006d: ldstr "gzipSync"
 		IL_0072: ldstr "abc"
 		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -705,41 +701,41 @@
 		IL_008b: neg
 		IL_008c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0096: stloc.s 9
-		IL_0098: ldloc.s 8
+		IL_0096: stloc.s 8
+		IL_0098: ldloc.s 7
 		IL_009a: ldstr "gunzipSync"
-		IL_009f: ldloc.s 9
+		IL_009f: ldloc.s 8
 		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a6: stloc.s 9
-		IL_00a8: ldloc.s 9
+		IL_00a6: stloc.s 8
+		IL_00a8: ldloc.s 8
 		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: stloc.s 9
-		IL_00b1: ldloc.s 9
+		IL_00af: stloc.s 8
+		IL_00b1: ldloc.s 8
 		IL_00b3: ldstr "toString"
 		IL_00b8: ldstr "utf8"
 		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c2: stloc.s 9
-		IL_00c4: ldloc.s 7
+		IL_00c2: stloc.s 8
+		IL_00c4: ldloc.s 6
 		IL_00c6: ldstr "log"
 		IL_00cb: ldstr "gzip level -1 roundtrip:"
-		IL_00d0: ldloc.s 9
+		IL_00d0: ldloc.s 8
 		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_00d7: pop
 		IL_00d8: ldstr "console"
 		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e2: stloc.s 9
-		IL_00e4: ldloc.s 9
+		IL_00e2: stloc.s 8
+		IL_00e4: ldloc.s 8
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: stloc.s 9
+		IL_00eb: stloc.s 8
 		IL_00ed: ldloc.0
 		IL_00ee: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: stloc.s 7
+		IL_00f8: stloc.s 6
 		IL_00fa: ldloc.0
 		IL_00fb: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0105: stloc.s 8
-		IL_0107: ldloc.s 8
+		IL_0105: stloc.s 7
+		IL_0107: ldloc.s 7
 		IL_0109: ldstr "gzipSync"
 		IL_010e: ldstr "abc"
 		IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -748,28 +744,28 @@
 		IL_011e: ldc.r8 1.5
 		IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0131: stloc.s 8
-		IL_0133: ldloc.s 7
+		IL_0131: stloc.s 7
+		IL_0133: ldloc.s 6
 		IL_0135: ldstr "gunzipSync"
-		IL_013a: ldloc.s 8
+		IL_013a: ldloc.s 7
 		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0141: stloc.s 8
-		IL_0143: ldloc.s 8
+		IL_0141: stloc.s 7
+		IL_0143: ldloc.s 7
 		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014a: stloc.s 8
-		IL_014c: ldloc.s 8
+		IL_014a: stloc.s 7
+		IL_014c: ldloc.s 7
 		IL_014e: ldstr "toString"
 		IL_0153: ldstr "utf8"
 		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_015d: stloc.s 8
-		IL_015f: ldloc.s 9
+		IL_015d: stloc.s 7
+		IL_015f: ldloc.s 8
 		IL_0161: ldstr "log"
 		IL_0166: ldstr "gzip level 1.5 roundtrip:"
-		IL_016b: ldloc.s 8
+		IL_016b: ldloc.s 7
 		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0172: pop
 		IL_0173: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0178: stloc.s 10
+		IL_0178: stloc.s 9
 		IL_017a: ldc.i4.1
 		IL_017b: newarr [System.Runtime]System.Object
 		IL_0180: dup
@@ -796,15 +792,15 @@
 		IL_01b2: ldc.i4.0
 		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01bd: stloc.s 8
+		IL_01bd: stloc.s 7
 		IL_01bf: ldloc.1
-		IL_01c0: ldloc.s 10
+		IL_01c0: ldloc.s 9
 		IL_01c2: ldstr "gzip unsupported option"
-		IL_01c7: ldloc.s 8
+		IL_01c7: ldloc.s 7
 		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_01ce: pop
 		IL_01cf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01d4: stloc.s 10
+		IL_01d4: stloc.s 9
 		IL_01d6: ldc.i4.1
 		IL_01d7: newarr [System.Runtime]System.Object
 		IL_01dc: dup
@@ -831,15 +827,15 @@
 		IL_020e: ldc.i4.0
 		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0219: stloc.s 8
+		IL_0219: stloc.s 7
 		IL_021b: ldloc.1
-		IL_021c: ldloc.s 10
+		IL_021c: ldloc.s 9
 		IL_021e: ldstr "gunzip unsupported option"
-		IL_0223: ldloc.s 8
+		IL_0223: ldloc.s 7
 		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_022a: pop
 		IL_022b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0230: stloc.s 10
+		IL_0230: stloc.s 9
 		IL_0232: ldc.i4.1
 		IL_0233: newarr [System.Runtime]System.Object
 		IL_0238: dup
@@ -866,15 +862,15 @@
 		IL_026a: ldc.i4.0
 		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0275: stloc.s 8
+		IL_0275: stloc.s 7
 		IL_0277: ldloc.1
-		IL_0278: ldloc.s 10
+		IL_0278: ldloc.s 9
 		IL_027a: ldstr "gzip bad level"
-		IL_027f: ldloc.s 8
+		IL_027f: ldloc.s 7
 		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_0286: pop
 		IL_0287: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_028c: stloc.s 10
+		IL_028c: stloc.s 9
 		IL_028e: ldc.i4.1
 		IL_028f: newarr [System.Runtime]System.Object
 		IL_0294: dup
@@ -901,15 +897,15 @@
 		IL_02c6: ldc.i4.0
 		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02d1: stloc.s 8
+		IL_02d1: stloc.s 7
 		IL_02d3: ldloc.1
-		IL_02d4: ldloc.s 10
+		IL_02d4: ldloc.s 9
 		IL_02d6: ldstr "gzip NaN level"
-		IL_02db: ldloc.s 8
+		IL_02db: ldloc.s 7
 		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_02e2: pop
 		IL_02e3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02e8: stloc.s 10
+		IL_02e8: stloc.s 9
 		IL_02ea: ldc.i4.1
 		IL_02eb: newarr [System.Runtime]System.Object
 		IL_02f0: dup
@@ -936,11 +932,11 @@
 		IL_0322: ldc.i4.0
 		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_032d: stloc.s 8
+		IL_032d: stloc.s 7
 		IL_032f: ldloc.1
-		IL_0330: ldloc.s 10
+		IL_0330: ldloc.s 9
 		IL_0332: ldstr "gzip Infinity level"
-		IL_0337: ldloc.s 8
+		IL_0337: ldloc.s 7
 		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_033e: pop
 		.try
@@ -949,29 +945,29 @@
 			IL_0340: ldloc.0
 			IL_0341: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
 			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_034b: stloc.s 8
+			IL_034b: stloc.s 7
 			IL_034d: ldstr "not gzip"
 			IL_0352: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0357: stloc.s 11
-			IL_0359: ldloc.s 8
+			IL_0357: stloc.s 10
+			IL_0359: ldloc.s 7
 			IL_035b: ldstr "gunzipSync"
-			IL_0360: ldloc.s 11
+			IL_0360: ldloc.s 10
 			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0367: pop
 			IL_0368: ldstr "console"
 			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0372: stloc.s 8
-			IL_0374: ldloc.s 8
+			IL_0372: stloc.s 7
+			IL_0374: ldloc.s 7
 			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_037b: stloc.s 8
-			IL_037d: ldloc.s 8
+			IL_037b: stloc.s 7
+			IL_037d: ldloc.s 7
 			IL_037f: ldstr "log"
 			IL_0384: ldstr "gunzip invalid data threw:"
 			IL_0389: ldc.i4.0
 			IL_038a: box [System.Runtime]System.Boolean
 			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_0394: pop
-			IL_0395: leave IL_04cb
+			IL_0395: leave IL_04c4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -997,87 +993,85 @@
 			IL_03c2: stloc.3
 
 			IL_03c3: ldloc.3
-			IL_03c4: stloc.s 8
-			IL_03c6: ldloc.s 8
+			IL_03c4: stloc.s 7
+			IL_03c6: ldloc.s 7
 			IL_03c8: stloc.s 4
-			IL_03ca: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L34C16::.ctor()
-			IL_03cf: stloc.s 5
-			IL_03d1: ldstr "console"
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03db: stloc.s 8
-			IL_03dd: ldloc.s 8
-			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03e4: stloc.s 8
-			IL_03e6: ldloc.s 8
-			IL_03e8: ldstr "log"
-			IL_03ed: ldstr "gunzip invalid data threw:"
-			IL_03f2: ldc.i4.1
-			IL_03f3: box [System.Runtime]System.Boolean
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03fd: pop
-			IL_03fe: ldstr "console"
-			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0408: stloc.s 8
-			IL_040a: ldloc.s 8
-			IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0411: stloc.s 8
-			IL_0413: ldloc.s 8
-			IL_0415: ldstr "log"
-			IL_041a: ldstr "gunzip invalid data name:"
-			IL_041f: ldloc.s 4
-			IL_0421: ldstr "name"
-			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0430: pop
-			IL_0431: ldstr "console"
-			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_043b: stloc.s 8
-			IL_043d: ldloc.s 8
-			IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0444: stloc.s 8
-			IL_0446: ldloc.s 4
-			IL_0448: ldstr "message"
-			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0452: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0457: ldstr "string"
-			IL_045c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0461: stloc.s 12
-			IL_0463: ldloc.s 12
-			IL_0465: box [System.Runtime]System.Boolean
-			IL_046a: stloc.s 13
-			IL_046c: ldloc.s 13
-			IL_046e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0473: stloc.s 12
-			IL_0475: ldloc.s 12
-			IL_0477: brfalse IL_04ae
+			IL_03ca: ldstr "console"
+			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03d4: stloc.s 7
+			IL_03d6: ldloc.s 7
+			IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03dd: stloc.s 7
+			IL_03df: ldloc.s 7
+			IL_03e1: ldstr "log"
+			IL_03e6: ldstr "gunzip invalid data threw:"
+			IL_03eb: ldc.i4.1
+			IL_03ec: box [System.Runtime]System.Boolean
+			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03f6: pop
+			IL_03f7: ldstr "console"
+			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0401: stloc.s 7
+			IL_0403: ldloc.s 7
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_040a: stloc.s 7
+			IL_040c: ldloc.s 7
+			IL_040e: ldstr "log"
+			IL_0413: ldstr "gunzip invalid data name:"
+			IL_0418: ldloc.s 4
+			IL_041a: ldstr "name"
+			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0429: pop
+			IL_042a: ldstr "console"
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0434: stloc.s 7
+			IL_0436: ldloc.s 7
+			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_043d: stloc.s 7
+			IL_043f: ldloc.s 4
+			IL_0441: ldstr "message"
+			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_044b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0450: ldstr "string"
+			IL_0455: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_045a: stloc.s 11
+			IL_045c: ldloc.s 11
+			IL_045e: box [System.Runtime]System.Boolean
+			IL_0463: stloc.s 12
+			IL_0465: ldloc.s 12
+			IL_0467: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_046c: stloc.s 11
+			IL_046e: ldloc.s 11
+			IL_0470: brfalse IL_04a7
 
-			IL_047c: ldloc.s 4
-			IL_047e: ldstr "message"
-			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0488: ldstr "length"
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0492: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0497: ldc.r8 0.0
-			IL_04a0: cgt
-			IL_04a2: box [System.Runtime]System.Boolean
-			IL_04a7: stloc.s 15
-			IL_04a9: br IL_04b2
+			IL_0475: ldloc.s 4
+			IL_0477: ldstr "message"
+			IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0481: ldstr "length"
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_048b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0490: ldc.r8 0.0
+			IL_0499: cgt
+			IL_049b: box [System.Runtime]System.Boolean
+			IL_04a0: stloc.s 14
+			IL_04a2: br IL_04ab
 
-			IL_04ae: ldloc.s 13
-			IL_04b0: stloc.s 15
+			IL_04a7: ldloc.s 12
+			IL_04a9: stloc.s 14
 
-			IL_04b2: ldloc.s 8
-			IL_04b4: ldstr "log"
-			IL_04b9: ldstr "gunzip invalid data message length > 0:"
-			IL_04be: ldloc.s 15
-			IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04c5: pop
-			IL_04c6: leave IL_04cb
+			IL_04ab: ldloc.s 7
+			IL_04ad: ldstr "log"
+			IL_04b2: ldstr "gunzip invalid data message length > 0:"
+			IL_04b7: ldloc.s 14
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04be: pop
+			IL_04bf: leave IL_04c4
 		} // end handler
 
-		IL_04cb: ldnull
-		IL_04cc: stloc.s 6
-		IL_04ce: ret
+		IL_04c4: ldnull
+		IL_04c5: stloc.s 5
+		IL_04c7: ret
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths
@@ -1089,7 +1083,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x286f
+		// Method begins at RVA 0x285f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x291c
+				// Method begins at RVA 0x2900
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28a0
+			// Method begins at RVA 0x2884
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2925
+				// Method begins at RVA 0x2909
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,7 +90,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x28ac
+			// Method begins at RVA 0x2890
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -129,7 +129,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x292e
+				// Method begins at RVA 0x2912
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x28e0
+			// Method begins at RVA 0x28c4
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -202,7 +202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2937
+				// Method begins at RVA 0x291b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -222,7 +222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2940
+				// Method begins at RVA 0x2924
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -242,7 +242,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2949
+				// Method begins at RVA 0x292d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -262,7 +262,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2952
+				// Method begins at RVA 0x2936
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -282,7 +282,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x295b
+				// Method begins at RVA 0x293f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,7 +302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2964
+				// Method begins at RVA 0x2948
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -322,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x296d
+				// Method begins at RVA 0x2951
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2976
+				// Method begins at RVA 0x295a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -366,7 +366,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2913
+			// Method begins at RVA 0x28f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -392,7 +392,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2063 (0x80f)
+		// Code size: 2035 (0x7f3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope,
@@ -404,31 +404,27 @@
 			[6] class [System.Runtime]System.Exception,
 			[7] object,
 			[8] object,
-			[9] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L44C12,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[11] class [System.Runtime]System.Exception,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[10] class [System.Runtime]System.Exception,
+			[11] object,
 			[12] object,
-			[13] object,
-			[14] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L61C12,
-			[15] class [System.Runtime]System.Exception,
+			[13] class [System.Runtime]System.Exception,
+			[14] object,
+			[15] object,
 			[16] object,
-			[17] object,
-			[18] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L70C12,
+			[17] class [System.Runtime]System.Exception,
+			[18] object,
 			[19] object,
-			[20] class [System.Runtime]System.Exception,
-			[21] object,
+			[20] object,
+			[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[22] object,
-			[23] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L80C12,
+			[23] object,
 			[24] object,
 			[25] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[26] object,
 			[27] object,
-			[28] object,
-			[29] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[30] object,
-			[31] object,
-			[32] bool,
-			[33] object
+			[28] bool,
+			[29] object
 		)
 
 		IL_0000: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope::.ctor()
@@ -442,8 +438,8 @@
 		IL_0019: ldc.i4.0
 		IL_001a: ldc.i4.1
 		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0020: stloc.s 28
-		IL_0022: ldloc.s 28
+		IL_0020: stloc.s 24
+		IL_0022: ldloc.s 24
 		IL_0024: stloc.1
 		IL_0025: ldc.i4.1
 		IL_0026: newarr [System.Runtime]System.Object
@@ -462,8 +458,8 @@
 		IL_0048: ldc.i4.0
 		IL_0049: ldc.i4.1
 		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_004f: stloc.s 28
-		IL_0051: ldloc.s 28
+		IL_004f: stloc.s 24
+		IL_0051: ldloc.s 24
 		IL_0053: stloc.2
 		IL_0054: ldc.i4.1
 		IL_0055: newarr [System.Runtime]System.Object
@@ -482,8 +478,8 @@
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
 		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_007e: stloc.s 28
-		IL_0080: ldloc.s 28
+		IL_007e: stloc.s 24
+		IL_0080: ldloc.s 24
 		IL_0082: stloc.3
 		IL_0083: nop
 		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -512,10 +508,10 @@
 		IL_00c4: ldstr "configurable"
 		IL_00c9: ldc.i4.1
 		IL_00ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00cf: stloc.s 29
+		IL_00cf: stloc.s 25
 		IL_00d1: ldloc.s 4
 		IL_00d3: ldstr "x"
-		IL_00d8: ldloc.s 29
+		IL_00d8: ldloc.s 25
 		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 		IL_00df: pop
 		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -523,10 +519,10 @@
 		IL_00e6: ldstr "set"
 		IL_00eb: ldloc.3
 		IL_00ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00f1: stloc.s 29
+		IL_00f1: stloc.s 25
 		IL_00f3: ldloc.s 4
 		IL_00f5: ldstr "x"
-		IL_00fa: ldloc.s 29
+		IL_00fa: ldloc.s 25
 		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 		IL_0101: pop
 		IL_0102: ldloc.s 4
@@ -538,130 +534,130 @@
 		IL_0119: ldloc.s 4
 		IL_011b: ldstr "x"
 		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0125: stloc.s 28
-		IL_0127: ldloc.s 28
+		IL_0125: stloc.s 24
+		IL_0127: ldloc.s 24
 		IL_0129: stloc.s 5
 		IL_012b: ldstr "console"
 		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0135: stloc.s 28
-		IL_0137: ldloc.s 28
+		IL_0135: stloc.s 24
+		IL_0137: ldloc.s 24
 		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013e: stloc.s 28
+		IL_013e: stloc.s 24
 		IL_0140: ldstr "get="
 		IL_0145: ldloc.s 4
 		IL_0147: ldstr "x"
 		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0156: stloc.s 30
-		IL_0158: ldloc.s 28
+		IL_0156: stloc.s 26
+		IL_0158: ldloc.s 24
 		IL_015a: ldstr "log"
-		IL_015f: ldloc.s 30
+		IL_015f: ldloc.s 26
 		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0166: pop
 		IL_0167: ldstr "console"
 		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0171: stloc.s 28
-		IL_0173: ldloc.s 28
+		IL_0171: stloc.s 24
+		IL_0173: ldloc.s 24
 		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017a: stloc.s 28
+		IL_017a: stloc.s 24
 		IL_017c: ldloc.0
 		IL_017d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope::log
 		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: stloc.s 31
-		IL_0189: ldloc.s 31
+		IL_0187: stloc.s 27
+		IL_0189: ldloc.s 27
 		IL_018b: ldstr "join"
 		IL_0190: ldstr ","
 		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_019a: stloc.s 31
+		IL_019a: stloc.s 27
 		IL_019c: ldstr "log="
-		IL_01a1: ldloc.s 31
+		IL_01a1: ldloc.s 27
 		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01a8: stloc.s 30
-		IL_01aa: ldloc.s 28
+		IL_01a8: stloc.s 26
+		IL_01aa: ldloc.s 24
 		IL_01ac: ldstr "log"
-		IL_01b1: ldloc.s 30
+		IL_01b1: ldloc.s 26
 		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01b8: pop
 		IL_01b9: ldstr "console"
 		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c3: stloc.s 28
-		IL_01c5: ldloc.s 28
+		IL_01c3: stloc.s 24
+		IL_01c5: ldloc.s 24
 		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cc: stloc.s 28
+		IL_01cc: stloc.s 24
 		IL_01ce: ldloc.s 5
 		IL_01d0: ldstr "get"
 		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_01da: ldloc.1
 		IL_01db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01e0: stloc.s 32
-		IL_01e2: ldloc.s 32
+		IL_01e0: stloc.s 28
+		IL_01e2: ldloc.s 28
 		IL_01e4: box [System.Runtime]System.Boolean
-		IL_01e9: stloc.s 33
+		IL_01e9: stloc.s 29
 		IL_01eb: ldstr "same_get="
-		IL_01f0: ldloc.s 33
+		IL_01f0: ldloc.s 29
 		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01f7: stloc.s 30
-		IL_01f9: ldloc.s 28
+		IL_01f7: stloc.s 26
+		IL_01f9: ldloc.s 24
 		IL_01fb: ldstr "log"
-		IL_0200: ldloc.s 30
+		IL_0200: ldloc.s 26
 		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0207: pop
 		IL_0208: ldstr "console"
 		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0212: stloc.s 28
-		IL_0214: ldloc.s 28
+		IL_0212: stloc.s 24
+		IL_0214: ldloc.s 24
 		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021b: stloc.s 28
+		IL_021b: stloc.s 24
 		IL_021d: ldloc.s 5
 		IL_021f: ldstr "set"
 		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0229: ldloc.3
 		IL_022a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_022f: stloc.s 32
-		IL_0231: ldloc.s 32
+		IL_022f: stloc.s 28
+		IL_0231: ldloc.s 28
 		IL_0233: box [System.Runtime]System.Boolean
-		IL_0238: stloc.s 33
+		IL_0238: stloc.s 29
 		IL_023a: ldstr "same_set="
-		IL_023f: ldloc.s 33
+		IL_023f: ldloc.s 29
 		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0246: stloc.s 30
-		IL_0248: ldloc.s 28
+		IL_0246: stloc.s 26
+		IL_0248: ldloc.s 24
 		IL_024a: ldstr "log"
-		IL_024f: ldloc.s 30
+		IL_024f: ldloc.s 26
 		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0256: pop
 		IL_0257: ldstr "console"
 		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0261: stloc.s 28
-		IL_0263: ldloc.s 28
+		IL_0261: stloc.s 24
+		IL_0263: ldloc.s 24
 		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026a: stloc.s 28
+		IL_026a: stloc.s 24
 		IL_026c: ldstr "enum="
 		IL_0271: ldloc.s 5
 		IL_0273: ldstr "enumerable"
 		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0282: stloc.s 30
-		IL_0284: ldloc.s 28
+		IL_0282: stloc.s 26
+		IL_0284: ldloc.s 24
 		IL_0286: ldstr "log"
-		IL_028b: ldloc.s 30
+		IL_028b: ldloc.s 26
 		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0292: pop
 		IL_0293: ldstr "console"
 		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029d: stloc.s 28
-		IL_029f: ldloc.s 28
+		IL_029d: stloc.s 24
+		IL_029f: ldloc.s 24
 		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a6: stloc.s 28
+		IL_02a6: stloc.s 24
 		IL_02a8: ldstr "config="
 		IL_02ad: ldloc.s 5
 		IL_02af: ldstr "configurable"
 		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02be: stloc.s 30
-		IL_02c0: ldloc.s 28
+		IL_02be: stloc.s 26
+		IL_02c0: ldloc.s 24
 		IL_02c2: ldstr "log"
-		IL_02c7: ldloc.s 30
+		IL_02c7: ldloc.s 26
 		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_02ce: pop
 		.try
@@ -676,24 +672,24 @@
 			IL_02ea: ldstr "get"
 			IL_02ef: ldloc.1
 			IL_02f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02f5: stloc.s 29
+			IL_02f5: stloc.s 25
 			IL_02f7: ldloc.s 4
 			IL_02f9: ldstr "mixed"
-			IL_02fe: ldloc.s 29
+			IL_02fe: ldloc.s 25
 			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 			IL_0305: pop
 			IL_0306: ldstr "console"
 			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0310: stloc.s 28
-			IL_0312: ldloc.s 28
+			IL_0310: stloc.s 24
+			IL_0312: ldloc.s 24
 			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0319: stloc.s 28
-			IL_031b: ldloc.s 28
+			IL_0319: stloc.s 24
+			IL_031b: ldloc.s 24
 			IL_031d: ldstr "log"
 			IL_0322: ldstr "mixed=allowed"
 			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_032c: pop
-			IL_032d: leave IL_03b0
+			IL_032d: leave IL_03a9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -719,400 +715,392 @@
 			IL_035e: stloc.s 7
 
 			IL_0360: ldloc.s 7
-			IL_0362: stloc.s 28
-			IL_0364: ldloc.s 28
+			IL_0362: stloc.s 24
+			IL_0364: ldloc.s 24
 			IL_0366: stloc.s 8
-			IL_0368: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L44C12::.ctor()
-			IL_036d: stloc.s 9
-			IL_036f: ldstr "console"
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0379: stloc.s 28
-			IL_037b: ldloc.s 28
-			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0382: stloc.s 28
-			IL_0384: ldstr "mixed="
-			IL_0389: ldloc.s 8
-			IL_038b: ldstr "name"
-			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_039a: stloc.s 30
-			IL_039c: ldloc.s 28
-			IL_039e: ldstr "log"
-			IL_03a3: ldloc.s 30
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03aa: pop
-			IL_03ab: leave IL_03b0
+			IL_0368: ldstr "console"
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0372: stloc.s 24
+			IL_0374: ldloc.s 24
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037b: stloc.s 24
+			IL_037d: ldstr "mixed="
+			IL_0382: ldloc.s 8
+			IL_0384: ldstr "name"
+			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0393: stloc.s 26
+			IL_0395: ldloc.s 24
+			IL_0397: ldstr "log"
+			IL_039c: ldloc.s 26
+			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03a3: pop
+			IL_03a4: leave IL_03a9
 		} // end handler
 
-		IL_03b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03b5: stloc.s 10
-		IL_03b7: ldloc.s 10
-		IL_03b9: ldstr "y"
-		IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03c3: dup
-		IL_03c4: ldstr "value"
-		IL_03c9: ldc.r8 1
-		IL_03d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03d7: dup
-		IL_03d8: ldstr "enumerable"
-		IL_03dd: ldc.i4.1
-		IL_03de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_03e3: dup
-		IL_03e4: ldstr "configurable"
-		IL_03e9: ldc.i4.0
-		IL_03ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_03ef: dup
-		IL_03f0: ldstr "writable"
-		IL_03f5: ldc.i4.0
-		IL_03f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0400: pop
+		IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03ae: stloc.s 9
+		IL_03b0: ldloc.s 9
+		IL_03b2: ldstr "y"
+		IL_03b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03bc: dup
+		IL_03bd: ldstr "value"
+		IL_03c2: ldc.r8 1
+		IL_03cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03d0: dup
+		IL_03d1: ldstr "enumerable"
+		IL_03d6: ldc.i4.1
+		IL_03d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_03dc: dup
+		IL_03dd: ldstr "configurable"
+		IL_03e2: ldc.i4.0
+		IL_03e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_03e8: dup
+		IL_03e9: ldstr "writable"
+		IL_03ee: ldc.i4.0
+		IL_03ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_03f9: pop
 		.try
 		{
-			IL_0401: nop
-			IL_0402: ldloc.s 10
-			IL_0404: ldstr "y"
-			IL_0409: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_040e: dup
-			IL_040f: ldstr "value"
-			IL_0414: ldc.r8 2
-			IL_041d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0427: pop
-			IL_0428: ldstr "console"
-			IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0432: stloc.s 28
-			IL_0434: ldloc.s 28
-			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_043b: stloc.s 28
-			IL_043d: ldloc.s 28
-			IL_043f: ldstr "log"
-			IL_0444: ldstr "locked_value=allowed"
-			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_044e: pop
-			IL_044f: leave IL_04d2
+			IL_03fa: nop
+			IL_03fb: ldloc.s 9
+			IL_03fd: ldstr "y"
+			IL_0402: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0407: dup
+			IL_0408: ldstr "value"
+			IL_040d: ldc.r8 2
+			IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0420: pop
+			IL_0421: ldstr "console"
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_042b: stloc.s 24
+			IL_042d: ldloc.s 24
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0434: stloc.s 24
+			IL_0436: ldloc.s 24
+			IL_0438: ldstr "log"
+			IL_043d: ldstr "locked_value=allowed"
+			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0447: pop
+			IL_0448: leave IL_04c4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0454: stloc.s 11
-			IL_0456: ldloc.s 11
-			IL_0458: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_045d: dup
-			IL_045e: brtrue IL_0474
+			IL_044d: stloc.s 10
+			IL_044f: ldloc.s 10
+			IL_0451: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0456: dup
+			IL_0457: brtrue IL_046d
 
-			IL_0463: pop
-			IL_0464: ldloc.s 11
-			IL_0466: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_046b: dup
-			IL_046c: brtrue IL_0480
+			IL_045c: pop
+			IL_045d: ldloc.s 10
+			IL_045f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0464: dup
+			IL_0465: brtrue IL_0479
 
-			IL_0471: pop
-			IL_0472: rethrow
+			IL_046a: pop
+			IL_046b: rethrow
 
-			IL_0474: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0479: stloc.s 12
-			IL_047b: br IL_0482
+			IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0472: stloc.s 11
+			IL_0474: br IL_047b
 
-			IL_0480: stloc.s 12
+			IL_0479: stloc.s 11
 
-			IL_0482: ldloc.s 12
-			IL_0484: stloc.s 28
-			IL_0486: ldloc.s 28
-			IL_0488: stloc.s 13
-			IL_048a: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L61C12::.ctor()
-			IL_048f: stloc.s 14
-			IL_0491: ldstr "console"
-			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_049b: stloc.s 28
-			IL_049d: ldloc.s 28
-			IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04a4: stloc.s 28
-			IL_04a6: ldstr "locked_value="
-			IL_04ab: ldloc.s 13
-			IL_04ad: ldstr "name"
-			IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04bc: stloc.s 30
-			IL_04be: ldloc.s 28
-			IL_04c0: ldstr "log"
-			IL_04c5: ldloc.s 30
-			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04cc: pop
-			IL_04cd: leave IL_04d2
+			IL_047b: ldloc.s 11
+			IL_047d: stloc.s 24
+			IL_047f: ldloc.s 24
+			IL_0481: stloc.s 12
+			IL_0483: ldstr "console"
+			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_048d: stloc.s 24
+			IL_048f: ldloc.s 24
+			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0496: stloc.s 24
+			IL_0498: ldstr "locked_value="
+			IL_049d: ldloc.s 12
+			IL_049f: ldstr "name"
+			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04ae: stloc.s 26
+			IL_04b0: ldloc.s 24
+			IL_04b2: ldstr "log"
+			IL_04b7: ldloc.s 26
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04be: pop
+			IL_04bf: leave IL_04c4
 		} // end handler
 		.try
 		{
-			IL_04d2: nop
-			IL_04d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04d8: dup
-			IL_04d9: ldstr "get"
-			IL_04de: ldloc.1
-			IL_04df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04e4: stloc.s 29
-			IL_04e6: ldloc.s 10
-			IL_04e8: ldstr "y"
-			IL_04ed: ldloc.s 29
-			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_04f4: pop
-			IL_04f5: ldstr "console"
-			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04ff: stloc.s 28
-			IL_0501: ldloc.s 28
-			IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0508: stloc.s 28
-			IL_050a: ldloc.s 28
-			IL_050c: ldstr "log"
-			IL_0511: ldstr "locked_kind=allowed"
-			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_051b: pop
-			IL_051c: leave IL_059f
+			IL_04c4: nop
+			IL_04c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04ca: dup
+			IL_04cb: ldstr "get"
+			IL_04d0: ldloc.1
+			IL_04d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04d6: stloc.s 25
+			IL_04d8: ldloc.s 9
+			IL_04da: ldstr "y"
+			IL_04df: ldloc.s 25
+			IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_04e6: pop
+			IL_04e7: ldstr "console"
+			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04f1: stloc.s 24
+			IL_04f3: ldloc.s 24
+			IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04fa: stloc.s 24
+			IL_04fc: ldloc.s 24
+			IL_04fe: ldstr "log"
+			IL_0503: ldstr "locked_kind=allowed"
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_050d: pop
+			IL_050e: leave IL_058a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0521: stloc.s 15
-			IL_0523: ldloc.s 15
-			IL_0525: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0513: stloc.s 13
+			IL_0515: ldloc.s 13
+			IL_0517: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_051c: dup
+			IL_051d: brtrue IL_0533
+
+			IL_0522: pop
+			IL_0523: ldloc.s 13
+			IL_0525: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_052a: dup
-			IL_052b: brtrue IL_0541
+			IL_052b: brtrue IL_053f
 
 			IL_0530: pop
-			IL_0531: ldloc.s 15
-			IL_0533: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0538: dup
-			IL_0539: brtrue IL_054d
+			IL_0531: rethrow
 
-			IL_053e: pop
-			IL_053f: rethrow
+			IL_0533: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0538: stloc.s 14
+			IL_053a: br IL_0541
 
-			IL_0541: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0546: stloc.s 16
-			IL_0548: br IL_054f
+			IL_053f: stloc.s 14
 
-			IL_054d: stloc.s 16
-
-			IL_054f: ldloc.s 16
-			IL_0551: stloc.s 28
-			IL_0553: ldloc.s 28
-			IL_0555: stloc.s 17
-			IL_0557: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L70C12::.ctor()
-			IL_055c: stloc.s 18
-			IL_055e: ldstr "console"
-			IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0568: stloc.s 28
-			IL_056a: ldloc.s 28
-			IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0571: stloc.s 28
-			IL_0573: ldstr "locked_kind="
-			IL_0578: ldloc.s 17
-			IL_057a: ldstr "name"
-			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0589: stloc.s 30
-			IL_058b: ldloc.s 28
-			IL_058d: ldstr "log"
-			IL_0592: ldloc.s 30
-			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0599: pop
-			IL_059a: leave IL_059f
+			IL_0541: ldloc.s 14
+			IL_0543: stloc.s 24
+			IL_0545: ldloc.s 24
+			IL_0547: stloc.s 15
+			IL_0549: ldstr "console"
+			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0553: stloc.s 24
+			IL_0555: ldloc.s 24
+			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_055c: stloc.s 24
+			IL_055e: ldstr "locked_kind="
+			IL_0563: ldloc.s 15
+			IL_0565: ldstr "name"
+			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0574: stloc.s 26
+			IL_0576: ldloc.s 24
+			IL_0578: ldstr "log"
+			IL_057d: ldloc.s 26
+			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0584: pop
+			IL_0585: leave IL_058a
 		} // end handler
 
-		IL_059f: ldloc.s 10
-		IL_05a1: ldstr "y"
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_05ab: stloc.s 28
-		IL_05ad: ldloc.s 28
-		IL_05af: stloc.s 19
-		IL_05b1: ldstr "console"
-		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05bb: stloc.s 28
-		IL_05bd: ldloc.s 28
-		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05c4: stloc.s 28
-		IL_05c6: ldstr "locked_final="
-		IL_05cb: ldloc.s 19
-		IL_05cd: ldstr "value"
-		IL_05d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_05dc: stloc.s 30
-		IL_05de: ldloc.s 30
-		IL_05e0: ldstr ","
+		IL_058a: ldloc.s 9
+		IL_058c: ldstr "y"
+		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0596: stloc.s 24
+		IL_0598: ldloc.s 24
+		IL_059a: stloc.s 16
+		IL_059c: ldstr "console"
+		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05a6: stloc.s 24
+		IL_05a8: ldloc.s 24
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05af: stloc.s 24
+		IL_05b1: ldstr "locked_final="
+		IL_05b6: ldloc.s 16
+		IL_05b8: ldstr "value"
+		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_05c7: stloc.s 26
+		IL_05c9: ldloc.s 26
+		IL_05cb: ldstr ","
+		IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_05d5: stloc.s 26
+		IL_05d7: ldloc.s 26
+		IL_05d9: ldloc.s 16
+		IL_05db: ldstr "writable"
+		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_05ea: stloc.s 30
-		IL_05ec: ldloc.s 30
-		IL_05ee: ldloc.s 19
-		IL_05f0: ldstr "writable"
-		IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_05ff: stloc.s 30
-		IL_0601: ldloc.s 30
-		IL_0603: ldstr ","
+		IL_05ea: stloc.s 26
+		IL_05ec: ldloc.s 26
+		IL_05ee: ldstr ","
+		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_05f8: stloc.s 26
+		IL_05fa: ldloc.s 26
+		IL_05fc: ldloc.s 16
+		IL_05fe: ldstr "configurable"
+		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_060d: stloc.s 30
-		IL_060f: ldloc.s 30
-		IL_0611: ldloc.s 19
-		IL_0613: ldstr "configurable"
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0622: stloc.s 30
-		IL_0624: ldloc.s 28
-		IL_0626: ldstr "log"
-		IL_062b: ldloc.s 30
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0632: pop
+		IL_060d: stloc.s 26
+		IL_060f: ldloc.s 24
+		IL_0611: ldstr "log"
+		IL_0616: ldloc.s 26
+		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_061d: pop
 		.try
 		{
-			IL_0633: nop
-			IL_0634: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0639: ldstr "primitive"
-			IL_063e: ldstr "not-an-object"
-			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0648: pop
-			IL_0649: ldstr "console"
-			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0653: stloc.s 28
-			IL_0655: ldloc.s 28
-			IL_0657: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_065c: stloc.s 28
-			IL_065e: ldloc.s 28
-			IL_0660: ldstr "log"
-			IL_0665: ldstr "primitive=allowed"
-			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_066f: pop
-			IL_0670: leave IL_06f3
+			IL_061e: nop
+			IL_061f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0624: ldstr "primitive"
+			IL_0629: ldstr "not-an-object"
+			IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0633: pop
+			IL_0634: ldstr "console"
+			IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_063e: stloc.s 24
+			IL_0640: ldloc.s 24
+			IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0647: stloc.s 24
+			IL_0649: ldloc.s 24
+			IL_064b: ldstr "log"
+			IL_0650: ldstr "primitive=allowed"
+			IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_065a: pop
+			IL_065b: leave IL_06d7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0675: stloc.s 20
-			IL_0677: ldloc.s 20
-			IL_0679: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_067e: dup
-			IL_067f: brtrue IL_0695
+			IL_0660: stloc.s 17
+			IL_0662: ldloc.s 17
+			IL_0664: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0669: dup
+			IL_066a: brtrue IL_0680
 
-			IL_0684: pop
-			IL_0685: ldloc.s 20
-			IL_0687: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_068c: dup
-			IL_068d: brtrue IL_06a1
+			IL_066f: pop
+			IL_0670: ldloc.s 17
+			IL_0672: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0677: dup
+			IL_0678: brtrue IL_068c
 
-			IL_0692: pop
-			IL_0693: rethrow
+			IL_067d: pop
+			IL_067e: rethrow
 
-			IL_0695: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_069a: stloc.s 21
-			IL_069c: br IL_06a3
+			IL_0680: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0685: stloc.s 18
+			IL_0687: br IL_068e
 
-			IL_06a1: stloc.s 21
+			IL_068c: stloc.s 18
 
-			IL_06a3: ldloc.s 21
-			IL_06a5: stloc.s 28
-			IL_06a7: ldloc.s 28
-			IL_06a9: stloc.s 22
-			IL_06ab: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope/Block_L80C12::.ctor()
-			IL_06b0: stloc.s 23
-			IL_06b2: ldstr "console"
-			IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06bc: stloc.s 28
-			IL_06be: ldloc.s 28
-			IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06c5: stloc.s 28
-			IL_06c7: ldstr "primitive="
-			IL_06cc: ldloc.s 22
-			IL_06ce: ldstr "name"
-			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06dd: stloc.s 30
-			IL_06df: ldloc.s 28
-			IL_06e1: ldstr "log"
-			IL_06e6: ldloc.s 30
-			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06ed: pop
-			IL_06ee: leave IL_06f3
+			IL_068e: ldloc.s 18
+			IL_0690: stloc.s 24
+			IL_0692: ldloc.s 24
+			IL_0694: stloc.s 19
+			IL_0696: ldstr "console"
+			IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06a0: stloc.s 24
+			IL_06a2: ldloc.s 24
+			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06a9: stloc.s 24
+			IL_06ab: ldstr "primitive="
+			IL_06b0: ldloc.s 19
+			IL_06b2: ldstr "name"
+			IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06c1: stloc.s 26
+			IL_06c3: ldloc.s 24
+			IL_06c5: ldstr "log"
+			IL_06ca: ldloc.s 26
+			IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_06d1: pop
+			IL_06d2: leave IL_06d7
 		} // end handler
 
-		IL_06f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_06f8: dup
-		IL_06f9: ldstr "enumerable"
-		IL_06fe: ldc.i4.1
-		IL_06ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0704: dup
-		IL_0705: ldstr "configurable"
-		IL_070a: ldc.i4.1
-		IL_070b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0710: dup
-		IL_0711: ldstr "value"
-		IL_0716: ldc.r8 33
-		IL_071f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
-		IL_0729: stloc.s 28
-		IL_072b: ldloc.s 28
-		IL_072d: stloc.s 24
-		IL_072f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0734: stloc.s 25
-		IL_0736: ldloc.s 25
-		IL_0738: ldstr "proto"
-		IL_073d: ldloc.s 24
-		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0744: pop
-		IL_0745: ldloc.s 25
-		IL_0747: ldstr "proto"
-		IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0751: stloc.s 28
-		IL_0753: ldloc.s 28
-		IL_0755: stloc.s 26
-		IL_0757: ldstr "console"
-		IL_075c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0761: stloc.s 28
-		IL_0763: ldloc.s 28
-		IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_076a: stloc.s 28
-		IL_076c: ldstr "proto_value="
-		IL_0771: ldloc.s 25
-		IL_0773: ldstr "proto"
-		IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0782: stloc.s 30
-		IL_0784: ldloc.s 28
-		IL_0786: ldstr "log"
-		IL_078b: ldloc.s 30
-		IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0792: pop
-		IL_0793: ldstr "console"
-		IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_079d: stloc.s 28
-		IL_079f: ldloc.s 28
-		IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07a6: stloc.s 28
-		IL_07a8: ldstr "proto_enum="
-		IL_07ad: ldloc.s 26
-		IL_07af: ldstr "enumerable"
-		IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_07be: stloc.s 30
-		IL_07c0: ldloc.s 28
-		IL_07c2: ldstr "log"
-		IL_07c7: ldloc.s 30
-		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_07ce: pop
-		IL_07cf: ldstr "console"
-		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07d9: stloc.s 28
-		IL_07db: ldloc.s 28
-		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07e2: stloc.s 28
-		IL_07e4: ldstr "proto_config="
-		IL_07e9: ldloc.s 26
-		IL_07eb: ldstr "configurable"
-		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_07fa: stloc.s 30
-		IL_07fc: ldloc.s 28
-		IL_07fe: ldstr "log"
-		IL_0803: ldloc.s 30
-		IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_080a: pop
-		IL_080b: ldnull
-		IL_080c: stloc.s 27
-		IL_080e: ret
+		IL_06d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06dc: dup
+		IL_06dd: ldstr "enumerable"
+		IL_06e2: ldc.i4.1
+		IL_06e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_06e8: dup
+		IL_06e9: ldstr "configurable"
+		IL_06ee: ldc.i4.1
+		IL_06ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_06f4: dup
+		IL_06f5: ldstr "value"
+		IL_06fa: ldc.r8 33
+		IL_0703: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_070d: stloc.s 24
+		IL_070f: ldloc.s 24
+		IL_0711: stloc.s 20
+		IL_0713: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0718: stloc.s 21
+		IL_071a: ldloc.s 21
+		IL_071c: ldstr "proto"
+		IL_0721: ldloc.s 20
+		IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0728: pop
+		IL_0729: ldloc.s 21
+		IL_072b: ldstr "proto"
+		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0735: stloc.s 24
+		IL_0737: ldloc.s 24
+		IL_0739: stloc.s 22
+		IL_073b: ldstr "console"
+		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0745: stloc.s 24
+		IL_0747: ldloc.s 24
+		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_074e: stloc.s 24
+		IL_0750: ldstr "proto_value="
+		IL_0755: ldloc.s 21
+		IL_0757: ldstr "proto"
+		IL_075c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0766: stloc.s 26
+		IL_0768: ldloc.s 24
+		IL_076a: ldstr "log"
+		IL_076f: ldloc.s 26
+		IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0776: pop
+		IL_0777: ldstr "console"
+		IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0781: stloc.s 24
+		IL_0783: ldloc.s 24
+		IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_078a: stloc.s 24
+		IL_078c: ldstr "proto_enum="
+		IL_0791: ldloc.s 22
+		IL_0793: ldstr "enumerable"
+		IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_079d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_07a2: stloc.s 26
+		IL_07a4: ldloc.s 24
+		IL_07a6: ldstr "log"
+		IL_07ab: ldloc.s 26
+		IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_07b2: pop
+		IL_07b3: ldstr "console"
+		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07bd: stloc.s 24
+		IL_07bf: ldloc.s 24
+		IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07c6: stloc.s 24
+		IL_07c8: ldstr "proto_config="
+		IL_07cd: ldloc.s 22
+		IL_07cf: ldstr "configurable"
+		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_07de: stloc.s 26
+		IL_07e0: ldloc.s 24
+		IL_07e2: ldstr "log"
+		IL_07e7: ldloc.s 26
+		IL_07e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_07ee: pop
+		IL_07ef: ldnull
+		IL_07f0: stloc.s 23
+		IL_07f2: ret
 	} // end of method Object_DefineProperty_AccessorTransitions_And_Invariants::__js_module_init__
 
 } // end of class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants
@@ -1124,7 +1112,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x297f
+		// Method begins at RVA 0x2963
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_NonExtensible_ReconfigureExisting.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_NonExtensible_ReconfigureExisting.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d9
+				// Method begins at RVA 0x22d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e2
+				// Method begins at RVA 0x22da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22c8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 610 (0x262)
+		// Code size: 603 (0x25b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_DefineProperty_NonExtensible_ReconfigureExisting/Scope,
@@ -91,12 +91,11 @@
 			[3] class [System.Runtime]System.Exception,
 			[4] object,
 			[5] object,
-			[6] class Modules.Object_DefineProperty_NonExtensible_ReconfigureExisting/Scope/Block_L21C12,
+			[6] object,
 			[7] object,
 			[8] object,
-			[9] object,
-			[10] bool,
-			[11] object
+			[9] bool,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Object_DefineProperty_NonExtensible_ReconfigureExisting/Scope::.ctor()
@@ -123,75 +122,75 @@
 		IL_004d: ldloc.1
 		IL_004e: ldstr "visible"
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0058: stloc.s 8
-		IL_005a: ldloc.s 8
+		IL_0058: stloc.s 7
+		IL_005a: ldloc.s 7
 		IL_005c: stloc.2
 		IL_005d: ldstr "console"
 		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: stloc.s 8
-		IL_0069: ldloc.s 8
+		IL_0067: stloc.s 7
+		IL_0069: ldloc.s 7
 		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: stloc.s 8
+		IL_0070: stloc.s 7
 		IL_0072: ldstr "visible="
 		IL_0077: ldloc.1
 		IL_0078: ldstr "visible"
 		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0087: stloc.s 9
-		IL_0089: ldloc.s 8
+		IL_0087: stloc.s 8
+		IL_0089: ldloc.s 7
 		IL_008b: ldstr "log"
-		IL_0090: ldloc.s 9
+		IL_0090: ldloc.s 8
 		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0097: pop
 		IL_0098: ldstr "console"
 		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a2: stloc.s 8
-		IL_00a4: ldloc.s 8
+		IL_00a2: stloc.s 7
+		IL_00a4: ldloc.s 7
 		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ab: stloc.s 8
+		IL_00ab: stloc.s 7
 		IL_00ad: ldstr "visible_enum="
 		IL_00b2: ldloc.2
 		IL_00b3: ldstr "enumerable"
 		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00c2: stloc.s 9
-		IL_00c4: ldloc.s 8
+		IL_00c2: stloc.s 8
+		IL_00c4: ldloc.s 7
 		IL_00c6: ldstr "log"
-		IL_00cb: ldloc.s 9
+		IL_00cb: ldloc.s 8
 		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d2: pop
 		IL_00d3: ldstr "console"
 		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00dd: stloc.s 8
-		IL_00df: ldloc.s 8
+		IL_00dd: stloc.s 7
+		IL_00df: ldloc.s 7
 		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e6: stloc.s 8
+		IL_00e6: stloc.s 7
 		IL_00e8: ldstr "visible_config="
 		IL_00ed: ldloc.2
 		IL_00ee: ldstr "configurable"
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00fd: stloc.s 9
-		IL_00ff: ldloc.s 8
+		IL_00fd: stloc.s 8
+		IL_00ff: ldloc.s 7
 		IL_0101: ldstr "log"
-		IL_0106: ldloc.s 9
+		IL_0106: ldloc.s 8
 		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_010d: pop
 		IL_010e: ldstr "console"
 		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0118: stloc.s 8
-		IL_011a: ldloc.s 8
+		IL_0118: stloc.s 7
+		IL_011a: ldloc.s 7
 		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: stloc.s 8
+		IL_0121: stloc.s 7
 		IL_0123: ldstr "visible_writable="
 		IL_0128: ldloc.2
 		IL_0129: ldstr "writable"
 		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0138: stloc.s 9
-		IL_013a: ldloc.s 8
+		IL_0138: stloc.s 8
+		IL_013a: ldloc.s 7
 		IL_013c: ldstr "log"
-		IL_0141: ldloc.s 9
+		IL_0141: ldloc.s 8
 		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0148: pop
 		.try
@@ -208,16 +207,16 @@
 			IL_016e: pop
 			IL_016f: ldstr "console"
 			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0179: stloc.s 8
-			IL_017b: ldloc.s 8
+			IL_0179: stloc.s 7
+			IL_017b: ldloc.s 7
 			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0182: stloc.s 8
-			IL_0184: ldloc.s 8
+			IL_0182: stloc.s 7
+			IL_0184: ldloc.s 7
 			IL_0186: ldstr "log"
 			IL_018b: ldstr "new_prop=allowed"
 			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0195: pop
-			IL_0196: leave IL_0216
+			IL_0196: leave IL_020f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -243,56 +242,54 @@
 			IL_01c4: stloc.s 4
 
 			IL_01c6: ldloc.s 4
-			IL_01c8: stloc.s 8
-			IL_01ca: ldloc.s 8
+			IL_01c8: stloc.s 7
+			IL_01ca: ldloc.s 7
 			IL_01cc: stloc.s 5
-			IL_01ce: newobj instance void Modules.Object_DefineProperty_NonExtensible_ReconfigureExisting/Scope/Block_L21C12::.ctor()
-			IL_01d3: stloc.s 6
-			IL_01d5: ldstr "console"
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01df: stloc.s 8
-			IL_01e1: ldloc.s 8
-			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e8: stloc.s 8
-			IL_01ea: ldstr "new_prop="
-			IL_01ef: ldloc.s 5
-			IL_01f1: ldstr "name"
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0200: stloc.s 9
+			IL_01ce: ldstr "console"
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01d8: stloc.s 7
+			IL_01da: ldloc.s 7
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e1: stloc.s 7
+			IL_01e3: ldstr "new_prop="
+			IL_01e8: ldloc.s 5
+			IL_01ea: ldstr "name"
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01f9: stloc.s 8
+			IL_01fb: ldloc.s 7
+			IL_01fd: ldstr "log"
 			IL_0202: ldloc.s 8
-			IL_0204: ldstr "log"
-			IL_0209: ldloc.s 9
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0210: pop
-			IL_0211: leave IL_0216
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0209: pop
+			IL_020a: leave IL_020f
 		} // end handler
 
-		IL_0216: ldstr "console"
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0220: stloc.s 8
-		IL_0222: ldloc.s 8
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0229: stloc.s 8
-		IL_022b: ldloc.1
-		IL_022c: ldstr "newProp"
-		IL_0231: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0236: stloc.s 10
-		IL_0238: ldloc.s 10
-		IL_023a: box [System.Runtime]System.Boolean
-		IL_023f: stloc.s 11
-		IL_0241: ldstr "has_new="
-		IL_0246: ldloc.s 11
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_024d: stloc.s 9
+		IL_020f: ldstr "console"
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0219: stloc.s 7
+		IL_021b: ldloc.s 7
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0222: stloc.s 7
+		IL_0224: ldloc.1
+		IL_0225: ldstr "newProp"
+		IL_022a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_022f: stloc.s 9
+		IL_0231: ldloc.s 9
+		IL_0233: box [System.Runtime]System.Boolean
+		IL_0238: stloc.s 10
+		IL_023a: ldstr "has_new="
+		IL_023f: ldloc.s 10
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0246: stloc.s 8
+		IL_0248: ldloc.s 7
+		IL_024a: ldstr "log"
 		IL_024f: ldloc.s 8
-		IL_0251: ldstr "log"
-		IL_0256: ldloc.s 9
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_025d: pop
-		IL_025e: ldnull
-		IL_025f: stloc.s 7
-		IL_0261: ret
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0256: pop
+		IL_0257: ldnull
+		IL_0258: stloc.s 6
+		IL_025a: ret
 	} // end of method Object_DefineProperty_NonExtensible_ReconfigureExisting::__js_module_init__
 
 } // end of class Modules.Object_DefineProperty_NonExtensible_ReconfigureExisting
@@ -304,7 +301,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22eb
+		// Method begins at RVA 0x22e3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2748
+				// Method begins at RVA 0x2724
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26ec
+			// Method begins at RVA 0x26c8
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -63,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2700
+				// Method begins at RVA 0x26dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2709
+				// Method begins at RVA 0x26e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2712
+				// Method begins at RVA 0x26ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -123,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x271b
+				// Method begins at RVA 0x26f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,7 +143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2724
+				// Method begins at RVA 0x2700
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -163,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x272d
+				// Method begins at RVA 0x2709
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +183,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2736
+				// Method begins at RVA 0x2712
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273f
+				// Method begins at RVA 0x271b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,7 +223,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2751
+				// Method begins at RVA 0x272d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -243,7 +243,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x275a
+				// Method begins at RVA 0x2736
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -261,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26f7
+			// Method begins at RVA 0x26d3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -287,7 +287,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1615 (0x64f)
+		// Code size: 1580 (0x62c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope,
@@ -295,33 +295,28 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L10C12,
-			[6] class [System.Runtime]System.Exception,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L16C12,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[11] class [System.Runtime]System.Exception,
-			[12] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[9] class [System.Runtime]System.Exception,
+			[10] object,
+			[11] object,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[13] object,
-			[14] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L25C12,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[14] class [System.Runtime]System.Exception,
+			[15] object,
 			[16] object,
-			[17] class [System.Runtime]System.Exception,
-			[18] object,
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[18] class [System.Runtime]System.Exception,
 			[19] object,
-			[20] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L41C12,
-			[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[22] class [System.Runtime]System.Exception,
+			[20] object,
+			[21] object,
+			[22] object,
 			[23] object,
-			[24] object,
-			[25] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L58C12,
-			[26] object,
-			[27] object,
-			[28] object,
-			[29] bool,
-			[30] object,
-			[31] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[24] bool,
+			[25] object,
+			[26] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope::.ctor()
@@ -347,19 +342,19 @@
 		IL_004c: pop
 		IL_004d: ldstr "console"
 		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0057: stloc.s 27
-		IL_0059: ldloc.s 27
+		IL_0057: stloc.s 22
+		IL_0059: ldloc.s 22
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0060: stloc.s 27
+		IL_0060: stloc.s 22
 		IL_0062: ldstr "sealed_value="
 		IL_0067: ldloc.1
 		IL_0068: ldstr "a"
 		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0077: stloc.s 28
-		IL_0079: ldloc.s 27
+		IL_0077: stloc.s 23
+		IL_0079: ldloc.s 22
 		IL_007b: ldstr "log"
-		IL_0080: ldloc.s 28
+		IL_0080: ldloc.s 23
 		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0087: pop
 		.try
@@ -376,16 +371,16 @@
 			IL_00a5: pop
 			IL_00a6: ldstr "console"
 			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b0: stloc.s 27
-			IL_00b2: ldloc.s 27
+			IL_00b0: stloc.s 22
+			IL_00b2: ldloc.s 22
 			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b9: stloc.s 27
-			IL_00bb: ldloc.s 27
+			IL_00b9: stloc.s 22
+			IL_00bb: ldloc.s 22
 			IL_00bd: ldstr "log"
 			IL_00c2: ldstr "sealed_reconfig=ok"
 			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00cc: pop
-			IL_00cd: leave IL_014a
+			IL_00cd: leave IL_0143
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -411,464 +406,454 @@
 			IL_00fa: stloc.3
 
 			IL_00fb: ldloc.3
-			IL_00fc: stloc.s 27
-			IL_00fe: ldloc.s 27
+			IL_00fc: stloc.s 22
+			IL_00fe: ldloc.s 22
 			IL_0100: stloc.s 4
-			IL_0102: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L10C12::.ctor()
-			IL_0107: stloc.s 5
-			IL_0109: ldstr "console"
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0113: stloc.s 27
-			IL_0115: ldloc.s 27
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011c: stloc.s 27
-			IL_011e: ldstr "sealed_reconfig="
-			IL_0123: ldloc.s 4
-			IL_0125: ldstr "name"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0134: stloc.s 28
-			IL_0136: ldloc.s 27
-			IL_0138: ldstr "log"
-			IL_013d: ldloc.s 28
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0144: pop
-			IL_0145: leave IL_014a
+			IL_0102: ldstr "console"
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_010c: stloc.s 22
+			IL_010e: ldloc.s 22
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0115: stloc.s 22
+			IL_0117: ldstr "sealed_reconfig="
+			IL_011c: ldloc.s 4
+			IL_011e: ldstr "name"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_012d: stloc.s 23
+			IL_012f: ldloc.s 22
+			IL_0131: ldstr "log"
+			IL_0136: ldloc.s 23
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_013d: pop
+			IL_013e: leave IL_0143
 		} // end handler
 		.try
 		{
-			IL_014a: nop
-			IL_014b: ldloc.1
-			IL_014c: ldstr "b"
-			IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0156: dup
-			IL_0157: ldstr "value"
-			IL_015c: ldc.r8 1
-			IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_016f: pop
-			IL_0170: ldstr "console"
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017a: stloc.s 27
-			IL_017c: ldloc.s 27
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0183: stloc.s 27
-			IL_0185: ldloc.s 27
-			IL_0187: ldstr "log"
-			IL_018c: ldstr "sealed_add=ok"
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0196: pop
-			IL_0197: leave IL_021a
+			IL_0143: nop
+			IL_0144: ldloc.1
+			IL_0145: ldstr "b"
+			IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_014f: dup
+			IL_0150: ldstr "value"
+			IL_0155: ldc.r8 1
+			IL_015e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0168: pop
+			IL_0169: ldstr "console"
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0173: stloc.s 22
+			IL_0175: ldloc.s 22
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017c: stloc.s 22
+			IL_017e: ldloc.s 22
+			IL_0180: ldstr "log"
+			IL_0185: ldstr "sealed_add=ok"
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_018f: pop
+			IL_0190: leave IL_020c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_019c: stloc.s 6
-			IL_019e: ldloc.s 6
-			IL_01a0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01a5: dup
-			IL_01a6: brtrue IL_01bc
+			IL_0195: stloc.s 5
+			IL_0197: ldloc.s 5
+			IL_0199: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_019e: dup
+			IL_019f: brtrue IL_01b5
 
-			IL_01ab: pop
-			IL_01ac: ldloc.s 6
-			IL_01ae: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01b3: dup
-			IL_01b4: brtrue IL_01c8
+			IL_01a4: pop
+			IL_01a5: ldloc.s 5
+			IL_01a7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_01ac: dup
+			IL_01ad: brtrue IL_01c1
 
-			IL_01b9: pop
-			IL_01ba: rethrow
+			IL_01b2: pop
+			IL_01b3: rethrow
 
-			IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01c1: stloc.s 7
-			IL_01c3: br IL_01ca
+			IL_01b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_01ba: stloc.s 6
+			IL_01bc: br IL_01c3
 
-			IL_01c8: stloc.s 7
+			IL_01c1: stloc.s 6
 
-			IL_01ca: ldloc.s 7
-			IL_01cc: stloc.s 27
-			IL_01ce: ldloc.s 27
-			IL_01d0: stloc.s 8
-			IL_01d2: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L16C12::.ctor()
-			IL_01d7: stloc.s 9
-			IL_01d9: ldstr "console"
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e3: stloc.s 27
-			IL_01e5: ldloc.s 27
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ec: stloc.s 27
-			IL_01ee: ldstr "sealed_add="
-			IL_01f3: ldloc.s 8
-			IL_01f5: ldstr "name"
-			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0204: stloc.s 28
-			IL_0206: ldloc.s 27
-			IL_0208: ldstr "log"
-			IL_020d: ldloc.s 28
-			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0214: pop
-			IL_0215: leave IL_021a
+			IL_01c3: ldloc.s 6
+			IL_01c5: stloc.s 22
+			IL_01c7: ldloc.s 22
+			IL_01c9: stloc.s 7
+			IL_01cb: ldstr "console"
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01d5: stloc.s 22
+			IL_01d7: ldloc.s 22
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01de: stloc.s 22
+			IL_01e0: ldstr "sealed_add="
+			IL_01e5: ldloc.s 7
+			IL_01e7: ldstr "name"
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01f6: stloc.s 23
+			IL_01f8: ldloc.s 22
+			IL_01fa: ldstr "log"
+			IL_01ff: ldloc.s 23
+			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0206: pop
+			IL_0207: leave IL_020c
 		} // end handler
 
-		IL_021a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_021f: dup
-		IL_0220: ldstr "x"
-		IL_0225: ldc.r8 1
-		IL_022e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0233: stloc.s 10
-		IL_0235: ldloc.s 10
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_023c: pop
+		IL_020c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0211: dup
+		IL_0212: ldstr "x"
+		IL_0217: ldc.r8 1
+		IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0225: stloc.s 8
+		IL_0227: ldloc.s 8
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_022e: pop
 		.try
 		{
-			IL_023d: nop
-			IL_023e: ldloc.s 10
-			IL_0240: ldstr "x"
-			IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_024a: dup
-			IL_024b: ldstr "value"
-			IL_0250: ldc.r8 2
-			IL_0259: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0263: pop
-			IL_0264: ldstr "console"
-			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_026e: stloc.s 27
-			IL_0270: ldloc.s 27
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0277: stloc.s 27
-			IL_0279: ldloc.s 27
-			IL_027b: ldstr "log"
-			IL_0280: ldstr "frozen_value_write=ok"
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_028a: pop
-			IL_028b: leave IL_030e
+			IL_022f: nop
+			IL_0230: ldloc.s 8
+			IL_0232: ldstr "x"
+			IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_023c: dup
+			IL_023d: ldstr "value"
+			IL_0242: ldc.r8 2
+			IL_024b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0255: pop
+			IL_0256: ldstr "console"
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0260: stloc.s 22
+			IL_0262: ldloc.s 22
+			IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0269: stloc.s 22
+			IL_026b: ldloc.s 22
+			IL_026d: ldstr "log"
+			IL_0272: ldstr "frozen_value_write=ok"
+			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_027c: pop
+			IL_027d: leave IL_02f9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0290: stloc.s 11
-			IL_0292: ldloc.s 11
-			IL_0294: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0282: stloc.s 9
+			IL_0284: ldloc.s 9
+			IL_0286: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_028b: dup
+			IL_028c: brtrue IL_02a2
+
+			IL_0291: pop
+			IL_0292: ldloc.s 9
+			IL_0294: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_0299: dup
-			IL_029a: brtrue IL_02b0
+			IL_029a: brtrue IL_02ae
 
 			IL_029f: pop
-			IL_02a0: ldloc.s 11
-			IL_02a2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02a7: dup
-			IL_02a8: brtrue IL_02bc
+			IL_02a0: rethrow
 
-			IL_02ad: pop
-			IL_02ae: rethrow
+			IL_02a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02a7: stloc.s 10
+			IL_02a9: br IL_02b0
 
-			IL_02b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02b5: stloc.s 12
-			IL_02b7: br IL_02be
+			IL_02ae: stloc.s 10
 
-			IL_02bc: stloc.s 12
-
-			IL_02be: ldloc.s 12
-			IL_02c0: stloc.s 27
-			IL_02c2: ldloc.s 27
-			IL_02c4: stloc.s 13
-			IL_02c6: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L25C12::.ctor()
-			IL_02cb: stloc.s 14
-			IL_02cd: ldstr "console"
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02d7: stloc.s 27
-			IL_02d9: ldloc.s 27
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e0: stloc.s 27
-			IL_02e2: ldstr "frozen_value_write="
-			IL_02e7: ldloc.s 13
-			IL_02e9: ldstr "name"
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02f8: stloc.s 28
-			IL_02fa: ldloc.s 27
-			IL_02fc: ldstr "log"
-			IL_0301: ldloc.s 28
-			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0308: pop
-			IL_0309: leave IL_030e
+			IL_02b0: ldloc.s 10
+			IL_02b2: stloc.s 22
+			IL_02b4: ldloc.s 22
+			IL_02b6: stloc.s 11
+			IL_02b8: ldstr "console"
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02c2: stloc.s 22
+			IL_02c4: ldloc.s 22
+			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02cb: stloc.s 22
+			IL_02cd: ldstr "frozen_value_write="
+			IL_02d2: ldloc.s 11
+			IL_02d4: ldstr "name"
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02e3: stloc.s 23
+			IL_02e5: ldloc.s 22
+			IL_02e7: ldstr "log"
+			IL_02ec: ldloc.s 23
+			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02f3: pop
+			IL_02f4: leave IL_02f9
 		} // end handler
 
-		IL_030e: ldstr "console"
-		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0318: stloc.s 27
-		IL_031a: ldloc.s 27
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0321: stloc.s 27
-		IL_0323: ldstr "frozen_value="
-		IL_0328: ldloc.s 10
-		IL_032a: ldstr "x"
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0339: stloc.s 28
-		IL_033b: ldloc.s 27
-		IL_033d: ldstr "log"
-		IL_0342: ldloc.s 28
-		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0349: pop
-		IL_034a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_034f: stloc.s 15
-		IL_0351: ldloc.s 15
-		IL_0353: ldstr "blocked"
-		IL_0358: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_035d: dup
-		IL_035e: ldstr "value"
-		IL_0363: ldc.r8 1
-		IL_036c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0371: dup
-		IL_0372: ldstr "writable"
-		IL_0377: ldc.i4.0
-		IL_0378: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_037d: dup
-		IL_037e: ldstr "enumerable"
-		IL_0383: ldc.i4.1
-		IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0389: dup
-		IL_038a: ldstr "configurable"
-		IL_038f: ldc.i4.1
-		IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_039a: pop
-		IL_039b: ldloc.s 15
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
-		IL_03a2: stloc.s 27
-		IL_03a4: ldloc.s 27
-		IL_03a6: stloc.s 16
+		IL_02f9: ldstr "console"
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0303: stloc.s 22
+		IL_0305: ldloc.s 22
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_030c: stloc.s 22
+		IL_030e: ldstr "frozen_value="
+		IL_0313: ldloc.s 8
+		IL_0315: ldstr "x"
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0324: stloc.s 23
+		IL_0326: ldloc.s 22
+		IL_0328: ldstr "log"
+		IL_032d: ldloc.s 23
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0334: pop
+		IL_0335: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_033a: stloc.s 12
+		IL_033c: ldloc.s 12
+		IL_033e: ldstr "blocked"
+		IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0348: dup
+		IL_0349: ldstr "value"
+		IL_034e: ldc.r8 1
+		IL_0357: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_035c: dup
+		IL_035d: ldstr "writable"
+		IL_0362: ldc.i4.0
+		IL_0363: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0368: dup
+		IL_0369: ldstr "enumerable"
+		IL_036e: ldc.i4.1
+		IL_036f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0374: dup
+		IL_0375: ldstr "configurable"
+		IL_037a: ldc.i4.1
+		IL_037b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0385: pop
+		IL_0386: ldloc.s 12
+		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_038d: stloc.s 22
+		IL_038f: ldloc.s 22
+		IL_0391: stloc.s 13
 		.try
 		{
-			IL_03a8: nop
-			IL_03a9: ldloc.s 16
-			IL_03ab: ldstr "blocked"
-			IL_03b0: ldc.r8 2
-			IL_03b9: ldc.i4.1
-			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_03bf: pop
-			IL_03c0: ldstr "console"
-			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ca: stloc.s 27
-			IL_03cc: ldloc.s 27
-			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03d3: stloc.s 27
-			IL_03d5: ldloc.s 27
-			IL_03d7: ldstr "log"
-			IL_03dc: ldstr "inherited_write=ok"
-			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0393: nop
+			IL_0394: ldloc.s 13
+			IL_0396: ldstr "blocked"
+			IL_039b: ldc.r8 2
+			IL_03a4: ldc.i4.1
+			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_03aa: pop
+			IL_03ab: ldstr "console"
+			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03b5: stloc.s 22
+			IL_03b7: ldloc.s 22
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03be: stloc.s 22
+			IL_03c0: ldloc.s 22
+			IL_03c2: ldstr "log"
+			IL_03c7: ldstr "inherited_write=ok"
+			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03d1: pop
+			IL_03d2: leave IL_044e
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_03d7: stloc.s 14
+			IL_03d9: ldloc.s 14
+			IL_03db: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03e0: dup
+			IL_03e1: brtrue IL_03f7
+
 			IL_03e6: pop
-			IL_03e7: leave IL_046a
-		} // end .try
-		catch [System.Runtime]System.Exception
-		{
-			IL_03ec: stloc.s 17
-			IL_03ee: ldloc.s 17
-			IL_03f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03f5: dup
-			IL_03f6: brtrue IL_040c
+			IL_03e7: ldloc.s 14
+			IL_03e9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03ee: dup
+			IL_03ef: brtrue IL_0403
 
-			IL_03fb: pop
-			IL_03fc: ldloc.s 17
-			IL_03fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0403: dup
-			IL_0404: brtrue IL_0418
+			IL_03f4: pop
+			IL_03f5: rethrow
 
-			IL_0409: pop
-			IL_040a: rethrow
+			IL_03f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03fc: stloc.s 15
+			IL_03fe: br IL_0405
 
-			IL_040c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0411: stloc.s 18
-			IL_0413: br IL_041a
+			IL_0403: stloc.s 15
 
-			IL_0418: stloc.s 18
-
-			IL_041a: ldloc.s 18
-			IL_041c: stloc.s 27
-			IL_041e: ldloc.s 27
-			IL_0420: stloc.s 19
-			IL_0422: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L41C12::.ctor()
-			IL_0427: stloc.s 20
-			IL_0429: ldstr "console"
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0433: stloc.s 27
-			IL_0435: ldloc.s 27
-			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_043c: stloc.s 27
-			IL_043e: ldstr "inherited_write="
-			IL_0443: ldloc.s 19
-			IL_0445: ldstr "name"
-			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0454: stloc.s 28
-			IL_0456: ldloc.s 27
-			IL_0458: ldstr "log"
-			IL_045d: ldloc.s 28
-			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0464: pop
-			IL_0465: leave IL_046a
+			IL_0405: ldloc.s 15
+			IL_0407: stloc.s 22
+			IL_0409: ldloc.s 22
+			IL_040b: stloc.s 16
+			IL_040d: ldstr "console"
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0417: stloc.s 22
+			IL_0419: ldloc.s 22
+			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0420: stloc.s 22
+			IL_0422: ldstr "inherited_write="
+			IL_0427: ldloc.s 16
+			IL_0429: ldstr "name"
+			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0438: stloc.s 23
+			IL_043a: ldloc.s 22
+			IL_043c: ldstr "log"
+			IL_0441: ldloc.s 23
+			IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0448: pop
+			IL_0449: leave IL_044e
 		} // end handler
 
-		IL_046a: ldstr "console"
-		IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0474: stloc.s 27
-		IL_0476: ldloc.s 27
-		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_047d: stloc.s 27
-		IL_047f: ldloc.s 16
-		IL_0481: ldstr "blocked"
-		IL_0486: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_048b: stloc.s 29
-		IL_048d: ldloc.s 29
-		IL_048f: box [System.Runtime]System.Boolean
-		IL_0494: stloc.s 30
-		IL_0496: ldstr "inherited_has_own="
-		IL_049b: ldloc.s 30
-		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04a2: stloc.s 28
-		IL_04a4: ldloc.s 27
-		IL_04a6: ldstr "log"
-		IL_04ab: ldloc.s 28
-		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04b2: pop
-		IL_04b3: ldstr "console"
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04bd: stloc.s 27
-		IL_04bf: ldloc.s 27
-		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c6: stloc.s 27
-		IL_04c8: ldstr "inherited_value="
-		IL_04cd: ldloc.s 16
-		IL_04cf: ldstr "blocked"
-		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04de: stloc.s 28
-		IL_04e0: ldloc.s 27
-		IL_04e2: ldstr "log"
-		IL_04e7: ldloc.s 28
-		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04ee: pop
-		IL_04ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04f4: stloc.s 21
-		IL_04f6: ldnull
-		IL_04f7: ldftn float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
-		IL_04fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
-		IL_0502: ldc.i4.0
-		IL_0503: conv.r8
-		IL_0504: ldstr ""
-		IL_0509: ldc.i4.0
-		IL_050a: ldc.i4.1
-		IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0510: stloc.s 27
-		IL_0512: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0517: dup
-		IL_0518: ldstr "get"
-		IL_051d: ldloc.s 27
-		IL_051f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0524: dup
-		IL_0525: ldstr "enumerable"
-		IL_052a: ldc.i4.1
-		IL_052b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0530: dup
-		IL_0531: ldstr "configurable"
-		IL_0536: ldc.i4.1
-		IL_0537: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_053c: stloc.s 31
-		IL_053e: ldloc.s 21
-		IL_0540: ldstr "value"
-		IL_0545: ldloc.s 31
-		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_054c: pop
+		IL_044e: ldstr "console"
+		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0458: stloc.s 22
+		IL_045a: ldloc.s 22
+		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0461: stloc.s 22
+		IL_0463: ldloc.s 13
+		IL_0465: ldstr "blocked"
+		IL_046a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_046f: stloc.s 24
+		IL_0471: ldloc.s 24
+		IL_0473: box [System.Runtime]System.Boolean
+		IL_0478: stloc.s 25
+		IL_047a: ldstr "inherited_has_own="
+		IL_047f: ldloc.s 25
+		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0486: stloc.s 23
+		IL_0488: ldloc.s 22
+		IL_048a: ldstr "log"
+		IL_048f: ldloc.s 23
+		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0496: pop
+		IL_0497: ldstr "console"
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a1: stloc.s 22
+		IL_04a3: ldloc.s 22
+		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04aa: stloc.s 22
+		IL_04ac: ldstr "inherited_value="
+		IL_04b1: ldloc.s 13
+		IL_04b3: ldstr "blocked"
+		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_04c2: stloc.s 23
+		IL_04c4: ldloc.s 22
+		IL_04c6: ldstr "log"
+		IL_04cb: ldloc.s 23
+		IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04d2: pop
+		IL_04d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04d8: stloc.s 17
+		IL_04da: ldnull
+		IL_04db: ldftn float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
+		IL_04e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+		IL_04e6: ldc.i4.0
+		IL_04e7: conv.r8
+		IL_04e8: ldstr ""
+		IL_04ed: ldc.i4.0
+		IL_04ee: ldc.i4.1
+		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04f4: stloc.s 22
+		IL_04f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04fb: dup
+		IL_04fc: ldstr "get"
+		IL_0501: ldloc.s 22
+		IL_0503: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0508: dup
+		IL_0509: ldstr "enumerable"
+		IL_050e: ldc.i4.1
+		IL_050f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0514: dup
+		IL_0515: ldstr "configurable"
+		IL_051a: ldc.i4.1
+		IL_051b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0520: stloc.s 26
+		IL_0522: ldloc.s 17
+		IL_0524: ldstr "value"
+		IL_0529: ldloc.s 26
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0530: pop
 		.try
 		{
-			IL_054d: nop
-			IL_054e: ldloc.s 21
-			IL_0550: ldstr "value"
-			IL_0555: ldc.r8 8
-			IL_055e: ldc.i4.1
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0564: pop
-			IL_0565: ldstr "console"
-			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_056f: stloc.s 27
-			IL_0571: ldloc.s 27
-			IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0578: stloc.s 27
-			IL_057a: ldloc.s 27
-			IL_057c: ldstr "log"
-			IL_0581: ldstr "getter_only_write=ok"
-			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_058b: pop
-			IL_058c: leave IL_060f
+			IL_0531: nop
+			IL_0532: ldloc.s 17
+			IL_0534: ldstr "value"
+			IL_0539: ldc.r8 8
+			IL_0542: ldc.i4.1
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0548: pop
+			IL_0549: ldstr "console"
+			IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0553: stloc.s 22
+			IL_0555: ldloc.s 22
+			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_055c: stloc.s 22
+			IL_055e: ldloc.s 22
+			IL_0560: ldstr "log"
+			IL_0565: ldstr "getter_only_write=ok"
+			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_056f: pop
+			IL_0570: leave IL_05ec
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0591: stloc.s 22
-			IL_0593: ldloc.s 22
-			IL_0595: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_059a: dup
-			IL_059b: brtrue IL_05b1
+			IL_0575: stloc.s 18
+			IL_0577: ldloc.s 18
+			IL_0579: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_057e: dup
+			IL_057f: brtrue IL_0595
 
-			IL_05a0: pop
-			IL_05a1: ldloc.s 22
-			IL_05a3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05a8: dup
-			IL_05a9: brtrue IL_05bd
+			IL_0584: pop
+			IL_0585: ldloc.s 18
+			IL_0587: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_058c: dup
+			IL_058d: brtrue IL_05a1
 
-			IL_05ae: pop
-			IL_05af: rethrow
+			IL_0592: pop
+			IL_0593: rethrow
 
-			IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_05b6: stloc.s 23
-			IL_05b8: br IL_05bf
+			IL_0595: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_059a: stloc.s 19
+			IL_059c: br IL_05a3
 
-			IL_05bd: stloc.s 23
+			IL_05a1: stloc.s 19
 
-			IL_05bf: ldloc.s 23
-			IL_05c1: stloc.s 27
-			IL_05c3: ldloc.s 27
-			IL_05c5: stloc.s 24
-			IL_05c7: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/Scope/Block_L58C12::.ctor()
-			IL_05cc: stloc.s 25
-			IL_05ce: ldstr "console"
-			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05d8: stloc.s 27
-			IL_05da: ldloc.s 27
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05e1: stloc.s 27
-			IL_05e3: ldstr "getter_only_write="
-			IL_05e8: ldloc.s 24
-			IL_05ea: ldstr "name"
-			IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05f9: stloc.s 28
-			IL_05fb: ldloc.s 27
-			IL_05fd: ldstr "log"
-			IL_0602: ldloc.s 28
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0609: pop
-			IL_060a: leave IL_060f
+			IL_05a3: ldloc.s 19
+			IL_05a5: stloc.s 22
+			IL_05a7: ldloc.s 22
+			IL_05a9: stloc.s 20
+			IL_05ab: ldstr "console"
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05b5: stloc.s 22
+			IL_05b7: ldloc.s 22
+			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05be: stloc.s 22
+			IL_05c0: ldstr "getter_only_write="
+			IL_05c5: ldloc.s 20
+			IL_05c7: ldstr "name"
+			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05d6: stloc.s 23
+			IL_05d8: ldloc.s 22
+			IL_05da: ldstr "log"
+			IL_05df: ldloc.s 23
+			IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05e6: pop
+			IL_05e7: leave IL_05ec
 		} // end handler
 
-		IL_060f: ldstr "console"
-		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0619: stloc.s 27
-		IL_061b: ldloc.s 27
-		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0622: stloc.s 27
-		IL_0624: ldstr "getter_only_value="
-		IL_0629: ldloc.s 21
-		IL_062b: ldstr "value"
-		IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_063a: stloc.s 28
-		IL_063c: ldloc.s 27
-		IL_063e: ldstr "log"
-		IL_0643: ldloc.s 28
-		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_064a: pop
-		IL_064b: ldnull
-		IL_064c: stloc.s 26
-		IL_064e: ret
+		IL_05ec: ldstr "console"
+		IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05f6: stloc.s 22
+		IL_05f8: ldloc.s 22
+		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05ff: stloc.s 22
+		IL_0601: ldstr "getter_only_value="
+		IL_0606: ldloc.s 17
+		IL_0608: ldstr "value"
+		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0617: stloc.s 23
+		IL_0619: ldloc.s 22
+		IL_061b: ldstr "log"
+		IL_0620: ldloc.s 23
+		IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0627: pop
+		IL_0628: ldnull
+		IL_0629: stloc.s 21
+		IL_062b: ret
 	} // end of method Object_Integrity_DefineProperty_And_StrictWrites::__js_module_init__
 
 } // end of class Modules.Object_Integrity_DefineProperty_And_StrictWrites
@@ -880,7 +865,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2763
+		// Method begins at RVA 0x273f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_FreezeSeal_PreventExtensions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_FreezeSeal_PreventExtensions.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2799
+				// Method begins at RVA 0x277d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a2
+				// Method begins at RVA 0x2786
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ab
+				// Method begins at RVA 0x278f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b4
+				// Method begins at RVA 0x2798
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27bd
+				// Method begins at RVA 0x27a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c6
+				// Method begins at RVA 0x27aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27cf
+				// Method begins at RVA 0x27b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d8
+				// Method begins at RVA 0x27bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2790
+			// Method begins at RVA 0x2774
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1792 (0x700)
+		// Code size: 1764 (0x6e4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope,
@@ -210,27 +210,23 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L9C12,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[7] class [System.Runtime]System.Exception,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] class [System.Runtime]System.Exception,
+			[7] object,
 			[8] object,
-			[9] object,
-			[10] class Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L26C12,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[12] class [System.Runtime]System.Exception,
-			[13] object,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[10] class [System.Runtime]System.Exception,
+			[11] object,
+			[12] object,
+			[13] class [System.Runtime]System.Exception,
 			[14] object,
-			[15] class Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L38C12,
-			[16] class [System.Runtime]System.Exception,
+			[15] object,
+			[16] object,
 			[17] object,
-			[18] object,
-			[19] class Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L45C12,
+			[18] bool,
+			[19] object,
 			[20] object,
-			[21] object,
-			[22] bool,
-			[23] object,
-			[24] object,
-			[25] object
+			[21] object
 		)
 
 		IL_0000: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope::.ctor()
@@ -244,23 +240,23 @@
 		IL_0020: stloc.1
 		IL_0021: ldstr "console"
 		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002b: stloc.s 21
-		IL_002d: ldloc.s 21
+		IL_002b: stloc.s 17
+		IL_002d: ldloc.s 17
 		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0034: stloc.s 21
+		IL_0034: stloc.s 17
 		IL_0036: ldloc.1
 		IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_003c: stloc.s 22
-		IL_003e: ldloc.s 22
+		IL_003c: stloc.s 18
+		IL_003e: ldloc.s 18
 		IL_0040: box [System.Runtime]System.Boolean
-		IL_0045: stloc.s 23
+		IL_0045: stloc.s 19
 		IL_0047: ldstr "extensible0="
-		IL_004c: ldloc.s 23
+		IL_004c: ldloc.s 19
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0053: stloc.s 24
-		IL_0055: ldloc.s 21
+		IL_0053: stloc.s 20
+		IL_0055: ldloc.s 17
 		IL_0057: ldstr "log"
-		IL_005c: ldloc.s 24
+		IL_005c: ldloc.s 20
 		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0063: pop
 		IL_0064: ldloc.1
@@ -277,16 +273,16 @@
 			IL_0081: pop
 			IL_0082: ldstr "console"
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008c: stloc.s 21
-			IL_008e: ldloc.s 21
+			IL_008c: stloc.s 17
+			IL_008e: ldloc.s 17
 			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0095: stloc.s 21
-			IL_0097: ldloc.s 21
+			IL_0095: stloc.s 17
+			IL_0097: ldloc.s 17
 			IL_0099: ldstr "log"
 			IL_009e: ldstr "prevent_add=ok"
 			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_00a8: pop
-			IL_00a9: leave IL_0126
+			IL_00a9: leave IL_011f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -312,520 +308,512 @@
 			IL_00d6: stloc.3
 
 			IL_00d7: ldloc.3
-			IL_00d8: stloc.s 21
-			IL_00da: ldloc.s 21
+			IL_00d8: stloc.s 17
+			IL_00da: ldloc.s 17
 			IL_00dc: stloc.s 4
-			IL_00de: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L9C12::.ctor()
-			IL_00e3: stloc.s 5
-			IL_00e5: ldstr "console"
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ef: stloc.s 21
-			IL_00f1: ldloc.s 21
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f8: stloc.s 21
-			IL_00fa: ldstr "prevent_add="
-			IL_00ff: ldloc.s 4
-			IL_0101: ldstr "name"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0110: stloc.s 24
-			IL_0112: ldloc.s 21
-			IL_0114: ldstr "log"
-			IL_0119: ldloc.s 24
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0120: pop
-			IL_0121: leave IL_0126
+			IL_00de: ldstr "console"
+			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e8: stloc.s 17
+			IL_00ea: ldloc.s 17
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f1: stloc.s 17
+			IL_00f3: ldstr "prevent_add="
+			IL_00f8: ldloc.s 4
+			IL_00fa: ldstr "name"
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0109: stloc.s 20
+			IL_010b: ldloc.s 17
+			IL_010d: ldstr "log"
+			IL_0112: ldloc.s 20
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0119: pop
+			IL_011a: leave IL_011f
 		} // end handler
 
-		IL_0126: ldstr "console"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0130: stloc.s 21
-		IL_0132: ldloc.s 21
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0139: stloc.s 21
-		IL_013b: ldloc.1
-		IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0141: stloc.s 22
-		IL_0143: ldloc.s 22
-		IL_0145: box [System.Runtime]System.Boolean
-		IL_014a: stloc.s 23
-		IL_014c: ldstr "extensible1="
-		IL_0151: ldloc.s 23
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0158: stloc.s 24
-		IL_015a: ldloc.s 21
-		IL_015c: ldstr "log"
-		IL_0161: ldloc.s 24
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0168: pop
-		IL_0169: ldstr "console"
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0173: stloc.s 21
-		IL_0175: ldloc.s 21
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017c: stloc.s 21
-		IL_017e: ldloc.1
-		IL_017f: ldstr "b"
-		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0189: stloc.s 22
-		IL_018b: ldloc.s 22
-		IL_018d: box [System.Runtime]System.Boolean
-		IL_0192: stloc.s 23
-		IL_0194: ldstr "has_b="
-		IL_0199: ldloc.s 23
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01a0: stloc.s 24
-		IL_01a2: ldloc.s 21
-		IL_01a4: ldstr "log"
-		IL_01a9: ldloc.s 24
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01b0: pop
-		IL_01b1: ldstr "console"
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01bb: stloc.s 21
-		IL_01bd: ldloc.s 21
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c4: stloc.s 21
-		IL_01c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_01d0: stloc.s 25
-		IL_01d2: ldloc.s 25
-		IL_01d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_01d9: stloc.s 22
-		IL_01db: ldloc.s 22
-		IL_01dd: box [System.Runtime]System.Boolean
-		IL_01e2: stloc.s 23
-		IL_01e4: ldstr "empty_sealed="
-		IL_01e9: ldloc.s 23
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01f0: stloc.s 24
-		IL_01f2: ldloc.s 21
-		IL_01f4: ldstr "log"
-		IL_01f9: ldloc.s 24
-		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0200: pop
-		IL_0201: ldstr "console"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020b: stloc.s 21
-		IL_020d: ldloc.s 21
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0214: stloc.s 21
-		IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0220: stloc.s 25
-		IL_0222: ldloc.s 25
-		IL_0224: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_0229: stloc.s 22
-		IL_022b: ldloc.s 22
-		IL_022d: box [System.Runtime]System.Boolean
-		IL_0232: stloc.s 23
-		IL_0234: ldstr "empty_frozen="
-		IL_0239: ldloc.s 23
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0240: stloc.s 24
-		IL_0242: ldloc.s 21
-		IL_0244: ldstr "log"
-		IL_0249: ldloc.s 24
-		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0250: pop
-		IL_0251: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0256: dup
-		IL_0257: ldstr "x"
-		IL_025c: ldc.r8 1
-		IL_0265: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_026a: stloc.s 6
-		IL_026c: ldloc.s 6
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
-		IL_0273: pop
-		IL_0274: ldstr "console"
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027e: stloc.s 21
-		IL_0280: ldloc.s 21
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0287: stloc.s 21
-		IL_0289: ldloc.s 6
-		IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_0290: stloc.s 22
-		IL_0292: ldloc.s 22
-		IL_0294: box [System.Runtime]System.Boolean
-		IL_0299: stloc.s 23
-		IL_029b: ldstr "sealed="
-		IL_02a0: ldloc.s 23
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02a7: stloc.s 24
-		IL_02a9: ldloc.s 21
-		IL_02ab: ldstr "log"
-		IL_02b0: ldloc.s 24
-		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02b7: pop
-		IL_02b8: ldloc.s 6
-		IL_02ba: ldstr "x"
-		IL_02bf: ldc.r8 3
-		IL_02c8: ldc.i4.1
-		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_02ce: pop
-		IL_02cf: ldstr "console"
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d9: stloc.s 21
-		IL_02db: ldloc.s 21
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e2: stloc.s 21
-		IL_02e4: ldstr "sealed_write="
-		IL_02e9: ldloc.s 6
-		IL_02eb: ldstr "x"
-		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02fa: stloc.s 24
-		IL_02fc: ldloc.s 21
-		IL_02fe: ldstr "log"
-		IL_0303: ldloc.s 24
-		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_030a: pop
-		IL_030b: ldstr "console"
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0315: stloc.s 21
-		IL_0317: ldloc.s 21
-		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_031e: stloc.s 21
-		IL_0320: ldloc.s 6
-		IL_0322: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_0327: stloc.s 22
-		IL_0329: ldloc.s 22
-		IL_032b: box [System.Runtime]System.Boolean
-		IL_0330: stloc.s 23
-		IL_0332: ldstr "sealed_frozen="
-		IL_0337: ldloc.s 23
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_033e: stloc.s 24
-		IL_0340: ldloc.s 21
-		IL_0342: ldstr "log"
-		IL_0347: ldloc.s 24
-		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_034e: pop
+		IL_011f: ldstr "console"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0129: stloc.s 17
+		IL_012b: ldloc.s 17
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0132: stloc.s 17
+		IL_0134: ldloc.1
+		IL_0135: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_013a: stloc.s 18
+		IL_013c: ldloc.s 18
+		IL_013e: box [System.Runtime]System.Boolean
+		IL_0143: stloc.s 19
+		IL_0145: ldstr "extensible1="
+		IL_014a: ldloc.s 19
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0151: stloc.s 20
+		IL_0153: ldloc.s 17
+		IL_0155: ldstr "log"
+		IL_015a: ldloc.s 20
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0161: pop
+		IL_0162: ldstr "console"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016c: stloc.s 17
+		IL_016e: ldloc.s 17
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0175: stloc.s 17
+		IL_0177: ldloc.1
+		IL_0178: ldstr "b"
+		IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0182: stloc.s 18
+		IL_0184: ldloc.s 18
+		IL_0186: box [System.Runtime]System.Boolean
+		IL_018b: stloc.s 19
+		IL_018d: ldstr "has_b="
+		IL_0192: ldloc.s 19
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0199: stloc.s 20
+		IL_019b: ldloc.s 17
+		IL_019d: ldstr "log"
+		IL_01a2: ldloc.s 20
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01a9: pop
+		IL_01aa: ldstr "console"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b4: stloc.s 17
+		IL_01b6: ldloc.s 17
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bd: stloc.s 17
+		IL_01bf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_01c9: stloc.s 21
+		IL_01cb: ldloc.s 21
+		IL_01cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_01d2: stloc.s 18
+		IL_01d4: ldloc.s 18
+		IL_01d6: box [System.Runtime]System.Boolean
+		IL_01db: stloc.s 19
+		IL_01dd: ldstr "empty_sealed="
+		IL_01e2: ldloc.s 19
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01e9: stloc.s 20
+		IL_01eb: ldloc.s 17
+		IL_01ed: ldstr "log"
+		IL_01f2: ldloc.s 20
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01f9: pop
+		IL_01fa: ldstr "console"
+		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0204: stloc.s 17
+		IL_0206: ldloc.s 17
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020d: stloc.s 17
+		IL_020f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0219: stloc.s 21
+		IL_021b: ldloc.s 21
+		IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_0222: stloc.s 18
+		IL_0224: ldloc.s 18
+		IL_0226: box [System.Runtime]System.Boolean
+		IL_022b: stloc.s 19
+		IL_022d: ldstr "empty_frozen="
+		IL_0232: ldloc.s 19
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0239: stloc.s 20
+		IL_023b: ldloc.s 17
+		IL_023d: ldstr "log"
+		IL_0242: ldloc.s 20
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0249: pop
+		IL_024a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_024f: dup
+		IL_0250: ldstr "x"
+		IL_0255: ldc.r8 1
+		IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0263: stloc.s 5
+		IL_0265: ldloc.s 5
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
+		IL_026c: pop
+		IL_026d: ldstr "console"
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0277: stloc.s 17
+		IL_0279: ldloc.s 17
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0280: stloc.s 17
+		IL_0282: ldloc.s 5
+		IL_0284: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_0289: stloc.s 18
+		IL_028b: ldloc.s 18
+		IL_028d: box [System.Runtime]System.Boolean
+		IL_0292: stloc.s 19
+		IL_0294: ldstr "sealed="
+		IL_0299: ldloc.s 19
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02a0: stloc.s 20
+		IL_02a2: ldloc.s 17
+		IL_02a4: ldstr "log"
+		IL_02a9: ldloc.s 20
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02b0: pop
+		IL_02b1: ldloc.s 5
+		IL_02b3: ldstr "x"
+		IL_02b8: ldc.r8 3
+		IL_02c1: ldc.i4.1
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_02c7: pop
+		IL_02c8: ldstr "console"
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d2: stloc.s 17
+		IL_02d4: ldloc.s 17
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02db: stloc.s 17
+		IL_02dd: ldstr "sealed_write="
+		IL_02e2: ldloc.s 5
+		IL_02e4: ldstr "x"
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02f3: stloc.s 20
+		IL_02f5: ldloc.s 17
+		IL_02f7: ldstr "log"
+		IL_02fc: ldloc.s 20
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0303: pop
+		IL_0304: ldstr "console"
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030e: stloc.s 17
+		IL_0310: ldloc.s 17
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0317: stloc.s 17
+		IL_0319: ldloc.s 5
+		IL_031b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_0320: stloc.s 18
+		IL_0322: ldloc.s 18
+		IL_0324: box [System.Runtime]System.Boolean
+		IL_0329: stloc.s 19
+		IL_032b: ldstr "sealed_frozen="
+		IL_0330: ldloc.s 19
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0337: stloc.s 20
+		IL_0339: ldloc.s 17
+		IL_033b: ldstr "log"
+		IL_0340: ldloc.s 20
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0347: pop
 		.try
 		{
-			IL_034f: nop
-			IL_0350: ldloc.s 6
-			IL_0352: ldstr "x"
-			IL_0357: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_035c: stloc.s 22
-			IL_035e: ldstr "console"
-			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0368: stloc.s 21
-			IL_036a: ldloc.s 21
-			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0371: stloc.s 21
-			IL_0373: ldloc.s 21
-			IL_0375: ldstr "log"
-			IL_037a: ldstr "sealed_delete=ok"
-			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0384: pop
-			IL_0385: leave IL_0408
+			IL_0348: nop
+			IL_0349: ldloc.s 5
+			IL_034b: ldstr "x"
+			IL_0350: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_0355: stloc.s 18
+			IL_0357: ldstr "console"
+			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0361: stloc.s 17
+			IL_0363: ldloc.s 17
+			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036a: stloc.s 17
+			IL_036c: ldloc.s 17
+			IL_036e: ldstr "log"
+			IL_0373: ldstr "sealed_delete=ok"
+			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_037d: pop
+			IL_037e: leave IL_03fa
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_038a: stloc.s 7
-			IL_038c: ldloc.s 7
-			IL_038e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0393: dup
-			IL_0394: brtrue IL_03aa
+			IL_0383: stloc.s 6
+			IL_0385: ldloc.s 6
+			IL_0387: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_038c: dup
+			IL_038d: brtrue IL_03a3
 
-			IL_0399: pop
-			IL_039a: ldloc.s 7
-			IL_039c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03a1: dup
-			IL_03a2: brtrue IL_03b6
+			IL_0392: pop
+			IL_0393: ldloc.s 6
+			IL_0395: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_039a: dup
+			IL_039b: brtrue IL_03af
 
-			IL_03a7: pop
-			IL_03a8: rethrow
+			IL_03a0: pop
+			IL_03a1: rethrow
 
-			IL_03aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03af: stloc.s 8
-			IL_03b1: br IL_03b8
+			IL_03a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03a8: stloc.s 7
+			IL_03aa: br IL_03b1
 
-			IL_03b6: stloc.s 8
+			IL_03af: stloc.s 7
 
-			IL_03b8: ldloc.s 8
-			IL_03ba: stloc.s 21
-			IL_03bc: ldloc.s 21
-			IL_03be: stloc.s 9
-			IL_03c0: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L26C12::.ctor()
-			IL_03c5: stloc.s 10
-			IL_03c7: ldstr "console"
-			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03d1: stloc.s 21
-			IL_03d3: ldloc.s 21
-			IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03da: stloc.s 21
-			IL_03dc: ldstr "sealed_delete="
-			IL_03e1: ldloc.s 9
-			IL_03e3: ldstr "name"
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03f2: stloc.s 24
-			IL_03f4: ldloc.s 21
-			IL_03f6: ldstr "log"
-			IL_03fb: ldloc.s 24
-			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0402: pop
-			IL_0403: leave IL_0408
+			IL_03b1: ldloc.s 7
+			IL_03b3: stloc.s 17
+			IL_03b5: ldloc.s 17
+			IL_03b7: stloc.s 8
+			IL_03b9: ldstr "console"
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03c3: stloc.s 17
+			IL_03c5: ldloc.s 17
+			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03cc: stloc.s 17
+			IL_03ce: ldstr "sealed_delete="
+			IL_03d3: ldloc.s 8
+			IL_03d5: ldstr "name"
+			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03e4: stloc.s 20
+			IL_03e6: ldloc.s 17
+			IL_03e8: ldstr "log"
+			IL_03ed: ldloc.s 20
+			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03f4: pop
+			IL_03f5: leave IL_03fa
 		} // end handler
 
-		IL_0408: ldstr "console"
-		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0412: stloc.s 21
-		IL_0414: ldloc.s 21
-		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041b: stloc.s 21
-		IL_041d: ldloc.s 6
-		IL_041f: ldstr "x"
-		IL_0424: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0429: stloc.s 22
-		IL_042b: ldloc.s 22
-		IL_042d: box [System.Runtime]System.Boolean
-		IL_0432: stloc.s 23
-		IL_0434: ldstr "sealed_has_x="
-		IL_0439: ldloc.s 23
-		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0440: stloc.s 24
-		IL_0442: ldloc.s 21
-		IL_0444: ldstr "log"
-		IL_0449: ldloc.s 24
-		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0450: pop
-		IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0456: dup
-		IL_0457: ldstr "y"
-		IL_045c: ldc.r8 1
-		IL_0465: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_046a: stloc.s 11
-		IL_046c: ldloc.s 11
-		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_0473: pop
-		IL_0474: ldstr "console"
-		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_047e: stloc.s 21
-		IL_0480: ldloc.s 21
-		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0487: stloc.s 21
-		IL_0489: ldloc.s 11
-		IL_048b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_0490: stloc.s 22
-		IL_0492: ldloc.s 22
-		IL_0494: box [System.Runtime]System.Boolean
-		IL_0499: stloc.s 23
-		IL_049b: ldstr "frozen="
-		IL_04a0: ldloc.s 23
-		IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04a7: stloc.s 24
-		IL_04a9: ldloc.s 21
-		IL_04ab: ldstr "log"
-		IL_04b0: ldloc.s 24
-		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04b7: pop
-		IL_04b8: ldstr "console"
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04c2: stloc.s 21
-		IL_04c4: ldloc.s 21
-		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04cb: stloc.s 21
-		IL_04cd: ldloc.s 11
-		IL_04cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_04d4: stloc.s 22
-		IL_04d6: ldloc.s 22
-		IL_04d8: box [System.Runtime]System.Boolean
-		IL_04dd: stloc.s 23
-		IL_04df: ldstr "frozen_sealed="
-		IL_04e4: ldloc.s 23
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04eb: stloc.s 24
-		IL_04ed: ldloc.s 21
-		IL_04ef: ldstr "log"
-		IL_04f4: ldloc.s 24
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04fb: pop
+		IL_03fa: ldstr "console"
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0404: stloc.s 17
+		IL_0406: ldloc.s 17
+		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040d: stloc.s 17
+		IL_040f: ldloc.s 5
+		IL_0411: ldstr "x"
+		IL_0416: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_041b: stloc.s 18
+		IL_041d: ldloc.s 18
+		IL_041f: box [System.Runtime]System.Boolean
+		IL_0424: stloc.s 19
+		IL_0426: ldstr "sealed_has_x="
+		IL_042b: ldloc.s 19
+		IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0432: stloc.s 20
+		IL_0434: ldloc.s 17
+		IL_0436: ldstr "log"
+		IL_043b: ldloc.s 20
+		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0442: pop
+		IL_0443: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0448: dup
+		IL_0449: ldstr "y"
+		IL_044e: ldc.r8 1
+		IL_0457: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_045c: stloc.s 9
+		IL_045e: ldloc.s 9
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0465: pop
+		IL_0466: ldstr "console"
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0470: stloc.s 17
+		IL_0472: ldloc.s 17
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0479: stloc.s 17
+		IL_047b: ldloc.s 9
+		IL_047d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_0482: stloc.s 18
+		IL_0484: ldloc.s 18
+		IL_0486: box [System.Runtime]System.Boolean
+		IL_048b: stloc.s 19
+		IL_048d: ldstr "frozen="
+		IL_0492: ldloc.s 19
+		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0499: stloc.s 20
+		IL_049b: ldloc.s 17
+		IL_049d: ldstr "log"
+		IL_04a2: ldloc.s 20
+		IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04a9: pop
+		IL_04aa: ldstr "console"
+		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04b4: stloc.s 17
+		IL_04b6: ldloc.s 17
+		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04bd: stloc.s 17
+		IL_04bf: ldloc.s 9
+		IL_04c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_04c6: stloc.s 18
+		IL_04c8: ldloc.s 18
+		IL_04ca: box [System.Runtime]System.Boolean
+		IL_04cf: stloc.s 19
+		IL_04d1: ldstr "frozen_sealed="
+		IL_04d6: ldloc.s 19
+		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_04dd: stloc.s 20
+		IL_04df: ldloc.s 17
+		IL_04e1: ldstr "log"
+		IL_04e6: ldloc.s 20
+		IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04ed: pop
 		.try
 		{
-			IL_04fc: nop
-			IL_04fd: ldloc.s 11
-			IL_04ff: ldstr "y"
-			IL_0504: ldc.r8 5
-			IL_050d: ldc.i4.1
-			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0513: pop
-			IL_0514: ldstr "console"
-			IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_051e: stloc.s 21
-			IL_0520: ldloc.s 21
-			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0527: stloc.s 21
-			IL_0529: ldloc.s 21
-			IL_052b: ldstr "log"
-			IL_0530: ldstr "frozen_write=ok"
-			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_053a: pop
-			IL_053b: leave IL_05be
+			IL_04ee: nop
+			IL_04ef: ldloc.s 9
+			IL_04f1: ldstr "y"
+			IL_04f6: ldc.r8 5
+			IL_04ff: ldc.i4.1
+			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0505: pop
+			IL_0506: ldstr "console"
+			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0510: stloc.s 17
+			IL_0512: ldloc.s 17
+			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0519: stloc.s 17
+			IL_051b: ldloc.s 17
+			IL_051d: ldstr "log"
+			IL_0522: ldstr "frozen_write=ok"
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_052c: pop
+			IL_052d: leave IL_05a9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0540: stloc.s 12
-			IL_0542: ldloc.s 12
-			IL_0544: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0532: stloc.s 10
+			IL_0534: ldloc.s 10
+			IL_0536: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_053b: dup
+			IL_053c: brtrue IL_0552
+
+			IL_0541: pop
+			IL_0542: ldloc.s 10
+			IL_0544: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_0549: dup
-			IL_054a: brtrue IL_0560
+			IL_054a: brtrue IL_055e
 
 			IL_054f: pop
-			IL_0550: ldloc.s 12
-			IL_0552: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0557: dup
-			IL_0558: brtrue IL_056c
+			IL_0550: rethrow
 
-			IL_055d: pop
-			IL_055e: rethrow
+			IL_0552: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0557: stloc.s 11
+			IL_0559: br IL_0560
 
-			IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0565: stloc.s 13
-			IL_0567: br IL_056e
+			IL_055e: stloc.s 11
 
-			IL_056c: stloc.s 13
-
-			IL_056e: ldloc.s 13
-			IL_0570: stloc.s 21
-			IL_0572: ldloc.s 21
-			IL_0574: stloc.s 14
-			IL_0576: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L38C12::.ctor()
-			IL_057b: stloc.s 15
-			IL_057d: ldstr "console"
-			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0587: stloc.s 21
-			IL_0589: ldloc.s 21
-			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0590: stloc.s 21
-			IL_0592: ldstr "frozen_write="
-			IL_0597: ldloc.s 14
-			IL_0599: ldstr "name"
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05a8: stloc.s 24
-			IL_05aa: ldloc.s 21
-			IL_05ac: ldstr "log"
-			IL_05b1: ldloc.s 24
-			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05b8: pop
-			IL_05b9: leave IL_05be
+			IL_0560: ldloc.s 11
+			IL_0562: stloc.s 17
+			IL_0564: ldloc.s 17
+			IL_0566: stloc.s 12
+			IL_0568: ldstr "console"
+			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0572: stloc.s 17
+			IL_0574: ldloc.s 17
+			IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_057b: stloc.s 17
+			IL_057d: ldstr "frozen_write="
+			IL_0582: ldloc.s 12
+			IL_0584: ldstr "name"
+			IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0593: stloc.s 20
+			IL_0595: ldloc.s 17
+			IL_0597: ldstr "log"
+			IL_059c: ldloc.s 20
+			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05a3: pop
+			IL_05a4: leave IL_05a9
 		} // end handler
 
-		IL_05be: ldstr "console"
-		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05c8: stloc.s 21
-		IL_05ca: ldloc.s 21
-		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d1: stloc.s 21
-		IL_05d3: ldstr "frozen_value="
-		IL_05d8: ldloc.s 11
-		IL_05da: ldstr "y"
-		IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_05e9: stloc.s 24
-		IL_05eb: ldloc.s 21
-		IL_05ed: ldstr "log"
-		IL_05f2: ldloc.s 24
-		IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_05f9: pop
+		IL_05a9: ldstr "console"
+		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05b3: stloc.s 17
+		IL_05b5: ldloc.s 17
+		IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05bc: stloc.s 17
+		IL_05be: ldstr "frozen_value="
+		IL_05c3: ldloc.s 9
+		IL_05c5: ldstr "y"
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_05d4: stloc.s 20
+		IL_05d6: ldloc.s 17
+		IL_05d8: ldstr "log"
+		IL_05dd: ldloc.s 20
+		IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05e4: pop
 		.try
 		{
-			IL_05fa: nop
-			IL_05fb: ldloc.s 11
-			IL_05fd: ldstr "y"
-			IL_0602: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_0607: stloc.s 22
-			IL_0609: ldstr "console"
-			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0613: stloc.s 21
-			IL_0615: ldloc.s 21
-			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_061c: stloc.s 21
-			IL_061e: ldloc.s 21
-			IL_0620: ldstr "log"
-			IL_0625: ldstr "frozen_delete=ok"
-			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_062f: pop
-			IL_0630: leave IL_06b3
+			IL_05e5: nop
+			IL_05e6: ldloc.s 9
+			IL_05e8: ldstr "y"
+			IL_05ed: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_05f2: stloc.s 18
+			IL_05f4: ldstr "console"
+			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05fe: stloc.s 17
+			IL_0600: ldloc.s 17
+			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0607: stloc.s 17
+			IL_0609: ldloc.s 17
+			IL_060b: ldstr "log"
+			IL_0610: ldstr "frozen_delete=ok"
+			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_061a: pop
+			IL_061b: leave IL_0697
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0635: stloc.s 16
-			IL_0637: ldloc.s 16
-			IL_0639: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_063e: dup
-			IL_063f: brtrue IL_0655
+			IL_0620: stloc.s 13
+			IL_0622: ldloc.s 13
+			IL_0624: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0629: dup
+			IL_062a: brtrue IL_0640
 
-			IL_0644: pop
-			IL_0645: ldloc.s 16
-			IL_0647: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_064c: dup
-			IL_064d: brtrue IL_0661
+			IL_062f: pop
+			IL_0630: ldloc.s 13
+			IL_0632: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0637: dup
+			IL_0638: brtrue IL_064c
 
-			IL_0652: pop
-			IL_0653: rethrow
+			IL_063d: pop
+			IL_063e: rethrow
 
-			IL_0655: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_065a: stloc.s 17
-			IL_065c: br IL_0663
+			IL_0640: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0645: stloc.s 14
+			IL_0647: br IL_064e
 
-			IL_0661: stloc.s 17
+			IL_064c: stloc.s 14
 
-			IL_0663: ldloc.s 17
-			IL_0665: stloc.s 21
-			IL_0667: ldloc.s 21
-			IL_0669: stloc.s 18
-			IL_066b: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L45C12::.ctor()
-			IL_0670: stloc.s 19
-			IL_0672: ldstr "console"
-			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_067c: stloc.s 21
-			IL_067e: ldloc.s 21
-			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0685: stloc.s 21
-			IL_0687: ldstr "frozen_delete="
-			IL_068c: ldloc.s 18
-			IL_068e: ldstr "name"
-			IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_069d: stloc.s 24
-			IL_069f: ldloc.s 21
-			IL_06a1: ldstr "log"
-			IL_06a6: ldloc.s 24
-			IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_06ad: pop
-			IL_06ae: leave IL_06b3
+			IL_064e: ldloc.s 14
+			IL_0650: stloc.s 17
+			IL_0652: ldloc.s 17
+			IL_0654: stloc.s 15
+			IL_0656: ldstr "console"
+			IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0660: stloc.s 17
+			IL_0662: ldloc.s 17
+			IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0669: stloc.s 17
+			IL_066b: ldstr "frozen_delete="
+			IL_0670: ldloc.s 15
+			IL_0672: ldstr "name"
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_067c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0681: stloc.s 20
+			IL_0683: ldloc.s 17
+			IL_0685: ldstr "log"
+			IL_068a: ldloc.s 20
+			IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0691: pop
+			IL_0692: leave IL_0697
 		} // end handler
 
-		IL_06b3: ldstr "console"
-		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06bd: stloc.s 21
-		IL_06bf: ldloc.s 21
-		IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c6: stloc.s 21
-		IL_06c8: ldloc.s 11
-		IL_06ca: ldstr "y"
-		IL_06cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_06d4: stloc.s 22
-		IL_06d6: ldloc.s 22
-		IL_06d8: box [System.Runtime]System.Boolean
-		IL_06dd: stloc.s 23
-		IL_06df: ldstr "frozen_has_y="
-		IL_06e4: ldloc.s 23
-		IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_06eb: stloc.s 24
-		IL_06ed: ldloc.s 21
-		IL_06ef: ldstr "log"
-		IL_06f4: ldloc.s 24
-		IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_06fb: pop
-		IL_06fc: ldnull
-		IL_06fd: stloc.s 20
-		IL_06ff: ret
+		IL_0697: ldstr "console"
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06a1: stloc.s 17
+		IL_06a3: ldloc.s 17
+		IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06aa: stloc.s 17
+		IL_06ac: ldloc.s 9
+		IL_06ae: ldstr "y"
+		IL_06b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_06b8: stloc.s 18
+		IL_06ba: ldloc.s 18
+		IL_06bc: box [System.Runtime]System.Boolean
+		IL_06c1: stloc.s 19
+		IL_06c3: ldstr "frozen_has_y="
+		IL_06c8: ldloc.s 19
+		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_06cf: stloc.s 20
+		IL_06d1: ldloc.s 17
+		IL_06d3: ldstr "log"
+		IL_06d8: ldloc.s 20
+		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06df: pop
+		IL_06e0: ldnull
+		IL_06e1: stloc.s 16
+		IL_06e3: ret
 	} // end of method Object_Integrity_FreezeSeal_PreventExtensions::__js_module_init__
 
 } // end of class Modules.Object_Integrity_FreezeSeal_PreventExtensions
@@ -837,7 +825,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27e1
+		// Method begins at RVA 0x27c5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27d3
+					// Method begins at RVA 0x27c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27dc
+					// Method begins at RVA 0x27d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ca
+				// Method begins at RVA 0x27be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,113 +90,108 @@
 			)
 			// Method begins at RVA 0x24b8
 			// Header size: 12
-			// Code size: 227 (0xe3)
+			// Code size: 213 (0xd5)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/Scope/Block_L4C6,
-				[1] object,
-				[2] class [System.Runtime]System.Exception,
+				[0] object,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
 				[3] object,
 				[4] object,
-				[5] class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/Scope/Block_L7C18,
-				[6] object,
-				[7] object,
-				[8] object
+				[5] object,
+				[6] object
 			)
 
 			.try
 			{
-				IL_0000: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/Scope/Block_L4C6::.ctor()
-				IL_0005: stloc.0
-				IL_0006: ldarg.3
-				IL_0007: ldc.i4.1
-				IL_0008: newarr [System.Runtime]System.Object
-				IL_000d: dup
-				IL_000e: ldc.i4.0
-				IL_000f: ldarg.0
-				IL_0010: stelem.ref
-				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0016: stloc.s 7
-				IL_0018: ldloc.s 7
-				IL_001a: stloc.1
-				IL_001b: ldstr "console"
-				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0025: stloc.s 7
-				IL_0027: ldloc.s 7
-				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002e: stloc.s 7
-				IL_0030: ldarg.2
-				IL_0031: ldstr ":ok:"
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003b: stloc.s 8
-				IL_003d: ldloc.s 8
-				IL_003f: ldloc.1
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0045: stloc.s 8
-				IL_0047: ldloc.s 7
-				IL_0049: ldstr "log"
-				IL_004e: ldloc.s 8
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0055: pop
-				IL_0056: leave IL_00dd
+				IL_0000: nop
+				IL_0001: ldarg.3
+				IL_0002: ldc.i4.1
+				IL_0003: newarr [System.Runtime]System.Object
+				IL_0008: dup
+				IL_0009: ldc.i4.0
+				IL_000a: ldarg.0
+				IL_000b: stelem.ref
+				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0011: stloc.s 5
+				IL_0013: ldloc.s 5
+				IL_0015: stloc.0
+				IL_0016: ldstr "console"
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0020: stloc.s 5
+				IL_0022: ldloc.s 5
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0029: stloc.s 5
+				IL_002b: ldarg.2
+				IL_002c: ldstr ":ok:"
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0036: stloc.s 6
+				IL_0038: ldloc.s 6
+				IL_003a: ldloc.0
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0040: stloc.s 6
+				IL_0042: ldloc.s 5
+				IL_0044: ldstr "log"
+				IL_0049: ldloc.s 6
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0050: pop
+				IL_0051: leave IL_00cf
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_005b: stloc.2
-				IL_005c: ldloc.2
-				IL_005d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0062: dup
-				IL_0063: brtrue IL_0078
+				IL_0056: stloc.1
+				IL_0057: ldloc.1
+				IL_0058: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_005d: dup
+				IL_005e: brtrue IL_0073
 
-				IL_0068: pop
-				IL_0069: ldloc.2
-				IL_006a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_006f: dup
-				IL_0070: brtrue IL_0083
+				IL_0063: pop
+				IL_0064: ldloc.1
+				IL_0065: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_006a: dup
+				IL_006b: brtrue IL_007e
 
-				IL_0075: pop
-				IL_0076: rethrow
+				IL_0070: pop
+				IL_0071: rethrow
 
-				IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_007d: stloc.3
-				IL_007e: br IL_0084
+				IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0078: stloc.2
+				IL_0079: br IL_007f
 
-				IL_0083: stloc.3
+				IL_007e: stloc.2
 
-				IL_0084: ldloc.3
-				IL_0085: stloc.s 7
-				IL_0087: ldloc.s 7
-				IL_0089: stloc.s 4
-				IL_008b: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/Scope/Block_L7C18::.ctor()
-				IL_0090: stloc.s 5
-				IL_0092: ldstr "console"
-				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_009c: stloc.s 7
-				IL_009e: ldloc.s 7
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a5: stloc.s 7
-				IL_00a7: ldarg.2
-				IL_00a8: ldstr ":"
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00b2: stloc.s 8
-				IL_00b4: ldloc.s 8
-				IL_00b6: ldloc.s 4
-				IL_00b8: ldstr "name"
-				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00c7: stloc.s 8
-				IL_00c9: ldloc.s 7
-				IL_00cb: ldstr "log"
-				IL_00d0: ldloc.s 8
-				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00d7: pop
-				IL_00d8: leave IL_00dd
+				IL_007f: ldloc.2
+				IL_0080: stloc.s 5
+				IL_0082: ldloc.s 5
+				IL_0084: stloc.3
+				IL_0085: ldstr "console"
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_008f: stloc.s 5
+				IL_0091: ldloc.s 5
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0098: stloc.s 5
+				IL_009a: ldarg.2
+				IL_009b: ldstr ":"
+				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a5: stloc.s 6
+				IL_00a7: ldloc.s 6
+				IL_00a9: ldloc.3
+				IL_00aa: ldstr "name"
+				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b9: stloc.s 6
+				IL_00bb: ldloc.s 5
+				IL_00bd: ldstr "log"
+				IL_00c2: ldloc.s 6
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00c9: pop
+				IL_00ca: leave IL_00cf
 			} // end handler
 
-			IL_00dd: ldnull
-			IL_00de: stloc.s 6
-			IL_00e0: ldloc.s 6
-			IL_00e2: ret
+			IL_00cf: ldnull
+			IL_00d0: stloc.s 4
+			IL_00d2: ldloc.s 4
+			IL_00d4: ret
 		} // end of method logThrow::__js_call__
 
 	} // end of class logThrow
@@ -212,7 +207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e5
+				// Method begins at RVA 0x27d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +232,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25b8
+			// Method begins at RVA 0x25ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -261,7 +256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ee
+				// Method begins at RVA 0x27e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -287,7 +282,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25c1
+			// Method begins at RVA 0x25b5
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -316,7 +311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f7
+				// Method begins at RVA 0x27eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -342,7 +337,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x25d3
+			// Method begins at RVA 0x25c7
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -369,7 +364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2800
+				// Method begins at RVA 0x27f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -395,7 +390,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x25ef
+			// Method begins at RVA 0x25e3
 			// Header size: 1
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -426,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2809
+				// Method begins at RVA 0x27fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -452,7 +447,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x261c
+			// Method begins at RVA 0x2610
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -488,7 +483,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2812
+				// Method begins at RVA 0x2806
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -514,7 +509,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x264c
+			// Method begins at RVA 0x2640
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -550,7 +545,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281b
+				// Method begins at RVA 0x280f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -576,7 +571,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x267c
+			// Method begins at RVA 0x2670
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -615,7 +610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2824
+				// Method begins at RVA 0x2818
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -641,7 +636,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26b8
+			// Method begins at RVA 0x26ac
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -672,7 +667,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282d
+				// Method begins at RVA 0x2821
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -698,7 +693,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26dc
+			// Method begins at RVA 0x26d0
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -733,7 +728,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2836
+				// Method begins at RVA 0x282a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -757,7 +752,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2708
+			// Method begins at RVA 0x26fc
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -786,7 +781,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x283f
+				// Method begins at RVA 0x2833
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -812,7 +807,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2728
+			// Method begins at RVA 0x271c
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -853,7 +848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2848
+				// Method begins at RVA 0x283c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -877,7 +872,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x275c
+			// Method begins at RVA 0x2750
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -913,7 +908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2851
+				// Method begins at RVA 0x2845
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -939,7 +934,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2784
+			// Method begins at RVA 0x2778
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -990,7 +985,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27c1
+			// Method begins at RVA 0x27b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1438,7 +1433,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x285a
+		// Method begins at RVA 0x284e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a3c
+					// Method begins at RVA 0x2a30
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a45
+					// Method begins at RVA 0x2a39
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a33
+				// Method begins at RVA 0x2a27
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,113 +90,108 @@
 			)
 			// Method begins at RVA 0x26a0
 			// Header size: 12
-			// Code size: 227 (0xe3)
+			// Code size: 213 (0xd5)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Proxy_Validation_EdgeCases/log/Scope/Block_L4C6,
-				[1] object,
-				[2] class [System.Runtime]System.Exception,
+				[0] object,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
 				[3] object,
 				[4] object,
-				[5] class Modules.Proxy_Validation_EdgeCases/log/Scope/Block_L7C18,
-				[6] object,
-				[7] object,
-				[8] object
+				[5] object,
+				[6] object
 			)
 
 			.try
 			{
-				IL_0000: newobj instance void Modules.Proxy_Validation_EdgeCases/log/Scope/Block_L4C6::.ctor()
-				IL_0005: stloc.0
-				IL_0006: ldarg.3
-				IL_0007: ldc.i4.1
-				IL_0008: newarr [System.Runtime]System.Object
-				IL_000d: dup
-				IL_000e: ldc.i4.0
-				IL_000f: ldarg.0
-				IL_0010: stelem.ref
-				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0016: stloc.s 7
-				IL_0018: ldloc.s 7
-				IL_001a: stloc.1
-				IL_001b: ldstr "console"
-				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0025: stloc.s 7
-				IL_0027: ldloc.s 7
-				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002e: stloc.s 7
-				IL_0030: ldarg.2
-				IL_0031: ldstr ":ok:"
-				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_003b: stloc.s 8
-				IL_003d: ldloc.s 8
-				IL_003f: ldloc.1
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0045: stloc.s 8
-				IL_0047: ldloc.s 7
-				IL_0049: ldstr "log"
-				IL_004e: ldloc.s 8
-				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0055: pop
-				IL_0056: leave IL_00dd
+				IL_0000: nop
+				IL_0001: ldarg.3
+				IL_0002: ldc.i4.1
+				IL_0003: newarr [System.Runtime]System.Object
+				IL_0008: dup
+				IL_0009: ldc.i4.0
+				IL_000a: ldarg.0
+				IL_000b: stelem.ref
+				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0011: stloc.s 5
+				IL_0013: ldloc.s 5
+				IL_0015: stloc.0
+				IL_0016: ldstr "console"
+				IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0020: stloc.s 5
+				IL_0022: ldloc.s 5
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0029: stloc.s 5
+				IL_002b: ldarg.2
+				IL_002c: ldstr ":ok:"
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0036: stloc.s 6
+				IL_0038: ldloc.s 6
+				IL_003a: ldloc.0
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0040: stloc.s 6
+				IL_0042: ldloc.s 5
+				IL_0044: ldstr "log"
+				IL_0049: ldloc.s 6
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0050: pop
+				IL_0051: leave IL_00cf
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_005b: stloc.2
-				IL_005c: ldloc.2
-				IL_005d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0062: dup
-				IL_0063: brtrue IL_0078
+				IL_0056: stloc.1
+				IL_0057: ldloc.1
+				IL_0058: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_005d: dup
+				IL_005e: brtrue IL_0073
 
-				IL_0068: pop
-				IL_0069: ldloc.2
-				IL_006a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_006f: dup
-				IL_0070: brtrue IL_0083
+				IL_0063: pop
+				IL_0064: ldloc.1
+				IL_0065: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_006a: dup
+				IL_006b: brtrue IL_007e
 
-				IL_0075: pop
-				IL_0076: rethrow
+				IL_0070: pop
+				IL_0071: rethrow
 
-				IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_007d: stloc.3
-				IL_007e: br IL_0084
+				IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0078: stloc.2
+				IL_0079: br IL_007f
 
-				IL_0083: stloc.3
+				IL_007e: stloc.2
 
-				IL_0084: ldloc.3
-				IL_0085: stloc.s 7
-				IL_0087: ldloc.s 7
-				IL_0089: stloc.s 4
-				IL_008b: newobj instance void Modules.Proxy_Validation_EdgeCases/log/Scope/Block_L7C18::.ctor()
-				IL_0090: stloc.s 5
-				IL_0092: ldstr "console"
-				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_009c: stloc.s 7
-				IL_009e: ldloc.s 7
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a5: stloc.s 7
-				IL_00a7: ldarg.2
-				IL_00a8: ldstr ":"
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00b2: stloc.s 8
-				IL_00b4: ldloc.s 8
-				IL_00b6: ldloc.s 4
-				IL_00b8: ldstr "name"
-				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00c7: stloc.s 8
-				IL_00c9: ldloc.s 7
-				IL_00cb: ldstr "log"
-				IL_00d0: ldloc.s 8
-				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00d7: pop
-				IL_00d8: leave IL_00dd
+				IL_007f: ldloc.2
+				IL_0080: stloc.s 5
+				IL_0082: ldloc.s 5
+				IL_0084: stloc.3
+				IL_0085: ldstr "console"
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_008f: stloc.s 5
+				IL_0091: ldloc.s 5
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0098: stloc.s 5
+				IL_009a: ldarg.2
+				IL_009b: ldstr ":"
+				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a5: stloc.s 6
+				IL_00a7: ldloc.s 6
+				IL_00a9: ldloc.3
+				IL_00aa: ldstr "name"
+				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b9: stloc.s 6
+				IL_00bb: ldloc.s 5
+				IL_00bd: ldstr "log"
+				IL_00c2: ldloc.s 6
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00c9: pop
+				IL_00ca: leave IL_00cf
 			} // end handler
 
-			IL_00dd: ldnull
-			IL_00de: stloc.s 6
-			IL_00e0: ldloc.s 6
-			IL_00e2: ret
+			IL_00cf: ldnull
+			IL_00d0: stloc.s 4
+			IL_00d2: ldloc.s 4
+			IL_00d4: ret
 		} // end of method log::__js_call__
 
 	} // end of class log
@@ -212,7 +207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a4e
+				// Method begins at RVA 0x2a42
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -235,7 +230,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27a0
+			// Method begins at RVA 0x2794
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -265,7 +260,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a57
+				// Method begins at RVA 0x2a4b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -288,7 +283,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27c8
+			// Method begins at RVA 0x27bc
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -321,7 +316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a60
+				// Method begins at RVA 0x2a54
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -344,7 +339,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27f4
+			// Method begins at RVA 0x27e8
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -374,7 +369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a69
+				// Method begins at RVA 0x2a5d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -397,7 +392,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x281c
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -430,7 +425,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a72
+				// Method begins at RVA 0x2a66
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -453,7 +448,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2845
+			// Method begins at RVA 0x2839
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -475,7 +470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a7b
+				// Method begins at RVA 0x2a6f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -501,7 +496,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x284c
+			// Method begins at RVA 0x2840
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -536,7 +531,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a84
+				// Method begins at RVA 0x2a78
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -562,7 +557,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2870
+			// Method begins at RVA 0x2864
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -588,7 +583,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a8d
+				// Method begins at RVA 0x2a81
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -614,7 +609,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2884
+			// Method begins at RVA 0x2878
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -652,7 +647,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a96
+				// Method begins at RVA 0x2a8a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -675,7 +670,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28a4
+			// Method begins at RVA 0x2898
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -705,7 +700,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a9f
+				// Method begins at RVA 0x2a93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -728,7 +723,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28ba
+			// Method begins at RVA 0x28ae
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -750,7 +745,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa8
+				// Method begins at RVA 0x2a9c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -776,7 +771,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28bc
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -807,7 +802,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab1
+				// Method begins at RVA 0x2aa5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -830,7 +825,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28e8
+			// Method begins at RVA 0x28dc
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -853,7 +848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aba
+				// Method begins at RVA 0x2aae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -876,7 +871,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28f0
+			// Method begins at RVA 0x28e4
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -898,7 +893,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac3
+				// Method begins at RVA 0x2ab7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -924,7 +919,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28fc
+			// Method begins at RVA 0x28f0
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -953,7 +948,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2acc
+				// Method begins at RVA 0x2ac0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -979,7 +974,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2916
+			// Method begins at RVA 0x290a
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1013,7 +1008,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad5
+				// Method begins at RVA 0x2ac9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1039,7 +1034,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2954
+			// Method begins at RVA 0x2948
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -1082,7 +1077,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ade
+				// Method begins at RVA 0x2ad2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1105,7 +1100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a3
+			// Method begins at RVA 0x2997
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1127,7 +1122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae7
+				// Method begins at RVA 0x2adb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1153,7 +1148,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x29ac
+			// Method begins at RVA 0x29a0
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1190,7 +1185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af0
+				// Method begins at RVA 0x2ae4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1213,7 +1208,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29de
+			// Method begins at RVA 0x29d2
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -1239,7 +1234,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af9
+				// Method begins at RVA 0x2aed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1265,7 +1260,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x29f8
+			// Method begins at RVA 0x29ec
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1325,7 +1320,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a2a
+			// Method begins at RVA 0x2a1e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1954,7 +1949,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b02
+		// Method begins at RVA 0x2af6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Prototype_Surface.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2621
+				// Method begins at RVA 0x261d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262a
+				// Method begins at RVA 0x2626
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2618
+			// Method begins at RVA 0x2614
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1452 (0x5ac)
+		// Code size: 1445 (0x5a5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Prototype_Surface/Scope,
@@ -92,15 +92,14 @@
 			[4] class [System.Runtime]System.Exception,
 			[5] object,
 			[6] object,
-			[7] class Modules.Set_Constructor_Prototype_Surface/Scope/Block_L26C12,
+			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
-			[11] object,
-			[12] bool,
-			[13] object,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.Set,
-			[15] object
+			[11] bool,
+			[12] object,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Set,
+			[14] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -121,166 +120,166 @@
 		IL_0047: nop
 		IL_0048: ldstr "console"
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0052: stloc.s 9
-		IL_0054: ldloc.s 9
+		IL_0052: stloc.s 8
+		IL_0054: ldloc.s 8
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005b: stloc.s 9
+		IL_005b: stloc.s 8
 		IL_005d: ldstr "globalThis"
 		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0067: stloc.s 10
-		IL_0069: ldloc.s 10
+		IL_0067: stloc.s 9
+		IL_0069: ldloc.s 9
 		IL_006b: ldstr "Set"
 		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0075: stloc.s 10
+		IL_0075: stloc.s 9
 		IL_0077: ldstr "Set"
 		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0081: stloc.s 11
-		IL_0083: ldloc.s 10
-		IL_0085: ldloc.s 11
+		IL_0081: stloc.s 10
+		IL_0083: ldloc.s 9
+		IL_0085: ldloc.s 10
 		IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_008c: stloc.s 12
-		IL_008e: ldloc.s 12
+		IL_008c: stloc.s 11
+		IL_008e: ldloc.s 11
 		IL_0090: box [System.Runtime]System.Boolean
-		IL_0095: stloc.s 13
-		IL_0097: ldloc.s 9
+		IL_0095: stloc.s 12
+		IL_0097: ldloc.s 8
 		IL_0099: ldstr "log"
-		IL_009e: ldloc.s 13
+		IL_009e: ldloc.s 12
 		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00a5: pop
 		IL_00a6: ldstr "console"
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b0: stloc.s 9
-		IL_00b2: ldloc.s 9
+		IL_00b0: stloc.s 8
+		IL_00b2: ldloc.s 8
 		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b9: stloc.s 9
+		IL_00b9: stloc.s 8
 		IL_00bb: ldstr "Set"
 		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c5: stloc.s 11
-		IL_00c7: ldloc.s 11
+		IL_00c5: stloc.s 10
+		IL_00c7: ldloc.s 10
 		IL_00c9: ldstr "prototype"
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d3: stloc.s 11
-		IL_00d5: ldloc.s 11
+		IL_00d3: stloc.s 10
+		IL_00d5: ldloc.s 10
 		IL_00d7: ldstr "constructor"
 		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e1: stloc.s 11
+		IL_00e1: stloc.s 10
 		IL_00e3: ldstr "Set"
 		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ed: stloc.s 10
-		IL_00ef: ldloc.s 11
-		IL_00f1: ldloc.s 10
+		IL_00ed: stloc.s 9
+		IL_00ef: ldloc.s 10
+		IL_00f1: ldloc.s 9
 		IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f8: stloc.s 12
-		IL_00fa: ldloc.s 12
+		IL_00f8: stloc.s 11
+		IL_00fa: ldloc.s 11
 		IL_00fc: box [System.Runtime]System.Boolean
-		IL_0101: stloc.s 13
-		IL_0103: ldloc.s 9
+		IL_0101: stloc.s 12
+		IL_0103: ldloc.s 8
 		IL_0105: ldstr "log"
-		IL_010a: ldloc.s 13
+		IL_010a: ldloc.s 12
 		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0111: pop
 		IL_0112: ldstr "console"
 		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011c: stloc.s 9
-		IL_011e: ldloc.s 9
+		IL_011c: stloc.s 8
+		IL_011e: ldloc.s 8
 		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0125: stloc.s 9
+		IL_0125: stloc.s 8
 		IL_0127: ldstr "Set"
 		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0131: stloc.s 10
+		IL_0131: stloc.s 9
 		IL_0133: ldstr "Function"
 		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013d: stloc.s 11
-		IL_013f: ldloc.s 10
-		IL_0141: ldloc.s 11
+		IL_013d: stloc.s 10
+		IL_013f: ldloc.s 9
+		IL_0141: ldloc.s 10
 		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0148: stloc.s 12
-		IL_014a: ldloc.s 12
+		IL_0148: stloc.s 11
+		IL_014a: ldloc.s 11
 		IL_014c: box [System.Runtime]System.Boolean
-		IL_0151: stloc.s 13
-		IL_0153: ldloc.s 9
+		IL_0151: stloc.s 12
+		IL_0153: ldloc.s 8
 		IL_0155: ldstr "log"
-		IL_015a: ldloc.s 13
+		IL_015a: ldloc.s 12
 		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0161: pop
 		IL_0162: ldstr "console"
 		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016c: stloc.s 9
-		IL_016e: ldloc.s 9
+		IL_016c: stloc.s 8
+		IL_016e: ldloc.s 8
 		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0175: stloc.s 9
+		IL_0175: stloc.s 8
 		IL_0177: ldstr "Set"
 		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0181: stloc.s 11
-		IL_0183: ldloc.s 11
+		IL_0181: stloc.s 10
+		IL_0183: ldloc.s 10
 		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_018a: stloc.s 11
+		IL_018a: stloc.s 10
 		IL_018c: ldstr "Function"
 		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0196: stloc.s 10
-		IL_0198: ldloc.s 10
+		IL_0196: stloc.s 9
+		IL_0198: ldloc.s 9
 		IL_019a: ldstr "prototype"
 		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: stloc.s 10
-		IL_01a6: ldloc.s 11
-		IL_01a8: ldloc.s 10
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 10
+		IL_01a8: ldloc.s 9
 		IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01af: stloc.s 12
-		IL_01b1: ldloc.s 12
+		IL_01af: stloc.s 11
+		IL_01b1: ldloc.s 11
 		IL_01b3: box [System.Runtime]System.Boolean
-		IL_01b8: stloc.s 13
-		IL_01ba: ldloc.s 9
+		IL_01b8: stloc.s 12
+		IL_01ba: ldloc.s 8
 		IL_01bc: ldstr "log"
-		IL_01c1: ldloc.s 13
+		IL_01c1: ldloc.s 12
 		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01c8: pop
 		IL_01c9: ldstr "console"
 		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d3: stloc.s 9
-		IL_01d5: ldloc.s 9
+		IL_01d3: stloc.s 8
+		IL_01d5: ldloc.s 8
 		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dc: stloc.s 9
+		IL_01dc: stloc.s 8
 		IL_01de: ldstr "Set"
 		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e8: stloc.s 10
-		IL_01ea: ldloc.s 10
+		IL_01e8: stloc.s 9
+		IL_01ea: ldloc.s 9
 		IL_01ec: ldstr "prototype"
 		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f6: stloc.s 10
-		IL_01f8: ldloc.s 10
+		IL_01f6: stloc.s 9
+		IL_01f8: ldloc.s 9
 		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_01ff: stloc.s 10
+		IL_01ff: stloc.s 9
 		IL_0201: ldstr "Object"
 		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020b: stloc.s 11
-		IL_020d: ldloc.s 11
+		IL_020b: stloc.s 10
+		IL_020d: ldloc.s 10
 		IL_020f: ldstr "prototype"
 		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0219: stloc.s 11
-		IL_021b: ldloc.s 10
-		IL_021d: ldloc.s 11
+		IL_0219: stloc.s 10
+		IL_021b: ldloc.s 9
+		IL_021d: ldloc.s 10
 		IL_021f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0224: stloc.s 12
-		IL_0226: ldloc.s 12
+		IL_0224: stloc.s 11
+		IL_0226: ldloc.s 11
 		IL_0228: box [System.Runtime]System.Boolean
-		IL_022d: stloc.s 13
-		IL_022f: ldloc.s 9
+		IL_022d: stloc.s 12
+		IL_022f: ldloc.s 8
 		IL_0231: ldstr "log"
-		IL_0236: ldloc.s 13
+		IL_0236: ldloc.s 12
 		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_023d: pop
 		IL_023e: ldstr "Set"
 		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0248: stloc.s 9
-		IL_024a: ldloc.s 9
+		IL_0248: stloc.s 8
+		IL_024a: ldloc.s 8
 		IL_024c: ldstr "prototype"
 		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0256: stloc.s 9
-		IL_0258: ldloc.s 9
+		IL_0256: stloc.s 8
+		IL_0258: ldloc.s 8
 		IL_025a: stloc.1
 		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0260: stloc.s 9
-		IL_0262: ldloc.s 9
+		IL_0260: stloc.s 8
+		IL_0262: ldloc.s 8
 		IL_0264: ldstr "descriptor"
 		IL_0269: ldloc.1
 		IL_026a: ldc.i4.0
@@ -288,11 +287,11 @@
 		IL_0270: pop
 		IL_0271: ldstr "console"
 		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_027b: stloc.s 9
-		IL_027d: ldloc.s 9
+		IL_027b: stloc.s 8
+		IL_027d: ldloc.s 8
 		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0284: stloc.s 9
-		IL_0286: ldloc.s 9
+		IL_0284: stloc.s 8
+		IL_0286: ldloc.s 8
 		IL_0288: ldstr "log"
 		IL_028d: ldloc.1
 		IL_028e: ldstr "writable"
@@ -301,11 +300,11 @@
 		IL_029d: pop
 		IL_029e: ldstr "console"
 		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a8: stloc.s 9
-		IL_02aa: ldloc.s 9
+		IL_02a8: stloc.s 8
+		IL_02aa: ldloc.s 8
 		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b1: stloc.s 9
-		IL_02b3: ldloc.s 9
+		IL_02b1: stloc.s 8
+		IL_02b3: ldloc.s 8
 		IL_02b5: ldstr "log"
 		IL_02ba: ldloc.1
 		IL_02bb: ldstr "enumerable"
@@ -314,11 +313,11 @@
 		IL_02ca: pop
 		IL_02cb: ldstr "console"
 		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d5: stloc.s 9
-		IL_02d7: ldloc.s 9
+		IL_02d5: stloc.s 8
+		IL_02d7: ldloc.s 8
 		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02de: stloc.s 9
-		IL_02e0: ldloc.s 9
+		IL_02de: stloc.s 8
+		IL_02e0: ldloc.s 8
 		IL_02e2: ldstr "log"
 		IL_02e7: ldloc.1
 		IL_02e8: ldstr "configurable"
@@ -326,12 +325,12 @@
 		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_02f7: pop
 		IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
-		IL_02fd: stloc.s 14
-		IL_02ff: ldloc.s 14
+		IL_02fd: stloc.s 13
+		IL_02ff: ldloc.s 13
 		IL_0301: stloc.2
 		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0307: stloc.s 9
-		IL_0309: ldloc.s 9
+		IL_0307: stloc.s 8
+		IL_0309: ldloc.s 8
 		IL_030b: ldstr "set"
 		IL_0310: ldloc.2
 		IL_0311: ldc.i4.0
@@ -339,95 +338,95 @@
 		IL_0317: pop
 		IL_0318: ldstr "console"
 		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0322: stloc.s 9
-		IL_0324: ldloc.s 9
+		IL_0322: stloc.s 8
+		IL_0324: ldloc.s 8
 		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032b: stloc.s 9
+		IL_032b: stloc.s 8
 		IL_032d: ldloc.2
 		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0333: stloc.s 11
+		IL_0333: stloc.s 10
 		IL_0335: ldstr "Set"
 		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_033f: stloc.s 10
-		IL_0341: ldloc.s 10
+		IL_033f: stloc.s 9
+		IL_0341: ldloc.s 9
 		IL_0343: ldstr "prototype"
 		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_034d: stloc.s 10
-		IL_034f: ldloc.s 11
-		IL_0351: ldloc.s 10
+		IL_034d: stloc.s 9
+		IL_034f: ldloc.s 10
+		IL_0351: ldloc.s 9
 		IL_0353: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0358: stloc.s 12
-		IL_035a: ldloc.s 12
+		IL_0358: stloc.s 11
+		IL_035a: ldloc.s 11
 		IL_035c: box [System.Runtime]System.Boolean
-		IL_0361: stloc.s 13
-		IL_0363: ldloc.s 9
+		IL_0361: stloc.s 12
+		IL_0363: ldloc.s 8
 		IL_0365: ldstr "log"
-		IL_036a: ldloc.s 13
+		IL_036a: ldloc.s 12
 		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0371: pop
 		IL_0372: ldstr "console"
 		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037c: stloc.s 9
-		IL_037e: ldloc.s 9
+		IL_037c: stloc.s 8
+		IL_037e: ldloc.s 8
 		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0385: stloc.s 9
+		IL_0385: stloc.s 8
 		IL_0387: ldloc.2
-		IL_0388: stloc.s 14
+		IL_0388: stloc.s 13
 		IL_038a: ldstr "Set"
 		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0394: stloc.s 10
-		IL_0396: ldloc.s 14
-		IL_0398: ldloc.s 10
+		IL_0394: stloc.s 9
+		IL_0396: ldloc.s 13
+		IL_0398: ldloc.s 9
 		IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_039f: stloc.s 12
-		IL_03a1: ldloc.s 12
+		IL_039f: stloc.s 11
+		IL_03a1: ldloc.s 11
 		IL_03a3: box [System.Runtime]System.Boolean
-		IL_03a8: stloc.s 13
-		IL_03aa: ldloc.s 9
+		IL_03a8: stloc.s 12
+		IL_03aa: ldloc.s 8
 		IL_03ac: ldstr "log"
-		IL_03b1: ldloc.s 13
+		IL_03b1: ldloc.s 12
 		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_03b8: pop
 		IL_03b9: ldstr "console"
 		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c3: stloc.s 9
-		IL_03c5: ldloc.s 9
+		IL_03c3: stloc.s 8
+		IL_03c5: ldloc.s 8
 		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03cc: stloc.s 9
+		IL_03cc: stloc.s 8
 		IL_03ce: ldloc.2
 		IL_03cf: ldstr "constructor"
 		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d9: stloc.s 10
+		IL_03d9: stloc.s 9
 		IL_03db: ldstr "Set"
 		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e5: stloc.s 11
-		IL_03e7: ldloc.s 10
-		IL_03e9: ldloc.s 11
+		IL_03e5: stloc.s 10
+		IL_03e7: ldloc.s 9
+		IL_03e9: ldloc.s 10
 		IL_03eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03f0: stloc.s 12
-		IL_03f2: ldloc.s 12
+		IL_03f0: stloc.s 11
+		IL_03f2: ldloc.s 11
 		IL_03f4: box [System.Runtime]System.Boolean
-		IL_03f9: stloc.s 13
-		IL_03fb: ldloc.s 9
+		IL_03f9: stloc.s 12
+		IL_03fb: ldloc.s 8
 		IL_03fd: ldstr "log"
-		IL_0402: ldloc.s 13
+		IL_0402: ldloc.s 12
 		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0409: pop
 		IL_040a: ldstr "Set"
 		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0414: stloc.s 9
-		IL_0416: ldloc.s 9
+		IL_0414: stloc.s 8
+		IL_0416: ldloc.s 8
 		IL_0418: ldstr "prototype"
 		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0422: stloc.s 9
-		IL_0424: ldloc.s 9
+		IL_0422: stloc.s 8
+		IL_0424: ldloc.s 8
 		IL_0426: ldstr "add"
 		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0430: stloc.s 9
-		IL_0432: ldloc.s 9
+		IL_0430: stloc.s 8
+		IL_0432: ldloc.s 8
 		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0439: stloc.s 9
-		IL_043b: ldloc.s 9
+		IL_0439: stloc.s 8
+		IL_043b: ldloc.s 8
 		IL_043d: ldstr "call"
 		IL_0442: ldloc.2
 		IL_0443: ldstr "value"
@@ -435,33 +434,33 @@
 		IL_044d: pop
 		IL_044e: ldstr "console"
 		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0458: stloc.s 9
-		IL_045a: ldloc.s 9
+		IL_0458: stloc.s 8
+		IL_045a: ldloc.s 8
 		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0461: stloc.s 9
+		IL_0461: stloc.s 8
 		IL_0463: ldstr "Set"
 		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_046d: stloc.s 11
-		IL_046f: ldloc.s 11
+		IL_046d: stloc.s 10
+		IL_046f: ldloc.s 10
 		IL_0471: ldstr "prototype"
 		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_047b: stloc.s 11
-		IL_047d: ldloc.s 11
+		IL_047b: stloc.s 10
+		IL_047d: ldloc.s 10
 		IL_047f: ldstr "has"
 		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0489: stloc.s 11
-		IL_048b: ldloc.s 11
+		IL_0489: stloc.s 10
+		IL_048b: ldloc.s 10
 		IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0492: stloc.s 11
-		IL_0494: ldloc.s 11
+		IL_0492: stloc.s 10
+		IL_0494: ldloc.s 10
 		IL_0496: ldstr "call"
 		IL_049b: ldloc.2
 		IL_049c: ldstr "value"
 		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_04a6: stloc.s 11
-		IL_04a8: ldloc.s 9
+		IL_04a6: stloc.s 10
+		IL_04a8: ldloc.s 8
 		IL_04aa: ldstr "log"
-		IL_04af: ldloc.s 11
+		IL_04af: ldloc.s 10
 		IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_04b6: pop
 		.try
@@ -469,12 +468,12 @@
 			IL_04b7: nop
 			IL_04b8: ldstr "Set"
 			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04c2: stloc.s 11
-			IL_04c4: ldloc.s 11
+			IL_04c2: stloc.s 10
+			IL_04c4: ldloc.s 10
 			IL_04c6: stloc.3
 			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_04cc: stloc.s 11
-			IL_04ce: ldloc.s 11
+			IL_04cc: stloc.s 10
+			IL_04ce: ldloc.s 10
 			IL_04d0: ldstr "setCtor"
 			IL_04d5: ldloc.3
 			IL_04d6: ldc.i4.0
@@ -486,16 +485,16 @@
 			IL_04e8: pop
 			IL_04e9: ldstr "console"
 			IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04f3: stloc.s 11
-			IL_04f5: ldloc.s 11
+			IL_04f3: stloc.s 10
+			IL_04f5: ldloc.s 10
 			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04fc: stloc.s 11
-			IL_04fe: ldloc.s 11
+			IL_04fc: stloc.s 10
+			IL_04fe: ldloc.s 10
 			IL_0500: ldstr "log"
 			IL_0505: ldstr "no-throw"
 			IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_050f: pop
-			IL_0510: leave IL_05a8
+			IL_0510: leave IL_05a1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -521,40 +520,38 @@
 			IL_0541: stloc.s 5
 
 			IL_0543: ldloc.s 5
-			IL_0545: stloc.s 11
-			IL_0547: ldloc.s 11
+			IL_0545: stloc.s 10
+			IL_0547: ldloc.s 10
 			IL_0549: stloc.s 6
-			IL_054b: newobj instance void Modules.Set_Constructor_Prototype_Surface/Scope/Block_L26C12::.ctor()
-			IL_0550: stloc.s 7
-			IL_0552: ldstr "console"
-			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_055c: stloc.s 11
-			IL_055e: ldloc.s 11
-			IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0565: stloc.s 11
-			IL_0567: ldloc.s 6
-			IL_0569: ldstr "name"
-			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0573: ldstr ": "
-			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_057d: stloc.s 15
-			IL_057f: ldloc.s 15
-			IL_0581: ldloc.s 6
-			IL_0583: ldstr "message"
-			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0592: stloc.s 15
-			IL_0594: ldloc.s 11
-			IL_0596: ldstr "log"
-			IL_059b: ldloc.s 15
-			IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05a2: pop
-			IL_05a3: leave IL_05a8
+			IL_054b: ldstr "console"
+			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0555: stloc.s 10
+			IL_0557: ldloc.s 10
+			IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_055e: stloc.s 10
+			IL_0560: ldloc.s 6
+			IL_0562: ldstr "name"
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056c: ldstr ": "
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0576: stloc.s 14
+			IL_0578: ldloc.s 14
+			IL_057a: ldloc.s 6
+			IL_057c: ldstr "message"
+			IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_058b: stloc.s 14
+			IL_058d: ldloc.s 10
+			IL_058f: ldstr "log"
+			IL_0594: ldloc.s 14
+			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_059b: pop
+			IL_059c: leave IL_05a1
 		} // end handler
 
-		IL_05a8: ldnull
-		IL_05a9: stloc.s 8
-		IL_05ab: ret
+		IL_05a1: ldnull
+		IL_05a2: stloc.s 7
+		IL_05a4: ret
 	} // end of method Set_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Prototype_Surface
@@ -566,7 +563,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2633
+		// Method begins at RVA 0x262f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_Combined_TernaryInsideLoop.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_Combined_TernaryInsideLoop.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2133
+			// Method begins at RVA 0x212a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2145
+				// Method begins at RVA 0x213c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213c
+			// Method begins at RVA 0x2133
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,19 +82,18 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 215 (0xd7)
+		// Code size: 206 (0xce)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope,
 			[1] object,
 			[2] float64,
-			[3] class Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope_For_L8C5/Block_L8C28,
+			[3] object,
 			[4] object,
-			[5] object,
-			[6] float64,
+			[5] float64,
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] object
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope::.ctor()
@@ -107,73 +106,71 @@
 		IL_001f: stloc.2
 		// loop start (head: IL_0020)
 			IL_0020: ldloc.2
-			IL_0021: stloc.s 6
-			IL_0023: ldloc.s 6
+			IL_0021: stloc.s 5
+			IL_0023: ldloc.s 5
 			IL_0025: ldc.r8 5
 			IL_002e: clt
-			IL_0030: brfalse IL_00b3
+			IL_0030: brfalse IL_00aa
 
-			IL_0035: newobj instance void Modules.ShapeCoverage_Combined_TernaryInsideLoop/Scope_For_L8C5/Block_L8C28::.ctor()
-			IL_003a: stloc.3
-			IL_003b: ldloc.2
-			IL_003c: stloc.s 6
-			IL_003e: ldloc.s 6
-			IL_0040: ldc.r8 2
-			IL_0049: rem
-			IL_004a: stloc.s 6
-			IL_004c: ldloc.s 6
-			IL_004e: ldc.r8 0.0
-			IL_0057: ceq
-			IL_0059: brfalse IL_006f
+			IL_0035: ldloc.2
+			IL_0036: stloc.s 5
+			IL_0038: ldloc.s 5
+			IL_003a: ldc.r8 2
+			IL_0043: rem
+			IL_0044: stloc.s 5
+			IL_0046: ldloc.s 5
+			IL_0048: ldc.r8 0.0
+			IL_0051: ceq
+			IL_0053: brfalse IL_0068
 
-			IL_005e: ldloc.2
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: stloc.s 7
-			IL_0066: ldloc.s 7
-			IL_0068: stloc.s 4
-			IL_006a: br IL_008d
+			IL_0058: ldloc.2
+			IL_0059: box [System.Runtime]System.Double
+			IL_005e: stloc.s 6
+			IL_0060: ldloc.s 6
+			IL_0062: stloc.3
+			IL_0063: br IL_0085
 
-			IL_006f: ldloc.2
-			IL_0070: stloc.s 6
-			IL_0072: ldloc.s 6
-			IL_0074: ldc.r8 2
-			IL_007d: mul
-			IL_007e: stloc.s 6
-			IL_0080: ldloc.s 6
-			IL_0082: box [System.Runtime]System.Double
-			IL_0087: stloc.s 7
-			IL_0089: ldloc.s 7
-			IL_008b: stloc.s 4
+			IL_0068: ldloc.2
+			IL_0069: stloc.s 5
+			IL_006b: ldloc.s 5
+			IL_006d: ldc.r8 2
+			IL_0076: mul
+			IL_0077: stloc.s 5
+			IL_0079: ldloc.s 5
+			IL_007b: box [System.Runtime]System.Double
+			IL_0080: stloc.s 6
+			IL_0082: ldloc.s 6
+			IL_0084: stloc.3
 
+			IL_0085: ldloc.3
+			IL_0086: stloc.s 4
+			IL_0088: ldloc.1
+			IL_0089: stloc.s 6
+			IL_008b: ldloc.s 6
 			IL_008d: ldloc.s 4
-			IL_008f: stloc.s 5
-			IL_0091: ldloc.1
-			IL_0092: stloc.s 7
-			IL_0094: ldloc.s 7
-			IL_0096: ldloc.s 5
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009d: stloc.s 8
-			IL_009f: ldloc.s 8
-			IL_00a1: stloc.1
-			IL_00a2: ldloc.2
-			IL_00a3: ldc.r8 1
-			IL_00ac: add
-			IL_00ad: stloc.2
-			IL_00ae: br IL_0020
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0094: stloc.s 7
+			IL_0096: ldloc.s 7
+			IL_0098: stloc.1
+			IL_0099: ldloc.2
+			IL_009a: ldc.r8 1
+			IL_00a3: add
+			IL_00a4: stloc.2
+			IL_00a5: br IL_0020
 		// end loop
 
-		IL_00b3: ldstr "console"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00bd: stloc.s 9
-		IL_00bf: ldloc.s 9
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c6: stloc.s 9
-		IL_00c8: ldloc.s 9
-		IL_00ca: ldstr "log"
-		IL_00cf: ldloc.1
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d5: pop
-		IL_00d6: ret
+		IL_00aa: ldstr "console"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b4: stloc.s 8
+		IL_00b6: ldloc.s 8
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bd: stloc.s 8
+		IL_00bf: ldloc.s 8
+		IL_00c1: ldstr "log"
+		IL_00c6: ldloc.1
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00cc: pop
+		IL_00cd: ret
 	} // end of method ShapeCoverage_Combined_TernaryInsideLoop::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_Combined_TernaryInsideLoop
@@ -185,7 +182,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214e
+		// Method begins at RVA 0x2145
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f1
+				// Method begins at RVA 0x23e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23fa
+				// Method begins at RVA 0x23f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e8
+			// Method begins at RVA 0x23e0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 889 (0x379)
+		// Code size: 882 (0x372)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharAt_Basic/Scope,
@@ -90,15 +90,14 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.String_CharAt_Basic/Scope/Block_L11C16,
+			[5] object,
 			[6] object,
 			[7] object,
 			[8] object,
-			[9] object,
-			[10] string,
-			[11] bool,
-			[12] object,
-			[13] object
+			[9] string,
+			[10] bool,
+			[11] object,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.String_CharAt_Basic/Scope::.ctor()
@@ -108,115 +107,115 @@
 		IL_000c: stloc.1
 		IL_000d: ldstr "console"
 		IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0017: stloc.s 8
-		IL_0019: ldloc.s 8
+		IL_0017: stloc.s 7
+		IL_0019: ldloc.s 7
 		IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0020: stloc.s 8
+		IL_0020: stloc.s 7
 		IL_0022: ldloc.1
 		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0028: stloc.s 9
-		IL_002a: ldloc.s 9
+		IL_0028: stloc.s 8
+		IL_002a: ldloc.s 8
 		IL_002c: castclass [System.Runtime]System.String
 		IL_0031: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
-		IL_0036: stloc.s 10
-		IL_0038: ldloc.s 8
+		IL_0036: stloc.s 9
+		IL_0038: ldloc.s 7
 		IL_003a: ldstr "log"
-		IL_003f: ldloc.s 10
+		IL_003f: ldloc.s 9
 		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0046: pop
 		IL_0047: ldstr "console"
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0051: stloc.s 8
-		IL_0053: ldloc.s 8
+		IL_0051: stloc.s 7
+		IL_0053: ldloc.s 7
 		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005a: stloc.s 8
+		IL_005a: stloc.s 7
 		IL_005c: ldloc.1
 		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0062: stloc.s 9
-		IL_0064: ldloc.s 9
+		IL_0062: stloc.s 8
+		IL_0064: ldloc.s 8
 		IL_0066: castclass [System.Runtime]System.String
 		IL_006b: ldc.r8 1
 		IL_0074: box [System.Runtime]System.Double
 		IL_0079: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_007e: stloc.s 10
-		IL_0080: ldloc.s 8
+		IL_007e: stloc.s 9
+		IL_0080: ldloc.s 7
 		IL_0082: ldstr "log"
-		IL_0087: ldloc.s 10
+		IL_0087: ldloc.s 9
 		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_008e: pop
 		IL_008f: ldstr "console"
 		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0099: stloc.s 8
-		IL_009b: ldloc.s 8
+		IL_0099: stloc.s 7
+		IL_009b: ldloc.s 7
 		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: stloc.s 8
+		IL_00a2: stloc.s 7
 		IL_00a4: ldloc.1
 		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: stloc.s 9
-		IL_00ac: ldloc.s 9
+		IL_00aa: stloc.s 8
+		IL_00ac: ldloc.s 8
 		IL_00ae: castclass [System.Runtime]System.String
 		IL_00b3: ldc.r8 4
 		IL_00bc: box [System.Runtime]System.Double
 		IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_00c6: stloc.s 10
-		IL_00c8: ldloc.s 8
+		IL_00c6: stloc.s 9
+		IL_00c8: ldloc.s 7
 		IL_00ca: ldstr "log"
-		IL_00cf: ldloc.s 10
+		IL_00cf: ldloc.s 9
 		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00d6: pop
 		IL_00d7: ldstr "console"
 		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e1: stloc.s 8
-		IL_00e3: ldloc.s 8
+		IL_00e1: stloc.s 7
+		IL_00e3: ldloc.s 7
 		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ea: stloc.s 8
+		IL_00ea: stloc.s 7
 		IL_00ec: ldloc.1
 		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: stloc.s 9
-		IL_00f4: ldloc.s 9
+		IL_00f2: stloc.s 8
+		IL_00f4: ldloc.s 8
 		IL_00f6: castclass [System.Runtime]System.String
 		IL_00fb: ldc.r8 5
 		IL_0104: box [System.Runtime]System.Double
 		IL_0109: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_010e: stloc.s 10
-		IL_0110: ldloc.s 10
+		IL_010e: stloc.s 9
+		IL_0110: ldloc.s 9
 		IL_0112: ldstr ""
 		IL_0117: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_011c: stloc.s 11
-		IL_011e: ldloc.s 11
+		IL_011c: stloc.s 10
+		IL_011e: ldloc.s 10
 		IL_0120: box [System.Runtime]System.Boolean
-		IL_0125: stloc.s 12
-		IL_0127: ldloc.s 8
+		IL_0125: stloc.s 11
+		IL_0127: ldloc.s 7
 		IL_0129: ldstr "log"
-		IL_012e: ldloc.s 12
+		IL_012e: ldloc.s 11
 		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0135: pop
 		IL_0136: ldstr "console"
 		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0140: stloc.s 8
-		IL_0142: ldloc.s 8
+		IL_0140: stloc.s 7
+		IL_0142: ldloc.s 7
 		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0149: stloc.s 8
+		IL_0149: stloc.s 7
 		IL_014b: ldloc.1
 		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: stloc.s 9
-		IL_0153: ldloc.s 9
+		IL_0151: stloc.s 8
+		IL_0153: ldloc.s 8
 		IL_0155: castclass [System.Runtime]System.String
 		IL_015a: ldc.r8 1
 		IL_0163: neg
 		IL_0164: box [System.Runtime]System.Double
 		IL_0169: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_016e: stloc.s 10
-		IL_0170: ldloc.s 10
+		IL_016e: stloc.s 9
+		IL_0170: ldloc.s 9
 		IL_0172: ldstr ""
 		IL_0177: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_017c: stloc.s 11
-		IL_017e: ldloc.s 11
+		IL_017c: stloc.s 10
+		IL_017e: ldloc.s 10
 		IL_0180: box [System.Runtime]System.Boolean
-		IL_0185: stloc.s 12
-		IL_0187: ldloc.s 8
+		IL_0185: stloc.s 11
+		IL_0187: ldloc.s 7
 		IL_0189: ldstr "log"
-		IL_018e: ldloc.s 12
+		IL_018e: ldloc.s 11
 		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0195: pop
 		.try
@@ -224,28 +223,28 @@
 			IL_0196: nop
 			IL_0197: ldstr "console"
 			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a1: stloc.s 8
-			IL_01a3: ldloc.s 8
+			IL_01a1: stloc.s 7
+			IL_01a3: ldloc.s 7
 			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01aa: stloc.s 8
+			IL_01aa: stloc.s 7
 			IL_01ac: ldloc.1
 			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b2: stloc.s 9
+			IL_01b2: stloc.s 8
 			IL_01b4: ldc.r8 1
 			IL_01bd: box [System.Runtime]System.Double
 			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_01c7: stloc.s 13
-			IL_01c9: ldloc.s 9
+			IL_01c7: stloc.s 12
+			IL_01c9: ldloc.s 8
 			IL_01cb: castclass [System.Runtime]System.String
-			IL_01d0: ldloc.s 13
+			IL_01d0: ldloc.s 12
 			IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-			IL_01d7: stloc.s 10
-			IL_01d9: ldloc.s 8
+			IL_01d7: stloc.s 9
+			IL_01d9: ldloc.s 7
 			IL_01db: ldstr "log"
-			IL_01e0: ldloc.s 10
+			IL_01e0: ldloc.s 9
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_01e7: pop
-			IL_01e8: leave IL_02bc
+			IL_01e8: leave IL_02b5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -271,112 +270,110 @@
 			IL_0215: stloc.3
 
 			IL_0216: ldloc.3
-			IL_0217: stloc.s 8
-			IL_0219: ldloc.s 8
+			IL_0217: stloc.s 7
+			IL_0219: ldloc.s 7
 			IL_021b: stloc.s 4
-			IL_021d: newobj instance void Modules.String_CharAt_Basic/Scope/Block_L11C16::.ctor()
-			IL_0222: stloc.s 5
-			IL_0224: ldstr "console"
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_022e: stloc.s 8
-			IL_0230: ldloc.s 8
-			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0237: stloc.s 8
-			IL_0239: ldloc.s 8
-			IL_023b: ldstr "log"
-			IL_0240: ldstr "bigint threw:"
-			IL_0245: ldc.i4.1
-			IL_0246: box [System.Runtime]System.Boolean
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0250: pop
-			IL_0251: ldstr "console"
-			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_025b: stloc.s 8
-			IL_025d: ldloc.s 8
-			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0264: stloc.s 8
-			IL_0266: ldloc.s 8
-			IL_0268: ldstr "log"
-			IL_026d: ldstr "bigint name:"
-			IL_0272: ldloc.s 4
-			IL_0274: ldstr "name"
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0283: pop
-			IL_0284: ldstr "console"
-			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_028e: stloc.s 8
-			IL_0290: ldloc.s 8
-			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0297: stloc.s 8
-			IL_0299: ldloc.s 8
-			IL_029b: ldstr "log"
-			IL_02a0: ldstr "bigint message:"
-			IL_02a5: ldloc.s 4
-			IL_02a7: ldstr "message"
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02b6: pop
-			IL_02b7: leave IL_02bc
+			IL_021d: ldstr "console"
+			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0227: stloc.s 7
+			IL_0229: ldloc.s 7
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0230: stloc.s 7
+			IL_0232: ldloc.s 7
+			IL_0234: ldstr "log"
+			IL_0239: ldstr "bigint threw:"
+			IL_023e: ldc.i4.1
+			IL_023f: box [System.Runtime]System.Boolean
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0249: pop
+			IL_024a: ldstr "console"
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0254: stloc.s 7
+			IL_0256: ldloc.s 7
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025d: stloc.s 7
+			IL_025f: ldloc.s 7
+			IL_0261: ldstr "log"
+			IL_0266: ldstr "bigint name:"
+			IL_026b: ldloc.s 4
+			IL_026d: ldstr "name"
+			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_027c: pop
+			IL_027d: ldstr "console"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0287: stloc.s 7
+			IL_0289: ldloc.s 7
+			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0290: stloc.s 7
+			IL_0292: ldloc.s 7
+			IL_0294: ldstr "log"
+			IL_0299: ldstr "bigint message:"
+			IL_029e: ldloc.s 4
+			IL_02a0: ldstr "message"
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02af: pop
+			IL_02b0: leave IL_02b5
 		} // end handler
 
-		IL_02bc: ldstr "String"
-		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c6: stloc.s 8
-		IL_02c8: ldloc.s 8
-		IL_02ca: ldc.i4.1
-		IL_02cb: newarr [System.Runtime]System.Object
-		IL_02d0: dup
-		IL_02d1: ldc.i4.0
-		IL_02d2: ldstr "world"
-		IL_02d7: stelem.ref
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_02dd: stloc.s 8
-		IL_02df: ldloc.s 8
-		IL_02e1: stloc.s 6
-		IL_02e3: ldstr "console"
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ed: stloc.s 8
-		IL_02ef: ldloc.s 8
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f6: stloc.s 8
-		IL_02f8: ldloc.s 6
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ff: stloc.s 9
-		IL_0301: ldloc.s 9
-		IL_0303: ldstr "charAt"
-		IL_0308: ldc.r8 0.0
-		IL_0311: box [System.Runtime]System.Double
-		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_031b: stloc.s 9
+		IL_02b5: ldstr "String"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02bf: stloc.s 7
+		IL_02c1: ldloc.s 7
+		IL_02c3: ldc.i4.1
+		IL_02c4: newarr [System.Runtime]System.Object
+		IL_02c9: dup
+		IL_02ca: ldc.i4.0
+		IL_02cb: ldstr "world"
+		IL_02d0: stelem.ref
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_02d6: stloc.s 7
+		IL_02d8: ldloc.s 7
+		IL_02da: stloc.s 5
+		IL_02dc: ldstr "console"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e6: stloc.s 7
+		IL_02e8: ldloc.s 7
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ef: stloc.s 7
+		IL_02f1: ldloc.s 5
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f8: stloc.s 8
+		IL_02fa: ldloc.s 8
+		IL_02fc: ldstr "charAt"
+		IL_0301: ldc.r8 0.0
+		IL_030a: box [System.Runtime]System.Double
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0314: stloc.s 8
+		IL_0316: ldloc.s 7
+		IL_0318: ldstr "log"
 		IL_031d: ldloc.s 8
-		IL_031f: ldstr "log"
-		IL_0324: ldloc.s 9
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_032b: pop
-		IL_032c: ldstr "console"
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0336: stloc.s 9
-		IL_0338: ldloc.s 9
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_033f: stloc.s 9
-		IL_0341: ldloc.s 6
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0348: stloc.s 8
-		IL_034a: ldloc.s 8
-		IL_034c: ldstr "charAt"
-		IL_0351: ldc.r8 2
-		IL_035a: box [System.Runtime]System.Double
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0364: stloc.s 8
-		IL_0366: ldloc.s 9
-		IL_0368: ldstr "log"
-		IL_036d: ldloc.s 8
-		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0374: pop
-		IL_0375: ldnull
-		IL_0376: stloc.s 7
-		IL_0378: ret
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0324: pop
+		IL_0325: ldstr "console"
+		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_032f: stloc.s 8
+		IL_0331: ldloc.s 8
+		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0338: stloc.s 8
+		IL_033a: ldloc.s 5
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0341: stloc.s 7
+		IL_0343: ldloc.s 7
+		IL_0345: ldstr "charAt"
+		IL_034a: ldc.r8 2
+		IL_0353: box [System.Runtime]System.Double
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_035d: stloc.s 7
+		IL_035f: ldloc.s 8
+		IL_0361: ldstr "log"
+		IL_0366: ldloc.s 7
+		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_036d: pop
+		IL_036e: ldnull
+		IL_036f: stloc.s 6
+		IL_0371: ret
 	} // end of method String_CharAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharAt_Basic
@@ -388,7 +385,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2403
+		// Method begins at RVA 0x23fb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2451
+				// Method begins at RVA 0x2449
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245a
+				// Method begins at RVA 0x2452
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2448
+			// Method begins at RVA 0x2440
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 987 (0x3db)
+		// Code size: 980 (0x3d4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MatchAll_Basic/Scope,
@@ -91,11 +91,10 @@
 			[3] class [System.Runtime]System.Exception,
 			[4] object,
 			[5] object,
-			[6] class Modules.String_MatchAll_Basic/Scope/Block_L21C16,
+			[6] object,
 			[7] object,
-			[8] object,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.String_MatchAll_Basic/Scope::.ctor()
@@ -103,28 +102,28 @@
 		IL_0006: nop
 		IL_0007: ldstr "test1 test22"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0011: stloc.s 8
+		IL_0011: stloc.s 7
 		IL_0013: ldstr "t(e)(st\\d+)"
 		IL_0018: ldstr "g"
 		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0022: stloc.s 9
-		IL_0024: ldloc.s 8
+		IL_0022: stloc.s 8
+		IL_0024: ldloc.s 7
 		IL_0026: ldstr "matchAll"
-		IL_002b: ldloc.s 9
+		IL_002b: ldloc.s 8
 		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0032: stloc.s 8
-		IL_0034: ldloc.s 8
+		IL_0032: stloc.s 7
+		IL_0034: ldloc.s 7
 		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_003b: stloc.s 10
-		IL_003d: ldloc.s 10
+		IL_003b: stloc.s 9
+		IL_003d: ldloc.s 9
 		IL_003f: stloc.1
 		IL_0040: ldstr "console"
 		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_004a: stloc.s 8
-		IL_004c: ldloc.s 8
+		IL_004a: stloc.s 7
+		IL_004c: ldloc.s 7
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0053: stloc.s 8
-		IL_0055: ldloc.s 8
+		IL_0053: stloc.s 7
+		IL_0055: ldloc.s 7
 		IL_0057: ldstr "log"
 		IL_005c: ldloc.1
 		IL_005d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
@@ -133,11 +132,11 @@
 		IL_006c: pop
 		IL_006d: ldstr "console"
 		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0077: stloc.s 8
-		IL_0079: ldloc.s 8
+		IL_0077: stloc.s 7
+		IL_0079: ldloc.s 7
 		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: stloc.s 8
-		IL_0082: ldloc.s 8
+		IL_0080: stloc.s 7
+		IL_0082: ldloc.s 7
 		IL_0084: ldstr "log"
 		IL_0089: ldloc.1
 		IL_008a: ldc.r8 0.0
@@ -148,11 +147,11 @@
 		IL_00ab: pop
 		IL_00ac: ldstr "console"
 		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b6: stloc.s 8
-		IL_00b8: ldloc.s 8
+		IL_00b6: stloc.s 7
+		IL_00b8: ldloc.s 7
 		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bf: stloc.s 8
-		IL_00c1: ldloc.s 8
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 7
 		IL_00c3: ldstr "log"
 		IL_00c8: ldloc.1
 		IL_00c9: ldc.r8 0.0
@@ -163,11 +162,11 @@
 		IL_00ea: pop
 		IL_00eb: ldstr "console"
 		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: stloc.s 8
-		IL_00f7: ldloc.s 8
+		IL_00f5: stloc.s 7
+		IL_00f7: ldloc.s 7
 		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fe: stloc.s 8
-		IL_0100: ldloc.s 8
+		IL_00fe: stloc.s 7
+		IL_0100: ldloc.s 7
 		IL_0102: ldstr "log"
 		IL_0107: ldloc.1
 		IL_0108: ldc.r8 0.0
@@ -178,11 +177,11 @@
 		IL_0129: pop
 		IL_012a: ldstr "console"
 		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0134: stloc.s 8
-		IL_0136: ldloc.s 8
+		IL_0134: stloc.s 7
+		IL_0136: ldloc.s 7
 		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013d: stloc.s 8
-		IL_013f: ldloc.s 8
+		IL_013d: stloc.s 7
+		IL_013f: ldloc.s 7
 		IL_0141: ldstr "log"
 		IL_0146: ldloc.1
 		IL_0147: ldc.r8 0.0
@@ -193,11 +192,11 @@
 		IL_0164: pop
 		IL_0165: ldstr "console"
 		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016f: stloc.s 8
-		IL_0171: ldloc.s 8
+		IL_016f: stloc.s 7
+		IL_0171: ldloc.s 7
 		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0178: stloc.s 8
-		IL_017a: ldloc.s 8
+		IL_0178: stloc.s 7
+		IL_017a: ldloc.s 7
 		IL_017c: ldstr "log"
 		IL_0181: ldloc.1
 		IL_0182: ldc.r8 1
@@ -208,11 +207,11 @@
 		IL_01a3: pop
 		IL_01a4: ldstr "console"
 		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ae: stloc.s 8
-		IL_01b0: ldloc.s 8
+		IL_01ae: stloc.s 7
+		IL_01b0: ldloc.s 7
 		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b7: stloc.s 8
-		IL_01b9: ldloc.s 8
+		IL_01b7: stloc.s 7
+		IL_01b9: ldloc.s 7
 		IL_01bb: ldstr "log"
 		IL_01c0: ldloc.1
 		IL_01c1: ldc.r8 1
@@ -223,11 +222,11 @@
 		IL_01e2: pop
 		IL_01e3: ldstr "console"
 		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ed: stloc.s 8
-		IL_01ef: ldloc.s 8
+		IL_01ed: stloc.s 7
+		IL_01ef: ldloc.s 7
 		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f6: stloc.s 8
-		IL_01f8: ldloc.s 8
+		IL_01f6: stloc.s 7
+		IL_01f8: ldloc.s 7
 		IL_01fa: ldstr "log"
 		IL_01ff: ldloc.1
 		IL_0200: ldc.r8 1
@@ -238,11 +237,11 @@
 		IL_0221: pop
 		IL_0222: ldstr "console"
 		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022c: stloc.s 8
-		IL_022e: ldloc.s 8
+		IL_022c: stloc.s 7
+		IL_022e: ldloc.s 7
 		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0235: stloc.s 8
-		IL_0237: ldloc.s 8
+		IL_0235: stloc.s 7
+		IL_0237: ldloc.s 7
 		IL_0239: ldstr "log"
 		IL_023e: ldloc.1
 		IL_023f: ldc.r8 1
@@ -253,24 +252,24 @@
 		IL_025c: pop
 		IL_025d: ldstr "aba"
 		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0267: stloc.s 8
-		IL_0269: ldloc.s 8
+		IL_0267: stloc.s 7
+		IL_0269: ldloc.s 7
 		IL_026b: ldstr "matchAll"
 		IL_0270: ldstr "a"
 		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_027a: stloc.s 8
-		IL_027c: ldloc.s 8
+		IL_027a: stloc.s 7
+		IL_027c: ldloc.s 7
 		IL_027e: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0283: stloc.s 10
-		IL_0285: ldloc.s 10
+		IL_0283: stloc.s 9
+		IL_0285: ldloc.s 9
 		IL_0287: stloc.2
 		IL_0288: ldstr "console"
 		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0292: stloc.s 8
-		IL_0294: ldloc.s 8
+		IL_0292: stloc.s 7
+		IL_0294: ldloc.s 7
 		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_029b: stloc.s 8
-		IL_029d: ldloc.s 8
+		IL_029b: stloc.s 7
+		IL_029d: ldloc.s 7
 		IL_029f: ldstr "log"
 		IL_02a4: ldloc.2
 		IL_02a5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
@@ -279,11 +278,11 @@
 		IL_02b4: pop
 		IL_02b5: ldstr "console"
 		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02bf: stloc.s 8
-		IL_02c1: ldloc.s 8
+		IL_02bf: stloc.s 7
+		IL_02c1: ldloc.s 7
 		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c8: stloc.s 8
-		IL_02ca: ldloc.s 8
+		IL_02c8: stloc.s 7
+		IL_02ca: ldloc.s 7
 		IL_02cc: ldstr "log"
 		IL_02d1: ldloc.2
 		IL_02d2: ldc.r8 0.0
@@ -294,11 +293,11 @@
 		IL_02f3: pop
 		IL_02f4: ldstr "console"
 		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fe: stloc.s 8
-		IL_0300: ldloc.s 8
+		IL_02fe: stloc.s 7
+		IL_0300: ldloc.s 7
 		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0307: stloc.s 8
-		IL_0309: ldloc.s 8
+		IL_0307: stloc.s 7
+		IL_0309: ldloc.s 7
 		IL_030b: ldstr "log"
 		IL_0310: ldloc.2
 		IL_0311: ldc.r8 1
@@ -312,20 +311,20 @@
 			IL_032f: nop
 			IL_0330: ldstr "aba"
 			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_033a: stloc.s 8
+			IL_033a: stloc.s 7
 			IL_033c: ldstr "a"
 			IL_0341: ldstr ""
 			IL_0346: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_034b: stloc.s 9
-			IL_034d: ldloc.s 8
+			IL_034b: stloc.s 8
+			IL_034d: ldloc.s 7
 			IL_034f: ldstr "matchAll"
-			IL_0354: ldloc.s 9
+			IL_0354: ldloc.s 8
 			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_035b: stloc.s 8
-			IL_035d: ldloc.s 8
+			IL_035b: stloc.s 7
+			IL_035d: ldloc.s 7
 			IL_035f: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
 			IL_0364: pop
-			IL_0365: leave IL_03d7
+			IL_0365: leave IL_03d0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -351,30 +350,28 @@
 			IL_0393: stloc.s 4
 
 			IL_0395: ldloc.s 4
-			IL_0397: stloc.s 8
-			IL_0399: ldloc.s 8
+			IL_0397: stloc.s 7
+			IL_0399: ldloc.s 7
 			IL_039b: stloc.s 5
-			IL_039d: newobj instance void Modules.String_MatchAll_Basic/Scope/Block_L21C16::.ctor()
-			IL_03a2: stloc.s 6
-			IL_03a4: ldstr "console"
-			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ae: stloc.s 8
-			IL_03b0: ldloc.s 8
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b7: stloc.s 8
-			IL_03b9: ldloc.s 8
-			IL_03bb: ldstr "log"
-			IL_03c0: ldloc.s 5
-			IL_03c2: ldstr "name"
-			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03d1: pop
-			IL_03d2: leave IL_03d7
+			IL_039d: ldstr "console"
+			IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03a7: stloc.s 7
+			IL_03a9: ldloc.s 7
+			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b0: stloc.s 7
+			IL_03b2: ldloc.s 7
+			IL_03b4: ldstr "log"
+			IL_03b9: ldloc.s 5
+			IL_03bb: ldstr "name"
+			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03ca: pop
+			IL_03cb: leave IL_03d0
 		} // end handler
 
-		IL_03d7: ldnull
-		IL_03d8: stloc.s 7
-		IL_03da: ret
+		IL_03d0: ldnull
+		IL_03d1: stloc.s 6
+		IL_03d3: ret
 	} // end of method String_MatchAll_Basic::__js_module_init__
 
 } // end of class Modules.String_MatchAll_Basic
@@ -386,7 +383,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2463
+		// Method begins at RVA 0x245b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2674
+				// Method begins at RVA 0x266c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2468
+			// Method begins at RVA 0x2460
 			// Header size: 12
 			// Code size: 104 (0x68)
 			.maxstack 8
@@ -106,7 +106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x267d
+				// Method begins at RVA 0x2675
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -134,7 +134,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x24dc
+			// Method begins at RVA 0x24d4
 			// Header size: 12
 			// Code size: 132 (0x84)
 			.maxstack 8
@@ -203,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2686
+				// Method begins at RVA 0x267e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +230,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x256c
+			// Method begins at RVA 0x2564
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -287,7 +287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x268f
+				// Method begins at RVA 0x2687
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -315,7 +315,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x25cc
 			// Header size: 12
 			// Code size: 139 (0x8b)
 			.maxstack 8
@@ -391,7 +391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2698
+				// Method begins at RVA 0x2690
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -411,7 +411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26a1
+				// Method begins at RVA 0x2699
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -432,7 +432,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x266b
+			// Method begins at RVA 0x2663
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -458,7 +458,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1019 (0x3fb)
+		// Code size: 1012 (0x3f4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_Custom/Scope,
@@ -470,11 +470,10 @@
 			[6] class [System.Runtime]System.Exception,
 			[7] object,
 			[8] object,
-			[9] class Modules.String_RegExp_SymbolDispatch_Custom/Scope/Block_L50C12,
+			[9] object,
 			[10] object,
 			[11] object,
-			[12] object,
-			[13] object
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/Scope::.ctor()
@@ -485,10 +484,10 @@
 		IL_000d: stfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
 		IL_0012: ldloc.0
 		IL_0013: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0018: stloc.s 11
+		IL_0018: stloc.s 10
 		IL_001a: ldstr "match"
 		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0024: stloc.s 12
+		IL_0024: stloc.s 11
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
 		IL_002c: dup
@@ -506,19 +505,19 @@
 		IL_0049: ldc.i4.0
 		IL_004a: ldc.i4.1
 		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0050: stloc.s 13
-		IL_0052: ldloc.s 11
-		IL_0054: ldloc.s 12
-		IL_0056: ldloc.s 13
+		IL_0050: stloc.s 12
+		IL_0052: ldloc.s 10
+		IL_0054: ldloc.s 11
+		IL_0056: ldloc.s 12
 		IL_0058: ldc.i4.1
 		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_005e: pop
 		IL_005f: ldloc.0
 		IL_0060: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0065: stloc.s 13
+		IL_0065: stloc.s 12
 		IL_0067: ldstr "replace"
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0071: stloc.s 12
+		IL_0071: stloc.s 11
 		IL_0073: ldc.i4.1
 		IL_0074: newarr [System.Runtime]System.Object
 		IL_0079: dup
@@ -536,19 +535,19 @@
 		IL_0096: ldc.i4.0
 		IL_0097: ldc.i4.1
 		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_009d: stloc.s 11
-		IL_009f: ldloc.s 13
-		IL_00a1: ldloc.s 12
-		IL_00a3: ldloc.s 11
+		IL_009d: stloc.s 10
+		IL_009f: ldloc.s 12
+		IL_00a1: ldloc.s 11
+		IL_00a3: ldloc.s 10
 		IL_00a5: ldc.i4.1
 		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_00ab: pop
 		IL_00ac: ldloc.0
 		IL_00ad: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_00b2: stloc.s 11
+		IL_00b2: stloc.s 10
 		IL_00b4: ldstr "search"
 		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00be: stloc.s 12
+		IL_00be: stloc.s 11
 		IL_00c0: ldc.i4.1
 		IL_00c1: newarr [System.Runtime]System.Object
 		IL_00c6: dup
@@ -566,19 +565,19 @@
 		IL_00e3: ldc.i4.0
 		IL_00e4: ldc.i4.1
 		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00ea: stloc.s 13
-		IL_00ec: ldloc.s 11
-		IL_00ee: ldloc.s 12
-		IL_00f0: ldloc.s 13
+		IL_00ea: stloc.s 12
+		IL_00ec: ldloc.s 10
+		IL_00ee: ldloc.s 11
+		IL_00f0: ldloc.s 12
 		IL_00f2: ldc.i4.1
 		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_00f8: pop
 		IL_00f9: ldloc.0
 		IL_00fa: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_00ff: stloc.s 13
+		IL_00ff: stloc.s 12
 		IL_0101: ldstr "split"
 		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_010b: stloc.s 12
+		IL_010b: stloc.s 11
 		IL_010d: ldc.i4.1
 		IL_010e: newarr [System.Runtime]System.Object
 		IL_0113: dup
@@ -596,31 +595,31 @@
 		IL_0130: ldc.i4.0
 		IL_0131: ldc.i4.1
 		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0137: stloc.s 11
-		IL_0139: ldloc.s 13
-		IL_013b: ldloc.s 12
-		IL_013d: ldloc.s 11
+		IL_0137: stloc.s 10
+		IL_0139: ldloc.s 12
+		IL_013b: ldloc.s 11
+		IL_013d: ldloc.s 10
 		IL_013f: ldc.i4.1
 		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
 		IL_0145: pop
 		IL_0146: ldstr "abc"
 		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0150: stloc.s 11
-		IL_0152: ldloc.s 11
+		IL_0150: stloc.s 10
+		IL_0152: ldloc.s 10
 		IL_0154: ldstr "match"
 		IL_0159: ldloc.0
 		IL_015a: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
 		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0164: stloc.s 11
-		IL_0166: ldloc.s 11
+		IL_0164: stloc.s 10
+		IL_0166: ldloc.s 10
 		IL_0168: stloc.1
 		IL_0169: ldstr "console"
 		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0173: stloc.s 11
-		IL_0175: ldloc.s 11
+		IL_0173: stloc.s 10
+		IL_0175: ldloc.s 10
 		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017c: stloc.s 11
-		IL_017e: ldloc.s 11
+		IL_017c: stloc.s 10
+		IL_017e: ldloc.s 10
 		IL_0180: ldstr "log"
 		IL_0185: ldloc.1
 		IL_0186: ldc.r8 0.0
@@ -629,25 +628,25 @@
 		IL_0199: pop
 		IL_019a: ldstr "abc"
 		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a4: stloc.s 11
+		IL_01a4: stloc.s 10
 		IL_01a6: ldloc.0
 		IL_01a7: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_01ac: stloc.s 12
-		IL_01ae: ldloc.s 11
+		IL_01ac: stloc.s 11
+		IL_01ae: ldloc.s 10
 		IL_01b0: ldstr "replace"
-		IL_01b5: ldloc.s 12
+		IL_01b5: ldloc.s 11
 		IL_01b7: ldstr "x"
 		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01c1: stloc.s 12
-		IL_01c3: ldloc.s 12
+		IL_01c1: stloc.s 11
+		IL_01c3: ldloc.s 11
 		IL_01c5: stloc.2
 		IL_01c6: ldstr "console"
 		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d0: stloc.s 12
-		IL_01d2: ldloc.s 12
+		IL_01d0: stloc.s 11
+		IL_01d2: ldloc.s 11
 		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d9: stloc.s 12
-		IL_01db: ldloc.s 12
+		IL_01d9: stloc.s 11
+		IL_01db: ldloc.s 11
 		IL_01dd: ldstr "log"
 		IL_01e2: ldloc.2
 		IL_01e3: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
@@ -655,33 +654,33 @@
 		IL_01ed: pop
 		IL_01ee: ldstr "console"
 		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f8: stloc.s 12
-		IL_01fa: ldloc.s 12
+		IL_01f8: stloc.s 11
+		IL_01fa: ldloc.s 11
 		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0201: stloc.s 12
-		IL_0203: ldloc.s 12
+		IL_0201: stloc.s 11
+		IL_0203: ldloc.s 11
 		IL_0205: ldstr "log"
 		IL_020a: ldloc.2
 		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0210: pop
 		IL_0211: ldstr "abc"
 		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021b: stloc.s 12
-		IL_021d: ldloc.s 12
+		IL_021b: stloc.s 11
+		IL_021d: ldloc.s 11
 		IL_021f: ldstr "search"
 		IL_0224: ldloc.0
 		IL_0225: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
 		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_022f: stloc.s 12
-		IL_0231: ldloc.s 12
+		IL_022f: stloc.s 11
+		IL_0231: ldloc.s 11
 		IL_0233: stloc.3
 		IL_0234: ldstr "console"
 		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_023e: stloc.s 12
-		IL_0240: ldloc.s 12
+		IL_023e: stloc.s 11
+		IL_0240: ldloc.s 11
 		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0247: stloc.s 12
-		IL_0249: ldloc.s 12
+		IL_0247: stloc.s 11
+		IL_0249: ldloc.s 11
 		IL_024b: ldstr "log"
 		IL_0250: ldloc.3
 		IL_0251: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
@@ -689,37 +688,37 @@
 		IL_025b: pop
 		IL_025c: ldstr "console"
 		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0266: stloc.s 12
-		IL_0268: ldloc.s 12
+		IL_0266: stloc.s 11
+		IL_0268: ldloc.s 11
 		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026f: stloc.s 12
-		IL_0271: ldloc.s 12
+		IL_026f: stloc.s 11
+		IL_0271: ldloc.s 11
 		IL_0273: ldstr "log"
 		IL_0278: ldloc.3
 		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_027e: pop
 		IL_027f: ldstr "abc"
 		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0289: stloc.s 12
+		IL_0289: stloc.s 11
 		IL_028b: ldloc.0
 		IL_028c: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0291: stloc.s 11
-		IL_0293: ldloc.s 12
+		IL_0291: stloc.s 10
+		IL_0293: ldloc.s 11
 		IL_0295: ldstr "split"
-		IL_029a: ldloc.s 11
+		IL_029a: ldloc.s 10
 		IL_029c: ldc.r8 5
 		IL_02a5: box [System.Runtime]System.Double
 		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_02af: stloc.s 11
-		IL_02b1: ldloc.s 11
+		IL_02af: stloc.s 10
+		IL_02b1: ldloc.s 10
 		IL_02b3: stloc.s 4
 		IL_02b5: ldstr "console"
 		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02bf: stloc.s 11
-		IL_02c1: ldloc.s 11
+		IL_02bf: stloc.s 10
+		IL_02c1: ldloc.s 10
 		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c8: stloc.s 11
-		IL_02ca: ldloc.s 11
+		IL_02c8: stloc.s 10
+		IL_02ca: ldloc.s 10
 		IL_02cc: ldstr "log"
 		IL_02d1: ldloc.s 4
 		IL_02d3: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
@@ -727,11 +726,11 @@
 		IL_02dd: pop
 		IL_02de: ldstr "console"
 		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e8: stloc.s 11
-		IL_02ea: ldloc.s 11
+		IL_02e8: stloc.s 10
+		IL_02ea: ldloc.s 10
 		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f1: stloc.s 11
-		IL_02f3: ldloc.s 11
+		IL_02f1: stloc.s 10
+		IL_02f3: ldloc.s 10
 		IL_02f5: ldstr "log"
 		IL_02fa: ldloc.s 4
 		IL_02fc: ldstr "marker"
@@ -742,9 +741,9 @@
 		IL_0311: stloc.s 5
 		IL_0313: ldstr "match"
 		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_031d: stloc.s 11
+		IL_031d: stloc.s 10
 		IL_031f: ldloc.s 5
-		IL_0321: ldloc.s 11
+		IL_0321: ldloc.s 10
 		IL_0323: ldc.r8 1
 		IL_032c: box [System.Runtime]System.Double
 		IL_0331: ldc.i4.1
@@ -755,13 +754,13 @@
 			IL_0338: nop
 			IL_0339: ldstr "abc"
 			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0343: stloc.s 11
-			IL_0345: ldloc.s 11
+			IL_0343: stloc.s 10
+			IL_0345: ldloc.s 10
 			IL_0347: ldstr "match"
 			IL_034c: ldloc.s 5
 			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0353: pop
-			IL_0354: leave IL_03f7
+			IL_0354: leave IL_03f0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -787,43 +786,41 @@
 			IL_0385: stloc.s 7
 
 			IL_0387: ldloc.s 7
-			IL_0389: stloc.s 11
-			IL_038b: ldloc.s 11
+			IL_0389: stloc.s 10
+			IL_038b: ldloc.s 10
 			IL_038d: stloc.s 8
-			IL_038f: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/Scope/Block_L50C12::.ctor()
-			IL_0394: stloc.s 9
-			IL_0396: ldstr "console"
-			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03a0: stloc.s 11
-			IL_03a2: ldloc.s 11
-			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a9: stloc.s 11
-			IL_03ab: ldloc.s 11
-			IL_03ad: ldstr "log"
-			IL_03b2: ldloc.s 8
-			IL_03b4: ldstr "name"
-			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03c3: pop
-			IL_03c4: ldstr "console"
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ce: stloc.s 11
-			IL_03d0: ldloc.s 11
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03d7: stloc.s 11
-			IL_03d9: ldloc.s 11
-			IL_03db: ldstr "log"
-			IL_03e0: ldloc.s 8
-			IL_03e2: ldstr "message"
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03f1: pop
-			IL_03f2: leave IL_03f7
+			IL_038f: ldstr "console"
+			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0399: stloc.s 10
+			IL_039b: ldloc.s 10
+			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a2: stloc.s 10
+			IL_03a4: ldloc.s 10
+			IL_03a6: ldstr "log"
+			IL_03ab: ldloc.s 8
+			IL_03ad: ldstr "name"
+			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03bc: pop
+			IL_03bd: ldstr "console"
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03c7: stloc.s 10
+			IL_03c9: ldloc.s 10
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d0: stloc.s 10
+			IL_03d2: ldloc.s 10
+			IL_03d4: ldstr "log"
+			IL_03d9: ldloc.s 8
+			IL_03db: ldstr "message"
+			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03ea: pop
+			IL_03eb: leave IL_03f0
 		} // end handler
 
-		IL_03f7: ldnull
-		IL_03f8: stloc.s 10
-		IL_03fa: ret
+		IL_03f0: ldnull
+		IL_03f1: stloc.s 9
+		IL_03f3: ret
 	} // end of method String_RegExp_SymbolDispatch_Custom::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_Custom
@@ -835,7 +832,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26aa
+		// Method begins at RVA 0x26a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22ae
+					// Method begins at RVA 0x229a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b7
+					// Method begins at RVA 0x22a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a5
+				// Method begins at RVA 0x2291
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,139 +90,134 @@
 			)
 			// Method begins at RVA 0x215c
 			// Header size: 12
-			// Code size: 289 (0x121)
+			// Code size: 271 (0x10f)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.String_Repeat_Basic/logRepeat/Scope/Block_L8C8,
-				[1] object,
-				[2] class [System.Runtime]System.Exception,
+				[0] object,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
 				[3] object,
 				[4] object,
-				[5] class Modules.String_Repeat_Basic/logRepeat/Scope/Block_L13C14,
+				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
+				[8] bool,
 				[9] object,
-				[10] bool,
-				[11] object,
-				[12] string
+				[10] string
 			)
 
 			.try
 			{
-				IL_0000: newobj instance void Modules.String_Repeat_Basic/logRepeat/Scope/Block_L8C8::.ctor()
-				IL_0005: stloc.0
-				IL_0006: ldarg.2
-				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: stloc.s 8
-				IL_000e: ldloc.s 8
-				IL_0010: ldstr "repeat"
-				IL_0015: ldarg.3
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_001b: stloc.s 8
-				IL_001d: ldloc.s 8
-				IL_001f: stloc.1
-				IL_0020: ldstr "console"
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_002a: stloc.s 8
-				IL_002c: ldloc.s 8
-				IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0033: stloc.s 8
-				IL_0035: ldstr "["
-				IL_003a: ldloc.1
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0040: stloc.s 9
-				IL_0042: ldloc.s 9
-				IL_0044: ldstr "]"
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_004e: stloc.s 9
-				IL_0050: ldloc.s 8
-				IL_0052: ldstr "log"
-				IL_0057: ldloc.s 9
-				IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_005e: pop
-				IL_005f: leave IL_011b
+				IL_0000: nop
+				IL_0001: ldarg.2
+				IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0007: stloc.s 6
+				IL_0009: ldloc.s 6
+				IL_000b: ldstr "repeat"
+				IL_0010: ldarg.3
+				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0016: stloc.s 6
+				IL_0018: ldloc.s 6
+				IL_001a: stloc.0
+				IL_001b: ldstr "console"
+				IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0025: stloc.s 6
+				IL_0027: ldloc.s 6
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002e: stloc.s 6
+				IL_0030: ldstr "["
+				IL_0035: ldloc.0
+				IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_003b: stloc.s 7
+				IL_003d: ldloc.s 7
+				IL_003f: ldstr "]"
+				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0049: stloc.s 7
+				IL_004b: ldloc.s 6
+				IL_004d: ldstr "log"
+				IL_0052: ldloc.s 7
+				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0059: pop
+				IL_005a: leave IL_0109
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0064: stloc.2
-				IL_0065: ldloc.2
-				IL_0066: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_006b: dup
-				IL_006c: brtrue IL_0081
+				IL_005f: stloc.1
+				IL_0060: ldloc.1
+				IL_0061: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0066: dup
+				IL_0067: brtrue IL_007c
 
-				IL_0071: pop
-				IL_0072: ldloc.2
-				IL_0073: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0078: dup
-				IL_0079: brtrue IL_008c
+				IL_006c: pop
+				IL_006d: ldloc.1
+				IL_006e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0073: dup
+				IL_0074: brtrue IL_0087
 
-				IL_007e: pop
-				IL_007f: rethrow
+				IL_0079: pop
+				IL_007a: rethrow
 
-				IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0086: stloc.3
-				IL_0087: br IL_008d
+				IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0081: stloc.2
+				IL_0082: br IL_0088
 
-				IL_008c: stloc.3
+				IL_0087: stloc.2
 
-				IL_008d: ldloc.3
-				IL_008e: stloc.s 8
-				IL_0090: ldloc.s 8
-				IL_0092: stloc.s 4
-				IL_0094: newobj instance void Modules.String_Repeat_Basic/logRepeat/Scope/Block_L13C14::.ctor()
-				IL_0099: stloc.s 5
-				IL_009b: ldstr "console"
-				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00a5: stloc.s 8
-				IL_00a7: ldloc.s 8
-				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ae: stloc.s 8
-				IL_00b0: ldloc.s 4
-				IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00b7: stloc.s 10
-				IL_00b9: ldloc.s 10
-				IL_00bb: brfalse IL_00d3
+				IL_0088: ldloc.2
+				IL_0089: stloc.s 6
+				IL_008b: ldloc.s 6
+				IL_008d: stloc.3
+				IL_008e: ldstr "console"
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0098: stloc.s 6
+				IL_009a: ldloc.s 6
+				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a1: stloc.s 6
+				IL_00a3: ldloc.3
+				IL_00a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00a9: stloc.s 8
+				IL_00ab: ldloc.s 8
+				IL_00ad: brfalse IL_00c4
 
-				IL_00c0: ldloc.s 4
-				IL_00c2: ldstr "name"
-				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00cc: stloc.s 11
-				IL_00ce: br IL_00d7
+				IL_00b2: ldloc.3
+				IL_00b3: ldstr "name"
+				IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00bd: stloc.s 9
+				IL_00bf: br IL_00c7
 
-				IL_00d3: ldloc.s 4
-				IL_00d5: stloc.s 11
+				IL_00c4: ldloc.3
+				IL_00c5: stloc.s 9
 
-				IL_00d7: ldloc.s 11
-				IL_00d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00de: stloc.s 10
-				IL_00e0: ldloc.s 10
-				IL_00e2: brfalse IL_00fa
+				IL_00c7: ldloc.s 9
+				IL_00c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00ce: stloc.s 8
+				IL_00d0: ldloc.s 8
+				IL_00d2: brfalse IL_00e9
 
-				IL_00e7: ldloc.s 4
-				IL_00e9: ldstr "name"
-				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00f3: stloc.s 6
-				IL_00f5: br IL_0107
+				IL_00d7: ldloc.3
+				IL_00d8: ldstr "name"
+				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e2: stloc.s 4
+				IL_00e4: br IL_00f5
 
-				IL_00fa: ldloc.s 4
-				IL_00fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0101: stloc.s 12
-				IL_0103: ldloc.s 12
-				IL_0105: stloc.s 6
+				IL_00e9: ldloc.3
+				IL_00ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_00ef: stloc.s 10
+				IL_00f1: ldloc.s 10
+				IL_00f3: stloc.s 4
 
-				IL_0107: ldloc.s 8
-				IL_0109: ldstr "log"
-				IL_010e: ldloc.s 6
-				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0115: pop
-				IL_0116: leave IL_011b
+				IL_00f5: ldloc.s 6
+				IL_00f7: ldstr "log"
+				IL_00fc: ldloc.s 4
+				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0103: pop
+				IL_0104: leave IL_0109
 			} // end handler
 
-			IL_011b: ldnull
-			IL_011c: stloc.s 7
-			IL_011e: ldloc.s 7
-			IL_0120: ret
+			IL_0109: ldnull
+			IL_010a: stloc.s 5
+			IL_010c: ldloc.s 5
+			IL_010e: ret
 		} // end of method logRepeat::__js_call__
 
 	} // end of class logRepeat
@@ -241,7 +236,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2288
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -367,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c0
+		// Method begins at RVA 0x22ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatchFinally_ThrowValue.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatchFinally_ThrowValue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2165
+				// Method begins at RVA 0x2161
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216e
+				// Method begins at RVA 0x216a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2177
+				// Method begins at RVA 0x2173
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2158
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 228 (0xe4)
+		// Code size: 221 (0xdd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatchFinally_ThrowValue/Scope,
@@ -110,9 +110,8 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.TryCatchFinally_ThrowValue/Scope/Block_L7C12,
-			[6] object,
-			[7] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.TryCatchFinally_ThrowValue/Scope::.ctor()
@@ -120,11 +119,11 @@
 		IL_0006: nop
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0011: stloc.s 7
-		IL_0013: ldloc.s 7
+		IL_0011: stloc.s 6
+		IL_0013: ldloc.s 6
 		IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001a: stloc.s 7
-		IL_001c: ldloc.s 7
+		IL_001a: stloc.s 6
+		IL_001c: ldloc.s 6
 		IL_001e: ldstr "log"
 		IL_0023: ldstr "a"
 		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
@@ -149,7 +148,7 @@
 
 				IL_0052: throw
 
-				IL_0053: leave IL_00e0
+				IL_0053: leave IL_00d9
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -175,44 +174,42 @@
 				IL_0080: stloc.3
 
 				IL_0081: ldloc.3
-				IL_0082: stloc.s 7
-				IL_0084: ldloc.s 7
+				IL_0082: stloc.s 6
+				IL_0084: ldloc.s 6
 				IL_0086: stloc.s 4
-				IL_0088: newobj instance void Modules.TryCatchFinally_ThrowValue/Scope/Block_L7C12::.ctor()
-				IL_008d: stloc.s 5
-				IL_008f: ldstr "console"
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0099: stloc.s 7
-				IL_009b: ldloc.s 7
-				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a2: stloc.s 7
-				IL_00a4: ldloc.s 7
-				IL_00a6: ldstr "log"
-				IL_00ab: ldloc.s 4
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_00b2: pop
-				IL_00b3: leave IL_00e0
+				IL_0088: ldstr "console"
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0092: stloc.s 6
+				IL_0094: ldloc.s 6
+				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009b: stloc.s 6
+				IL_009d: ldloc.s 6
+				IL_009f: ldstr "log"
+				IL_00a4: ldloc.s 4
+				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_00ab: pop
+				IL_00ac: leave IL_00d9
 			} // end handler
 		} // end .try
 		finally
 		{
-			IL_00b8: ldstr "console"
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c2: stloc.s 7
-			IL_00c4: ldloc.s 7
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cb: stloc.s 7
-			IL_00cd: ldloc.s 7
-			IL_00cf: ldstr "log"
-			IL_00d4: ldstr "c"
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00de: pop
-			IL_00df: endfinally
+			IL_00b1: ldstr "console"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00bb: stloc.s 6
+			IL_00bd: ldloc.s 6
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c4: stloc.s 6
+			IL_00c6: ldloc.s 6
+			IL_00c8: ldstr "log"
+			IL_00cd: ldstr "c"
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d7: pop
+			IL_00d8: endfinally
 		} // end handler
 
-		IL_00e0: ldnull
-		IL_00e1: stloc.s 6
-		IL_00e3: ret
+		IL_00d9: ldnull
+		IL_00da: stloc.s 5
+		IL_00dc: ret
 	} // end of method TryCatchFinally_ThrowValue::__js_module_init__
 
 } // end of class Modules.TryCatchFinally_ThrowValue
@@ -224,7 +221,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2180
+		// Method begins at RVA 0x217c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228d
+				// Method begins at RVA 0x2285
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2296
+				// Method begins at RVA 0x228e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x227c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 534 (0x216)
+		// Code size: 527 (0x20f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_NewExpression_BuiltInErrors/Scope,
@@ -90,10 +90,9 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.TryCatch_NewExpression_BuiltInErrors/Scope/Block_L6C12,
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.TryCatch_NewExpression_BuiltInErrors/Scope::.ctor()
@@ -106,8 +105,8 @@
 			IL_0011: box [System.Runtime]System.Double
 			IL_0016: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_001b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-			IL_0020: stloc.s 7
-			IL_0022: ldloc.s 7
+			IL_0020: stloc.s 6
+			IL_0022: ldloc.s 6
 			IL_0024: stloc.1
 			IL_0025: ldloc.1
 			IL_0026: isinst [System.Runtime]System.Exception
@@ -121,7 +120,7 @@
 
 			IL_0039: throw
 
-			IL_003a: leave IL_009f
+			IL_003a: leave IL_0098
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -147,133 +146,131 @@
 			IL_0067: stloc.3
 
 			IL_0068: ldloc.3
-			IL_0069: stloc.s 7
-			IL_006b: ldloc.s 7
+			IL_0069: stloc.s 6
+			IL_006b: ldloc.s 6
 			IL_006d: stloc.s 4
-			IL_006f: newobj instance void Modules.TryCatch_NewExpression_BuiltInErrors/Scope/Block_L6C12::.ctor()
-			IL_0074: stloc.s 5
-			IL_0076: ldstr "console"
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0080: stloc.s 7
-			IL_0082: ldloc.s 7
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0089: stloc.s 7
-			IL_008b: ldloc.s 7
-			IL_008d: ldstr "log"
-			IL_0092: ldloc.s 4
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0099: pop
-			IL_009a: leave IL_009f
+			IL_006f: ldstr "console"
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0079: stloc.s 6
+			IL_007b: ldloc.s 6
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0082: stloc.s 6
+			IL_0084: ldloc.s 6
+			IL_0086: ldstr "log"
+			IL_008b: ldloc.s 4
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0092: pop
+			IL_0093: leave IL_0098
 		} // end handler
 
-		IL_009f: ldstr "console"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a9: stloc.s 7
-		IL_00ab: ldloc.s 7
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b2: stloc.s 7
-		IL_00b4: ldstr "boom"
-		IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-		IL_00c3: stloc.s 8
+		IL_0098: ldstr "console"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a2: stloc.s 6
+		IL_00a4: ldloc.s 6
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ab: stloc.s 6
+		IL_00ad: ldstr "boom"
+		IL_00b2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+		IL_00bc: stloc.s 7
+		IL_00be: ldloc.s 6
+		IL_00c0: ldstr "log"
 		IL_00c5: ldloc.s 7
-		IL_00c7: ldstr "log"
-		IL_00cc: ldloc.s 8
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldstr "console"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: stloc.s 8
-		IL_00e0: ldloc.s 8
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e7: stloc.s 8
-		IL_00e9: ldstr "eval"
-		IL_00ee: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.EvalError::.ctor(string)
-		IL_00f8: stloc.s 7
-		IL_00fa: ldloc.s 8
-		IL_00fc: ldstr "log"
-		IL_0101: ldloc.s 7
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0108: pop
-		IL_0109: ldstr "console"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0113: stloc.s 7
-		IL_0115: ldloc.s 7
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011c: stloc.s 7
-		IL_011e: ldstr "range"
-		IL_0123: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RangeError::.ctor(string)
-		IL_012d: stloc.s 8
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00cc: pop
+		IL_00cd: ldstr "console"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d7: stloc.s 7
+		IL_00d9: ldloc.s 7
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e0: stloc.s 7
+		IL_00e2: ldstr "eval"
+		IL_00e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.EvalError::.ctor(string)
+		IL_00f1: stloc.s 6
+		IL_00f3: ldloc.s 7
+		IL_00f5: ldstr "log"
+		IL_00fa: ldloc.s 6
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0101: pop
+		IL_0102: ldstr "console"
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010c: stloc.s 6
+		IL_010e: ldloc.s 6
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0115: stloc.s 6
+		IL_0117: ldstr "range"
+		IL_011c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RangeError::.ctor(string)
+		IL_0126: stloc.s 7
+		IL_0128: ldloc.s 6
+		IL_012a: ldstr "log"
 		IL_012f: ldloc.s 7
-		IL_0131: ldstr "log"
-		IL_0136: ldloc.s 8
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_013d: pop
-		IL_013e: ldstr "console"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0148: stloc.s 8
-		IL_014a: ldloc.s 8
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: stloc.s 8
-		IL_0153: ldstr "ref"
-		IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-		IL_0162: stloc.s 7
-		IL_0164: ldloc.s 8
-		IL_0166: ldstr "log"
-		IL_016b: ldloc.s 7
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0172: pop
-		IL_0173: ldstr "console"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017d: stloc.s 7
-		IL_017f: ldloc.s 7
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0186: stloc.s 7
-		IL_0188: ldstr "syntax"
-		IL_018d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0192: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.SyntaxError::.ctor(string)
-		IL_0197: stloc.s 8
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0136: pop
+		IL_0137: ldstr "console"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0141: stloc.s 7
+		IL_0143: ldloc.s 7
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014a: stloc.s 7
+		IL_014c: ldstr "ref"
+		IL_0151: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+		IL_015b: stloc.s 6
+		IL_015d: ldloc.s 7
+		IL_015f: ldstr "log"
+		IL_0164: ldloc.s 6
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_016b: pop
+		IL_016c: ldstr "console"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0176: stloc.s 6
+		IL_0178: ldloc.s 6
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017f: stloc.s 6
+		IL_0181: ldstr "syntax"
+		IL_0186: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_018b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.SyntaxError::.ctor(string)
+		IL_0190: stloc.s 7
+		IL_0192: ldloc.s 6
+		IL_0194: ldstr "log"
 		IL_0199: ldloc.s 7
-		IL_019b: ldstr "log"
-		IL_01a0: ldloc.s 8
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ldstr "console"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b2: stloc.s 8
-		IL_01b4: ldloc.s 8
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bb: stloc.s 8
-		IL_01bd: ldstr "uri"
-		IL_01c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_01c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.URIError::.ctor(string)
-		IL_01cc: stloc.s 7
-		IL_01ce: ldloc.s 8
-		IL_01d0: ldstr "log"
-		IL_01d5: ldloc.s 7
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01dc: pop
-		IL_01dd: ldstr "console"
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e7: stloc.s 7
-		IL_01e9: ldloc.s 7
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f0: stloc.s 7
-		IL_01f2: ldstr "agg"
-		IL_01f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.AggregateError::.ctor(string)
-		IL_0201: stloc.s 8
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01a0: pop
+		IL_01a1: ldstr "console"
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ab: stloc.s 7
+		IL_01ad: ldloc.s 7
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b4: stloc.s 7
+		IL_01b6: ldstr "uri"
+		IL_01bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_01c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.URIError::.ctor(string)
+		IL_01c5: stloc.s 6
+		IL_01c7: ldloc.s 7
+		IL_01c9: ldstr "log"
+		IL_01ce: ldloc.s 6
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d5: pop
+		IL_01d6: ldstr "console"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e0: stloc.s 6
+		IL_01e2: ldloc.s 6
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e9: stloc.s 6
+		IL_01eb: ldstr "agg"
+		IL_01f0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_01f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.AggregateError::.ctor(string)
+		IL_01fa: stloc.s 7
+		IL_01fc: ldloc.s 6
+		IL_01fe: ldstr "log"
 		IL_0203: ldloc.s 7
-		IL_0205: ldstr "log"
-		IL_020a: ldloc.s 8
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0211: pop
-		IL_0212: ldnull
-		IL_0213: stloc.s 6
-		IL_0215: ret
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_020a: pop
+		IL_020b: ldnull
+		IL_020c: stloc.s 5
+		IL_020e: ret
 	} // end of method TryCatch_NewExpression_BuiltInErrors::__js_module_init__
 
 } // end of class Modules.TryCatch_NewExpression_BuiltInErrors
@@ -285,7 +282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x229f
+		// Method begins at RVA 0x2297
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_UnknownGlobalIdentifier.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_UnknownGlobalIdentifier.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2161
+				// Method begins at RVA 0x215d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216a
+				// Method begins at RVA 0x2166
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2158
+			// Method begins at RVA 0x2154
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,16 +82,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 236 (0xec)
+		// Code size: 229 (0xe5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope,
 			[1] class [System.Runtime]System.Exception,
 			[2] object,
 			[3] object,
-			[4] class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope/Block_L6C12,
-			[5] object,
-			[6] object
+			[4] object,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope::.ctor()
@@ -102,8 +101,8 @@
 			IL_0007: nop
 			IL_0008: ldstr "Enumerator"
 			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0012: stloc.s 6
-			IL_0014: ldloc.s 6
+			IL_0012: stloc.s 5
+			IL_0014: ldloc.s 5
 			IL_0016: ldc.i4.1
 			IL_0017: newarr [System.Runtime]System.Object
 			IL_001c: dup
@@ -115,16 +114,16 @@
 			IL_0032: pop
 			IL_0033: ldstr "console"
 			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_003d: stloc.s 6
-			IL_003f: ldloc.s 6
+			IL_003d: stloc.s 5
+			IL_003f: ldloc.s 5
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0046: stloc.s 6
-			IL_0048: ldloc.s 6
+			IL_0046: stloc.s 5
+			IL_0048: ldloc.s 5
 			IL_004a: ldstr "log"
 			IL_004f: ldstr "unreachable"
 			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0059: pop
-			IL_005a: leave IL_00c1
+			IL_005a: leave IL_00ba
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -150,39 +149,37 @@
 			IL_0087: stloc.2
 
 			IL_0088: ldloc.2
-			IL_0089: stloc.s 6
-			IL_008b: ldloc.s 6
+			IL_0089: stloc.s 5
+			IL_008b: ldloc.s 5
 			IL_008d: stloc.3
-			IL_008e: newobj instance void Modules.TryCatch_NewExpression_UnknownGlobalIdentifier/Scope/Block_L6C12::.ctor()
-			IL_0093: stloc.s 4
-			IL_0095: ldstr "console"
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009f: stloc.s 6
-			IL_00a1: ldloc.s 6
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a8: stloc.s 6
-			IL_00aa: ldloc.s 6
-			IL_00ac: ldstr "log"
-			IL_00b1: ldstr "caught"
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00bb: pop
-			IL_00bc: leave IL_00c1
+			IL_008e: ldstr "console"
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0098: stloc.s 5
+			IL_009a: ldloc.s 5
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a1: stloc.s 5
+			IL_00a3: ldloc.s 5
+			IL_00a5: ldstr "log"
+			IL_00aa: ldstr "caught"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00b4: pop
+			IL_00b5: leave IL_00ba
 		} // end handler
 
-		IL_00c1: ldstr "console"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cb: stloc.s 6
-		IL_00cd: ldloc.s 6
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d4: stloc.s 6
-		IL_00d6: ldloc.s 6
-		IL_00d8: ldstr "log"
-		IL_00dd: ldstr "done"
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e7: pop
-		IL_00e8: ldnull
-		IL_00e9: stloc.s 5
-		IL_00eb: ret
+		IL_00ba: ldstr "console"
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c4: stloc.s 5
+		IL_00c6: ldloc.s 5
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cd: stloc.s 5
+		IL_00cf: ldloc.s 5
+		IL_00d1: ldstr "log"
+		IL_00d6: ldstr "done"
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e0: pop
+		IL_00e1: ldnull
+		IL_00e2: stloc.s 4
+		IL_00e4: ret
 	} // end of method TryCatch_NewExpression_UnknownGlobalIdentifier::__js_module_init__
 
 } // end of class Modules.TryCatch_NewExpression_UnknownGlobalIdentifier
@@ -194,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2173
+		// Method begins at RVA 0x216f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NoBinding_NoThrow.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2159
+				// Method begins at RVA 0x2151
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2162
+				// Method begins at RVA 0x215a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2150
+			// Method begins at RVA 0x2148
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,18 +82,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 225 (0xe1)
+		// Code size: 219 (0xdb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_NoBinding_NoThrow/Scope,
 			[1] float64,
-			[2] class Modules.TryCatch_NoBinding_NoThrow/Scope/Block_L5C4,
-			[3] float64,
-			[4] class [System.Runtime]System.Exception,
+			[2] float64,
+			[3] class [System.Runtime]System.Exception,
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] float64,
-			[8] object
+			[6] float64,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.TryCatch_NoBinding_NoThrow/Scope::.ctor()
@@ -103,75 +102,74 @@
 		IL_0010: stloc.1
 		IL_0011: ldstr "console"
 		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_001b: stloc.s 6
-		IL_001d: ldloc.s 6
+		IL_001b: stloc.s 5
+		IL_001d: ldloc.s 5
 		IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0024: stloc.s 6
-		IL_0026: ldloc.s 6
+		IL_0024: stloc.s 5
+		IL_0026: ldloc.s 5
 		IL_0028: ldstr "log"
 		IL_002d: ldstr "before try"
 		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0037: pop
 		.try
 		{
-			IL_0038: newobj instance void Modules.TryCatch_NoBinding_NoThrow/Scope/Block_L5C4::.ctor()
-			IL_003d: stloc.2
-			IL_003e: ldloc.1
-			IL_003f: stloc.s 7
-			IL_0041: ldloc.s 7
-			IL_0043: ldc.r8 4
-			IL_004c: add
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 7
-			IL_0051: stloc.3
-			IL_0052: ldstr "console"
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005c: stloc.s 6
-			IL_005e: ldloc.s 6
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0065: stloc.s 6
-			IL_0067: ldloc.3
-			IL_0068: box [System.Runtime]System.Double
-			IL_006d: stloc.s 8
-			IL_006f: ldloc.s 6
-			IL_0071: ldstr "log"
-			IL_0076: ldstr "Inside catch.  Calculated value is"
-			IL_007b: ldloc.s 8
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0082: pop
-			IL_0083: leave IL_00b6
+			IL_0038: nop
+			IL_0039: ldloc.1
+			IL_003a: stloc.s 6
+			IL_003c: ldloc.s 6
+			IL_003e: ldc.r8 4
+			IL_0047: add
+			IL_0048: stloc.s 6
+			IL_004a: ldloc.s 6
+			IL_004c: stloc.2
+			IL_004d: ldstr "console"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0057: stloc.s 5
+			IL_0059: ldloc.s 5
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0060: stloc.s 5
+			IL_0062: ldloc.2
+			IL_0063: box [System.Runtime]System.Double
+			IL_0068: stloc.s 7
+			IL_006a: ldloc.s 5
+			IL_006c: ldstr "log"
+			IL_0071: ldstr "Inside catch.  Calculated value is"
+			IL_0076: ldloc.s 7
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_007d: pop
+			IL_007e: leave IL_00b0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0088: stloc.s 4
-			IL_008a: ldstr "console"
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0094: stloc.s 6
-			IL_0096: ldloc.s 6
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009d: stloc.s 6
-			IL_009f: ldloc.s 6
-			IL_00a1: ldstr "log"
-			IL_00a6: ldstr "inside catch.. we should not be here"
-			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00b0: pop
-			IL_00b1: leave IL_00b6
+			IL_0083: stloc.3
+			IL_0084: ldstr "console"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_008e: stloc.s 5
+			IL_0090: ldloc.s 5
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0097: stloc.s 5
+			IL_0099: ldloc.s 5
+			IL_009b: ldstr "log"
+			IL_00a0: ldstr "inside catch.. we should not be here"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00aa: pop
+			IL_00ab: leave IL_00b0
 		} // end handler
 
-		IL_00b6: ldstr "console"
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c0: stloc.s 6
-		IL_00c2: ldloc.s 6
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c9: stloc.s 6
-		IL_00cb: ldloc.s 6
-		IL_00cd: ldstr "log"
-		IL_00d2: ldstr "try/catch finished."
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00dc: pop
-		IL_00dd: ldnull
-		IL_00de: stloc.s 5
-		IL_00e0: ret
+		IL_00b0: ldstr "console"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.s 5
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c3: stloc.s 5
+		IL_00c5: ldloc.s 5
+		IL_00c7: ldstr "log"
+		IL_00cc: ldstr "try/catch finished."
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00d6: pop
+		IL_00d7: ldnull
+		IL_00d8: stloc.s 4
+		IL_00da: ret
 	} // end of method TryCatch_NoBinding_NoThrow::__js_module_init__
 
 } // end of class Modules.TryCatch_NoBinding_NoThrow
@@ -183,7 +181,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216b
+		// Method begins at RVA 0x2163
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_ScopedParam.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_ScopedParam.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212d
+				// Method begins at RVA 0x2129
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2136
+				// Method begins at RVA 0x2132
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2120
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 184 (0xb8)
+		// Code size: 177 (0xb1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_ScopedParam/Scope,
@@ -91,9 +91,8 @@
 			[3] class [System.Runtime]System.Exception,
 			[4] object,
 			[5] object,
-			[6] class Modules.TryCatch_ScopedParam/Scope/Block_L7C12,
-			[7] object,
-			[8] object
+			[6] object,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.TryCatch_ScopedParam/Scope::.ctor()
@@ -118,7 +117,7 @@
 
 			IL_0028: throw
 
-			IL_0029: leave IL_0091
+			IL_0029: leave IL_008a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -144,39 +143,37 @@
 			IL_0057: stloc.s 4
 
 			IL_0059: ldloc.s 4
-			IL_005b: stloc.s 8
-			IL_005d: ldloc.s 8
+			IL_005b: stloc.s 7
+			IL_005d: ldloc.s 7
 			IL_005f: stloc.s 5
-			IL_0061: newobj instance void Modules.TryCatch_ScopedParam/Scope/Block_L7C12::.ctor()
-			IL_0066: stloc.s 6
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.s 8
-			IL_0074: ldloc.s 8
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007b: stloc.s 8
-			IL_007d: ldloc.s 8
-			IL_007f: ldstr "log"
-			IL_0084: ldloc.s 5
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008b: pop
-			IL_008c: leave IL_0091
+			IL_0061: ldstr "console"
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006b: stloc.s 7
+			IL_006d: ldloc.s 7
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0074: stloc.s 7
+			IL_0076: ldloc.s 7
+			IL_0078: ldstr "log"
+			IL_007d: ldloc.s 5
+			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0084: pop
+			IL_0085: leave IL_008a
 		} // end handler
 
-		IL_0091: ldstr "console"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009b: stloc.s 8
-		IL_009d: ldloc.s 8
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: stloc.s 8
-		IL_00a6: ldloc.s 8
-		IL_00a8: ldstr "log"
-		IL_00ad: ldloc.1
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00b3: pop
-		IL_00b4: ldnull
-		IL_00b5: stloc.s 7
-		IL_00b7: ret
+		IL_008a: ldstr "console"
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0094: stloc.s 7
+		IL_0096: ldloc.s 7
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009d: stloc.s 7
+		IL_009f: ldloc.s 7
+		IL_00a1: ldstr "log"
+		IL_00a6: ldloc.1
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ac: pop
+		IL_00ad: ldnull
+		IL_00ae: stloc.s 6
+		IL_00b0: ret
 	} // end of method TryCatch_ScopedParam::__js_module_init__
 
 } // end of class Modules.TryCatch_ScopedParam
@@ -188,7 +185,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x213f
+		// Method begins at RVA 0x213b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ed
+				// Method begins at RVA 0x21e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f6
+				// Method begins at RVA 0x21ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ff
+				// Method begins at RVA 0x21f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2208
+				// Method begins at RVA 0x21fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e4
+			// Method begins at RVA 0x21d8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 363 (0x16b)
+		// Code size: 349 (0x15d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_BoundsChecks_RangeError/Scope,
@@ -131,15 +131,13 @@
 			[3] class [System.Runtime]System.Exception,
 			[4] object,
 			[5] object,
-			[6] class Modules.DataView_BoundsChecks_RangeError/Scope/Block_L8C12,
-			[7] class [System.Runtime]System.Exception,
+			[6] class [System.Runtime]System.Exception,
+			[7] object,
 			[8] object,
 			[9] object,
-			[10] class Modules.DataView_BoundsChecks_RangeError/Scope/Block_L14C12,
-			[11] object,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
-			[13] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[14] object
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[12] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_BoundsChecks_RangeError/Scope::.ctor()
@@ -148,8 +146,8 @@
 		IL_0007: ldc.r8 4
 		IL_0010: box [System.Runtime]System.Double
 		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
-		IL_001a: stloc.s 12
-		IL_001c: ldloc.s 12
+		IL_001a: stloc.s 10
+		IL_001c: ldloc.s 10
 		IL_001e: stloc.1
 		IL_001f: ldloc.1
 		IL_0020: ldc.r8 1
@@ -157,22 +155,22 @@
 		IL_002e: ldc.r8 2
 		IL_0037: box [System.Runtime]System.Double
 		IL_003c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object, object)
-		IL_0041: stloc.s 13
-		IL_0043: ldloc.s 13
+		IL_0041: stloc.s 11
+		IL_0043: ldloc.s 11
 		IL_0045: stloc.2
 		.try
 		{
 			IL_0046: nop
 			IL_0047: ldloc.2
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004d: stloc.s 14
-			IL_004f: ldloc.s 14
+			IL_004d: stloc.s 12
+			IL_004f: ldloc.s 12
 			IL_0051: ldstr "getUint32"
 			IL_0056: ldc.r8 0.0
 			IL_005f: box [System.Runtime]System.Double
 			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0069: pop
-			IL_006a: leave IL_00dc
+			IL_006a: leave IL_00d5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -198,84 +196,80 @@
 			IL_0098: stloc.s 4
 
 			IL_009a: ldloc.s 4
-			IL_009c: stloc.s 14
-			IL_009e: ldloc.s 14
+			IL_009c: stloc.s 12
+			IL_009e: ldloc.s 12
 			IL_00a0: stloc.s 5
-			IL_00a2: newobj instance void Modules.DataView_BoundsChecks_RangeError/Scope/Block_L8C12::.ctor()
-			IL_00a7: stloc.s 6
-			IL_00a9: ldstr "console"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b3: stloc.s 14
-			IL_00b5: ldloc.s 14
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bc: stloc.s 14
-			IL_00be: ldloc.s 14
-			IL_00c0: ldstr "log"
-			IL_00c5: ldloc.s 5
-			IL_00c7: ldstr "name"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00d6: pop
-			IL_00d7: leave IL_00dc
+			IL_00a2: ldstr "console"
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ac: stloc.s 12
+			IL_00ae: ldloc.s 12
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b5: stloc.s 12
+			IL_00b7: ldloc.s 12
+			IL_00b9: ldstr "log"
+			IL_00be: ldloc.s 5
+			IL_00c0: ldstr "name"
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cf: pop
+			IL_00d0: leave IL_00d5
 		} // end handler
 		.try
 		{
-			IL_00dc: nop
-			IL_00dd: ldloc.1
-			IL_00de: ldc.r8 5
-			IL_00e7: box [System.Runtime]System.Double
-			IL_00ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
-			IL_00f1: pop
-			IL_00f2: leave IL_0167
+			IL_00d5: nop
+			IL_00d6: ldloc.1
+			IL_00d7: ldc.r8 5
+			IL_00e0: box [System.Runtime]System.Double
+			IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
+			IL_00ea: pop
+			IL_00eb: leave IL_0159
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00f7: stloc.s 7
-			IL_00f9: ldloc.s 7
-			IL_00fb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0100: dup
-			IL_0101: brtrue IL_0117
+			IL_00f0: stloc.s 6
+			IL_00f2: ldloc.s 6
+			IL_00f4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00f9: dup
+			IL_00fa: brtrue IL_0110
 
-			IL_0106: pop
-			IL_0107: ldloc.s 7
-			IL_0109: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_010e: dup
-			IL_010f: brtrue IL_0123
+			IL_00ff: pop
+			IL_0100: ldloc.s 6
+			IL_0102: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0107: dup
+			IL_0108: brtrue IL_011c
 
-			IL_0114: pop
-			IL_0115: rethrow
+			IL_010d: pop
+			IL_010e: rethrow
 
-			IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_011c: stloc.s 8
-			IL_011e: br IL_0125
+			IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0115: stloc.s 7
+			IL_0117: br IL_011e
 
-			IL_0123: stloc.s 8
+			IL_011c: stloc.s 7
 
-			IL_0125: ldloc.s 8
-			IL_0127: stloc.s 14
-			IL_0129: ldloc.s 14
-			IL_012b: stloc.s 9
-			IL_012d: newobj instance void Modules.DataView_BoundsChecks_RangeError/Scope/Block_L14C12::.ctor()
-			IL_0132: stloc.s 10
-			IL_0134: ldstr "console"
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_013e: stloc.s 14
-			IL_0140: ldloc.s 14
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0147: stloc.s 14
-			IL_0149: ldloc.s 14
-			IL_014b: ldstr "log"
-			IL_0150: ldloc.s 9
-			IL_0152: ldstr "name"
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0161: pop
-			IL_0162: leave IL_0167
+			IL_011e: ldloc.s 7
+			IL_0120: stloc.s 12
+			IL_0122: ldloc.s 12
+			IL_0124: stloc.s 8
+			IL_0126: ldstr "console"
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0130: stloc.s 12
+			IL_0132: ldloc.s 12
+			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0139: stloc.s 12
+			IL_013b: ldloc.s 12
+			IL_013d: ldstr "log"
+			IL_0142: ldloc.s 8
+			IL_0144: ldstr "name"
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0153: pop
+			IL_0154: leave IL_0159
 		} // end handler
 
-		IL_0167: ldnull
-		IL_0168: stloc.s 11
-		IL_016a: ret
+		IL_0159: ldnull
+		IL_015a: stloc.s 9
+		IL_015c: ret
 	} // end of method DataView_BoundsChecks_RangeError::__js_module_init__
 
 } // end of class Modules.DataView_BoundsChecks_RangeError
@@ -287,7 +281,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2211
+		// Method begins at RVA 0x2205
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_InvalidByteOffset_ByteLength_Messages.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_InvalidByteOffset_ByteLength_Messages.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2295
+				// Method begins at RVA 0x2279
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229e
+				// Method begins at RVA 0x2282
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a7
+				// Method begins at RVA 0x228b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b0
+				// Method begins at RVA 0x2294
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x2270
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,27 +122,23 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 530 (0x212)
+		// Code size: 502 (0x1f6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
-			[2] class Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L5C4,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[4] class [System.Runtime]System.Exception,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[3] class [System.Runtime]System.Exception,
+			[4] object,
 			[5] object,
-			[6] object,
-			[7] class Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L8C12,
-			[8] class Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L13C4,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[10] class [System.Runtime]System.Exception,
-			[11] object,
-			[12] object,
-			[13] class Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L16C12,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
-			[16] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
-			[17] object
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[7] class [System.Runtime]System.Exception,
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.DataView,
+			[13] object
 		)
 
 		IL_0000: newobj instance void Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope::.ctor()
@@ -151,181 +147,175 @@
 		IL_0007: ldc.r8 4
 		IL_0010: box [System.Runtime]System.Double
 		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
-		IL_001a: stloc.s 15
-		IL_001c: ldloc.s 15
+		IL_001a: stloc.s 11
+		IL_001c: ldloc.s 11
 		IL_001e: stloc.1
 		.try
 		{
-			IL_001f: newobj instance void Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L5C4::.ctor()
-			IL_0024: stloc.2
-			IL_0025: ldloc.1
-			IL_0026: ldc.r8 5
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
-			IL_0039: stloc.s 16
-			IL_003b: ldloc.s 16
-			IL_003d: stloc.3
-			IL_003e: ldstr "console"
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0048: stloc.s 17
-			IL_004a: ldloc.s 17
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0051: stloc.s 17
-			IL_0053: ldloc.s 17
-			IL_0055: ldstr "log"
-			IL_005a: ldloc.3
-			IL_005b: ldstr "byteLength"
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_006a: pop
-			IL_006b: leave IL_010e
+			IL_001f: nop
+			IL_0020: ldloc.1
+			IL_0021: ldc.r8 5
+			IL_002a: box [System.Runtime]System.Double
+			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
+			IL_0034: stloc.s 12
+			IL_0036: ldloc.s 12
+			IL_0038: stloc.2
+			IL_0039: ldstr "console"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0043: stloc.s 13
+			IL_0045: ldloc.s 13
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004c: stloc.s 13
+			IL_004e: ldloc.s 13
+			IL_0050: ldstr "log"
+			IL_0055: ldloc.2
+			IL_0056: ldstr "byteLength"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0065: pop
+			IL_0066: leave IL_00ff
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0070: stloc.s 4
-			IL_0072: ldloc.s 4
-			IL_0074: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0079: dup
-			IL_007a: brtrue IL_0090
+			IL_006b: stloc.3
+			IL_006c: ldloc.3
+			IL_006d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0072: dup
+			IL_0073: brtrue IL_0088
 
-			IL_007f: pop
-			IL_0080: ldloc.s 4
-			IL_0082: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0087: dup
-			IL_0088: brtrue IL_009c
+			IL_0078: pop
+			IL_0079: ldloc.3
+			IL_007a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_007f: dup
+			IL_0080: brtrue IL_0094
 
-			IL_008d: pop
-			IL_008e: rethrow
+			IL_0085: pop
+			IL_0086: rethrow
 
-			IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0095: stloc.s 5
-			IL_0097: br IL_009e
+			IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_008d: stloc.s 4
+			IL_008f: br IL_0096
 
+			IL_0094: stloc.s 4
+
+			IL_0096: ldloc.s 4
+			IL_0098: stloc.s 13
+			IL_009a: ldloc.s 13
 			IL_009c: stloc.s 5
-
-			IL_009e: ldloc.s 5
-			IL_00a0: stloc.s 17
-			IL_00a2: ldloc.s 17
-			IL_00a4: stloc.s 6
-			IL_00a6: newobj instance void Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L8C12::.ctor()
-			IL_00ab: stloc.s 7
-			IL_00ad: ldstr "console"
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b7: stloc.s 17
-			IL_00b9: ldloc.s 17
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c0: stloc.s 17
-			IL_00c2: ldloc.s 17
-			IL_00c4: ldstr "log"
-			IL_00c9: ldloc.s 6
-			IL_00cb: ldstr "name"
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00da: pop
-			IL_00db: ldstr "console"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e5: stloc.s 17
-			IL_00e7: ldloc.s 17
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ee: stloc.s 17
-			IL_00f0: ldloc.s 17
-			IL_00f2: ldstr "log"
-			IL_00f7: ldloc.s 6
-			IL_00f9: ldstr "message"
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0108: pop
-			IL_0109: leave IL_010e
+			IL_009e: ldstr "console"
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a8: stloc.s 13
+			IL_00aa: ldloc.s 13
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b1: stloc.s 13
+			IL_00b3: ldloc.s 13
+			IL_00b5: ldstr "log"
+			IL_00ba: ldloc.s 5
+			IL_00bc: ldstr "name"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cb: pop
+			IL_00cc: ldstr "console"
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00d6: stloc.s 13
+			IL_00d8: ldloc.s 13
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00df: stloc.s 13
+			IL_00e1: ldloc.s 13
+			IL_00e3: ldstr "log"
+			IL_00e8: ldloc.s 5
+			IL_00ea: ldstr "message"
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00f9: pop
+			IL_00fa: leave IL_00ff
 		} // end handler
 		.try
 		{
-			IL_010e: newobj instance void Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L13C4::.ctor()
-			IL_0113: stloc.s 8
-			IL_0115: ldloc.1
-			IL_0116: ldc.r8 0.0
-			IL_011f: box [System.Runtime]System.Double
-			IL_0124: ldc.r8 5
-			IL_012d: box [System.Runtime]System.Double
-			IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object, object)
-			IL_0137: stloc.s 16
-			IL_0139: ldloc.s 16
-			IL_013b: stloc.s 9
-			IL_013d: ldstr "console"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0147: stloc.s 17
-			IL_0149: ldloc.s 17
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0150: stloc.s 17
-			IL_0152: ldloc.s 17
-			IL_0154: ldstr "log"
-			IL_0159: ldloc.s 9
-			IL_015b: ldstr "byteLength"
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_016a: pop
-			IL_016b: leave IL_020e
+			IL_00ff: nop
+			IL_0100: ldloc.1
+			IL_0101: ldc.r8 0.0
+			IL_010a: box [System.Runtime]System.Double
+			IL_010f: ldc.r8 5
+			IL_0118: box [System.Runtime]System.Double
+			IL_011d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object, object)
+			IL_0122: stloc.s 12
+			IL_0124: ldloc.s 12
+			IL_0126: stloc.s 6
+			IL_0128: ldstr "console"
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0132: stloc.s 13
+			IL_0134: ldloc.s 13
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013b: stloc.s 13
+			IL_013d: ldloc.s 13
+			IL_013f: ldstr "log"
+			IL_0144: ldloc.s 6
+			IL_0146: ldstr "byteLength"
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0155: pop
+			IL_0156: leave IL_01f2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0170: stloc.s 10
-			IL_0172: ldloc.s 10
-			IL_0174: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0179: dup
-			IL_017a: brtrue IL_0190
+			IL_015b: stloc.s 7
+			IL_015d: ldloc.s 7
+			IL_015f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0164: dup
+			IL_0165: brtrue IL_017b
 
-			IL_017f: pop
-			IL_0180: ldloc.s 10
-			IL_0182: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0187: dup
-			IL_0188: brtrue IL_019c
+			IL_016a: pop
+			IL_016b: ldloc.s 7
+			IL_016d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0172: dup
+			IL_0173: brtrue IL_0187
 
-			IL_018d: pop
-			IL_018e: rethrow
+			IL_0178: pop
+			IL_0179: rethrow
 
-			IL_0190: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0195: stloc.s 11
-			IL_0197: br IL_019e
+			IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0180: stloc.s 8
+			IL_0182: br IL_0189
 
-			IL_019c: stloc.s 11
+			IL_0187: stloc.s 8
 
-			IL_019e: ldloc.s 11
-			IL_01a0: stloc.s 17
-			IL_01a2: ldloc.s 17
-			IL_01a4: stloc.s 12
-			IL_01a6: newobj instance void Modules.DataView_InvalidByteOffset_ByteLength_Messages/Scope/Block_L16C12::.ctor()
-			IL_01ab: stloc.s 13
-			IL_01ad: ldstr "console"
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b7: stloc.s 17
-			IL_01b9: ldloc.s 17
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c0: stloc.s 17
-			IL_01c2: ldloc.s 17
-			IL_01c4: ldstr "log"
-			IL_01c9: ldloc.s 12
-			IL_01cb: ldstr "name"
-			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01da: pop
-			IL_01db: ldstr "console"
-			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e5: stloc.s 17
-			IL_01e7: ldloc.s 17
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 17
-			IL_01f0: ldloc.s 17
-			IL_01f2: ldstr "log"
-			IL_01f7: ldloc.s 12
-			IL_01f9: ldstr "message"
-			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0208: pop
-			IL_0209: leave IL_020e
+			IL_0189: ldloc.s 8
+			IL_018b: stloc.s 13
+			IL_018d: ldloc.s 13
+			IL_018f: stloc.s 9
+			IL_0191: ldstr "console"
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_019b: stloc.s 13
+			IL_019d: ldloc.s 13
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a4: stloc.s 13
+			IL_01a6: ldloc.s 13
+			IL_01a8: ldstr "log"
+			IL_01ad: ldloc.s 9
+			IL_01af: ldstr "name"
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01be: pop
+			IL_01bf: ldstr "console"
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c9: stloc.s 13
+			IL_01cb: ldloc.s 13
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d2: stloc.s 13
+			IL_01d4: ldloc.s 13
+			IL_01d6: ldstr "log"
+			IL_01db: ldloc.s 9
+			IL_01dd: ldstr "message"
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01ec: pop
+			IL_01ed: leave IL_01f2
 		} // end handler
 
-		IL_020e: ldnull
-		IL_020f: stloc.s 14
-		IL_0211: ret
+		IL_01f2: ldnull
+		IL_01f3: stloc.s 10
+		IL_01f5: ret
 	} // end of method DataView_InvalidByteOffset_ByteLength_Messages::__js_module_init__
 
 } // end of class Modules.DataView_InvalidByteOffset_ByteLength_Messages
@@ -337,7 +327,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b9
+		// Method begins at RVA 0x229d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Construct_ArrayBuffer_Alignment_RangeError.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Construct_ArrayBuffer_Alignment_RangeError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2211
+				// Method begins at RVA 0x2205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221a
+				// Method begins at RVA 0x220e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2223
+				// Method begins at RVA 0x2217
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222c
+				// Method begins at RVA 0x2220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21fc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -122,7 +122,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 399 (0x18f)
+		// Code size: 385 (0x181)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError/Scope,
@@ -130,14 +130,12 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError/Scope/Block_L7C12,
-			[6] class [System.Runtime]System.Exception,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
 			[7] object,
 			[8] object,
-			[9] class Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError/Scope/Block_L14C12,
-			[10] object,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
-			[12] object
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer,
+			[10] object
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError/Scope::.ctor()
@@ -146,8 +144,8 @@
 		IL_0007: ldc.r8 16
 		IL_0010: box [System.Runtime]System.Double
 		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ArrayBuffer::.ctor(object)
-		IL_001a: stloc.s 11
-		IL_001c: ldloc.s 11
+		IL_001a: stloc.s 9
+		IL_001c: ldloc.s 9
 		IL_001e: stloc.1
 		.try
 		{
@@ -157,7 +155,7 @@
 			IL_002a: box [System.Runtime]System.Double
 			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object, object)
 			IL_0034: pop
-			IL_0035: leave IL_00d2
+			IL_0035: leave IL_00cb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -183,110 +181,106 @@
 			IL_0062: stloc.3
 
 			IL_0063: ldloc.3
-			IL_0064: stloc.s 12
-			IL_0066: ldloc.s 12
+			IL_0064: stloc.s 10
+			IL_0066: ldloc.s 10
 			IL_0068: stloc.s 4
-			IL_006a: newobj instance void Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError/Scope/Block_L7C12::.ctor()
-			IL_006f: stloc.s 5
-			IL_0071: ldstr "console"
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_007b: stloc.s 12
-			IL_007d: ldloc.s 12
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0084: stloc.s 12
-			IL_0086: ldloc.s 12
-			IL_0088: ldstr "log"
-			IL_008d: ldloc.s 4
-			IL_008f: ldstr "name"
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_009e: pop
-			IL_009f: ldstr "console"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a9: stloc.s 12
-			IL_00ab: ldloc.s 12
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b2: stloc.s 12
-			IL_00b4: ldloc.s 12
-			IL_00b6: ldstr "log"
-			IL_00bb: ldloc.s 4
-			IL_00bd: ldstr "message"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cc: pop
-			IL_00cd: leave IL_00d2
+			IL_006a: ldstr "console"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0074: stloc.s 10
+			IL_0076: ldloc.s 10
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007d: stloc.s 10
+			IL_007f: ldloc.s 10
+			IL_0081: ldstr "log"
+			IL_0086: ldloc.s 4
+			IL_0088: ldstr "name"
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: pop
+			IL_0098: ldstr "console"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a2: stloc.s 10
+			IL_00a4: ldloc.s 10
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ab: stloc.s 10
+			IL_00ad: ldloc.s 10
+			IL_00af: ldstr "log"
+			IL_00b4: ldloc.s 4
+			IL_00b6: ldstr "message"
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c5: pop
+			IL_00c6: leave IL_00cb
 		} // end handler
 		.try
 		{
-			IL_00d2: nop
-			IL_00d3: ldloc.1
-			IL_00d4: ldc.r8 4
-			IL_00dd: box [System.Runtime]System.Double
-			IL_00e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object, object)
-			IL_00e7: pop
-			IL_00e8: leave IL_018b
+			IL_00cb: nop
+			IL_00cc: ldloc.1
+			IL_00cd: ldc.r8 4
+			IL_00d6: box [System.Runtime]System.Double
+			IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object, object)
+			IL_00e0: pop
+			IL_00e1: leave IL_017d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00ed: stloc.s 6
-			IL_00ef: ldloc.s 6
-			IL_00f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00f6: dup
-			IL_00f7: brtrue IL_010d
+			IL_00e6: stloc.s 5
+			IL_00e8: ldloc.s 5
+			IL_00ea: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00ef: dup
+			IL_00f0: brtrue IL_0106
 
-			IL_00fc: pop
-			IL_00fd: ldloc.s 6
-			IL_00ff: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0104: dup
-			IL_0105: brtrue IL_0119
+			IL_00f5: pop
+			IL_00f6: ldloc.s 5
+			IL_00f8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00fd: dup
+			IL_00fe: brtrue IL_0112
 
-			IL_010a: pop
-			IL_010b: rethrow
+			IL_0103: pop
+			IL_0104: rethrow
 
-			IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0112: stloc.s 7
-			IL_0114: br IL_011b
+			IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_010b: stloc.s 6
+			IL_010d: br IL_0114
 
-			IL_0119: stloc.s 7
+			IL_0112: stloc.s 6
 
-			IL_011b: ldloc.s 7
-			IL_011d: stloc.s 12
-			IL_011f: ldloc.s 12
-			IL_0121: stloc.s 8
-			IL_0123: newobj instance void Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError/Scope/Block_L14C12::.ctor()
-			IL_0128: stloc.s 9
-			IL_012a: ldstr "console"
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0134: stloc.s 12
-			IL_0136: ldloc.s 12
-			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013d: stloc.s 12
-			IL_013f: ldloc.s 12
-			IL_0141: ldstr "log"
-			IL_0146: ldloc.s 8
-			IL_0148: ldstr "name"
-			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0157: pop
-			IL_0158: ldstr "console"
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0162: stloc.s 12
-			IL_0164: ldloc.s 12
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016b: stloc.s 12
-			IL_016d: ldloc.s 12
-			IL_016f: ldstr "log"
-			IL_0174: ldloc.s 8
-			IL_0176: ldstr "message"
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0185: pop
-			IL_0186: leave IL_018b
+			IL_0114: ldloc.s 6
+			IL_0116: stloc.s 10
+			IL_0118: ldloc.s 10
+			IL_011a: stloc.s 7
+			IL_011c: ldstr "console"
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0126: stloc.s 10
+			IL_0128: ldloc.s 10
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012f: stloc.s 10
+			IL_0131: ldloc.s 10
+			IL_0133: ldstr "log"
+			IL_0138: ldloc.s 7
+			IL_013a: ldstr "name"
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0149: pop
+			IL_014a: ldstr "console"
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0154: stloc.s 10
+			IL_0156: ldloc.s 10
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015d: stloc.s 10
+			IL_015f: ldloc.s 10
+			IL_0161: ldstr "log"
+			IL_0166: ldloc.s 7
+			IL_0168: ldstr "message"
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0177: pop
+			IL_0178: leave IL_017d
 		} // end handler
 
-		IL_018b: ldnull
-		IL_018c: stloc.s 10
-		IL_018e: ret
+		IL_017d: ldnull
+		IL_017e: stloc.s 8
+		IL_0180: ret
 	} // end of method Int32Array_Construct_ArrayBuffer_Alignment_RangeError::__js_module_init__
 
 } // end of class Modules.Int32Array_Construct_ArrayBuffer_Alignment_RangeError
@@ -298,7 +292,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2235
+		// Method begins at RVA 0x2229
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Set_BoundsChecks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243d
+				// Method begins at RVA 0x242d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2446
+				// Method begins at RVA 0x2436
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244f
+				// Method begins at RVA 0x243f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2458
+				// Method begins at RVA 0x2448
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2410
+			// Method begins at RVA 0x2400
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2422
+				// Method begins at RVA 0x2412
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2419
+			// Method begins at RVA 0x2409
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2434
+				// Method begins at RVA 0x2424
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,7 +180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x242b
+			// Method begins at RVA 0x241b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -206,7 +206,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 917 (0x395)
+		// Code size: 903 (0x387)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Set_BoundsChecks/Scope,
@@ -217,16 +217,14 @@
 			[5] class [System.Runtime]System.Exception,
 			[6] object,
 			[7] object,
-			[8] class Modules.Int32Array_Set_BoundsChecks/Scope/Block_L17C12,
-			[9] class [System.Runtime]System.Exception,
+			[8] class [System.Runtime]System.Exception,
+			[9] object,
 			[10] object,
 			[11] object,
-			[12] class Modules.Int32Array_Set_BoundsChecks/Scope/Block_L24C12,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[13] object,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[15] object,
-			[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[17] float64
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[15] float64
 		)
 
 		IL_0000: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope::.ctor()
@@ -247,12 +245,12 @@
 		IL_003b: ldc.r8 4
 		IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_004e: stloc.s 14
-		IL_0050: ldloc.s 14
+		IL_004e: stloc.s 12
+		IL_0050: ldloc.s 12
 		IL_0052: stloc.1
 		IL_0053: ldloc.1
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: stloc.s 15
+		IL_0059: stloc.s 13
 		IL_005b: ldc.i4.2
 		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_0061: dup
@@ -261,10 +259,10 @@
 		IL_0070: dup
 		IL_0071: ldc.r8 8
 		IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_007f: stloc.s 16
-		IL_0081: ldloc.s 15
+		IL_007f: stloc.s 14
+		IL_0081: ldloc.s 13
 		IL_0083: ldstr "set"
-		IL_0088: ldloc.s 16
+		IL_0088: ldloc.s 14
 		IL_008a: ldc.r8 2
 		IL_0093: box [System.Runtime]System.Double
 		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
@@ -273,8 +271,8 @@
 		IL_00a7: stloc.2
 		// loop start (head: IL_00a8)
 			IL_00a8: ldloc.2
-			IL_00a9: stloc.s 17
-			IL_00ab: ldloc.s 17
+			IL_00a9: stloc.s 15
+			IL_00ab: ldloc.s 15
 			IL_00ad: ldloc.1
 			IL_00ae: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
 			IL_00b3: clt
@@ -282,11 +280,11 @@
 
 			IL_00ba: ldstr "console"
 			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c4: stloc.s 15
-			IL_00c6: ldloc.s 15
+			IL_00c4: stloc.s 13
+			IL_00c6: ldloc.s 13
 			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cd: stloc.s 15
-			IL_00cf: ldloc.s 15
+			IL_00cd: stloc.s 13
+			IL_00cf: ldloc.s 13
 			IL_00d1: ldstr "log"
 			IL_00d6: ldloc.1
 			IL_00d7: ldloc.2
@@ -303,21 +301,21 @@
 
 		IL_00f9: ldloc.1
 		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ff: stloc.s 15
-		IL_0101: ldloc.s 15
+		IL_00ff: stloc.s 13
+		IL_0101: ldloc.s 13
 		IL_0103: ldstr "subarray"
 		IL_0108: ldc.r8 1
 		IL_0111: box [System.Runtime]System.Double
 		IL_0116: ldc.r8 3
 		IL_011f: box [System.Runtime]System.Double
 		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0129: stloc.s 15
-		IL_012b: ldloc.s 15
+		IL_0129: stloc.s 13
+		IL_012b: ldloc.s 13
 		IL_012d: stloc.3
 		IL_012e: ldloc.1
 		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0134: stloc.s 15
-		IL_0136: ldloc.s 15
+		IL_0134: stloc.s 13
+		IL_0136: ldloc.s 13
 		IL_0138: ldstr "set"
 		IL_013d: ldloc.3
 		IL_013e: ldc.r8 0.0
@@ -328,8 +326,8 @@
 		IL_015b: stloc.s 4
 		// loop start (head: IL_015d)
 			IL_015d: ldloc.s 4
-			IL_015f: stloc.s 17
-			IL_0161: ldloc.s 17
+			IL_015f: stloc.s 15
+			IL_0161: ldloc.s 15
 			IL_0163: ldloc.1
 			IL_0164: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_length()
 			IL_0169: clt
@@ -337,11 +335,11 @@
 
 			IL_0170: ldstr "console"
 			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_017a: stloc.s 15
-			IL_017c: ldloc.s 15
+			IL_017a: stloc.s 13
+			IL_017c: ldloc.s 13
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0183: stloc.s 15
-			IL_0185: ldloc.s 15
+			IL_0183: stloc.s 13
+			IL_0185: ldloc.s 13
 			IL_0187: ldstr "log"
 			IL_018c: ldloc.1
 			IL_018d: ldloc.s 4
@@ -360,7 +358,7 @@
 			IL_01b2: nop
 			IL_01b3: ldloc.1
 			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b9: stloc.s 15
+			IL_01b9: stloc.s 13
 			IL_01bb: ldc.i4.3
 			IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_01c1: dup
@@ -372,15 +370,15 @@
 			IL_01df: dup
 			IL_01e0: ldc.r8 5
 			IL_01e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_01ee: stloc.s 16
-			IL_01f0: ldloc.s 15
+			IL_01ee: stloc.s 14
+			IL_01f0: ldloc.s 13
 			IL_01f2: ldstr "set"
-			IL_01f7: ldloc.s 16
+			IL_01f7: ldloc.s 14
 			IL_01f9: ldc.r8 2
 			IL_0202: box [System.Runtime]System.Double
 			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_020c: pop
-			IL_020d: leave IL_02b0
+			IL_020d: leave IL_02a9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -406,122 +404,118 @@
 			IL_023e: stloc.s 6
 
 			IL_0240: ldloc.s 6
-			IL_0242: stloc.s 15
-			IL_0244: ldloc.s 15
+			IL_0242: stloc.s 13
+			IL_0244: ldloc.s 13
 			IL_0246: stloc.s 7
-			IL_0248: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L17C12::.ctor()
-			IL_024d: stloc.s 8
-			IL_024f: ldstr "console"
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0259: stloc.s 15
-			IL_025b: ldloc.s 15
-			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0262: stloc.s 15
-			IL_0264: ldloc.s 15
-			IL_0266: ldstr "log"
-			IL_026b: ldloc.s 7
-			IL_026d: ldstr "name"
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_027c: pop
-			IL_027d: ldstr "console"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0287: stloc.s 15
-			IL_0289: ldloc.s 15
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0290: stloc.s 15
-			IL_0292: ldloc.s 15
-			IL_0294: ldstr "log"
-			IL_0299: ldloc.s 7
-			IL_029b: ldstr "message"
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02aa: pop
-			IL_02ab: leave IL_02b0
+			IL_0248: ldstr "console"
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0252: stloc.s 13
+			IL_0254: ldloc.s 13
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025b: stloc.s 13
+			IL_025d: ldloc.s 13
+			IL_025f: ldstr "log"
+			IL_0264: ldloc.s 7
+			IL_0266: ldstr "name"
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0275: pop
+			IL_0276: ldstr "console"
+			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0280: stloc.s 13
+			IL_0282: ldloc.s 13
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0289: stloc.s 13
+			IL_028b: ldloc.s 13
+			IL_028d: ldstr "log"
+			IL_0292: ldloc.s 7
+			IL_0294: ldstr "message"
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02a3: pop
+			IL_02a4: leave IL_02a9
 		} // end handler
 		.try
 		{
-			IL_02b0: nop
-			IL_02b1: ldloc.1
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b7: stloc.s 15
-			IL_02b9: ldc.i4.1
-			IL_02ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02bf: dup
-			IL_02c0: ldc.r8 1
-			IL_02c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_02ce: stloc.s 16
-			IL_02d0: ldloc.s 15
-			IL_02d2: ldstr "set"
-			IL_02d7: ldloc.s 16
-			IL_02d9: ldc.r8 1
-			IL_02e2: neg
-			IL_02e3: box [System.Runtime]System.Double
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_02ed: pop
-			IL_02ee: leave IL_0391
+			IL_02a9: nop
+			IL_02aa: ldloc.1
+			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b0: stloc.s 13
+			IL_02b2: ldc.i4.1
+			IL_02b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02b8: dup
+			IL_02b9: ldc.r8 1
+			IL_02c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_02c7: stloc.s 14
+			IL_02c9: ldloc.s 13
+			IL_02cb: ldstr "set"
+			IL_02d0: ldloc.s 14
+			IL_02d2: ldc.r8 1
+			IL_02db: neg
+			IL_02dc: box [System.Runtime]System.Double
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_02e6: pop
+			IL_02e7: leave IL_0383
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02f3: stloc.s 9
-			IL_02f5: ldloc.s 9
-			IL_02f7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02fc: dup
-			IL_02fd: brtrue IL_0313
+			IL_02ec: stloc.s 8
+			IL_02ee: ldloc.s 8
+			IL_02f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02f5: dup
+			IL_02f6: brtrue IL_030c
 
-			IL_0302: pop
-			IL_0303: ldloc.s 9
-			IL_0305: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_030a: dup
-			IL_030b: brtrue IL_031f
+			IL_02fb: pop
+			IL_02fc: ldloc.s 8
+			IL_02fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0303: dup
+			IL_0304: brtrue IL_0318
 
-			IL_0310: pop
-			IL_0311: rethrow
+			IL_0309: pop
+			IL_030a: rethrow
 
-			IL_0313: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0318: stloc.s 10
-			IL_031a: br IL_0321
+			IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0311: stloc.s 9
+			IL_0313: br IL_031a
 
-			IL_031f: stloc.s 10
+			IL_0318: stloc.s 9
 
-			IL_0321: ldloc.s 10
-			IL_0323: stloc.s 15
-			IL_0325: ldloc.s 15
-			IL_0327: stloc.s 11
-			IL_0329: newobj instance void Modules.Int32Array_Set_BoundsChecks/Scope/Block_L24C12::.ctor()
-			IL_032e: stloc.s 12
-			IL_0330: ldstr "console"
-			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_033a: stloc.s 15
-			IL_033c: ldloc.s 15
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0343: stloc.s 15
-			IL_0345: ldloc.s 15
-			IL_0347: ldstr "log"
-			IL_034c: ldloc.s 11
-			IL_034e: ldstr "name"
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_035d: pop
-			IL_035e: ldstr "console"
-			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0368: stloc.s 15
-			IL_036a: ldloc.s 15
-			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0371: stloc.s 15
-			IL_0373: ldloc.s 15
-			IL_0375: ldstr "log"
-			IL_037a: ldloc.s 11
-			IL_037c: ldstr "message"
-			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_038b: pop
-			IL_038c: leave IL_0391
+			IL_031a: ldloc.s 9
+			IL_031c: stloc.s 13
+			IL_031e: ldloc.s 13
+			IL_0320: stloc.s 10
+			IL_0322: ldstr "console"
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_032c: stloc.s 13
+			IL_032e: ldloc.s 13
+			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0335: stloc.s 13
+			IL_0337: ldloc.s 13
+			IL_0339: ldstr "log"
+			IL_033e: ldloc.s 10
+			IL_0340: ldstr "name"
+			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_034f: pop
+			IL_0350: ldstr "console"
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_035a: stloc.s 13
+			IL_035c: ldloc.s 13
+			IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0363: stloc.s 13
+			IL_0365: ldloc.s 13
+			IL_0367: ldstr "log"
+			IL_036c: ldloc.s 10
+			IL_036e: ldstr "message"
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_037d: pop
+			IL_037e: leave IL_0383
 		} // end handler
 
-		IL_0391: ldnull
-		IL_0392: stloc.s 13
-		IL_0394: ret
+		IL_0383: ldnull
+		IL_0384: stloc.s 11
+		IL_0386: ret
 	} // end of method Int32Array_Set_BoundsChecks::__js_module_init__
 
 } // end of class Modules.Int32Array_Set_BoundsChecks
@@ -533,7 +527,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2461
+		// Method begins at RVA 0x2451
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab0
+				// Method begins at RVA 0x2a9c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab9
+				// Method begins at RVA 0x2aa5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2acb
+					// Method begins at RVA 0x2ab7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac2
+				// Method begins at RVA 0x2aae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ae6
+						// Method begins at RVA 0x2ad2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2af8
+							// Method begins at RVA 0x2ae4
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2aef
+						// Method begins at RVA 0x2adb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2add
+					// Method begins at RVA 0x2ac9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2b13
+							// Method begins at RVA 0x2aff
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b0a
+						// Method begins at RVA 0x2af6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b01
+					// Method begins at RVA 0x2aed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad4
+				// Method begins at RVA 0x2ac0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b25
+					// Method begins at RVA 0x2b11
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b1c
+				// Method begins at RVA 0x2b08
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2e
+				// Method begins at RVA 0x2b1a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b40
+					// Method begins at RVA 0x2b2c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b37
+				// Method begins at RVA 0x2b23
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -430,7 +430,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b0
+			// Method begins at RVA 0x299c
 			// Header size: 12
 			// Code size: 191 (0xbf)
 			.maxstack 8
@@ -549,20 +549,18 @@
 			)
 			// Method begins at RVA 0x277c
 			// Header size: 12
-			// Code size: 433 (0x1b1)
+			// Code size: 414 (0x19e)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28,
+				[0] float64,
 				[1] float64,
 				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75,
+				[5] float64,
 				[6] float64,
 				[7] float64,
-				[8] float64,
-				[9] float64,
-				[10] float64
+				[8] float64
 			)
 
 			IL_0000: ldarg.0
@@ -573,194 +571,190 @@
 			IL_000d: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
 			IL_0012: ldc.r8 2
 			IL_001b: div
-			IL_001c: stloc.s 10
+			IL_001c: stloc.s 8
 			IL_001e: ldarg.2
 			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0024: ldloc.s 10
+			IL_0024: ldloc.s 8
 			IL_0026: cgt
-			IL_0028: brfalse IL_0178
+			IL_0028: brfalse IL_0165
 
-			IL_002d: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28::.ctor()
-			IL_0032: stloc.0
-			IL_0033: ldarg.1
-			IL_0034: ldc.r8 32
-			IL_003d: ldarg.2
-			IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0043: mul
-			IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
-			IL_0049: stloc.s 10
-			IL_004b: ldloc.s 10
-			IL_004d: stloc.1
-			IL_004e: ldloc.1
-			IL_004f: stloc.s 10
-			IL_0051: ldloc.s 10
-			IL_0053: ldarg.3
-			IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0059: cgt
-			IL_005b: brfalse IL_0094
+			IL_002d: ldarg.1
+			IL_002e: ldc.r8 32
+			IL_0037: ldarg.2
+			IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003d: mul
+			IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
+			IL_0043: stloc.s 8
+			IL_0045: ldloc.s 8
+			IL_0047: stloc.0
+			IL_0048: ldloc.0
+			IL_0049: stloc.s 8
+			IL_004b: ldloc.s 8
+			IL_004d: ldarg.3
+			IL_004e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0053: cgt
+			IL_0055: brfalse IL_008e
 
-			IL_0060: ldarg.1
-			IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0066: stloc.2
-			// loop start (head: IL_0067)
-				IL_0067: ldloc.2
-				IL_0068: stloc.s 10
-				IL_006a: ldloc.s 10
-				IL_006c: ldarg.3
-				IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0072: clt
-				IL_0074: brfalse IL_0092
+			IL_005a: ldarg.1
+			IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0060: stloc.1
+			// loop start (head: IL_0061)
+				IL_0061: ldloc.1
+				IL_0062: stloc.s 8
+				IL_0064: ldloc.s 8
+				IL_0066: ldarg.3
+				IL_0067: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_006c: clt
+				IL_006e: brfalse IL_008c
 
-				IL_0079: ldarg.0
-				IL_007a: ldloc.2
-				IL_007b: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_0080: pop
-				IL_0081: ldloc.2
-				IL_0082: ldarg.2
-				IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0088: stloc.s 10
-				IL_008a: ldloc.s 10
-				IL_008c: stloc.2
-				IL_008d: br IL_0067
+				IL_0073: ldarg.0
+				IL_0074: ldloc.1
+				IL_0075: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_007a: pop
+				IL_007b: ldloc.1
+				IL_007c: ldarg.2
+				IL_007d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0082: stloc.s 8
+				IL_0084: ldloc.s 8
+				IL_0086: stloc.1
+				IL_0087: br IL_0061
 			// end loop
 
-			IL_0092: ldnull
-			IL_0093: ret
+			IL_008c: ldnull
+			IL_008d: ret
 
-			IL_0094: ldarg.3
-			IL_0095: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_009a: conv.i4
-			IL_009b: conv.u4
-			IL_009c: ldc.r8 5
-			IL_00a5: conv.i4
-			IL_00a6: shr.un
-			IL_00a7: conv.r.un
-			IL_00a8: stloc.s 10
-			IL_00aa: ldloc.s 10
-			IL_00ac: stloc.3
-			IL_00ad: ldarg.1
-			IL_00ae: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b3: stloc.s 4
-			// loop start (head: IL_00b5)
-				IL_00b5: ldloc.s 4
-				IL_00b7: stloc.s 10
-				IL_00b9: ldloc.s 10
-				IL_00bb: ldloc.1
-				IL_00bc: clt
-				IL_00be: brfalse IL_0176
+			IL_008e: ldarg.3
+			IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0094: conv.i4
+			IL_0095: conv.u4
+			IL_0096: ldc.r8 5
+			IL_009f: conv.i4
+			IL_00a0: shr.un
+			IL_00a1: conv.r.un
+			IL_00a2: stloc.s 8
+			IL_00a4: ldloc.s 8
+			IL_00a6: stloc.2
+			IL_00a7: ldarg.1
+			IL_00a8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ad: stloc.3
+			// loop start (head: IL_00ae)
+				IL_00ae: ldloc.3
+				IL_00af: stloc.s 8
+				IL_00b1: ldloc.s 8
+				IL_00b3: ldloc.0
+				IL_00b4: clt
+				IL_00b6: brfalse IL_0163
 
-				IL_00c3: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
-				IL_00c8: stloc.s 5
-				IL_00ca: ldloc.s 4
-				IL_00cc: stloc.s 10
-				IL_00ce: ldloc.s 10
-				IL_00d0: conv.i4
-				IL_00d1: conv.u4
-				IL_00d2: ldc.r8 5
-				IL_00db: conv.i4
-				IL_00dc: shr.un
-				IL_00dd: conv.r.un
-				IL_00de: stloc.s 10
-				IL_00e0: ldloc.s 10
-				IL_00e2: stloc.s 6
-				IL_00e4: ldloc.s 4
-				IL_00e6: stloc.s 10
-				IL_00e8: ldloc.s 10
-				IL_00ea: conv.i4
-				IL_00eb: ldc.r8 31
-				IL_00f4: conv.i4
-				IL_00f5: and
-				IL_00f6: conv.r8
-				IL_00f7: stloc.s 10
-				IL_00f9: ldloc.s 10
-				IL_00fb: stloc.s 7
-				IL_00fd: ldc.r8 1
-				IL_0106: conv.i4
-				IL_0107: ldloc.s 7
-				IL_0109: conv.i4
-				IL_010a: shl
-				IL_010b: conv.r8
-				IL_010c: stloc.s 10
-				IL_010e: ldloc.s 10
-				IL_0110: stloc.s 8
-				// loop start (head: IL_0112)
-					IL_0112: nop
-					IL_0113: ldarg.0
-					IL_0114: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0119: ldloc.s 6
-					IL_011b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0120: stloc.s 10
-					IL_0122: ldloc.s 10
-					IL_0124: stloc.s 10
-					IL_0126: ldloc.s 10
-					IL_0128: conv.i4
-					IL_0129: ldloc.s 8
-					IL_012b: conv.i4
-					IL_012c: or
-					IL_012d: conv.r8
-					IL_012e: stloc.s 10
-					IL_0130: ldarg.0
-					IL_0131: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0136: ldloc.s 6
-					IL_0138: ldloc.s 10
-					IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_013f: ldloc.s 6
-					IL_0141: ldarg.2
-					IL_0142: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-					IL_0147: stloc.s 10
-					IL_0149: ldloc.s 10
-					IL_014b: stloc.s 6
-					IL_014d: ldloc.s 6
-					IL_014f: stloc.s 10
-					IL_0151: ldloc.s 10
-					IL_0153: ldloc.3
-					IL_0154: cgt
-					IL_0156: ldc.i4.0
-					IL_0157: ceq
-					IL_0159: brfalse IL_0163
+				IL_00bb: ldloc.3
+				IL_00bc: stloc.s 8
+				IL_00be: ldloc.s 8
+				IL_00c0: conv.i4
+				IL_00c1: conv.u4
+				IL_00c2: ldc.r8 5
+				IL_00cb: conv.i4
+				IL_00cc: shr.un
+				IL_00cd: conv.r.un
+				IL_00ce: stloc.s 8
+				IL_00d0: ldloc.s 8
+				IL_00d2: stloc.s 4
+				IL_00d4: ldloc.3
+				IL_00d5: stloc.s 8
+				IL_00d7: ldloc.s 8
+				IL_00d9: conv.i4
+				IL_00da: ldc.r8 31
+				IL_00e3: conv.i4
+				IL_00e4: and
+				IL_00e5: conv.r8
+				IL_00e6: stloc.s 8
+				IL_00e8: ldloc.s 8
+				IL_00ea: stloc.s 5
+				IL_00ec: ldc.r8 1
+				IL_00f5: conv.i4
+				IL_00f6: ldloc.s 5
+				IL_00f8: conv.i4
+				IL_00f9: shl
+				IL_00fa: conv.r8
+				IL_00fb: stloc.s 8
+				IL_00fd: ldloc.s 8
+				IL_00ff: stloc.s 6
+				// loop start (head: IL_0101)
+					IL_0101: nop
+					IL_0102: ldarg.0
+					IL_0103: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_0108: ldloc.s 4
+					IL_010a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_010f: stloc.s 8
+					IL_0111: ldloc.s 8
+					IL_0113: stloc.s 8
+					IL_0115: ldloc.s 8
+					IL_0117: conv.i4
+					IL_0118: ldloc.s 6
+					IL_011a: conv.i4
+					IL_011b: or
+					IL_011c: conv.r8
+					IL_011d: stloc.s 8
+					IL_011f: ldarg.0
+					IL_0120: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_0125: ldloc.s 4
+					IL_0127: ldloc.s 8
+					IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_012e: ldloc.s 4
+					IL_0130: ldarg.2
+					IL_0131: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+					IL_0136: stloc.s 8
+					IL_0138: ldloc.s 8
+					IL_013a: stloc.s 4
+					IL_013c: ldloc.s 4
+					IL_013e: stloc.s 8
+					IL_0140: ldloc.s 8
+					IL_0142: ldloc.2
+					IL_0143: cgt
+					IL_0145: ldc.i4.0
+					IL_0146: ceq
+					IL_0148: brfalse IL_0152
 
-					IL_015e: br IL_0112
+					IL_014d: br IL_0101
 				// end loop
 
-				IL_0163: ldloc.s 4
-				IL_0165: ldarg.2
-				IL_0166: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_016b: stloc.s 10
-				IL_016d: ldloc.s 10
-				IL_016f: stloc.s 4
-				IL_0171: br IL_00b5
+				IL_0152: ldloc.3
+				IL_0153: ldarg.2
+				IL_0154: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0159: stloc.s 8
+				IL_015b: ldloc.s 8
+				IL_015d: stloc.3
+				IL_015e: br IL_00ae
 			// end loop
 
-			IL_0176: ldnull
-			IL_0177: ret
+			IL_0163: ldnull
+			IL_0164: ret
 
-			IL_0178: ldarg.1
-			IL_0179: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_017e: stloc.s 9
-			// loop start (head: IL_0180)
-				IL_0180: ldloc.s 9
-				IL_0182: stloc.s 10
-				IL_0184: ldloc.s 10
-				IL_0186: ldarg.3
-				IL_0187: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_018c: clt
-				IL_018e: brfalse IL_01af
+			IL_0165: ldarg.1
+			IL_0166: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_016b: stloc.s 7
+			// loop start (head: IL_016d)
+				IL_016d: ldloc.s 7
+				IL_016f: stloc.s 8
+				IL_0171: ldloc.s 8
+				IL_0173: ldarg.3
+				IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0179: clt
+				IL_017b: brfalse IL_019c
 
-				IL_0193: ldarg.0
-				IL_0194: ldloc.s 9
-				IL_0196: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_019b: pop
-				IL_019c: ldloc.s 9
-				IL_019e: ldarg.2
-				IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_01a4: stloc.s 10
-				IL_01a6: ldloc.s 10
-				IL_01a8: stloc.s 9
-				IL_01aa: br IL_0180
+				IL_0180: ldarg.0
+				IL_0181: ldloc.s 7
+				IL_0183: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_0188: pop
+				IL_0189: ldloc.s 7
+				IL_018b: ldarg.2
+				IL_018c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0191: stloc.s 8
+				IL_0193: ldloc.s 8
+				IL_0195: stloc.s 7
+				IL_0197: br IL_016d
 			// end loop
 
-			IL_01af: ldnull
-			IL_01b0: ret
+			IL_019c: ldnull
+			IL_019d: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -773,7 +767,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x293c
+			// Method begins at RVA 0x2928
 			// Header size: 12
 			// Code size: 104 (0x68)
 			.maxstack 8
@@ -862,7 +856,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b64
+				// Method begins at RVA 0x2b50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -887,7 +881,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a7b
+			// Method begins at RVA 0x2a67
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -927,7 +921,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b5b
+					// Method begins at RVA 0x2b47
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -945,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b52
+				// Method begins at RVA 0x2b3e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -963,7 +957,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b49
+			// Method begins at RVA 0x2b35
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1597,7 +1591,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b6d
+		// Method begins at RVA 0x2b59
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a9c
+				// Method begins at RVA 0x2a94
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa5
+				// Method begins at RVA 0x2a9d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aae
+				// Method begins at RVA 0x2aa6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac0
+					// Method begins at RVA 0x2ab8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ad2
+						// Method begins at RVA 0x2aca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2adb
+						// Method begins at RVA 0x2ad3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ac9
+					// Method begins at RVA 0x2ac1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab7
+				// Method begins at RVA 0x2aaf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae4
+				// Method begins at RVA 0x2adc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -333,7 +333,7 @@
 			)
 			// Method begins at RVA 0x2610
 			// Header size: 12
-			// Code size: 1049 (0x419)
+			// Code size: 1042 (0x412)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -341,26 +341,25 @@
 				[2] object,
 				[3] float64,
 				[4] float64,
-				[5] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29,
+				[5] float64,
 				[6] float64,
-				[7] float64,
-				[8] object,
-				[9] float64,
+				[7] object,
+				[8] float64,
+				[9] object,
 				[10] object,
-				[11] object,
-				[12] object[],
-				[13] bool,
-				[14] object,
-				[15] object
+				[11] object[],
+				[12] bool,
+				[13] object,
+				[14] object
 			)
 
 			IL_0000: ldstr "console"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_000a: stloc.s 8
-			IL_000c: ldloc.s 8
+			IL_000a: stloc.s 7
+			IL_000c: ldloc.s 7
 			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 8
+			IL_0013: stloc.s 7
+			IL_0015: ldloc.s 7
 			IL_0017: ldstr "log"
 			IL_001c: ldc.i4.4
 			IL_001d: newarr [System.Runtime]System.Object
@@ -384,14 +383,14 @@
 			IL_003b: pop
 			IL_003c: ldstr "console"
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0046: stloc.s 8
-			IL_0048: ldloc.s 8
+			IL_0046: stloc.s 7
+			IL_0048: ldloc.s 7
 			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004f: stloc.s 8
+			IL_004f: stloc.s 7
 			IL_0051: ldarg.1
 			IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0057: stloc.s 9
-			IL_0059: ldloc.s 9
+			IL_0057: stloc.s 8
+			IL_0059: ldloc.s 8
 			IL_005b: ldarg.3
 			IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0061: clt
@@ -406,7 +405,7 @@
 			IL_0085: box [System.Runtime]System.Double
 			IL_008a: stloc.0
 
-			IL_008b: ldloc.s 8
+			IL_008b: ldloc.s 7
 			IL_008d: ldstr "log"
 			IL_0092: ldstr "cmp0"
 			IL_0097: ldloc.0
@@ -420,18 +419,18 @@
 			IL_00ab: ldfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
 			IL_00b0: ldc.r8 2
 			IL_00b9: div
-			IL_00ba: stloc.s 9
+			IL_00ba: stloc.s 8
 			IL_00bc: ldarg.2
 			IL_00bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c2: ldloc.s 9
+			IL_00c2: ldloc.s 8
 			IL_00c4: cgt
 			IL_00c6: brfalse IL_00f4
 
 			IL_00cb: ldstr "not used in this test"
 			IL_00d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00da: stloc.s 8
-			IL_00dc: ldloc.s 8
+			IL_00da: stloc.s 7
+			IL_00dc: ldloc.s 7
 			IL_00de: stloc.1
 			IL_00df: ldloc.1
 			IL_00e0: isinst [System.Runtime]System.Exception
@@ -448,39 +447,39 @@
 			IL_00f4: ldarg.1
 			IL_00f5: stloc.2
 			IL_00f6: ldloc.2
-			IL_00f7: stloc.s 8
-			IL_00f9: ldloc.s 8
+			IL_00f7: stloc.s 7
+			IL_00f9: ldloc.s 7
 			IL_00fb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0100: stloc.s 9
-			IL_0102: ldloc.s 9
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
 			IL_0104: conv.i4
 			IL_0105: conv.u4
 			IL_0106: ldc.r8 5
 			IL_010f: conv.i4
 			IL_0110: shr.un
 			IL_0111: conv.r.un
-			IL_0112: stloc.s 9
-			IL_0114: ldloc.s 9
+			IL_0112: stloc.s 8
+			IL_0114: ldloc.s 8
 			IL_0116: stloc.3
 			IL_0117: ldarg.0
 			IL_0118: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
 			IL_011d: ldloc.3
 			IL_011e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0123: stloc.s 9
-			IL_0125: ldloc.s 9
+			IL_0123: stloc.s 8
+			IL_0125: ldloc.s 8
 			IL_0127: stloc.s 4
 			IL_0129: ldstr "console"
 			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0133: stloc.s 8
-			IL_0135: ldloc.s 8
+			IL_0133: stloc.s 7
+			IL_0135: ldloc.s 7
 			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013c: stloc.s 8
+			IL_013c: stloc.s 7
 			IL_013e: ldloc.3
 			IL_013f: box [System.Runtime]System.Double
-			IL_0144: stloc.s 10
+			IL_0144: stloc.s 9
 			IL_0146: ldloc.s 4
 			IL_0148: box [System.Runtime]System.Double
-			IL_014d: stloc.s 11
+			IL_014d: stloc.s 10
 			IL_014f: ldc.i4.4
 			IL_0150: newarr [System.Runtime]System.Object
 			IL_0155: dup
@@ -493,298 +492,296 @@
 			IL_0160: stelem.ref
 			IL_0161: dup
 			IL_0162: ldc.i4.2
-			IL_0163: ldloc.s 10
+			IL_0163: ldloc.s 9
 			IL_0165: stelem.ref
 			IL_0166: dup
 			IL_0167: ldc.i4.3
-			IL_0168: ldloc.s 11
+			IL_0168: ldloc.s 10
 			IL_016a: stelem.ref
-			IL_016b: stloc.s 12
-			IL_016d: ldloc.s 8
+			IL_016b: stloc.s 11
+			IL_016d: ldloc.s 7
 			IL_016f: ldstr "log"
-			IL_0174: ldloc.s 12
+			IL_0174: ldloc.s 11
 			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
 			IL_017b: pop
 			// loop start (head: IL_017c)
 				IL_017c: ldloc.2
-				IL_017d: stloc.s 8
-				IL_017f: ldloc.s 8
+				IL_017d: stloc.s 7
+				IL_017f: ldloc.s 7
 				IL_0181: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0186: stloc.s 9
-				IL_0188: ldloc.s 9
+				IL_0186: stloc.s 8
+				IL_0188: ldloc.s 8
 				IL_018a: ldarg.3
 				IL_018b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0190: clt
-				IL_0192: brfalse IL_0316
+				IL_0192: brfalse IL_030f
 
-				IL_0197: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/Block_L28C29::.ctor()
-				IL_019c: stloc.s 5
-				IL_019e: ldloc.2
-				IL_019f: stloc.s 8
-				IL_01a1: ldloc.s 8
-				IL_01a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01a8: stloc.s 9
-				IL_01aa: ldloc.s 9
-				IL_01ac: conv.i4
-				IL_01ad: ldc.r8 31
-				IL_01b6: conv.i4
-				IL_01b7: and
-				IL_01b8: conv.r8
-				IL_01b9: stloc.s 9
-				IL_01bb: ldloc.s 9
-				IL_01bd: stloc.s 6
-				IL_01bf: ldc.r8 1
-				IL_01c8: conv.i4
-				IL_01c9: ldloc.s 6
+				IL_0197: ldloc.2
+				IL_0198: stloc.s 7
+				IL_019a: ldloc.s 7
+				IL_019c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01a1: stloc.s 8
+				IL_01a3: ldloc.s 8
+				IL_01a5: conv.i4
+				IL_01a6: ldc.r8 31
+				IL_01af: conv.i4
+				IL_01b0: and
+				IL_01b1: conv.r8
+				IL_01b2: stloc.s 8
+				IL_01b4: ldloc.s 8
+				IL_01b6: stloc.s 5
+				IL_01b8: ldc.r8 1
+				IL_01c1: conv.i4
+				IL_01c2: ldloc.s 5
+				IL_01c4: conv.i4
+				IL_01c5: shl
+				IL_01c6: conv.r8
+				IL_01c7: stloc.s 8
+				IL_01c9: ldloc.s 4
 				IL_01cb: conv.i4
-				IL_01cc: shl
-				IL_01cd: conv.r8
-				IL_01ce: stloc.s 9
-				IL_01d0: ldloc.s 4
-				IL_01d2: conv.i4
-				IL_01d3: ldloc.s 9
-				IL_01d5: conv.i4
-				IL_01d6: or
-				IL_01d7: conv.r8
-				IL_01d8: stloc.s 9
-				IL_01da: ldloc.s 9
-				IL_01dc: stloc.s 4
-				IL_01de: ldloc.2
-				IL_01df: stloc.s 8
-				IL_01e1: ldloc.s 8
-				IL_01e3: ldarg.1
-				IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01e9: stloc.s 13
-				IL_01eb: ldloc.s 13
-				IL_01ed: brfalse IL_0246
+				IL_01cc: ldloc.s 8
+				IL_01ce: conv.i4
+				IL_01cf: or
+				IL_01d0: conv.r8
+				IL_01d1: stloc.s 8
+				IL_01d3: ldloc.s 8
+				IL_01d5: stloc.s 4
+				IL_01d7: ldloc.2
+				IL_01d8: stloc.s 7
+				IL_01da: ldloc.s 7
+				IL_01dc: ldarg.1
+				IL_01dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01e2: stloc.s 12
+				IL_01e4: ldloc.s 12
+				IL_01e6: brfalse IL_023f
 
-				IL_01f2: ldstr "console"
-				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01fc: stloc.s 8
-				IL_01fe: ldloc.s 8
-				IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0205: stloc.s 8
-				IL_0207: ldloc.s 6
-				IL_0209: box [System.Runtime]System.Double
-				IL_020e: stloc.s 11
-				IL_0210: ldloc.s 4
-				IL_0212: box [System.Runtime]System.Double
-				IL_0217: stloc.s 10
-				IL_0219: ldc.i4.4
-				IL_021a: newarr [System.Runtime]System.Object
-				IL_021f: dup
-				IL_0220: ldc.i4.0
-				IL_0221: ldstr "iter0"
-				IL_0226: stelem.ref
-				IL_0227: dup
-				IL_0228: ldc.i4.1
-				IL_0229: ldloc.2
-				IL_022a: stelem.ref
-				IL_022b: dup
-				IL_022c: ldc.i4.2
-				IL_022d: ldloc.s 11
-				IL_022f: stelem.ref
-				IL_0230: dup
-				IL_0231: ldc.i4.3
-				IL_0232: ldloc.s 10
-				IL_0234: stelem.ref
-				IL_0235: stloc.s 12
-				IL_0237: ldloc.s 8
-				IL_0239: ldstr "log"
-				IL_023e: ldloc.s 12
-				IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0245: pop
+				IL_01eb: ldstr "console"
+				IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01f5: stloc.s 7
+				IL_01f7: ldloc.s 7
+				IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01fe: stloc.s 7
+				IL_0200: ldloc.s 5
+				IL_0202: box [System.Runtime]System.Double
+				IL_0207: stloc.s 10
+				IL_0209: ldloc.s 4
+				IL_020b: box [System.Runtime]System.Double
+				IL_0210: stloc.s 9
+				IL_0212: ldc.i4.4
+				IL_0213: newarr [System.Runtime]System.Object
+				IL_0218: dup
+				IL_0219: ldc.i4.0
+				IL_021a: ldstr "iter0"
+				IL_021f: stelem.ref
+				IL_0220: dup
+				IL_0221: ldc.i4.1
+				IL_0222: ldloc.2
+				IL_0223: stelem.ref
+				IL_0224: dup
+				IL_0225: ldc.i4.2
+				IL_0226: ldloc.s 10
+				IL_0228: stelem.ref
+				IL_0229: dup
+				IL_022a: ldc.i4.3
+				IL_022b: ldloc.s 9
+				IL_022d: stelem.ref
+				IL_022e: stloc.s 11
+				IL_0230: ldloc.s 7
+				IL_0232: ldstr "log"
+				IL_0237: ldloc.s 11
+				IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_023e: pop
 
-				IL_0246: ldloc.2
-				IL_0247: ldarg.2
-				IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_024d: stloc.s 14
-				IL_024f: ldloc.s 14
-				IL_0251: stloc.2
-				IL_0252: ldloc.2
-				IL_0253: stloc.s 14
-				IL_0255: ldloc.s 14
-				IL_0257: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_025c: stloc.s 9
-				IL_025e: ldloc.s 9
-				IL_0260: conv.i4
-				IL_0261: conv.u4
-				IL_0262: ldc.r8 5
-				IL_026b: conv.i4
-				IL_026c: shr.un
-				IL_026d: conv.r.un
-				IL_026e: stloc.s 9
-				IL_0270: ldloc.s 9
-				IL_0272: stloc.s 7
-				IL_0274: ldloc.s 7
-				IL_0276: stloc.s 9
-				IL_0278: ldloc.s 9
-				IL_027a: ldloc.3
-				IL_027b: ceq
-				IL_027d: ldc.i4.0
-				IL_027e: ceq
-				IL_0280: brfalse IL_0311
+				IL_023f: ldloc.2
+				IL_0240: ldarg.2
+				IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0246: stloc.s 13
+				IL_0248: ldloc.s 13
+				IL_024a: stloc.2
+				IL_024b: ldloc.2
+				IL_024c: stloc.s 13
+				IL_024e: ldloc.s 13
+				IL_0250: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0255: stloc.s 8
+				IL_0257: ldloc.s 8
+				IL_0259: conv.i4
+				IL_025a: conv.u4
+				IL_025b: ldc.r8 5
+				IL_0264: conv.i4
+				IL_0265: shr.un
+				IL_0266: conv.r.un
+				IL_0267: stloc.s 8
+				IL_0269: ldloc.s 8
+				IL_026b: stloc.s 6
+				IL_026d: ldloc.s 6
+				IL_026f: stloc.s 8
+				IL_0271: ldloc.s 8
+				IL_0273: ldloc.3
+				IL_0274: ceq
+				IL_0276: ldc.i4.0
+				IL_0277: ceq
+				IL_0279: brfalse IL_030a
 
-				IL_0285: ldstr "console"
-				IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_028f: stloc.s 8
-				IL_0291: ldloc.s 8
-				IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0298: stloc.s 8
-				IL_029a: ldloc.3
-				IL_029b: box [System.Runtime]System.Double
-				IL_02a0: stloc.s 10
-				IL_02a2: ldloc.s 4
-				IL_02a4: box [System.Runtime]System.Double
-				IL_02a9: stloc.s 11
-				IL_02ab: ldloc.s 7
-				IL_02ad: box [System.Runtime]System.Double
-				IL_02b2: stloc.s 15
-				IL_02b4: ldc.i4.5
-				IL_02b5: newarr [System.Runtime]System.Object
-				IL_02ba: dup
-				IL_02bb: ldc.i4.0
-				IL_02bc: ldstr "commit"
-				IL_02c1: stelem.ref
-				IL_02c2: dup
-				IL_02c3: ldc.i4.1
-				IL_02c4: ldloc.s 10
-				IL_02c6: stelem.ref
-				IL_02c7: dup
-				IL_02c8: ldc.i4.2
-				IL_02c9: ldloc.s 11
-				IL_02cb: stelem.ref
-				IL_02cc: dup
-				IL_02cd: ldc.i4.3
-				IL_02ce: ldstr "->"
-				IL_02d3: stelem.ref
-				IL_02d4: dup
-				IL_02d5: ldc.i4.4
-				IL_02d6: ldloc.s 15
-				IL_02d8: stelem.ref
-				IL_02d9: stloc.s 12
-				IL_02db: ldloc.s 8
-				IL_02dd: ldstr "log"
-				IL_02e2: ldloc.s 12
-				IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_02e9: pop
-				IL_02ea: ldarg.0
-				IL_02eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_02f0: ldloc.3
-				IL_02f1: ldloc.s 4
-				IL_02f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_02f8: ldloc.s 7
-				IL_02fa: stloc.s 9
-				IL_02fc: ldloc.s 9
-				IL_02fe: stloc.3
-				IL_02ff: ldarg.0
-				IL_0300: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_0305: ldloc.3
-				IL_0306: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_030b: stloc.s 9
-				IL_030d: ldloc.s 9
-				IL_030f: stloc.s 4
+				IL_027e: ldstr "console"
+				IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0288: stloc.s 7
+				IL_028a: ldloc.s 7
+				IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0291: stloc.s 7
+				IL_0293: ldloc.3
+				IL_0294: box [System.Runtime]System.Double
+				IL_0299: stloc.s 9
+				IL_029b: ldloc.s 4
+				IL_029d: box [System.Runtime]System.Double
+				IL_02a2: stloc.s 10
+				IL_02a4: ldloc.s 6
+				IL_02a6: box [System.Runtime]System.Double
+				IL_02ab: stloc.s 14
+				IL_02ad: ldc.i4.5
+				IL_02ae: newarr [System.Runtime]System.Object
+				IL_02b3: dup
+				IL_02b4: ldc.i4.0
+				IL_02b5: ldstr "commit"
+				IL_02ba: stelem.ref
+				IL_02bb: dup
+				IL_02bc: ldc.i4.1
+				IL_02bd: ldloc.s 9
+				IL_02bf: stelem.ref
+				IL_02c0: dup
+				IL_02c1: ldc.i4.2
+				IL_02c2: ldloc.s 10
+				IL_02c4: stelem.ref
+				IL_02c5: dup
+				IL_02c6: ldc.i4.3
+				IL_02c7: ldstr "->"
+				IL_02cc: stelem.ref
+				IL_02cd: dup
+				IL_02ce: ldc.i4.4
+				IL_02cf: ldloc.s 14
+				IL_02d1: stelem.ref
+				IL_02d2: stloc.s 11
+				IL_02d4: ldloc.s 7
+				IL_02d6: ldstr "log"
+				IL_02db: ldloc.s 11
+				IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_02e2: pop
+				IL_02e3: ldarg.0
+				IL_02e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_02e9: ldloc.3
+				IL_02ea: ldloc.s 4
+				IL_02ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_02f1: ldloc.s 6
+				IL_02f3: stloc.s 8
+				IL_02f5: ldloc.s 8
+				IL_02f7: stloc.3
+				IL_02f8: ldarg.0
+				IL_02f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_02fe: ldloc.3
+				IL_02ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0304: stloc.s 8
+				IL_0306: ldloc.s 8
+				IL_0308: stloc.s 4
 
-				IL_0311: br IL_017c
+				IL_030a: br IL_017c
 			// end loop
 
-			IL_0316: ldstr "console"
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0320: stloc.s 8
-			IL_0322: ldloc.s 8
-			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0329: stloc.s 8
-			IL_032b: ldloc.3
-			IL_032c: box [System.Runtime]System.Double
-			IL_0331: stloc.s 15
-			IL_0333: ldloc.s 4
-			IL_0335: box [System.Runtime]System.Double
-			IL_033a: stloc.s 11
-			IL_033c: ldc.i4.4
-			IL_033d: newarr [System.Runtime]System.Object
-			IL_0342: dup
-			IL_0343: ldc.i4.0
-			IL_0344: ldstr "end"
-			IL_0349: stelem.ref
-			IL_034a: dup
-			IL_034b: ldc.i4.1
-			IL_034c: ldloc.2
-			IL_034d: stelem.ref
-			IL_034e: dup
-			IL_034f: ldc.i4.2
-			IL_0350: ldloc.s 15
-			IL_0352: stelem.ref
-			IL_0353: dup
-			IL_0354: ldc.i4.3
-			IL_0355: ldloc.s 11
-			IL_0357: stelem.ref
-			IL_0358: stloc.s 12
-			IL_035a: ldloc.s 8
-			IL_035c: ldstr "log"
-			IL_0361: ldloc.s 12
-			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0368: pop
-			IL_0369: ldarg.0
-			IL_036a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_036f: ldloc.3
-			IL_0370: ldloc.s 4
-			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_0377: ldstr "console"
-			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0381: stloc.s 8
-			IL_0383: ldloc.s 8
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_038a: stloc.s 8
-			IL_038c: ldarg.0
-			IL_038d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0392: ldc.r8 0.0
-			IL_039b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_03a0: stloc.s 9
-			IL_03a2: ldloc.s 9
-			IL_03a4: box [System.Runtime]System.Double
-			IL_03a9: stloc.s 11
-			IL_03ab: ldarg.0
-			IL_03ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_03b1: ldc.r8 1
-			IL_03ba: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_03bf: stloc.s 9
-			IL_03c1: ldloc.s 9
-			IL_03c3: box [System.Runtime]System.Double
-			IL_03c8: stloc.s 15
-			IL_03ca: ldarg.0
-			IL_03cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_03d0: ldc.r8 2
-			IL_03d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_03de: stloc.s 9
-			IL_03e0: ldloc.s 9
-			IL_03e2: box [System.Runtime]System.Double
-			IL_03e7: stloc.s 10
-			IL_03e9: ldc.i4.4
-			IL_03ea: newarr [System.Runtime]System.Object
-			IL_03ef: dup
-			IL_03f0: ldc.i4.0
-			IL_03f1: ldstr "after"
-			IL_03f6: stelem.ref
-			IL_03f7: dup
-			IL_03f8: ldc.i4.1
-			IL_03f9: ldloc.s 11
-			IL_03fb: stelem.ref
-			IL_03fc: dup
-			IL_03fd: ldc.i4.2
-			IL_03fe: ldloc.s 15
-			IL_0400: stelem.ref
-			IL_0401: dup
-			IL_0402: ldc.i4.3
-			IL_0403: ldloc.s 10
-			IL_0405: stelem.ref
-			IL_0406: stloc.s 12
-			IL_0408: ldloc.s 8
-			IL_040a: ldstr "log"
-			IL_040f: ldloc.s 12
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0416: pop
-			IL_0417: ldnull
-			IL_0418: ret
+			IL_030f: ldstr "console"
+			IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0319: stloc.s 7
+			IL_031b: ldloc.s 7
+			IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0322: stloc.s 7
+			IL_0324: ldloc.3
+			IL_0325: box [System.Runtime]System.Double
+			IL_032a: stloc.s 14
+			IL_032c: ldloc.s 4
+			IL_032e: box [System.Runtime]System.Double
+			IL_0333: stloc.s 10
+			IL_0335: ldc.i4.4
+			IL_0336: newarr [System.Runtime]System.Object
+			IL_033b: dup
+			IL_033c: ldc.i4.0
+			IL_033d: ldstr "end"
+			IL_0342: stelem.ref
+			IL_0343: dup
+			IL_0344: ldc.i4.1
+			IL_0345: ldloc.2
+			IL_0346: stelem.ref
+			IL_0347: dup
+			IL_0348: ldc.i4.2
+			IL_0349: ldloc.s 14
+			IL_034b: stelem.ref
+			IL_034c: dup
+			IL_034d: ldc.i4.3
+			IL_034e: ldloc.s 10
+			IL_0350: stelem.ref
+			IL_0351: stloc.s 11
+			IL_0353: ldloc.s 7
+			IL_0355: ldstr "log"
+			IL_035a: ldloc.s 11
+			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0361: pop
+			IL_0362: ldarg.0
+			IL_0363: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_0368: ldloc.3
+			IL_0369: ldloc.s 4
+			IL_036b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_0370: ldstr "console"
+			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_037a: stloc.s 7
+			IL_037c: ldloc.s 7
+			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0383: stloc.s 7
+			IL_0385: ldarg.0
+			IL_0386: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_038b: ldc.r8 0.0
+			IL_0394: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0399: stloc.s 8
+			IL_039b: ldloc.s 8
+			IL_039d: box [System.Runtime]System.Double
+			IL_03a2: stloc.s 10
+			IL_03a4: ldarg.0
+			IL_03a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_03aa: ldc.r8 1
+			IL_03b3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_03b8: stloc.s 8
+			IL_03ba: ldloc.s 8
+			IL_03bc: box [System.Runtime]System.Double
+			IL_03c1: stloc.s 14
+			IL_03c3: ldarg.0
+			IL_03c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_03c9: ldc.r8 2
+			IL_03d2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_03d7: stloc.s 8
+			IL_03d9: ldloc.s 8
+			IL_03db: box [System.Runtime]System.Double
+			IL_03e0: stloc.s 9
+			IL_03e2: ldc.i4.4
+			IL_03e3: newarr [System.Runtime]System.Object
+			IL_03e8: dup
+			IL_03e9: ldc.i4.0
+			IL_03ea: ldstr "after"
+			IL_03ef: stelem.ref
+			IL_03f0: dup
+			IL_03f1: ldc.i4.1
+			IL_03f2: ldloc.s 10
+			IL_03f4: stelem.ref
+			IL_03f5: dup
+			IL_03f6: ldc.i4.2
+			IL_03f7: ldloc.s 14
+			IL_03f9: stelem.ref
+			IL_03fa: dup
+			IL_03fb: ldc.i4.3
+			IL_03fc: ldloc.s 9
+			IL_03fe: stelem.ref
+			IL_03ff: stloc.s 11
+			IL_0401: ldloc.s 7
+			IL_0403: ldstr "log"
+			IL_0408: ldloc.s 11
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_040f: pop
+			IL_0410: ldnull
+			IL_0411: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -795,7 +792,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a38
+			// Method begins at RVA 0x2a30
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -867,7 +864,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a93
+			// Method begins at RVA 0x2a8b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1336,7 +1333,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2aed
+		// Method begins at RVA 0x2ae5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2425
+				// Method begins at RVA 0x2409
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242e
+				// Method begins at RVA 0x2412
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2437
+				// Method begins at RVA 0x241b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2440
+				// Method begins at RVA 0x2424
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2449
+				// Method begins at RVA 0x242d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2452
+				// Method begins at RVA 0x2436
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245b
+				// Method begins at RVA 0x243f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2464
+				// Method begins at RVA 0x2448
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x241c
+			// Method begins at RVA 0x2400
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,33 +202,29 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 907 (0x38b)
+		// Code size: 879 (0x36f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_ConstructorAndSet_Errors/Scope,
 			[1] class [System.Runtime]System.Exception,
 			[2] object,
 			[3] object,
-			[4] class Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L8C16,
-			[5] class [System.Runtime]System.Exception,
+			[4] class [System.Runtime]System.Exception,
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] class Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L15C16,
-			[9] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[10] class [System.Runtime]System.Exception,
-			[11] object,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[8] class [System.Runtime]System.Exception,
+			[9] object,
+			[10] object,
+			[11] class [System.Runtime]System.Exception,
 			[12] object,
-			[13] class Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L24C16,
-			[14] class [System.Runtime]System.Exception,
+			[13] object,
+			[14] object,
 			[15] object,
-			[16] object,
-			[17] class Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L31C16,
+			[16] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[17] float64,
 			[18] object,
-			[19] object,
-			[20] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[21] float64,
-			[22] object,
-			[23] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			[19] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope::.ctor()
@@ -236,43 +232,43 @@
 		IL_0006: nop
 		IL_0007: ldstr "console"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0011: stloc.s 19
-		IL_0013: ldloc.s 19
+		IL_0011: stloc.s 15
+		IL_0013: ldloc.s 15
 		IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001a: stloc.s 19
+		IL_001a: stloc.s 15
 		IL_001c: ldc.i4.1
 		IL_001d: box [System.Runtime]System.Boolean
 		IL_0022: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0027: stloc.s 20
-		IL_0029: ldloc.s 20
+		IL_0027: stloc.s 16
+		IL_0029: ldloc.s 16
 		IL_002b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0030: stloc.s 21
-		IL_0032: ldloc.s 21
+		IL_0030: stloc.s 17
+		IL_0032: ldloc.s 17
 		IL_0034: box [System.Runtime]System.Double
-		IL_0039: stloc.s 22
-		IL_003b: ldloc.s 19
+		IL_0039: stloc.s 18
+		IL_003b: ldloc.s 15
 		IL_003d: ldstr "log"
-		IL_0042: ldloc.s 22
+		IL_0042: ldloc.s 18
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0049: pop
 		IL_004a: ldstr "console"
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0054: stloc.s 19
-		IL_0056: ldloc.s 19
+		IL_0054: stloc.s 15
+		IL_0056: ldloc.s 15
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005d: stloc.s 19
+		IL_005d: stloc.s 15
 		IL_005f: ldstr "3"
 		IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0069: stloc.s 20
-		IL_006b: ldloc.s 20
+		IL_0069: stloc.s 16
+		IL_006b: ldloc.s 16
 		IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-		IL_0072: stloc.s 21
-		IL_0074: ldloc.s 21
+		IL_0072: stloc.s 17
+		IL_0074: ldloc.s 17
 		IL_0076: box [System.Runtime]System.Double
-		IL_007b: stloc.s 22
-		IL_007d: ldloc.s 19
+		IL_007b: stloc.s 18
+		IL_007d: ldloc.s 15
 		IL_007f: ldstr "log"
-		IL_0084: ldloc.s 22
+		IL_0084: ldloc.s 18
 		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_008b: pop
 		.try
@@ -283,7 +279,7 @@
 			IL_0097: box [System.Runtime]System.Double
 			IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
 			IL_00a1: pop
-			IL_00a2: leave IL_013c
+			IL_00a2: leave IL_0135
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -309,256 +305,248 @@
 			IL_00cf: stloc.2
 
 			IL_00d0: ldloc.2
-			IL_00d1: stloc.s 19
-			IL_00d3: ldloc.s 19
+			IL_00d1: stloc.s 15
+			IL_00d3: ldloc.s 15
 			IL_00d5: stloc.3
-			IL_00d6: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L8C16::.ctor()
-			IL_00db: stloc.s 4
-			IL_00dd: ldstr "console"
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e7: stloc.s 19
-			IL_00e9: ldloc.s 19
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f0: stloc.s 19
-			IL_00f2: ldloc.s 19
-			IL_00f4: ldstr "log"
-			IL_00f9: ldloc.3
-			IL_00fa: ldstr "name"
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0109: pop
-			IL_010a: ldstr "console"
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0114: stloc.s 19
-			IL_0116: ldloc.s 19
-			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011d: stloc.s 19
-			IL_011f: ldloc.s 19
-			IL_0121: ldstr "log"
-			IL_0126: ldloc.3
-			IL_0127: ldstr "message"
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0136: pop
-			IL_0137: leave IL_013c
+			IL_00d6: ldstr "console"
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e0: stloc.s 15
+			IL_00e2: ldloc.s 15
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e9: stloc.s 15
+			IL_00eb: ldloc.s 15
+			IL_00ed: ldstr "log"
+			IL_00f2: ldloc.3
+			IL_00f3: ldstr "name"
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0102: pop
+			IL_0103: ldstr "console"
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_010d: stloc.s 15
+			IL_010f: ldloc.s 15
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0116: stloc.s 15
+			IL_0118: ldloc.s 15
+			IL_011a: ldstr "log"
+			IL_011f: ldloc.3
+			IL_0120: ldstr "message"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_012f: pop
+			IL_0130: leave IL_0135
 		} // end handler
 		.try
 		{
-			IL_013c: nop
-			IL_013d: ldc.r8 (00 00 00 00 00 00 F0 7F)
-			IL_0146: box [System.Runtime]System.Double
-			IL_014b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object)
-			IL_0150: pop
-			IL_0151: leave IL_01f4
+			IL_0135: nop
+			IL_0136: ldc.r8 (00 00 00 00 00 00 F0 7F)
+			IL_013f: box [System.Runtime]System.Double
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object)
+			IL_0149: pop
+			IL_014a: leave IL_01e6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0156: stloc.s 5
-			IL_0158: ldloc.s 5
-			IL_015a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_015f: dup
-			IL_0160: brtrue IL_0176
+			IL_014f: stloc.s 4
+			IL_0151: ldloc.s 4
+			IL_0153: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0158: dup
+			IL_0159: brtrue IL_016f
 
-			IL_0165: pop
-			IL_0166: ldloc.s 5
-			IL_0168: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_016d: dup
-			IL_016e: brtrue IL_0182
+			IL_015e: pop
+			IL_015f: ldloc.s 4
+			IL_0161: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0166: dup
+			IL_0167: brtrue IL_017b
 
-			IL_0173: pop
-			IL_0174: rethrow
+			IL_016c: pop
+			IL_016d: rethrow
 
-			IL_0176: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_017b: stloc.s 6
-			IL_017d: br IL_0184
+			IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0174: stloc.s 5
+			IL_0176: br IL_017d
 
-			IL_0182: stloc.s 6
+			IL_017b: stloc.s 5
 
-			IL_0184: ldloc.s 6
-			IL_0186: stloc.s 19
-			IL_0188: ldloc.s 19
-			IL_018a: stloc.s 7
-			IL_018c: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L15C16::.ctor()
-			IL_0191: stloc.s 8
-			IL_0193: ldstr "console"
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019d: stloc.s 19
-			IL_019f: ldloc.s 19
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a6: stloc.s 19
-			IL_01a8: ldloc.s 19
-			IL_01aa: ldstr "log"
-			IL_01af: ldloc.s 7
-			IL_01b1: ldstr "name"
-			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c0: pop
-			IL_01c1: ldstr "console"
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01cb: stloc.s 19
-			IL_01cd: ldloc.s 19
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d4: stloc.s 19
-			IL_01d6: ldloc.s 19
-			IL_01d8: ldstr "log"
-			IL_01dd: ldloc.s 7
-			IL_01df: ldstr "message"
-			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01ee: pop
-			IL_01ef: leave IL_01f4
+			IL_017d: ldloc.s 5
+			IL_017f: stloc.s 15
+			IL_0181: ldloc.s 15
+			IL_0183: stloc.s 6
+			IL_0185: ldstr "console"
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_018f: stloc.s 15
+			IL_0191: ldloc.s 15
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0198: stloc.s 15
+			IL_019a: ldloc.s 15
+			IL_019c: ldstr "log"
+			IL_01a1: ldloc.s 6
+			IL_01a3: ldstr "name"
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b2: pop
+			IL_01b3: ldstr "console"
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01bd: stloc.s 15
+			IL_01bf: ldloc.s 15
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c6: stloc.s 15
+			IL_01c8: ldloc.s 15
+			IL_01ca: ldstr "log"
+			IL_01cf: ldloc.s 6
+			IL_01d1: ldstr "message"
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01e0: pop
+			IL_01e1: leave IL_01e6
 		} // end handler
 
-		IL_01f4: ldc.r8 2
-		IL_01fd: box [System.Runtime]System.Double
-		IL_0202: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0207: stloc.s 23
-		IL_0209: ldloc.s 23
-		IL_020b: stloc.s 9
+		IL_01e6: ldc.r8 2
+		IL_01ef: box [System.Runtime]System.Double
+		IL_01f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_01f9: stloc.s 19
+		IL_01fb: ldloc.s 19
+		IL_01fd: stloc.s 7
 		.try
 		{
-			IL_020d: nop
-			IL_020e: ldloc.s 9
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0215: stloc.s 19
-			IL_0217: ldloc.s 19
-			IL_0219: ldstr "set"
-			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0223: pop
-			IL_0224: leave IL_02c7
+			IL_01ff: nop
+			IL_0200: ldloc.s 7
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0207: stloc.s 15
+			IL_0209: ldloc.s 15
+			IL_020b: ldstr "set"
+			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0215: pop
+			IL_0216: leave IL_02b2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0229: stloc.s 10
-			IL_022b: ldloc.s 10
-			IL_022d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_021b: stloc.s 8
+			IL_021d: ldloc.s 8
+			IL_021f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0224: dup
+			IL_0225: brtrue IL_023b
+
+			IL_022a: pop
+			IL_022b: ldloc.s 8
+			IL_022d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
 			IL_0232: dup
-			IL_0233: brtrue IL_0249
+			IL_0233: brtrue IL_0247
 
 			IL_0238: pop
-			IL_0239: ldloc.s 10
-			IL_023b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0240: dup
-			IL_0241: brtrue IL_0255
+			IL_0239: rethrow
 
-			IL_0246: pop
-			IL_0247: rethrow
+			IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0240: stloc.s 9
+			IL_0242: br IL_0249
 
-			IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_024e: stloc.s 11
-			IL_0250: br IL_0257
+			IL_0247: stloc.s 9
 
-			IL_0255: stloc.s 11
-
-			IL_0257: ldloc.s 11
-			IL_0259: stloc.s 19
-			IL_025b: ldloc.s 19
-			IL_025d: stloc.s 12
-			IL_025f: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L24C16::.ctor()
-			IL_0264: stloc.s 13
-			IL_0266: ldstr "console"
-			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0270: stloc.s 19
-			IL_0272: ldloc.s 19
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0279: stloc.s 19
-			IL_027b: ldloc.s 19
-			IL_027d: ldstr "log"
-			IL_0282: ldloc.s 12
-			IL_0284: ldstr "name"
-			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0293: pop
-			IL_0294: ldstr "console"
-			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_029e: stloc.s 19
-			IL_02a0: ldloc.s 19
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a7: stloc.s 19
-			IL_02a9: ldloc.s 19
-			IL_02ab: ldstr "log"
-			IL_02b0: ldloc.s 12
-			IL_02b2: ldstr "message"
-			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02c1: pop
-			IL_02c2: leave IL_02c7
+			IL_0249: ldloc.s 9
+			IL_024b: stloc.s 15
+			IL_024d: ldloc.s 15
+			IL_024f: stloc.s 10
+			IL_0251: ldstr "console"
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_025b: stloc.s 15
+			IL_025d: ldloc.s 15
+			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0264: stloc.s 15
+			IL_0266: ldloc.s 15
+			IL_0268: ldstr "log"
+			IL_026d: ldloc.s 10
+			IL_026f: ldstr "name"
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_027e: pop
+			IL_027f: ldstr "console"
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0289: stloc.s 15
+			IL_028b: ldloc.s 15
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0292: stloc.s 15
+			IL_0294: ldloc.s 15
+			IL_0296: ldstr "log"
+			IL_029b: ldloc.s 10
+			IL_029d: ldstr "message"
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ac: pop
+			IL_02ad: leave IL_02b2
 		} // end handler
 		.try
 		{
-			IL_02c7: nop
-			IL_02c8: ldloc.s 9
-			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02cf: stloc.s 19
-			IL_02d1: ldloc.s 19
-			IL_02d3: ldstr "set"
-			IL_02d8: ldc.i4.0
-			IL_02d9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02e3: pop
-			IL_02e4: leave IL_0387
+			IL_02b2: nop
+			IL_02b3: ldloc.s 7
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ba: stloc.s 15
+			IL_02bc: ldloc.s 15
+			IL_02be: ldstr "set"
+			IL_02c3: ldc.i4.0
+			IL_02c4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ce: pop
+			IL_02cf: leave IL_036b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02e9: stloc.s 14
-			IL_02eb: ldloc.s 14
-			IL_02ed: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02f2: dup
-			IL_02f3: brtrue IL_0309
+			IL_02d4: stloc.s 11
+			IL_02d6: ldloc.s 11
+			IL_02d8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02dd: dup
+			IL_02de: brtrue IL_02f4
 
-			IL_02f8: pop
-			IL_02f9: ldloc.s 14
-			IL_02fb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0300: dup
-			IL_0301: brtrue IL_0315
+			IL_02e3: pop
+			IL_02e4: ldloc.s 11
+			IL_02e6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02eb: dup
+			IL_02ec: brtrue IL_0300
 
-			IL_0306: pop
-			IL_0307: rethrow
+			IL_02f1: pop
+			IL_02f2: rethrow
 
-			IL_0309: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_030e: stloc.s 15
-			IL_0310: br IL_0317
+			IL_02f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02f9: stloc.s 12
+			IL_02fb: br IL_0302
 
-			IL_0315: stloc.s 15
+			IL_0300: stloc.s 12
 
-			IL_0317: ldloc.s 15
-			IL_0319: stloc.s 19
-			IL_031b: ldloc.s 19
-			IL_031d: stloc.s 16
-			IL_031f: newobj instance void Modules.TypedArray_ConstructorAndSet_Errors/Scope/Block_L31C16::.ctor()
-			IL_0324: stloc.s 17
-			IL_0326: ldstr "console"
-			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0330: stloc.s 19
-			IL_0332: ldloc.s 19
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0339: stloc.s 19
-			IL_033b: ldloc.s 19
-			IL_033d: ldstr "log"
-			IL_0342: ldloc.s 16
-			IL_0344: ldstr "name"
-			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0353: pop
-			IL_0354: ldstr "console"
-			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_035e: stloc.s 19
-			IL_0360: ldloc.s 19
-			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0367: stloc.s 19
-			IL_0369: ldloc.s 19
-			IL_036b: ldstr "log"
-			IL_0370: ldloc.s 16
-			IL_0372: ldstr "message"
-			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0381: pop
-			IL_0382: leave IL_0387
+			IL_0302: ldloc.s 12
+			IL_0304: stloc.s 15
+			IL_0306: ldloc.s 15
+			IL_0308: stloc.s 13
+			IL_030a: ldstr "console"
+			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0314: stloc.s 15
+			IL_0316: ldloc.s 15
+			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_031d: stloc.s 15
+			IL_031f: ldloc.s 15
+			IL_0321: ldstr "log"
+			IL_0326: ldloc.s 13
+			IL_0328: ldstr "name"
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0337: pop
+			IL_0338: ldstr "console"
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0342: stloc.s 15
+			IL_0344: ldloc.s 15
+			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_034b: stloc.s 15
+			IL_034d: ldloc.s 15
+			IL_034f: ldstr "log"
+			IL_0354: ldloc.s 13
+			IL_0356: ldstr "message"
+			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0365: pop
+			IL_0366: leave IL_036b
 		} // end handler
 
-		IL_0387: ldnull
-		IL_0388: stloc.s 18
-		IL_038a: ret
+		IL_036b: ldnull
+		IL_036c: stloc.s 14
+		IL_036e: ret
 	} // end of method TypedArray_ConstructorAndSet_Errors::__js_module_init__
 
 } // end of class Modules.TypedArray_ConstructorAndSet_Errors
@@ -570,7 +558,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x246d
+		// Method begins at RVA 0x2451
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2565
+				// Method begins at RVA 0x255d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x252c
+			// Method begins at RVA 0x2524
 			// Header size: 1
 			// Code size: 47 (0x2f)
 			.maxstack 8
@@ -79,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x256e
+				// Method begins at RVA 0x2566
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2577
+				// Method begins at RVA 0x256f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -120,7 +120,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x255c
+			// Method begins at RVA 0x2554
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -146,7 +146,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1213 (0x4bd)
+		// Code size: 1206 (0x4b6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -159,18 +159,17 @@
 			[7] class [System.Runtime]System.Exception,
 			[8] object,
 			[9] object,
-			[10] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope/Block_L28C16,
-			[11] object,
+			[10] object,
+			[11] float64,
 			[12] float64,
 			[13] float64,
-			[14] float64,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Int8Array,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.Int8Array,
+			[15] object,
 			[16] object,
-			[17] object,
-			[18] class [JavaScriptRuntime]JavaScriptRuntime.Int16Array,
-			[19] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[20] class [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray,
-			[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.Int16Array,
+			[18] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
+			[19] class [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray,
+			[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::.ctor()
@@ -178,23 +177,23 @@
 		IL_0006: nop
 		IL_0007: ldc.r8 129
 		IL_0010: neg
-		IL_0011: stloc.s 12
+		IL_0011: stloc.s 11
 		IL_0013: ldc.r8 128
 		IL_001c: neg
-		IL_001d: stloc.s 13
+		IL_001d: stloc.s 12
 		IL_001f: ldc.r8 127
 		IL_0028: neg
-		IL_0029: stloc.s 14
+		IL_0029: stloc.s 13
 		IL_002b: ldc.i4.8
 		IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_0031: dup
-		IL_0032: ldloc.s 12
+		IL_0032: ldloc.s 11
 		IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0039: dup
-		IL_003a: ldloc.s 13
+		IL_003a: ldloc.s 12
 		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0041: dup
-		IL_0042: ldloc.s 14
+		IL_0042: ldloc.s 13
 		IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0049: dup
 		IL_004a: ldc.r8 127
@@ -212,47 +211,47 @@
 		IL_0086: ldc.r8 256
 		IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int8Array::.ctor(object)
-		IL_0099: stloc.s 15
-		IL_009b: ldloc.s 15
+		IL_0099: stloc.s 14
+		IL_009b: ldloc.s 14
 		IL_009d: stloc.1
 		IL_009e: ldstr "console"
 		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a8: stloc.s 16
-		IL_00aa: ldloc.s 16
+		IL_00a8: stloc.s 15
+		IL_00aa: ldloc.s 15
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b1: stloc.s 16
+		IL_00b1: stloc.s 15
 		IL_00b3: ldloc.1
 		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b9: stloc.s 17
-		IL_00bb: ldloc.s 17
+		IL_00b9: stloc.s 16
+		IL_00bb: ldloc.s 16
 		IL_00bd: ldstr "join"
 		IL_00c2: ldstr "|"
 		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cc: stloc.s 17
-		IL_00ce: ldloc.s 16
+		IL_00cc: stloc.s 16
+		IL_00ce: ldloc.s 15
 		IL_00d0: ldstr "log"
-		IL_00d5: ldloc.s 17
+		IL_00d5: ldloc.s 16
 		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00dc: pop
 		IL_00dd: ldc.r8 32769
 		IL_00e6: neg
-		IL_00e7: stloc.s 14
+		IL_00e7: stloc.s 13
 		IL_00e9: ldc.r8 32768
 		IL_00f2: neg
-		IL_00f3: stloc.s 13
+		IL_00f3: stloc.s 12
 		IL_00f5: ldc.r8 32767
 		IL_00fe: neg
-		IL_00ff: stloc.s 12
+		IL_00ff: stloc.s 11
 		IL_0101: ldc.i4.8
 		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_0107: dup
-		IL_0108: ldloc.s 14
+		IL_0108: ldloc.s 13
 		IL_010a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_010f: dup
-		IL_0110: ldloc.s 13
+		IL_0110: ldloc.s 12
 		IL_0112: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0117: dup
-		IL_0118: ldloc.s 12
+		IL_0118: ldloc.s 11
 		IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_011f: dup
 		IL_0120: ldc.r8 32767
@@ -270,26 +269,26 @@
 		IL_015c: ldc.r8 65536
 		IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
-		IL_016f: stloc.s 18
-		IL_0171: ldloc.s 18
+		IL_016f: stloc.s 17
+		IL_0171: ldloc.s 17
 		IL_0173: stloc.2
 		IL_0174: ldstr "console"
 		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017e: stloc.s 17
-		IL_0180: ldloc.s 17
+		IL_017e: stloc.s 16
+		IL_0180: ldloc.s 16
 		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: stloc.s 17
+		IL_0187: stloc.s 16
 		IL_0189: ldloc.2
 		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018f: stloc.s 16
-		IL_0191: ldloc.s 16
+		IL_018f: stloc.s 15
+		IL_0191: ldloc.s 15
 		IL_0193: ldstr "join"
 		IL_0198: ldstr "|"
 		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a2: stloc.s 16
-		IL_01a4: ldloc.s 17
+		IL_01a2: stloc.s 15
+		IL_01a4: ldloc.s 16
 		IL_01a6: ldstr "log"
-		IL_01ab: ldloc.s 16
+		IL_01ab: ldloc.s 15
 		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01b2: pop
 		IL_01b3: ldc.i4.8
@@ -320,41 +319,41 @@
 		IL_0224: ldc.r8 1.9
 		IL_022d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0232: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0237: stloc.s 19
-		IL_0239: ldloc.s 19
+		IL_0237: stloc.s 18
+		IL_0239: ldloc.s 18
 		IL_023b: stloc.3
 		IL_023c: ldstr "console"
 		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0246: stloc.s 16
-		IL_0248: ldloc.s 16
+		IL_0246: stloc.s 15
+		IL_0248: ldloc.s 15
 		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024f: stloc.s 16
+		IL_024f: stloc.s 15
 		IL_0251: ldloc.3
 		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0257: stloc.s 17
-		IL_0259: ldloc.s 17
+		IL_0257: stloc.s 16
+		IL_0259: ldloc.s 16
 		IL_025b: ldstr "join"
 		IL_0260: ldstr "|"
 		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_026a: stloc.s 17
-		IL_026c: ldloc.s 16
+		IL_026a: stloc.s 16
+		IL_026c: ldloc.s 15
 		IL_026e: ldstr "log"
-		IL_0273: ldloc.s 17
+		IL_0273: ldloc.s 16
 		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_027a: pop
 		IL_027b: ldc.r8 20
 		IL_0284: neg
-		IL_0285: stloc.s 12
+		IL_0285: stloc.s 11
 		IL_0287: ldc.r8 0.5
 		IL_0290: neg
-		IL_0291: stloc.s 13
+		IL_0291: stloc.s 12
 		IL_0293: ldc.i4.s 10
 		IL_0295: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_029a: dup
-		IL_029b: ldloc.s 12
+		IL_029b: ldloc.s 11
 		IL_029d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_02a2: dup
-		IL_02a3: ldloc.s 13
+		IL_02a3: ldloc.s 12
 		IL_02a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_02aa: dup
 		IL_02ab: ldc.r8 0.49
@@ -381,26 +380,26 @@
 		IL_0314: ldc.r8 (00 00 00 00 00 00 F8 FF)
 		IL_031d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0322: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
-		IL_0327: stloc.s 20
-		IL_0329: ldloc.s 20
+		IL_0327: stloc.s 19
+		IL_0329: ldloc.s 19
 		IL_032b: stloc.s 4
 		IL_032d: ldstr "console"
 		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0337: stloc.s 17
-		IL_0339: ldloc.s 17
+		IL_0337: stloc.s 16
+		IL_0339: ldloc.s 16
 		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0340: stloc.s 17
+		IL_0340: stloc.s 16
 		IL_0342: ldloc.s 4
 		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0349: stloc.s 16
-		IL_034b: ldloc.s 16
+		IL_0349: stloc.s 15
+		IL_034b: ldloc.s 15
 		IL_034d: ldstr "join"
 		IL_0352: ldstr "|"
 		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_035c: stloc.s 16
-		IL_035e: ldloc.s 17
+		IL_035c: stloc.s 15
+		IL_035e: ldloc.s 16
 		IL_0360: ldstr "log"
-		IL_0365: ldloc.s 16
+		IL_0365: ldloc.s 15
 		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_036c: pop
 		IL_036d: ldloc.0
@@ -424,23 +423,23 @@
 		IL_03a4: ldc.i4.0
 		IL_03a5: ldc.i4.1
 		IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03ab: stloc.s 16
-		IL_03ad: ldloc.s 16
+		IL_03ab: stloc.s 15
+		IL_03ad: ldloc.s 15
 		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_03b4: stloc.s 16
+		IL_03b4: stloc.s 15
 		IL_03b6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03bb: dup
 		IL_03bc: ldstr "valueOf"
-		IL_03c1: ldloc.s 16
+		IL_03c1: ldloc.s 15
 		IL_03c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03c8: stloc.s 21
-		IL_03ca: ldloc.s 21
+		IL_03c8: stloc.s 20
+		IL_03ca: ldloc.s 20
 		IL_03cc: stloc.s 5
 		IL_03ce: ldc.r8 0.0
 		IL_03d7: box [System.Runtime]System.Double
 		IL_03dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_03e1: stloc.s 19
-		IL_03e3: ldloc.s 19
+		IL_03e1: stloc.s 18
+		IL_03e3: ldloc.s 18
 		IL_03e5: stloc.s 6
 		IL_03e7: ldloc.s 6
 		IL_03e9: ldc.r8 0.0
@@ -450,11 +449,11 @@
 		IL_03fa: pop
 		IL_03fb: ldstr "console"
 		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0405: stloc.s 16
-		IL_0407: ldloc.s 16
+		IL_0405: stloc.s 15
+		IL_0407: ldloc.s 15
 		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040e: stloc.s 16
-		IL_0410: ldloc.s 16
+		IL_040e: stloc.s 15
+		IL_0410: ldloc.s 15
 		IL_0412: ldstr "log"
 		IL_0417: ldloc.0
 		IL_0418: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
@@ -465,14 +464,14 @@
 			IL_0423: nop
 			IL_0424: ldstr "value"
 			IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_042e: stloc.s 16
+			IL_042e: stloc.s 15
 			IL_0430: ldloc.s 6
 			IL_0432: ldc.r8 0.0
-			IL_043b: ldloc.s 16
+			IL_043b: ldloc.s 15
 			IL_043d: ldc.i4.1
 			IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
 			IL_0443: pop
-			IL_0444: leave IL_04b9
+			IL_0444: leave IL_04b2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -498,30 +497,28 @@
 			IL_0475: stloc.s 8
 
 			IL_0477: ldloc.s 8
-			IL_0479: stloc.s 16
-			IL_047b: ldloc.s 16
+			IL_0479: stloc.s 15
+			IL_047b: ldloc.s 15
 			IL_047d: stloc.s 9
-			IL_047f: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope/Block_L28C16::.ctor()
-			IL_0484: stloc.s 10
-			IL_0486: ldstr "console"
-			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0490: stloc.s 16
-			IL_0492: ldloc.s 16
-			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0499: stloc.s 16
-			IL_049b: ldloc.s 16
-			IL_049d: ldstr "log"
-			IL_04a2: ldloc.s 9
-			IL_04a4: ldstr "name"
-			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_04b3: pop
-			IL_04b4: leave IL_04b9
+			IL_047f: ldstr "console"
+			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0489: stloc.s 15
+			IL_048b: ldloc.s 15
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0492: stloc.s 15
+			IL_0494: ldloc.s 15
+			IL_0496: ldstr "log"
+			IL_049b: ldloc.s 9
+			IL_049d: ldstr "name"
+			IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04ac: pop
+			IL_04ad: leave IL_04b2
 		} // end handler
 
-		IL_04b9: ldnull
-		IL_04ba: stloc.s 11
-		IL_04bc: ret
+		IL_04b2: ldnull
+		IL_04b3: stloc.s 10
+		IL_04b5: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics
@@ -533,7 +530,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2580
+		// Method begins at RVA 0x2578
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_FromBase64_InvalidInput.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_FromBase64_InvalidInput.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2294
+			// Method begins at RVA 0x228c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22af
+					// Method begins at RVA 0x22a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b8
+					// Method begins at RVA 0x22b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a6
+				// Method begins at RVA 0x229e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229d
+			// Method begins at RVA 0x2295
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,7 +124,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 513 (0x201)
+		// Code size: 506 (0x1fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_FromBase64_InvalidInput/Scope,
@@ -135,14 +135,13 @@
 			[5] class [System.Runtime]System.Exception,
 			[6] object,
 			[7] object,
-			[8] class Modules.Uint8Array_FromBase64_InvalidInput/Scope_ForOf_L3C5/Block_L3C49/Block_L7C18,
+			[8] object,
 			[9] object,
-			[10] object,
-			[11] bool,
+			[10] bool,
+			[11] object,
 			[12] object,
 			[13] object,
-			[14] object,
-			[15] object
+			[14] object
 		)
 
 		IL_0000: newobj instance void Modules.Uint8Array_FromBase64_InvalidInput/Scope::.ctor()
@@ -173,17 +172,17 @@
 			// loop start (head: IL_0043)
 				IL_0043: ldloc.1
 				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-				IL_0049: stloc.s 10
-				IL_004b: ldloc.s 10
+				IL_0049: stloc.s 9
+				IL_004b: ldloc.s 9
 				IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-				IL_0052: stloc.s 11
-				IL_0054: ldloc.s 11
-				IL_0056: brtrue IL_01e3
+				IL_0052: stloc.s 10
+				IL_0054: ldloc.s 10
+				IL_0056: brtrue IL_01dc
 
-				IL_005b: ldloc.s 10
+				IL_005b: ldloc.s 9
 				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-				IL_0062: stloc.s 10
-				IL_0064: ldloc.s 10
+				IL_0062: stloc.s 9
+				IL_0064: ldloc.s 9
 				IL_0066: stloc.s 4
 				.try
 				{
@@ -193,16 +192,16 @@
 					IL_0070: pop
 					IL_0071: ldstr "console"
 					IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_007b: stloc.s 10
-					IL_007d: ldloc.s 10
+					IL_007b: stloc.s 9
+					IL_007d: ldloc.s 9
 					IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0084: stloc.s 10
-					IL_0086: ldloc.s 10
+					IL_0084: stloc.s 9
+					IL_0086: ldloc.s 9
 					IL_0088: ldstr "log"
 					IL_008d: ldstr "no error"
 					IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 					IL_0097: pop
-					IL_0098: leave IL_01d1
+					IL_0098: leave IL_01ca
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
@@ -228,118 +227,116 @@
 					IL_00c9: stloc.s 6
 
 					IL_00cb: ldloc.s 6
-					IL_00cd: stloc.s 10
-					IL_00cf: ldloc.s 10
+					IL_00cd: stloc.s 9
+					IL_00cf: ldloc.s 9
 					IL_00d1: stloc.s 7
-					IL_00d3: newobj instance void Modules.Uint8Array_FromBase64_InvalidInput/Scope_ForOf_L3C5/Block_L3C49/Block_L7C18::.ctor()
-					IL_00d8: stloc.s 8
-					IL_00da: ldstr "console"
-					IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_00e4: stloc.s 10
-					IL_00e6: ldloc.s 10
-					IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00ed: stloc.s 10
-					IL_00ef: ldloc.s 7
-					IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00f6: stloc.s 11
-					IL_00f8: ldloc.s 11
-					IL_00fa: brfalse IL_0129
+					IL_00d3: ldstr "console"
+					IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_00dd: stloc.s 9
+					IL_00df: ldloc.s 9
+					IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00e6: stloc.s 9
+					IL_00e8: ldloc.s 7
+					IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00ef: stloc.s 10
+					IL_00f1: ldloc.s 10
+					IL_00f3: brfalse IL_0122
 
-					IL_00ff: ldloc.s 7
-					IL_0101: ldstr "name"
-					IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_010b: ldstr "SyntaxError"
-					IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_0115: stloc.s 11
-					IL_0117: ldloc.s 11
-					IL_0119: box [System.Runtime]System.Boolean
-					IL_011e: stloc.s 12
-					IL_0120: ldloc.s 12
-					IL_0122: stloc.s 14
-					IL_0124: br IL_012d
+					IL_00f8: ldloc.s 7
+					IL_00fa: ldstr "name"
+					IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0104: ldstr "SyntaxError"
+					IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_010e: stloc.s 10
+					IL_0110: ldloc.s 10
+					IL_0112: box [System.Runtime]System.Boolean
+					IL_0117: stloc.s 11
+					IL_0119: ldloc.s 11
+					IL_011b: stloc.s 13
+					IL_011d: br IL_0126
 
-					IL_0129: ldloc.s 7
-					IL_012b: stloc.s 14
+					IL_0122: ldloc.s 7
+					IL_0124: stloc.s 13
 
-					IL_012d: ldloc.s 10
-					IL_012f: ldstr "log"
-					IL_0134: ldloc.s 14
-					IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_013b: pop
-					IL_013c: ldstr "console"
-					IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_0146: stloc.s 10
-					IL_0148: ldloc.s 10
-					IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_014f: stloc.s 10
-					IL_0151: ldloc.s 7
-					IL_0153: ldstr "message"
-					IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_015d: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-					IL_0162: ldstr "string"
-					IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_016c: stloc.s 11
-					IL_016e: ldloc.s 11
-					IL_0170: box [System.Runtime]System.Boolean
-					IL_0175: stloc.s 12
-					IL_0177: ldloc.s 12
-					IL_0179: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_017e: stloc.s 11
-					IL_0180: ldloc.s 11
-					IL_0182: brfalse IL_01b9
+					IL_0126: ldloc.s 9
+					IL_0128: ldstr "log"
+					IL_012d: ldloc.s 13
+					IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0134: pop
+					IL_0135: ldstr "console"
+					IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_013f: stloc.s 9
+					IL_0141: ldloc.s 9
+					IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0148: stloc.s 9
+					IL_014a: ldloc.s 7
+					IL_014c: ldstr "message"
+					IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0156: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+					IL_015b: ldstr "string"
+					IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_0165: stloc.s 10
+					IL_0167: ldloc.s 10
+					IL_0169: box [System.Runtime]System.Boolean
+					IL_016e: stloc.s 11
+					IL_0170: ldloc.s 11
+					IL_0172: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0177: stloc.s 10
+					IL_0179: ldloc.s 10
+					IL_017b: brfalse IL_01b2
 
-					IL_0187: ldloc.s 7
-					IL_0189: ldstr "message"
-					IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0193: ldstr "length"
-					IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_019d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01a2: ldc.r8 0.0
-					IL_01ab: cgt
-					IL_01ad: box [System.Runtime]System.Boolean
-					IL_01b2: stloc.s 15
-					IL_01b4: br IL_01bd
+					IL_0180: ldloc.s 7
+					IL_0182: ldstr "message"
+					IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_018c: ldstr "length"
+					IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0196: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_019b: ldc.r8 0.0
+					IL_01a4: cgt
+					IL_01a6: box [System.Runtime]System.Boolean
+					IL_01ab: stloc.s 14
+					IL_01ad: br IL_01b6
 
-					IL_01b9: ldloc.s 12
-					IL_01bb: stloc.s 15
+					IL_01b2: ldloc.s 11
+					IL_01b4: stloc.s 14
 
-					IL_01bd: ldloc.s 10
-					IL_01bf: ldstr "log"
-					IL_01c4: ldloc.s 15
-					IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_01cb: pop
-					IL_01cc: leave IL_01d1
+					IL_01b6: ldloc.s 9
+					IL_01b8: ldstr "log"
+					IL_01bd: ldloc.s 14
+					IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_01c4: pop
+					IL_01c5: leave IL_01ca
 				} // end handler
 
-				IL_01d1: br IL_0043
+				IL_01ca: br IL_0043
 			// end loop
-			IL_01d6: ldloc.1
-			IL_01d7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-			IL_01dc: ldc.i4.1
-			IL_01dd: stloc.3
-			IL_01de: leave IL_01fd
+			IL_01cf: ldloc.1
+			IL_01d0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+			IL_01d5: ldc.i4.1
+			IL_01d6: stloc.3
+			IL_01d7: leave IL_01f6
 
-			IL_01e3: ldc.i4.1
-			IL_01e4: stloc.2
-			IL_01e5: leave IL_01fd
+			IL_01dc: ldc.i4.1
+			IL_01dd: stloc.2
+			IL_01de: leave IL_01f6
 		} // end .try
 		finally
 		{
-			IL_01ea: ldloc.2
-			IL_01eb: brtrue IL_01fc
+			IL_01e3: ldloc.2
+			IL_01e4: brtrue IL_01f5
 
-			IL_01f0: ldloc.3
-			IL_01f1: brtrue IL_01fc
+			IL_01e9: ldloc.3
+			IL_01ea: brtrue IL_01f5
 
-			IL_01f6: ldloc.1
-			IL_01f7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+			IL_01ef: ldloc.1
+			IL_01f0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-			IL_01fc: endfinally
+			IL_01f5: endfinally
 		} // end handler
 
-		IL_01fd: ldnull
-		IL_01fe: stloc.s 9
-		IL_0200: ret
+		IL_01f6: ldnull
+		IL_01f7: stloc.s 8
+		IL_01f9: ret
 	} // end of method Uint8Array_FromBase64_InvalidInput::__js_module_init__
 
 } // end of class Modules.Uint8Array_FromBase64_InvalidInput
@@ -351,7 +348,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c1
+		// Method begins at RVA 0x22b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstReassignmentError.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstReassignmentError.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2125
+				// Method begins at RVA 0x2121
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212e
+				// Method begins at RVA 0x212a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211c
+			// Method begins at RVA 0x2118
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 176 (0xb0)
+		// Code size: 169 (0xa9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ConstReassignmentError/Scope,
@@ -90,9 +90,8 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Variable_ConstReassignmentError/Scope/Block_L7C12,
-			[6] object,
-			[7] object
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_ConstReassignmentError/Scope::.ctor()
@@ -109,16 +108,16 @@
 
 			IL_001d: ldstr "console"
 			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0027: stloc.s 7
-			IL_0029: ldloc.s 7
+			IL_0027: stloc.s 6
+			IL_0029: ldloc.s 6
 			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0030: stloc.s 7
-			IL_0032: ldloc.s 7
+			IL_0030: stloc.s 6
+			IL_0032: ldloc.s 6
 			IL_0034: ldstr "log"
 			IL_0039: ldstr "NO_ERROR"
 			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0043: pop
-			IL_0044: leave IL_00ac
+			IL_0044: leave IL_00a5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -144,28 +143,26 @@
 			IL_0071: stloc.3
 
 			IL_0072: ldloc.3
-			IL_0073: stloc.s 7
-			IL_0075: ldloc.s 7
+			IL_0073: stloc.s 6
+			IL_0075: ldloc.s 6
 			IL_0077: stloc.s 4
-			IL_0079: newobj instance void Modules.Variable_ConstReassignmentError/Scope/Block_L7C12::.ctor()
-			IL_007e: stloc.s 5
-			IL_0080: ldstr "console"
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008a: stloc.s 7
-			IL_008c: ldloc.s 7
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0093: stloc.s 7
-			IL_0095: ldloc.s 7
-			IL_0097: ldstr "log"
-			IL_009c: ldstr "CONST_REASSIGN_ERROR"
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a6: pop
-			IL_00a7: leave IL_00ac
+			IL_0079: ldstr "console"
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0083: stloc.s 6
+			IL_0085: ldloc.s 6
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008c: stloc.s 6
+			IL_008e: ldloc.s 6
+			IL_0090: ldstr "log"
+			IL_0095: ldstr "CONST_REASSIGN_ERROR"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_009f: pop
+			IL_00a0: leave IL_00a5
 		} // end handler
 
-		IL_00ac: ldnull
-		IL_00ad: stloc.s 6
-		IL_00af: ret
+		IL_00a5: ldnull
+		IL_00a6: stloc.s 5
+		IL_00a8: ret
 	} // end of method Variable_ConstReassignmentError::__js_module_init__
 
 } // end of class Modules.Variable_ConstReassignmentError
@@ -177,7 +174,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2137
+		// Method begins at RVA 0x2133
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x249e
+					// Method begins at RVA 0x2496
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24a7
+					// Method begins at RVA 0x249f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2495
+				// Method begins at RVA 0x248d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,16 +86,15 @@
 			)
 			// Method begins at RVA 0x21f4
 			// Header size: 12
-			// Code size: 161 (0xa1)
+			// Code size: 153 (0x99)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
 				[1] object,
 				[2] object,
-				[3] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/Scope/Block_L6C14,
+				[3] object,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object
 			)
 
 			.try
@@ -105,7 +104,7 @@
 				IL_0002: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 				IL_000c: pop
-				IL_000d: leave IL_009b
+				IL_000d: leave IL_0095
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -131,41 +130,39 @@
 				IL_003a: stloc.1
 
 				IL_003b: ldloc.1
-				IL_003c: stloc.s 5
-				IL_003e: ldloc.s 5
+				IL_003c: stloc.s 4
+				IL_003e: ldloc.s 4
 				IL_0040: stloc.2
-				IL_0041: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/Scope/Block_L6C14::.ctor()
-				IL_0046: stloc.3
-				IL_0047: ldstr "console"
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0051: stloc.s 5
-				IL_0053: ldloc.s 5
-				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005a: stloc.s 5
-				IL_005c: ldloc.2
-				IL_005d: ldstr "name"
-				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0067: ldstr ": "
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0071: stloc.s 6
-				IL_0073: ldloc.s 6
-				IL_0075: ldloc.2
-				IL_0076: ldstr "message"
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0085: stloc.s 6
-				IL_0087: ldloc.s 5
-				IL_0089: ldstr "log"
-				IL_008e: ldloc.s 6
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0095: pop
-				IL_0096: leave IL_009b
+				IL_0041: ldstr "console"
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_004b: stloc.s 4
+				IL_004d: ldloc.s 4
+				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0054: stloc.s 4
+				IL_0056: ldloc.2
+				IL_0057: ldstr "name"
+				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0061: ldstr ": "
+				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_006b: stloc.s 5
+				IL_006d: ldloc.s 5
+				IL_006f: ldloc.2
+				IL_0070: ldstr "message"
+				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_007f: stloc.s 5
+				IL_0081: ldloc.s 4
+				IL_0083: ldstr "log"
+				IL_0088: ldloc.s 5
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_008f: pop
+				IL_0090: leave IL_0095
 			} // end handler
 
-			IL_009b: ldnull
-			IL_009c: stloc.s 4
-			IL_009e: ldloc.s 4
-			IL_00a0: ret
+			IL_0095: ldnull
+			IL_0096: stloc.3
+			IL_0097: ldloc.3
+			IL_0098: ret
 		} // end of method logError::__js_call__
 
 	} // end of class logError
@@ -181,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x24a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -207,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22b4
+			// Method begins at RVA 0x22ac
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -252,7 +249,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24b9
+				// Method begins at RVA 0x24b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,7 +275,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -323,7 +320,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24c2
+				// Method begins at RVA 0x24ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -349,7 +346,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x233c
+			// Method begins at RVA 0x2334
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -450,7 +447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cb
+				// Method begins at RVA 0x24c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -476,7 +473,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23e4
+			// Method begins at RVA 0x23dc
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -583,7 +580,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x248c
+			// Method begins at RVA 0x2484
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -796,7 +793,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24d4
+		// Method begins at RVA 0x24cc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetBlockScope.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetBlockScope.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20df
+				// Method begins at RVA 0x20d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -36,7 +36,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d6
+			// Method begins at RVA 0x20c9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -62,15 +62,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 122 (0x7a)
+		// Code size: 109 (0x6d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetBlockScope/Scope,
 			[1] float64,
-			[2] class Modules.Variable_LetBlockScope/Scope/Block_L4C0,
-			[3] float64,
-			[4] object,
-			[5] object
+			[2] float64,
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_LetBlockScope/Scope::.ctor()
@@ -78,39 +77,38 @@
 		IL_0006: nop
 		IL_0007: ldc.r8 1
 		IL_0010: stloc.1
-		IL_0011: newobj instance void Modules.Variable_LetBlockScope/Scope/Block_L4C0::.ctor()
-		IL_0016: stloc.2
-		IL_0017: ldc.r8 2
-		IL_0020: stloc.3
-		IL_0021: ldstr "console"
-		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002b: stloc.s 4
-		IL_002d: ldloc.s 4
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0011: nop
+		IL_0012: ldc.r8 2
+		IL_001b: stloc.2
+		IL_001c: ldstr "console"
+		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0026: stloc.3
+		IL_0027: ldloc.3
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_002d: stloc.3
+		IL_002e: ldloc.2
+		IL_002f: box [System.Runtime]System.Double
 		IL_0034: stloc.s 4
 		IL_0036: ldloc.3
-		IL_0037: box [System.Runtime]System.Double
-		IL_003c: stloc.s 5
-		IL_003e: ldloc.s 4
-		IL_0040: ldstr "log"
-		IL_0045: ldloc.s 5
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_004c: pop
-		IL_004d: ldstr "console"
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0057: stloc.s 4
-		IL_0059: ldloc.s 4
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0060: stloc.s 4
-		IL_0062: ldloc.1
-		IL_0063: box [System.Runtime]System.Double
-		IL_0068: stloc.s 5
-		IL_006a: ldloc.s 4
-		IL_006c: ldstr "log"
-		IL_0071: ldloc.s 5
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0078: pop
-		IL_0079: ret
+		IL_0037: ldstr "log"
+		IL_003c: ldloc.s 4
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0043: pop
+		IL_0044: ldstr "console"
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_004e: stloc.3
+		IL_004f: ldloc.3
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0055: stloc.3
+		IL_0056: ldloc.1
+		IL_0057: box [System.Runtime]System.Double
+		IL_005c: stloc.s 4
+		IL_005e: ldloc.3
+		IL_005f: ldstr "log"
+		IL_0064: ldloc.s 4
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_006b: pop
+		IL_006c: ret
 	} // end of method Variable_LetBlockScope::__js_module_init__
 
 } // end of class Modules.Variable_LetBlockScope
@@ -122,7 +120,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e8
+		// Method begins at RVA 0x20db
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetNestedShadowingChain.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21c8
+						// Method begins at RVA 0x21b2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21bf
+					// Method begins at RVA 0x21a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b6
+				// Method begins at RVA 0x21a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ad
+			// Method begins at RVA 0x2197
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,19 +106,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 337 (0x151)
+		// Code size: 315 (0x13b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetNestedShadowingChain/Scope,
 			[1] float64,
-			[2] class Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0,
+			[2] float64,
 			[3] float64,
-			[4] class Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2,
-			[5] float64,
-			[6] class Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2/Block_L10C4,
-			[7] float64,
-			[8] object,
-			[9] object
+			[4] float64,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope::.ctor()
@@ -126,103 +123,98 @@
 		IL_0006: nop
 		IL_0007: ldc.r8 0.0
 		IL_0010: stloc.1
-		IL_0011: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0::.ctor()
-		IL_0016: stloc.2
-		IL_0017: ldc.r8 1
-		IL_0020: stloc.3
-		IL_0021: ldstr "console"
-		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_002b: stloc.s 8
-		IL_002d: ldloc.s 8
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0034: stloc.s 8
-		IL_0036: ldloc.3
-		IL_0037: box [System.Runtime]System.Double
-		IL_003c: stloc.s 9
-		IL_003e: ldloc.s 8
-		IL_0040: ldstr "log"
-		IL_0045: ldloc.s 9
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_004c: pop
-		IL_004d: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2::.ctor()
-		IL_0052: stloc.s 4
-		IL_0054: ldc.r8 2
-		IL_005d: stloc.s 5
-		IL_005f: ldstr "console"
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0069: stloc.s 8
-		IL_006b: ldloc.s 8
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 8
-		IL_0074: ldloc.s 5
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: stloc.s 9
-		IL_007d: ldloc.s 8
-		IL_007f: ldstr "log"
-		IL_0084: ldloc.s 9
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_008b: pop
-		IL_008c: newobj instance void Modules.Variable_LetNestedShadowingChain/Scope/Block_L4C0/Block_L7C2/Block_L10C4::.ctor()
-		IL_0091: stloc.s 6
-		IL_0093: ldc.r8 3
-		IL_009c: stloc.s 7
-		IL_009e: ldstr "console"
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a8: stloc.s 8
-		IL_00aa: ldloc.s 8
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b1: stloc.s 8
-		IL_00b3: ldloc.s 7
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: stloc.s 9
-		IL_00bc: ldloc.s 8
-		IL_00be: ldstr "log"
-		IL_00c3: ldloc.s 9
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ldstr "console"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d5: stloc.s 8
-		IL_00d7: ldloc.s 8
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: stloc.s 8
-		IL_00e0: ldloc.s 5
-		IL_00e2: box [System.Runtime]System.Double
-		IL_00e7: stloc.s 9
-		IL_00e9: ldloc.s 8
-		IL_00eb: ldstr "log"
-		IL_00f0: ldloc.s 9
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f7: pop
-		IL_00f8: ldstr "console"
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0102: stloc.s 8
-		IL_0104: ldloc.s 8
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010b: stloc.s 8
-		IL_010d: ldloc.3
-		IL_010e: box [System.Runtime]System.Double
-		IL_0113: stloc.s 9
-		IL_0115: ldloc.s 8
-		IL_0117: ldstr "log"
-		IL_011c: ldloc.s 9
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0123: pop
-		IL_0124: ldstr "console"
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012e: stloc.s 8
-		IL_0130: ldloc.s 8
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0137: stloc.s 8
-		IL_0139: ldloc.1
-		IL_013a: box [System.Runtime]System.Double
-		IL_013f: stloc.s 9
-		IL_0141: ldloc.s 8
-		IL_0143: ldstr "log"
-		IL_0148: ldloc.s 9
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014f: pop
-		IL_0150: ret
+		IL_0011: nop
+		IL_0012: ldc.r8 1
+		IL_001b: stloc.2
+		IL_001c: ldstr "console"
+		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0026: stloc.s 5
+		IL_0028: ldloc.s 5
+		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_002f: stloc.s 5
+		IL_0031: ldloc.2
+		IL_0032: box [System.Runtime]System.Double
+		IL_0037: stloc.s 6
+		IL_0039: ldloc.s 5
+		IL_003b: ldstr "log"
+		IL_0040: ldloc.s 6
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0047: pop
+		IL_0048: ldc.r8 2
+		IL_0051: stloc.3
+		IL_0052: ldstr "console"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005c: stloc.s 5
+		IL_005e: ldloc.s 5
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: stloc.s 5
+		IL_0067: ldloc.3
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: stloc.s 6
+		IL_006f: ldloc.s 5
+		IL_0071: ldstr "log"
+		IL_0076: ldloc.s 6
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007d: pop
+		IL_007e: ldc.r8 3
+		IL_0087: stloc.s 4
+		IL_0089: ldstr "console"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0093: stloc.s 5
+		IL_0095: ldloc.s 5
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009c: stloc.s 5
+		IL_009e: ldloc.s 4
+		IL_00a0: box [System.Runtime]System.Double
+		IL_00a5: stloc.s 6
+		IL_00a7: ldloc.s 5
+		IL_00a9: ldstr "log"
+		IL_00ae: ldloc.s 6
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00b5: pop
+		IL_00b6: ldstr "console"
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c0: stloc.s 5
+		IL_00c2: ldloc.s 5
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c9: stloc.s 5
+		IL_00cb: ldloc.3
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: stloc.s 6
+		IL_00d3: ldloc.s 5
+		IL_00d5: ldstr "log"
+		IL_00da: ldloc.s 6
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e1: pop
+		IL_00e2: ldstr "console"
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldloc.s 5
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f5: stloc.s 5
+		IL_00f7: ldloc.2
+		IL_00f8: box [System.Runtime]System.Double
+		IL_00fd: stloc.s 6
+		IL_00ff: ldloc.s 5
+		IL_0101: ldstr "log"
+		IL_0106: ldloc.s 6
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010d: pop
+		IL_010e: ldstr "console"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0118: stloc.s 5
+		IL_011a: ldloc.s 5
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0121: stloc.s 5
+		IL_0123: ldloc.1
+		IL_0124: box [System.Runtime]System.Double
+		IL_0129: stloc.s 6
+		IL_012b: ldloc.s 5
+		IL_012d: ldstr "log"
+		IL_0132: ldloc.s 6
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0139: pop
+		IL_013a: ret
 	} // end of method Variable_LetNestedShadowingChain::__js_module_init__
 
 } // end of class Modules.Variable_LetNestedShadowingChain
@@ -234,7 +226,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d1
+		// Method begins at RVA 0x21bb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2768
+					// Method begins at RVA 0x2764
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2771
+					// Method begins at RVA 0x276d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x277a
+					// Method begins at RVA 0x2776
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x275f
+				// Method begins at RVA 0x275b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,7 +189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2783
+				// Method begins at RVA 0x277f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -286,7 +286,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2795
+					// Method begins at RVA 0x2791
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -304,7 +304,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x278c
+				// Method begins at RVA 0x2788
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -370,7 +370,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27a7
+					// Method begins at RVA 0x27a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -388,7 +388,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x279e
+				// Method begins at RVA 0x279a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -453,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27b9
+					// Method begins at RVA 0x27b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -477,7 +477,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2718
+				// Method begins at RVA 0x2714
 				// Header size: 12
 				// Code size: 50 (0x32)
 				.maxstack 8
@@ -521,7 +521,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b0
+				// Method begins at RVA 0x27ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -598,7 +598,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c2
+				// Method begins at RVA 0x27be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -654,7 +654,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27cb
+				// Method begins at RVA 0x27c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -739,7 +739,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27e6
+						// Method begins at RVA 0x27e2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -757,7 +757,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27dd
+					// Method begins at RVA 0x27d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -775,7 +775,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d4
+				// Method begins at RVA 0x27d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -840,7 +840,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ef
+				// Method begins at RVA 0x27eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -926,7 +926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2801
+					// Method begins at RVA 0x27fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -944,7 +944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f8
+				// Method begins at RVA 0x27f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -969,30 +969,28 @@
 			)
 			// Method begins at RVA 0x26ec
 			// Header size: 12
-			// Code size: 32 (0x20)
+			// Code size: 25 (0x19)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
-				[2] class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/Scope/Block_L80C4,
-				[3] string,
-				[4] string
+				[2] string,
+				[3] string
 			)
 
 			IL_0000: ldc.r8 1
 			IL_0009: stloc.0
 			IL_000a: ldnull
 			IL_000b: stloc.1
-			IL_000c: newobj instance void Modules.Variable_NumericVarLocalSpecialization/shadowedSource/Scope/Block_L80C4::.ctor()
-			IL_0011: stloc.2
-			IL_0012: ldstr "text"
-			IL_0017: stloc.3
-			IL_0018: ldloc.3
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: stloc.1
-			IL_001e: ldloc.1
-			IL_001f: ret
+			IL_000c: nop
+			IL_000d: ldstr "text"
+			IL_0012: stloc.2
+			IL_0013: ldloc.2
+			IL_0014: stloc.3
+			IL_0015: ldloc.3
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: ret
 		} // end of method shadowedSource::__js_call__
 
 	} // end of class shadowedSource
@@ -1037,7 +1035,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2756
+			// Method begins at RVA 0x2752
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1064,7 +1062,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280a
+				// Method begins at RVA 0x2806
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1077,7 +1075,7 @@
 			.method public hidebysig 
 				instance object get_property () cil managed 
 			{
-				// Method begins at RVA 0x2812
+				// Method begins at RVA 0x280e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -1092,7 +1090,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x281a
+				// Method begins at RVA 0x2816
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -1508,7 +1506,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x282f
+		// Method begins at RVA 0x282b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneAccess.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneAccess.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2179
+				// Method begins at RVA 0x2169
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2182
+				// Method begins at RVA 0x2172
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2170
+			// Method begins at RVA 0x2160
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,18 +82,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 257 (0x101)
+		// Code size: 242 (0xf2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneAccess/Scope,
-			[1] class Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L3C4,
-			[2] float64,
-			[3] class [System.Runtime]System.Exception,
+			[1] float64,
+			[2] class [System.Runtime]System.Exception,
+			[3] object,
 			[4] object,
 			[5] object,
-			[6] class Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L7C12,
-			[7] object,
-			[8] object
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_TemporalDeadZoneAccess/Scope::.ctor()
@@ -101,96 +99,93 @@
 		IL_0006: nop
 		.try
 		{
-			IL_0007: newobj instance void Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L3C4::.ctor()
-			IL_000c: stloc.1
-			IL_000d: ldstr "console"
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0017: stloc.s 8
-			IL_0019: ldloc.s 8
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0020: stloc.s 8
-			IL_0022: ldstr "Cannot access 'a' before initialization"
-			IL_0027: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0031: isinst [System.Runtime]System.Exception
-			IL_0036: dup
-			IL_0037: brtrue IL_0052
+			IL_0007: nop
+			IL_0008: ldstr "console"
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0012: stloc.s 6
+			IL_0014: ldloc.s 6
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001b: stloc.s 6
+			IL_001d: ldstr "Cannot access 'a' before initialization"
+			IL_0022: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_002c: isinst [System.Runtime]System.Exception
+			IL_0031: dup
+			IL_0032: brtrue IL_004d
 
-			IL_003c: pop
-			IL_003d: ldstr "Cannot access 'a' before initialization"
-			IL_0042: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0051: throw
+			IL_0037: pop
+			IL_0038: ldstr "Cannot access 'a' before initialization"
+			IL_003d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_004c: throw
 
-			IL_0052: throw
+			IL_004d: throw
 
-			IL_0053: ldloc.s 8
-			IL_0055: ldstr "log"
-			IL_005a: ldnull
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0060: pop
-			IL_0061: ldc.r8 3
-			IL_006a: stloc.2
-			IL_006b: ldstr "console"
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0075: stloc.s 8
-			IL_0077: ldloc.s 8
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007e: stloc.s 8
-			IL_0080: ldloc.s 8
-			IL_0082: ldstr "log"
-			IL_0087: ldstr "NO_TDZ"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0091: pop
-			IL_0092: leave IL_00fd
+			IL_004e: ldloc.s 6
+			IL_0050: ldstr "log"
+			IL_0055: ldnull
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_005b: pop
+			IL_005c: ldc.r8 3
+			IL_0065: stloc.1
+			IL_0066: ldstr "console"
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0070: stloc.s 6
+			IL_0072: ldloc.s 6
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0079: stloc.s 6
+			IL_007b: ldloc.s 6
+			IL_007d: ldstr "log"
+			IL_0082: ldstr "NO_TDZ"
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008c: pop
+			IL_008d: leave IL_00ee
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0097: stloc.3
-			IL_0098: ldloc.3
-			IL_0099: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_009e: dup
-			IL_009f: brtrue IL_00b4
+			IL_0092: stloc.2
+			IL_0093: ldloc.2
+			IL_0094: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0099: dup
+			IL_009a: brtrue IL_00af
 
-			IL_00a4: pop
-			IL_00a5: ldloc.3
-			IL_00a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00ab: dup
-			IL_00ac: brtrue IL_00c0
+			IL_009f: pop
+			IL_00a0: ldloc.2
+			IL_00a1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00a6: dup
+			IL_00a7: brtrue IL_00ba
 
-			IL_00b1: pop
-			IL_00b2: rethrow
+			IL_00ac: pop
+			IL_00ad: rethrow
 
-			IL_00b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00b9: stloc.s 4
-			IL_00bb: br IL_00c2
+			IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00b4: stloc.3
+			IL_00b5: br IL_00bb
 
+			IL_00ba: stloc.3
+
+			IL_00bb: ldloc.3
+			IL_00bc: stloc.s 6
+			IL_00be: ldloc.s 6
 			IL_00c0: stloc.s 4
-
-			IL_00c2: ldloc.s 4
-			IL_00c4: stloc.s 8
-			IL_00c6: ldloc.s 8
-			IL_00c8: stloc.s 5
-			IL_00ca: newobj instance void Modules.Variable_TemporalDeadZoneAccess/Scope/Block_L7C12::.ctor()
-			IL_00cf: stloc.s 6
-			IL_00d1: ldstr "console"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00db: stloc.s 8
-			IL_00dd: ldloc.s 8
-			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e4: stloc.s 8
-			IL_00e6: ldloc.s 8
-			IL_00e8: ldstr "log"
-			IL_00ed: ldstr "TDZ_ERROR"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f7: pop
-			IL_00f8: leave IL_00fd
+			IL_00c2: ldstr "console"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00cc: stloc.s 6
+			IL_00ce: ldloc.s 6
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d5: stloc.s 6
+			IL_00d7: ldloc.s 6
+			IL_00d9: ldstr "log"
+			IL_00de: ldstr "TDZ_ERROR"
+			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e8: pop
+			IL_00e9: leave IL_00ee
 		} // end handler
 
-		IL_00fd: ldnull
-		IL_00fe: stloc.s 7
-		IL_0100: ret
+		IL_00ee: ldnull
+		IL_00ef: stloc.s 5
+		IL_00f1: ret
 	} // end of method Variable_TemporalDeadZoneAccess::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneAccess
@@ -202,7 +197,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218b
+		// Method begins at RVA 0x217b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d6
+				// Method begins at RVA 0x21d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x2180
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21df
+				// Method begins at RVA 0x21db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e8
+				// Method begins at RVA 0x21e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x21be
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -162,7 +162,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 280 (0x118)
+		// Code size: 273 (0x111)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope,
@@ -170,10 +170,9 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L10C12,
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope::.ctor()
@@ -195,8 +194,8 @@
 		IL_0029: ldc.i4.0
 		IL_002a: ldc.i4.1
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0030: stloc.s 7
-		IL_0032: ldloc.s 7
+		IL_0030: stloc.s 6
+		IL_0032: ldloc.s 6
 		IL_0034: stloc.1
 		IL_0035: nop
 		IL_0036: nop
@@ -209,16 +208,16 @@
 			IL_0043: pop
 			IL_0044: ldstr "console"
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004e: stloc.s 7
-			IL_0050: ldloc.s 7
+			IL_004e: stloc.s 6
+			IL_0050: ldloc.s 6
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0057: stloc.s 7
-			IL_0059: ldloc.s 7
+			IL_0057: stloc.s 6
+			IL_0059: ldloc.s 6
 			IL_005b: ldstr "log"
 			IL_0060: ldstr "NO_TDZ"
 			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_006a: pop
-			IL_006b: leave IL_00d3
+			IL_006b: leave IL_00cc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -244,47 +243,45 @@
 			IL_0098: stloc.3
 
 			IL_0099: ldloc.3
-			IL_009a: stloc.s 7
-			IL_009c: ldloc.s 7
+			IL_009a: stloc.s 6
+			IL_009c: ldloc.s 6
 			IL_009e: stloc.s 4
-			IL_00a0: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L10C12::.ctor()
-			IL_00a5: stloc.s 5
-			IL_00a7: ldstr "console"
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b1: stloc.s 7
-			IL_00b3: ldloc.s 7
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ba: stloc.s 7
-			IL_00bc: ldloc.s 7
-			IL_00be: ldstr "log"
-			IL_00c3: ldstr "TDZ_CAPTURED"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00cd: pop
-			IL_00ce: leave IL_00d3
+			IL_00a0: ldstr "console"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00aa: stloc.s 6
+			IL_00ac: ldloc.s 6
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b3: stloc.s 6
+			IL_00b5: ldloc.s 6
+			IL_00b7: ldstr "log"
+			IL_00bc: ldstr "TDZ_CAPTURED"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c6: pop
+			IL_00c7: leave IL_00cc
 		} // end handler
 
-		IL_00d3: ldloc.0
-		IL_00d4: ldstr "ready"
-		IL_00d9: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00de: ldstr "console"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e8: stloc.s 7
-		IL_00ea: ldloc.s 7
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f1: stloc.s 7
-		IL_00f3: ldloc.0
-		IL_00f4: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00f9: ldstr "Cannot access 'value' before initialization"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0103: stloc.s 8
+		IL_00cc: ldloc.0
+		IL_00cd: ldstr "ready"
+		IL_00d2: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00d7: ldstr "console"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e1: stloc.s 6
+		IL_00e3: ldloc.s 6
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ea: stloc.s 6
+		IL_00ec: ldloc.0
+		IL_00ed: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00f2: ldstr "Cannot access 'value' before initialization"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_00fc: stloc.s 7
+		IL_00fe: ldloc.s 6
+		IL_0100: ldstr "log"
 		IL_0105: ldloc.s 7
-		IL_0107: ldstr "log"
-		IL_010c: ldloc.s 8
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0113: pop
-		IL_0114: ldnull
-		IL_0115: stloc.s 6
-		IL_0117: ret
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010c: pop
+		IL_010d: ldnull
+		IL_010e: stloc.s 5
+		IL_0110: ret
 	} // end of method Variable_TemporalDeadZoneCapturedRead::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneCapturedRead
@@ -296,7 +293,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f1
+		// Method begins at RVA 0x21ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneShadowing.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ca
+					// Method begins at RVA 0x21be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d3
+					// Method begins at RVA 0x21c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c1
+				// Method begins at RVA 0x21b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,19 +104,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 332 (0x14c)
+		// Code size: 317 (0x13d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneShadowing/Scope,
 			[1] string,
-			[2] class Modules.Variable_TemporalDeadZoneShadowing/Scope/Block_L5C0,
-			[3] class [System.Runtime]System.Exception,
+			[2] class [System.Runtime]System.Exception,
+			[3] object,
 			[4] object,
-			[5] object,
-			[6] class Modules.Variable_TemporalDeadZoneShadowing/Scope/Block_L5C0/Block_L9C14,
-			[7] string,
-			[8] object,
-			[9] object
+			[5] string,
+			[6] object,
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_TemporalDeadZoneShadowing/Scope::.ctor()
@@ -124,121 +122,118 @@
 		IL_0006: nop
 		IL_0007: ldstr "outer"
 		IL_000c: stloc.1
-		IL_000d: newobj instance void Modules.Variable_TemporalDeadZoneShadowing/Scope/Block_L5C0::.ctor()
-		IL_0012: stloc.2
+		IL_000d: nop
 		.try
 		{
-			IL_0013: nop
-			IL_0014: ldstr "console"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001e: stloc.s 9
-			IL_0020: ldloc.s 9
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0027: stloc.s 9
-			IL_0029: ldstr "Cannot access 'value' before initialization"
-			IL_002e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0038: isinst [System.Runtime]System.Exception
-			IL_003d: dup
-			IL_003e: brtrue IL_0059
+			IL_000e: nop
+			IL_000f: ldstr "console"
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0019: stloc.s 7
+			IL_001b: ldloc.s 7
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0022: stloc.s 7
+			IL_0024: ldstr "Cannot access 'value' before initialization"
+			IL_0029: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0033: isinst [System.Runtime]System.Exception
+			IL_0038: dup
+			IL_0039: brtrue IL_0054
 
-			IL_0043: pop
-			IL_0044: ldstr "Cannot access 'value' before initialization"
-			IL_0049: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0058: throw
+			IL_003e: pop
+			IL_003f: ldstr "Cannot access 'value' before initialization"
+			IL_0044: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0053: throw
 
-			IL_0059: throw
+			IL_0054: throw
 
-			IL_005a: ldloc.s 9
-			IL_005c: ldstr "log"
-			IL_0061: ldnull
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0067: pop
-			IL_0068: ldstr "console"
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0072: stloc.s 9
-			IL_0074: ldloc.s 9
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007b: stloc.s 9
-			IL_007d: ldloc.s 9
-			IL_007f: ldstr "log"
-			IL_0084: ldstr "NO_TDZ"
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008e: pop
-			IL_008f: leave IL_00fa
+			IL_0055: ldloc.s 7
+			IL_0057: ldstr "log"
+			IL_005c: ldnull
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0062: pop
+			IL_0063: ldstr "console"
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006d: stloc.s 7
+			IL_006f: ldloc.s 7
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0076: stloc.s 7
+			IL_0078: ldloc.s 7
+			IL_007a: ldstr "log"
+			IL_007f: ldstr "NO_TDZ"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0089: pop
+			IL_008a: leave IL_00eb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0094: stloc.3
-			IL_0095: ldloc.3
-			IL_0096: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_009b: dup
-			IL_009c: brtrue IL_00b1
+			IL_008f: stloc.2
+			IL_0090: ldloc.2
+			IL_0091: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0096: dup
+			IL_0097: brtrue IL_00ac
 
-			IL_00a1: pop
-			IL_00a2: ldloc.3
-			IL_00a3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00a8: dup
-			IL_00a9: brtrue IL_00bd
+			IL_009c: pop
+			IL_009d: ldloc.2
+			IL_009e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00a3: dup
+			IL_00a4: brtrue IL_00b7
 
-			IL_00ae: pop
-			IL_00af: rethrow
+			IL_00a9: pop
+			IL_00aa: rethrow
 
-			IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00b6: stloc.s 4
-			IL_00b8: br IL_00bf
+			IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00b1: stloc.3
+			IL_00b2: br IL_00b8
 
+			IL_00b7: stloc.3
+
+			IL_00b8: ldloc.3
+			IL_00b9: stloc.s 7
+			IL_00bb: ldloc.s 7
 			IL_00bd: stloc.s 4
-
-			IL_00bf: ldloc.s 4
-			IL_00c1: stloc.s 9
-			IL_00c3: ldloc.s 9
-			IL_00c5: stloc.s 5
-			IL_00c7: newobj instance void Modules.Variable_TemporalDeadZoneShadowing/Scope/Block_L5C0/Block_L9C14::.ctor()
-			IL_00cc: stloc.s 6
-			IL_00ce: ldstr "console"
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d8: stloc.s 9
-			IL_00da: ldloc.s 9
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e1: stloc.s 9
-			IL_00e3: ldloc.s 9
-			IL_00e5: ldstr "log"
-			IL_00ea: ldstr "INNER_TDZ"
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f4: pop
-			IL_00f5: leave IL_00fa
+			IL_00bf: ldstr "console"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c9: stloc.s 7
+			IL_00cb: ldloc.s 7
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d2: stloc.s 7
+			IL_00d4: ldloc.s 7
+			IL_00d6: ldstr "log"
+			IL_00db: ldstr "INNER_TDZ"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e5: pop
+			IL_00e6: leave IL_00eb
 		} // end handler
 
-		IL_00fa: ldstr "inner"
-		IL_00ff: stloc.s 7
-		IL_0101: ldstr "console"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_010b: stloc.s 9
-		IL_010d: ldloc.s 9
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0114: stloc.s 9
-		IL_0116: ldloc.s 9
-		IL_0118: ldstr "log"
-		IL_011d: ldloc.s 7
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0124: pop
-		IL_0125: ldstr "console"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012f: stloc.s 9
-		IL_0131: ldloc.s 9
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0138: stloc.s 9
-		IL_013a: ldloc.s 9
-		IL_013c: ldstr "log"
-		IL_0141: ldloc.1
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0147: pop
-		IL_0148: ldnull
-		IL_0149: stloc.s 8
-		IL_014b: ret
+		IL_00eb: ldstr "inner"
+		IL_00f0: stloc.s 5
+		IL_00f2: ldstr "console"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00fc: stloc.s 7
+		IL_00fe: ldloc.s 7
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 7
+		IL_0107: ldloc.s 7
+		IL_0109: ldstr "log"
+		IL_010e: ldloc.s 5
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0115: pop
+		IL_0116: ldstr "console"
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0120: stloc.s 7
+		IL_0122: ldloc.s 7
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0129: stloc.s 7
+		IL_012b: ldloc.s 7
+		IL_012d: ldstr "log"
+		IL_0132: ldloc.1
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0138: pop
+		IL_0139: ldnull
+		IL_013a: stloc.s 6
+		IL_013c: ret
 	} // end of method Variable_TemporalDeadZoneShadowing::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneShadowing
@@ -250,7 +245,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dc
+		// Method begins at RVA 0x21d0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneSwitchScope.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneSwitchScope.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21aa
+					// Method begins at RVA 0x219a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b3
+					// Method begins at RVA 0x21a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a1
+				// Method begins at RVA 0x2191
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2198
+			// Method begins at RVA 0x2188
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,130 +104,124 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 298 (0x12a)
+		// Code size: 284 (0x11c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneSwitchScope/Scope,
-			[1] class Modules.Variable_TemporalDeadZoneSwitchScope/Scope/Switch_L3C0,
-			[2] class [System.Runtime]System.Exception,
+			[1] class [System.Runtime]System.Exception,
+			[2] object,
 			[3] object,
-			[4] object,
-			[5] class Modules.Variable_TemporalDeadZoneSwitchScope/Scope/Switch_L3C0/Block_L8C16,
-			[6] string,
-			[7] object,
-			[8] object
+			[4] string,
+			[5] object,
+			[6] object
 		)
 
 		IL_0000: newobj instance void Modules.Variable_TemporalDeadZoneSwitchScope/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: newobj instance void Modules.Variable_TemporalDeadZoneSwitchScope/Scope/Switch_L3C0::.ctor()
-		IL_000c: stloc.1
-		IL_000d: br IL_0012
+		IL_0007: br IL_000c
 		.try
 		{
-			IL_0012: nop
-			IL_0013: ldstr "console"
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001d: stloc.s 8
-			IL_001f: ldloc.s 8
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0026: stloc.s 8
-			IL_0028: ldstr "Cannot access 'value' before initialization"
-			IL_002d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0037: isinst [System.Runtime]System.Exception
-			IL_003c: dup
-			IL_003d: brtrue IL_0058
+			IL_000c: nop
+			IL_000d: ldstr "console"
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0017: stloc.s 6
+			IL_0019: ldloc.s 6
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0020: stloc.s 6
+			IL_0022: ldstr "Cannot access 'value' before initialization"
+			IL_0027: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_002c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0031: isinst [System.Runtime]System.Exception
+			IL_0036: dup
+			IL_0037: brtrue IL_0052
 
-			IL_0042: pop
-			IL_0043: ldstr "Cannot access 'value' before initialization"
-			IL_0048: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0052: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0057: throw
+			IL_003c: pop
+			IL_003d: ldstr "Cannot access 'value' before initialization"
+			IL_0042: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0051: throw
 
-			IL_0058: throw
+			IL_0052: throw
 
-			IL_0059: ldloc.s 8
-			IL_005b: ldstr "log"
-			IL_0060: ldnull
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0066: pop
-			IL_0067: ldstr "console"
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0071: stloc.s 8
-			IL_0073: ldloc.s 8
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007a: stloc.s 8
-			IL_007c: ldloc.s 8
-			IL_007e: ldstr "log"
-			IL_0083: ldstr "NO_TDZ"
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008d: pop
-			IL_008e: leave IL_00f6
+			IL_0053: ldloc.s 6
+			IL_0055: ldstr "log"
+			IL_005a: ldnull
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0060: pop
+			IL_0061: ldstr "console"
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006b: stloc.s 6
+			IL_006d: ldloc.s 6
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0074: stloc.s 6
+			IL_0076: ldloc.s 6
+			IL_0078: ldstr "log"
+			IL_007d: ldstr "NO_TDZ"
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0087: pop
+			IL_0088: leave IL_00e8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0093: stloc.2
-			IL_0094: ldloc.2
-			IL_0095: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_009a: dup
-			IL_009b: brtrue IL_00b0
+			IL_008d: stloc.1
+			IL_008e: ldloc.1
+			IL_008f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0094: dup
+			IL_0095: brtrue IL_00aa
 
-			IL_00a0: pop
-			IL_00a1: ldloc.2
-			IL_00a2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00a7: dup
-			IL_00a8: brtrue IL_00bb
+			IL_009a: pop
+			IL_009b: ldloc.1
+			IL_009c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00a1: dup
+			IL_00a2: brtrue IL_00b5
 
-			IL_00ad: pop
-			IL_00ae: rethrow
+			IL_00a7: pop
+			IL_00a8: rethrow
 
-			IL_00b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00b5: stloc.3
-			IL_00b6: br IL_00bc
+			IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00af: stloc.2
+			IL_00b0: br IL_00b6
 
+			IL_00b5: stloc.2
+
+			IL_00b6: ldloc.2
+			IL_00b7: stloc.s 6
+			IL_00b9: ldloc.s 6
 			IL_00bb: stloc.3
-
-			IL_00bc: ldloc.3
-			IL_00bd: stloc.s 8
-			IL_00bf: ldloc.s 8
-			IL_00c1: stloc.s 4
-			IL_00c3: newobj instance void Modules.Variable_TemporalDeadZoneSwitchScope/Scope/Switch_L3C0/Block_L8C16::.ctor()
-			IL_00c8: stloc.s 5
-			IL_00ca: ldstr "console"
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d4: stloc.s 8
-			IL_00d6: ldloc.s 8
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.s 8
-			IL_00e1: ldstr "log"
-			IL_00e6: ldstr "SWITCH_TDZ"
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00f0: pop
-			IL_00f1: leave IL_00f6
+			IL_00bc: ldstr "console"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00c6: stloc.s 6
+			IL_00c8: ldloc.s 6
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00cf: stloc.s 6
+			IL_00d1: ldloc.s 6
+			IL_00d3: ldstr "log"
+			IL_00d8: ldstr "SWITCH_TDZ"
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00e2: pop
+			IL_00e3: leave IL_00e8
 		} // end handler
 
-		IL_00f6: ldstr "ready"
-		IL_00fb: stloc.s 6
-		IL_00fd: ldstr "console"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0107: stloc.s 8
-		IL_0109: ldloc.s 8
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0110: stloc.s 8
-		IL_0112: ldloc.s 8
-		IL_0114: ldstr "log"
-		IL_0119: ldloc.s 6
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0120: pop
-		IL_0121: br IL_0126
+		IL_00e8: ldstr "ready"
+		IL_00ed: stloc.s 4
+		IL_00ef: ldstr "console"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f9: stloc.s 6
+		IL_00fb: ldloc.s 6
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0102: stloc.s 6
+		IL_0104: ldloc.s 6
+		IL_0106: ldstr "log"
+		IL_010b: ldloc.s 4
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0112: pop
+		IL_0113: br IL_0118
 
-		IL_0126: ldnull
-		IL_0127: stloc.s 7
-		IL_0129: ret
+		IL_0118: ldnull
+		IL_0119: stloc.s 5
+		IL_011b: ret
 	} // end of method Variable_TemporalDeadZoneSwitchScope::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneSwitchScope
@@ -239,7 +233,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21bc
+		// Method begins at RVA 0x21ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Constructor_Prototype_Surface.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2651
+				// Method begins at RVA 0x2649
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x265a
+				// Method begins at RVA 0x2652
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2648
+			// Method begins at RVA 0x2640
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1499 (0x5db)
+		// Code size: 1492 (0x5d4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Constructor_Prototype_Surface/Scope,
@@ -93,15 +93,14 @@
 			[5] class [System.Runtime]System.Exception,
 			[6] object,
 			[7] object,
-			[8] class Modules.WeakMap_Constructor_Prototype_Surface/Scope/Block_L27C12,
+			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
-			[12] object,
-			[13] bool,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
-			[16] object
+			[12] bool,
+			[13] object,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.WeakMap,
+			[15] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -124,166 +123,166 @@
 		IL_0051: nop
 		IL_0052: ldstr "console"
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005c: stloc.s 10
-		IL_005e: ldloc.s 10
+		IL_005c: stloc.s 9
+		IL_005e: ldloc.s 9
 		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0065: stloc.s 10
+		IL_0065: stloc.s 9
 		IL_0067: ldstr "globalThis"
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0071: stloc.s 11
-		IL_0073: ldloc.s 11
+		IL_0071: stloc.s 10
+		IL_0073: ldloc.s 10
 		IL_0075: ldstr "WeakMap"
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.s 11
+		IL_007f: stloc.s 10
 		IL_0081: ldstr "WeakMap"
 		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008b: stloc.s 12
-		IL_008d: ldloc.s 11
-		IL_008f: ldloc.s 12
+		IL_008b: stloc.s 11
+		IL_008d: ldloc.s 10
+		IL_008f: ldloc.s 11
 		IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0096: stloc.s 13
-		IL_0098: ldloc.s 13
+		IL_0096: stloc.s 12
+		IL_0098: ldloc.s 12
 		IL_009a: box [System.Runtime]System.Boolean
-		IL_009f: stloc.s 14
-		IL_00a1: ldloc.s 10
+		IL_009f: stloc.s 13
+		IL_00a1: ldloc.s 9
 		IL_00a3: ldstr "log"
-		IL_00a8: ldloc.s 14
+		IL_00a8: ldloc.s 13
 		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00af: pop
 		IL_00b0: ldstr "console"
 		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ba: stloc.s 10
-		IL_00bc: ldloc.s 10
+		IL_00ba: stloc.s 9
+		IL_00bc: ldloc.s 9
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c3: stloc.s 10
+		IL_00c3: stloc.s 9
 		IL_00c5: ldstr "WeakMap"
 		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cf: stloc.s 12
-		IL_00d1: ldloc.s 12
+		IL_00cf: stloc.s 11
+		IL_00d1: ldloc.s 11
 		IL_00d3: ldstr "prototype"
 		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dd: stloc.s 12
-		IL_00df: ldloc.s 12
+		IL_00dd: stloc.s 11
+		IL_00df: ldloc.s 11
 		IL_00e1: ldstr "constructor"
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00eb: stloc.s 12
+		IL_00eb: stloc.s 11
 		IL_00ed: ldstr "WeakMap"
 		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f7: stloc.s 11
-		IL_00f9: ldloc.s 12
-		IL_00fb: ldloc.s 11
+		IL_00f7: stloc.s 10
+		IL_00f9: ldloc.s 11
+		IL_00fb: ldloc.s 10
 		IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0102: stloc.s 13
-		IL_0104: ldloc.s 13
+		IL_0102: stloc.s 12
+		IL_0104: ldloc.s 12
 		IL_0106: box [System.Runtime]System.Boolean
-		IL_010b: stloc.s 14
-		IL_010d: ldloc.s 10
+		IL_010b: stloc.s 13
+		IL_010d: ldloc.s 9
 		IL_010f: ldstr "log"
-		IL_0114: ldloc.s 14
+		IL_0114: ldloc.s 13
 		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_011b: pop
 		IL_011c: ldstr "console"
 		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0126: stloc.s 10
-		IL_0128: ldloc.s 10
+		IL_0126: stloc.s 9
+		IL_0128: ldloc.s 9
 		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012f: stloc.s 10
+		IL_012f: stloc.s 9
 		IL_0131: ldstr "WeakMap"
 		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013b: stloc.s 11
+		IL_013b: stloc.s 10
 		IL_013d: ldstr "Function"
 		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: stloc.s 12
-		IL_0149: ldloc.s 11
-		IL_014b: ldloc.s 12
+		IL_0147: stloc.s 11
+		IL_0149: ldloc.s 10
+		IL_014b: ldloc.s 11
 		IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0152: stloc.s 13
-		IL_0154: ldloc.s 13
+		IL_0152: stloc.s 12
+		IL_0154: ldloc.s 12
 		IL_0156: box [System.Runtime]System.Boolean
-		IL_015b: stloc.s 14
-		IL_015d: ldloc.s 10
+		IL_015b: stloc.s 13
+		IL_015d: ldloc.s 9
 		IL_015f: ldstr "log"
-		IL_0164: ldloc.s 14
+		IL_0164: ldloc.s 13
 		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_016b: pop
 		IL_016c: ldstr "console"
 		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0176: stloc.s 10
-		IL_0178: ldloc.s 10
+		IL_0176: stloc.s 9
+		IL_0178: ldloc.s 9
 		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017f: stloc.s 10
+		IL_017f: stloc.s 9
 		IL_0181: ldstr "WeakMap"
 		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018b: stloc.s 12
-		IL_018d: ldloc.s 12
+		IL_018b: stloc.s 11
+		IL_018d: ldloc.s 11
 		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0194: stloc.s 12
+		IL_0194: stloc.s 11
 		IL_0196: ldstr "Function"
 		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a0: stloc.s 11
-		IL_01a2: ldloc.s 11
+		IL_01a0: stloc.s 10
+		IL_01a2: ldloc.s 10
 		IL_01a4: ldstr "prototype"
 		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ae: stloc.s 11
-		IL_01b0: ldloc.s 12
-		IL_01b2: ldloc.s 11
+		IL_01ae: stloc.s 10
+		IL_01b0: ldloc.s 11
+		IL_01b2: ldloc.s 10
 		IL_01b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01b9: stloc.s 13
-		IL_01bb: ldloc.s 13
+		IL_01b9: stloc.s 12
+		IL_01bb: ldloc.s 12
 		IL_01bd: box [System.Runtime]System.Boolean
-		IL_01c2: stloc.s 14
-		IL_01c4: ldloc.s 10
+		IL_01c2: stloc.s 13
+		IL_01c4: ldloc.s 9
 		IL_01c6: ldstr "log"
-		IL_01cb: ldloc.s 14
+		IL_01cb: ldloc.s 13
 		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01d2: pop
 		IL_01d3: ldstr "console"
 		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01dd: stloc.s 10
-		IL_01df: ldloc.s 10
+		IL_01dd: stloc.s 9
+		IL_01df: ldloc.s 9
 		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e6: stloc.s 10
+		IL_01e6: stloc.s 9
 		IL_01e8: ldstr "WeakMap"
 		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f2: stloc.s 11
-		IL_01f4: ldloc.s 11
+		IL_01f2: stloc.s 10
+		IL_01f4: ldloc.s 10
 		IL_01f6: ldstr "prototype"
 		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0200: stloc.s 11
-		IL_0202: ldloc.s 11
+		IL_0200: stloc.s 10
+		IL_0202: ldloc.s 10
 		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0209: stloc.s 11
+		IL_0209: stloc.s 10
 		IL_020b: ldstr "Object"
 		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0215: stloc.s 12
-		IL_0217: ldloc.s 12
+		IL_0215: stloc.s 11
+		IL_0217: ldloc.s 11
 		IL_0219: ldstr "prototype"
 		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0223: stloc.s 12
-		IL_0225: ldloc.s 11
-		IL_0227: ldloc.s 12
+		IL_0223: stloc.s 11
+		IL_0225: ldloc.s 10
+		IL_0227: ldloc.s 11
 		IL_0229: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_022e: stloc.s 13
-		IL_0230: ldloc.s 13
+		IL_022e: stloc.s 12
+		IL_0230: ldloc.s 12
 		IL_0232: box [System.Runtime]System.Boolean
-		IL_0237: stloc.s 14
-		IL_0239: ldloc.s 10
+		IL_0237: stloc.s 13
+		IL_0239: ldloc.s 9
 		IL_023b: ldstr "log"
-		IL_0240: ldloc.s 14
+		IL_0240: ldloc.s 13
 		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0247: pop
 		IL_0248: ldstr "WeakMap"
 		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0252: stloc.s 10
-		IL_0254: ldloc.s 10
+		IL_0252: stloc.s 9
+		IL_0254: ldloc.s 9
 		IL_0256: ldstr "prototype"
 		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0260: stloc.s 10
-		IL_0262: ldloc.s 10
+		IL_0260: stloc.s 9
+		IL_0262: ldloc.s 9
 		IL_0264: stloc.1
 		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_026a: stloc.s 10
-		IL_026c: ldloc.s 10
+		IL_026a: stloc.s 9
+		IL_026c: ldloc.s 9
 		IL_026e: ldstr "descriptor"
 		IL_0273: ldloc.1
 		IL_0274: ldc.i4.0
@@ -291,11 +290,11 @@
 		IL_027a: pop
 		IL_027b: ldstr "console"
 		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0285: stloc.s 10
-		IL_0287: ldloc.s 10
+		IL_0285: stloc.s 9
+		IL_0287: ldloc.s 9
 		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028e: stloc.s 10
-		IL_0290: ldloc.s 10
+		IL_028e: stloc.s 9
+		IL_0290: ldloc.s 9
 		IL_0292: ldstr "log"
 		IL_0297: ldloc.1
 		IL_0298: ldstr "writable"
@@ -304,11 +303,11 @@
 		IL_02a7: pop
 		IL_02a8: ldstr "console"
 		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02b2: stloc.s 10
-		IL_02b4: ldloc.s 10
+		IL_02b2: stloc.s 9
+		IL_02b4: ldloc.s 9
 		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bb: stloc.s 10
-		IL_02bd: ldloc.s 10
+		IL_02bb: stloc.s 9
+		IL_02bd: ldloc.s 9
 		IL_02bf: ldstr "log"
 		IL_02c4: ldloc.1
 		IL_02c5: ldstr "enumerable"
@@ -317,11 +316,11 @@
 		IL_02d4: pop
 		IL_02d5: ldstr "console"
 		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02df: stloc.s 10
-		IL_02e1: ldloc.s 10
+		IL_02df: stloc.s 9
+		IL_02e1: ldloc.s 9
 		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e8: stloc.s 10
-		IL_02ea: ldloc.s 10
+		IL_02e8: stloc.s 9
+		IL_02ea: ldloc.s 9
 		IL_02ec: ldstr "log"
 		IL_02f1: ldloc.1
 		IL_02f2: ldstr "configurable"
@@ -329,12 +328,12 @@
 		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0301: pop
 		IL_0302: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
-		IL_0307: stloc.s 15
-		IL_0309: ldloc.s 15
+		IL_0307: stloc.s 14
+		IL_0309: ldloc.s 14
 		IL_030b: stloc.2
 		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0311: stloc.s 10
-		IL_0313: ldloc.s 10
+		IL_0311: stloc.s 9
+		IL_0313: ldloc.s 9
 		IL_0315: ldstr "weakMap"
 		IL_031a: ldloc.2
 		IL_031b: ldc.i4.0
@@ -342,85 +341,85 @@
 		IL_0321: pop
 		IL_0322: ldstr "console"
 		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_032c: stloc.s 10
-		IL_032e: ldloc.s 10
+		IL_032c: stloc.s 9
+		IL_032e: ldloc.s 9
 		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0335: stloc.s 10
+		IL_0335: stloc.s 9
 		IL_0337: ldloc.2
 		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_033d: stloc.s 12
+		IL_033d: stloc.s 11
 		IL_033f: ldstr "WeakMap"
 		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0349: stloc.s 11
-		IL_034b: ldloc.s 11
+		IL_0349: stloc.s 10
+		IL_034b: ldloc.s 10
 		IL_034d: ldstr "prototype"
 		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0357: stloc.s 11
-		IL_0359: ldloc.s 12
-		IL_035b: ldloc.s 11
+		IL_0357: stloc.s 10
+		IL_0359: ldloc.s 11
+		IL_035b: ldloc.s 10
 		IL_035d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0362: stloc.s 13
-		IL_0364: ldloc.s 13
+		IL_0362: stloc.s 12
+		IL_0364: ldloc.s 12
 		IL_0366: box [System.Runtime]System.Boolean
-		IL_036b: stloc.s 14
-		IL_036d: ldloc.s 10
+		IL_036b: stloc.s 13
+		IL_036d: ldloc.s 9
 		IL_036f: ldstr "log"
-		IL_0374: ldloc.s 14
+		IL_0374: ldloc.s 13
 		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_037b: pop
 		IL_037c: ldstr "console"
 		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0386: stloc.s 10
-		IL_0388: ldloc.s 10
+		IL_0386: stloc.s 9
+		IL_0388: ldloc.s 9
 		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_038f: stloc.s 10
+		IL_038f: stloc.s 9
 		IL_0391: ldloc.2
-		IL_0392: stloc.s 15
+		IL_0392: stloc.s 14
 		IL_0394: ldstr "WeakMap"
 		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_039e: stloc.s 11
-		IL_03a0: ldloc.s 15
-		IL_03a2: ldloc.s 11
+		IL_039e: stloc.s 10
+		IL_03a0: ldloc.s 14
+		IL_03a2: ldloc.s 10
 		IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_03a9: stloc.s 13
-		IL_03ab: ldloc.s 13
+		IL_03a9: stloc.s 12
+		IL_03ab: ldloc.s 12
 		IL_03ad: box [System.Runtime]System.Boolean
-		IL_03b2: stloc.s 14
-		IL_03b4: ldloc.s 10
+		IL_03b2: stloc.s 13
+		IL_03b4: ldloc.s 9
 		IL_03b6: ldstr "log"
-		IL_03bb: ldloc.s 14
+		IL_03bb: ldloc.s 13
 		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_03c2: pop
 		IL_03c3: ldstr "console"
 		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03cd: stloc.s 10
-		IL_03cf: ldloc.s 10
+		IL_03cd: stloc.s 9
+		IL_03cf: ldloc.s 9
 		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d6: stloc.s 10
+		IL_03d6: stloc.s 9
 		IL_03d8: ldloc.2
 		IL_03d9: ldstr "constructor"
 		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e3: stloc.s 11
+		IL_03e3: stloc.s 10
 		IL_03e5: ldstr "WeakMap"
 		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ef: stloc.s 12
-		IL_03f1: ldloc.s 11
-		IL_03f3: ldloc.s 12
+		IL_03ef: stloc.s 11
+		IL_03f1: ldloc.s 10
+		IL_03f3: ldloc.s 11
 		IL_03f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03fa: stloc.s 13
-		IL_03fc: ldloc.s 13
+		IL_03fa: stloc.s 12
+		IL_03fc: ldloc.s 12
 		IL_03fe: box [System.Runtime]System.Boolean
-		IL_0403: stloc.s 14
-		IL_0405: ldloc.s 10
+		IL_0403: stloc.s 13
+		IL_0405: ldloc.s 9
 		IL_0407: ldstr "log"
-		IL_040c: ldloc.s 14
+		IL_040c: ldloc.s 13
 		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0413: pop
 		IL_0414: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0419: stloc.3
 		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_041f: stloc.s 10
-		IL_0421: ldloc.s 10
+		IL_041f: stloc.s 9
+		IL_0421: ldloc.s 9
 		IL_0423: ldstr "key"
 		IL_0428: ldloc.3
 		IL_0429: ldc.i4.0
@@ -428,19 +427,19 @@
 		IL_042f: pop
 		IL_0430: ldstr "WeakMap"
 		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043a: stloc.s 10
-		IL_043c: ldloc.s 10
+		IL_043a: stloc.s 9
+		IL_043c: ldloc.s 9
 		IL_043e: ldstr "prototype"
 		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0448: stloc.s 10
-		IL_044a: ldloc.s 10
+		IL_0448: stloc.s 9
+		IL_044a: ldloc.s 9
 		IL_044c: ldstr "set"
 		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0456: stloc.s 10
-		IL_0458: ldloc.s 10
+		IL_0456: stloc.s 9
+		IL_0458: ldloc.s 9
 		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_045f: stloc.s 10
-		IL_0461: ldloc.s 10
+		IL_045f: stloc.s 9
+		IL_0461: ldloc.s 9
 		IL_0463: ldstr "call"
 		IL_0468: ldloc.2
 		IL_0469: ldloc.3
@@ -450,33 +449,33 @@
 		IL_047d: pop
 		IL_047e: ldstr "console"
 		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0488: stloc.s 10
-		IL_048a: ldloc.s 10
+		IL_0488: stloc.s 9
+		IL_048a: ldloc.s 9
 		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0491: stloc.s 10
+		IL_0491: stloc.s 9
 		IL_0493: ldstr "WeakMap"
 		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_049d: stloc.s 12
-		IL_049f: ldloc.s 12
+		IL_049d: stloc.s 11
+		IL_049f: ldloc.s 11
 		IL_04a1: ldstr "prototype"
 		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ab: stloc.s 12
-		IL_04ad: ldloc.s 12
+		IL_04ab: stloc.s 11
+		IL_04ad: ldloc.s 11
 		IL_04af: ldstr "get"
 		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b9: stloc.s 12
-		IL_04bb: ldloc.s 12
+		IL_04b9: stloc.s 11
+		IL_04bb: ldloc.s 11
 		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c2: stloc.s 12
-		IL_04c4: ldloc.s 12
+		IL_04c2: stloc.s 11
+		IL_04c4: ldloc.s 11
 		IL_04c6: ldstr "call"
 		IL_04cb: ldloc.2
 		IL_04cc: ldloc.3
 		IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_04d2: stloc.s 12
-		IL_04d4: ldloc.s 10
+		IL_04d2: stloc.s 11
+		IL_04d4: ldloc.s 9
 		IL_04d6: ldstr "log"
-		IL_04db: ldloc.s 12
+		IL_04db: ldloc.s 11
 		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_04e2: pop
 		.try
@@ -484,12 +483,12 @@
 			IL_04e3: nop
 			IL_04e4: ldstr "WeakMap"
 			IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04ee: stloc.s 12
-			IL_04f0: ldloc.s 12
+			IL_04ee: stloc.s 11
+			IL_04f0: ldloc.s 11
 			IL_04f2: stloc.s 4
 			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_04f9: stloc.s 12
-			IL_04fb: ldloc.s 12
+			IL_04f9: stloc.s 11
+			IL_04fb: ldloc.s 11
 			IL_04fd: ldstr "weakMapCtor"
 			IL_0502: ldloc.s 4
 			IL_0504: ldc.i4.0
@@ -501,16 +500,16 @@
 			IL_0517: pop
 			IL_0518: ldstr "console"
 			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0522: stloc.s 12
-			IL_0524: ldloc.s 12
+			IL_0522: stloc.s 11
+			IL_0524: ldloc.s 11
 			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_052b: stloc.s 12
-			IL_052d: ldloc.s 12
+			IL_052b: stloc.s 11
+			IL_052d: ldloc.s 11
 			IL_052f: ldstr "log"
 			IL_0534: ldstr "no-throw"
 			IL_0539: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_053e: pop
-			IL_053f: leave IL_05d7
+			IL_053f: leave IL_05d0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -536,40 +535,38 @@
 			IL_0570: stloc.s 6
 
 			IL_0572: ldloc.s 6
-			IL_0574: stloc.s 12
-			IL_0576: ldloc.s 12
+			IL_0574: stloc.s 11
+			IL_0576: ldloc.s 11
 			IL_0578: stloc.s 7
-			IL_057a: newobj instance void Modules.WeakMap_Constructor_Prototype_Surface/Scope/Block_L27C12::.ctor()
-			IL_057f: stloc.s 8
-			IL_0581: ldstr "console"
-			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_058b: stloc.s 12
-			IL_058d: ldloc.s 12
-			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0594: stloc.s 12
-			IL_0596: ldloc.s 7
-			IL_0598: ldstr "name"
-			IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a2: ldstr ": "
-			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05ac: stloc.s 16
-			IL_05ae: ldloc.s 16
-			IL_05b0: ldloc.s 7
-			IL_05b2: ldstr "message"
-			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05c1: stloc.s 16
-			IL_05c3: ldloc.s 12
-			IL_05c5: ldstr "log"
-			IL_05ca: ldloc.s 16
-			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05d1: pop
-			IL_05d2: leave IL_05d7
+			IL_057a: ldstr "console"
+			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0584: stloc.s 11
+			IL_0586: ldloc.s 11
+			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_058d: stloc.s 11
+			IL_058f: ldloc.s 7
+			IL_0591: ldstr "name"
+			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_059b: ldstr ": "
+			IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05a5: stloc.s 15
+			IL_05a7: ldloc.s 15
+			IL_05a9: ldloc.s 7
+			IL_05ab: ldstr "message"
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05ba: stloc.s 15
+			IL_05bc: ldloc.s 11
+			IL_05be: ldstr "log"
+			IL_05c3: ldloc.s 15
+			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05ca: pop
+			IL_05cb: leave IL_05d0
 		} // end handler
 
-		IL_05d7: ldnull
-		IL_05d8: stloc.s 9
-		IL_05da: ret
+		IL_05d0: ldnull
+		IL_05d1: stloc.s 8
+		IL_05d3: ret
 	} // end of method WeakMap_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.WeakMap_Constructor_Prototype_Surface
@@ -581,7 +578,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2663
+		// Method begins at RVA 0x265b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2380
+				// Method begins at RVA 0x2378
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x225c
+			// Method begins at RVA 0x2254
 			// Header size: 12
 			// Code size: 173 (0xad)
 			.maxstack 8
@@ -130,7 +130,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x239b
+				// Method begins at RVA 0x2393
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x2310
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2389
+				// Method begins at RVA 0x2381
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2392
+				// Method begins at RVA 0x238a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -261,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2377
+			// Method begins at RVA 0x236f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -287,7 +287,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 495 (0x1ef)
+		// Code size: 488 (0x1e8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
@@ -295,10 +295,9 @@
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
-			[5] class Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16,
+			[5] object,
 			[6] object,
-			[7] object,
-			[8] object
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope::.ctor()
@@ -320,47 +319,47 @@
 		IL_0029: ldc.i4.0
 		IL_002a: ldc.i4.1
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0030: stloc.s 7
-		IL_0032: ldloc.s 7
+		IL_0030: stloc.s 6
+		IL_0032: ldloc.s 6
 		IL_0034: stloc.1
 		IL_0035: nop
 		IL_0036: nop
 		IL_0037: ldloc.1
 		IL_0038: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0042: stloc.s 7
+		IL_0042: stloc.s 6
 		IL_0044: ldloc.0
-		IL_0045: ldloc.s 7
+		IL_0045: ldloc.s 6
 		IL_0047: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
 		IL_004c: ldstr "console"
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0056: stloc.s 7
-		IL_0058: ldloc.s 7
+		IL_0056: stloc.s 6
+		IL_0058: ldloc.s 6
 		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005f: stloc.s 7
+		IL_005f: stloc.s 6
 		IL_0061: ldstr "Object"
 		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006b: stloc.s 8
-		IL_006d: ldloc.s 8
+		IL_006b: stloc.s 7
+		IL_006d: ldloc.s 7
 		IL_006f: ldstr "prototype"
 		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0079: stloc.s 8
-		IL_007b: ldloc.s 8
+		IL_0079: stloc.s 7
+		IL_007b: ldloc.s 7
 		IL_007d: ldstr "toString"
 		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0087: stloc.s 8
-		IL_0089: ldloc.s 8
+		IL_0087: stloc.s 7
+		IL_0089: ldloc.s 7
 		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0090: stloc.s 8
-		IL_0092: ldloc.s 8
+		IL_0090: stloc.s 7
+		IL_0092: ldloc.s 7
 		IL_0094: ldstr "call"
 		IL_0099: ldloc.0
 		IL_009a: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
 		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a4: stloc.s 8
-		IL_00a6: ldloc.s 7
+		IL_00a4: stloc.s 7
+		IL_00a6: ldloc.s 6
 		IL_00a8: ldstr "log"
-		IL_00ad: ldloc.s 8
+		IL_00ad: ldloc.s 7
 		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00b4: pop
 		.try
@@ -372,18 +371,18 @@
 			IL_00c9: pop
 			IL_00ca: ldstr "console"
 			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d4: stloc.s 8
-			IL_00d6: ldloc.s 8
+			IL_00d4: stloc.s 7
+			IL_00d6: ldloc.s 7
 			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.s 8
+			IL_00dd: stloc.s 7
+			IL_00df: ldloc.s 7
 			IL_00e1: ldstr "log"
 			IL_00e6: ldstr "primitive target threw:"
 			IL_00eb: ldc.i4.0
 			IL_00ec: box [System.Runtime]System.Boolean
 			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_00f6: pop
-			IL_00f7: leave IL_0198
+			IL_00f7: leave IL_0191
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -409,76 +408,74 @@
 			IL_0124: stloc.3
 
 			IL_0125: ldloc.3
-			IL_0126: stloc.s 8
-			IL_0128: ldloc.s 8
+			IL_0126: stloc.s 7
+			IL_0128: ldloc.s 7
 			IL_012a: stloc.s 4
-			IL_012c: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
-			IL_0131: stloc.s 5
-			IL_0133: ldstr "console"
-			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_013d: stloc.s 8
-			IL_013f: ldloc.s 8
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0146: stloc.s 8
-			IL_0148: ldloc.s 8
-			IL_014a: ldstr "log"
-			IL_014f: ldstr "primitive target threw:"
-			IL_0154: ldc.i4.1
-			IL_0155: box [System.Runtime]System.Boolean
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_015f: pop
-			IL_0160: ldstr "console"
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016a: stloc.s 8
-			IL_016c: ldloc.s 8
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0173: stloc.s 8
-			IL_0175: ldloc.s 8
-			IL_0177: ldstr "log"
-			IL_017c: ldstr "primitive target name:"
-			IL_0181: ldloc.s 4
-			IL_0183: ldstr "name"
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0192: pop
-			IL_0193: leave IL_0198
+			IL_012c: ldstr "console"
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0136: stloc.s 7
+			IL_0138: ldloc.s 7
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013f: stloc.s 7
+			IL_0141: ldloc.s 7
+			IL_0143: ldstr "log"
+			IL_0148: ldstr "primitive target threw:"
+			IL_014d: ldc.i4.1
+			IL_014e: box [System.Runtime]System.Boolean
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0158: pop
+			IL_0159: ldstr "console"
+			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0163: stloc.s 7
+			IL_0165: ldloc.s 7
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016c: stloc.s 7
+			IL_016e: ldloc.s 7
+			IL_0170: ldstr "log"
+			IL_0175: ldstr "primitive target name:"
+			IL_017a: ldloc.s 4
+			IL_017c: ldstr "name"
+			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_018b: pop
+			IL_018c: leave IL_0191
 		} // end handler
 
-		IL_0198: ldc.i4.1
-		IL_0199: newarr [System.Runtime]System.Object
-		IL_019e: dup
-		IL_019f: ldc.i4.0
-		IL_01a0: ldloc.0
-		IL_01a1: stelem.ref
-		IL_01a2: ldc.i4.0
-		IL_01a3: ldelem.ref
-		IL_01a4: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_01a9: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_01af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b4: ldc.i4.1
-		IL_01b5: newarr [System.Runtime]System.Object
-		IL_01ba: dup
-		IL_01bb: ldc.i4.0
-		IL_01bc: ldloc.0
-		IL_01bd: stelem.ref
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0191: ldc.i4.1
+		IL_0192: newarr [System.Runtime]System.Object
+		IL_0197: dup
+		IL_0198: ldc.i4.0
+		IL_0199: ldloc.0
+		IL_019a: stelem.ref
+		IL_019b: ldc.i4.0
+		IL_019c: ldelem.ref
+		IL_019d: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_01a2: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+		IL_01a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01ad: ldc.i4.1
+		IL_01ae: newarr [System.Runtime]System.Object
+		IL_01b3: dup
+		IL_01b4: ldc.i4.0
+		IL_01b5: ldloc.0
+		IL_01b6: stelem.ref
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01c1: ldc.i4.0
+		IL_01c2: conv.r8
+		IL_01c3: ldstr ""
 		IL_01c8: ldc.i4.0
-		IL_01c9: conv.r8
-		IL_01ca: ldstr ""
-		IL_01cf: ldc.i4.0
-		IL_01d0: ldc.i4.0
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01db: stloc.s 8
-		IL_01dd: ldloc.s 8
-		IL_01df: ldc.i4.0
-		IL_01e0: newarr [System.Runtime]System.Object
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_01ea: pop
-		IL_01eb: ldnull
-		IL_01ec: stloc.s 6
-		IL_01ee: ret
+		IL_01c9: ldc.i4.0
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_01d4: stloc.s 7
+		IL_01d6: ldloc.s 7
+		IL_01d8: ldc.i4.0
+		IL_01d9: newarr [System.Runtime]System.Object
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_01e3: pop
+		IL_01e4: ldnull
+		IL_01e5: stloc.s 5
+		IL_01e7: ret
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects
@@ -490,7 +487,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23a4
+		// Method begins at RVA 0x239c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Constructor_Prototype_Surface.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2645
+				// Method begins at RVA 0x263d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x264e
+				// Method begins at RVA 0x2646
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x263c
+			// Method begins at RVA 0x2634
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -82,7 +82,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1485 (0x5cd)
+		// Code size: 1478 (0x5c6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Constructor_Prototype_Surface/Scope,
@@ -93,15 +93,14 @@
 			[5] class [System.Runtime]System.Exception,
 			[6] object,
 			[7] object,
-			[8] class Modules.WeakSet_Constructor_Prototype_Surface/Scope/Block_L27C12,
+			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
-			[12] object,
-			[13] bool,
-			[14] object,
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
-			[16] object
+			[12] bool,
+			[13] object,
+			[14] class [JavaScriptRuntime]JavaScriptRuntime.WeakSet,
+			[15] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -124,166 +123,166 @@
 		IL_0051: nop
 		IL_0052: ldstr "console"
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005c: stloc.s 10
-		IL_005e: ldloc.s 10
+		IL_005c: stloc.s 9
+		IL_005e: ldloc.s 9
 		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0065: stloc.s 10
+		IL_0065: stloc.s 9
 		IL_0067: ldstr "globalThis"
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0071: stloc.s 11
-		IL_0073: ldloc.s 11
+		IL_0071: stloc.s 10
+		IL_0073: ldloc.s 10
 		IL_0075: ldstr "WeakSet"
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007f: stloc.s 11
+		IL_007f: stloc.s 10
 		IL_0081: ldstr "WeakSet"
 		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_008b: stloc.s 12
-		IL_008d: ldloc.s 11
-		IL_008f: ldloc.s 12
+		IL_008b: stloc.s 11
+		IL_008d: ldloc.s 10
+		IL_008f: ldloc.s 11
 		IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0096: stloc.s 13
-		IL_0098: ldloc.s 13
+		IL_0096: stloc.s 12
+		IL_0098: ldloc.s 12
 		IL_009a: box [System.Runtime]System.Boolean
-		IL_009f: stloc.s 14
-		IL_00a1: ldloc.s 10
+		IL_009f: stloc.s 13
+		IL_00a1: ldloc.s 9
 		IL_00a3: ldstr "log"
-		IL_00a8: ldloc.s 14
+		IL_00a8: ldloc.s 13
 		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_00af: pop
 		IL_00b0: ldstr "console"
 		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ba: stloc.s 10
-		IL_00bc: ldloc.s 10
+		IL_00ba: stloc.s 9
+		IL_00bc: ldloc.s 9
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c3: stloc.s 10
+		IL_00c3: stloc.s 9
 		IL_00c5: ldstr "WeakSet"
 		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cf: stloc.s 12
-		IL_00d1: ldloc.s 12
+		IL_00cf: stloc.s 11
+		IL_00d1: ldloc.s 11
 		IL_00d3: ldstr "prototype"
 		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dd: stloc.s 12
-		IL_00df: ldloc.s 12
+		IL_00dd: stloc.s 11
+		IL_00df: ldloc.s 11
 		IL_00e1: ldstr "constructor"
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00eb: stloc.s 12
+		IL_00eb: stloc.s 11
 		IL_00ed: ldstr "WeakSet"
 		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f7: stloc.s 11
-		IL_00f9: ldloc.s 12
-		IL_00fb: ldloc.s 11
+		IL_00f7: stloc.s 10
+		IL_00f9: ldloc.s 11
+		IL_00fb: ldloc.s 10
 		IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0102: stloc.s 13
-		IL_0104: ldloc.s 13
+		IL_0102: stloc.s 12
+		IL_0104: ldloc.s 12
 		IL_0106: box [System.Runtime]System.Boolean
-		IL_010b: stloc.s 14
-		IL_010d: ldloc.s 10
+		IL_010b: stloc.s 13
+		IL_010d: ldloc.s 9
 		IL_010f: ldstr "log"
-		IL_0114: ldloc.s 14
+		IL_0114: ldloc.s 13
 		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_011b: pop
 		IL_011c: ldstr "console"
 		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0126: stloc.s 10
-		IL_0128: ldloc.s 10
+		IL_0126: stloc.s 9
+		IL_0128: ldloc.s 9
 		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012f: stloc.s 10
+		IL_012f: stloc.s 9
 		IL_0131: ldstr "WeakSet"
 		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013b: stloc.s 11
+		IL_013b: stloc.s 10
 		IL_013d: ldstr "Function"
 		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0147: stloc.s 12
-		IL_0149: ldloc.s 11
-		IL_014b: ldloc.s 12
+		IL_0147: stloc.s 11
+		IL_0149: ldloc.s 10
+		IL_014b: ldloc.s 11
 		IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0152: stloc.s 13
-		IL_0154: ldloc.s 13
+		IL_0152: stloc.s 12
+		IL_0154: ldloc.s 12
 		IL_0156: box [System.Runtime]System.Boolean
-		IL_015b: stloc.s 14
-		IL_015d: ldloc.s 10
+		IL_015b: stloc.s 13
+		IL_015d: ldloc.s 9
 		IL_015f: ldstr "log"
-		IL_0164: ldloc.s 14
+		IL_0164: ldloc.s 13
 		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_016b: pop
 		IL_016c: ldstr "console"
 		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0176: stloc.s 10
-		IL_0178: ldloc.s 10
+		IL_0176: stloc.s 9
+		IL_0178: ldloc.s 9
 		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017f: stloc.s 10
+		IL_017f: stloc.s 9
 		IL_0181: ldstr "WeakSet"
 		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018b: stloc.s 12
-		IL_018d: ldloc.s 12
+		IL_018b: stloc.s 11
+		IL_018d: ldloc.s 11
 		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0194: stloc.s 12
+		IL_0194: stloc.s 11
 		IL_0196: ldstr "Function"
 		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a0: stloc.s 11
-		IL_01a2: ldloc.s 11
+		IL_01a0: stloc.s 10
+		IL_01a2: ldloc.s 10
 		IL_01a4: ldstr "prototype"
 		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ae: stloc.s 11
-		IL_01b0: ldloc.s 12
-		IL_01b2: ldloc.s 11
+		IL_01ae: stloc.s 10
+		IL_01b0: ldloc.s 11
+		IL_01b2: ldloc.s 10
 		IL_01b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01b9: stloc.s 13
-		IL_01bb: ldloc.s 13
+		IL_01b9: stloc.s 12
+		IL_01bb: ldloc.s 12
 		IL_01bd: box [System.Runtime]System.Boolean
-		IL_01c2: stloc.s 14
-		IL_01c4: ldloc.s 10
+		IL_01c2: stloc.s 13
+		IL_01c4: ldloc.s 9
 		IL_01c6: ldstr "log"
-		IL_01cb: ldloc.s 14
+		IL_01cb: ldloc.s 13
 		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_01d2: pop
 		IL_01d3: ldstr "console"
 		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01dd: stloc.s 10
-		IL_01df: ldloc.s 10
+		IL_01dd: stloc.s 9
+		IL_01df: ldloc.s 9
 		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e6: stloc.s 10
+		IL_01e6: stloc.s 9
 		IL_01e8: ldstr "WeakSet"
 		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f2: stloc.s 11
-		IL_01f4: ldloc.s 11
+		IL_01f2: stloc.s 10
+		IL_01f4: ldloc.s 10
 		IL_01f6: ldstr "prototype"
 		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0200: stloc.s 11
-		IL_0202: ldloc.s 11
+		IL_0200: stloc.s 10
+		IL_0202: ldloc.s 10
 		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0209: stloc.s 11
+		IL_0209: stloc.s 10
 		IL_020b: ldstr "Object"
 		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0215: stloc.s 12
-		IL_0217: ldloc.s 12
+		IL_0215: stloc.s 11
+		IL_0217: ldloc.s 11
 		IL_0219: ldstr "prototype"
 		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0223: stloc.s 12
-		IL_0225: ldloc.s 11
-		IL_0227: ldloc.s 12
+		IL_0223: stloc.s 11
+		IL_0225: ldloc.s 10
+		IL_0227: ldloc.s 11
 		IL_0229: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_022e: stloc.s 13
-		IL_0230: ldloc.s 13
+		IL_022e: stloc.s 12
+		IL_0230: ldloc.s 12
 		IL_0232: box [System.Runtime]System.Boolean
-		IL_0237: stloc.s 14
-		IL_0239: ldloc.s 10
+		IL_0237: stloc.s 13
+		IL_0239: ldloc.s 9
 		IL_023b: ldstr "log"
-		IL_0240: ldloc.s 14
+		IL_0240: ldloc.s 13
 		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0247: pop
 		IL_0248: ldstr "WeakSet"
 		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0252: stloc.s 10
-		IL_0254: ldloc.s 10
+		IL_0252: stloc.s 9
+		IL_0254: ldloc.s 9
 		IL_0256: ldstr "prototype"
 		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0260: stloc.s 10
-		IL_0262: ldloc.s 10
+		IL_0260: stloc.s 9
+		IL_0262: ldloc.s 9
 		IL_0264: stloc.1
 		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_026a: stloc.s 10
-		IL_026c: ldloc.s 10
+		IL_026a: stloc.s 9
+		IL_026c: ldloc.s 9
 		IL_026e: ldstr "descriptor"
 		IL_0273: ldloc.1
 		IL_0274: ldc.i4.0
@@ -291,11 +290,11 @@
 		IL_027a: pop
 		IL_027b: ldstr "console"
 		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0285: stloc.s 10
-		IL_0287: ldloc.s 10
+		IL_0285: stloc.s 9
+		IL_0287: ldloc.s 9
 		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028e: stloc.s 10
-		IL_0290: ldloc.s 10
+		IL_028e: stloc.s 9
+		IL_0290: ldloc.s 9
 		IL_0292: ldstr "log"
 		IL_0297: ldloc.1
 		IL_0298: ldstr "writable"
@@ -304,11 +303,11 @@
 		IL_02a7: pop
 		IL_02a8: ldstr "console"
 		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02b2: stloc.s 10
-		IL_02b4: ldloc.s 10
+		IL_02b2: stloc.s 9
+		IL_02b4: ldloc.s 9
 		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bb: stloc.s 10
-		IL_02bd: ldloc.s 10
+		IL_02bb: stloc.s 9
+		IL_02bd: ldloc.s 9
 		IL_02bf: ldstr "log"
 		IL_02c4: ldloc.1
 		IL_02c5: ldstr "enumerable"
@@ -317,11 +316,11 @@
 		IL_02d4: pop
 		IL_02d5: ldstr "console"
 		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02df: stloc.s 10
-		IL_02e1: ldloc.s 10
+		IL_02df: stloc.s 9
+		IL_02e1: ldloc.s 9
 		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e8: stloc.s 10
-		IL_02ea: ldloc.s 10
+		IL_02e8: stloc.s 9
+		IL_02ea: ldloc.s 9
 		IL_02ec: ldstr "log"
 		IL_02f1: ldloc.1
 		IL_02f2: ldstr "configurable"
@@ -329,12 +328,12 @@
 		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0301: pop
 		IL_0302: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakSet::.ctor()
-		IL_0307: stloc.s 15
-		IL_0309: ldloc.s 15
+		IL_0307: stloc.s 14
+		IL_0309: ldloc.s 14
 		IL_030b: stloc.2
 		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0311: stloc.s 10
-		IL_0313: ldloc.s 10
+		IL_0311: stloc.s 9
+		IL_0313: ldloc.s 9
 		IL_0315: ldstr "weakSet"
 		IL_031a: ldloc.2
 		IL_031b: ldc.i4.0
@@ -342,85 +341,85 @@
 		IL_0321: pop
 		IL_0322: ldstr "console"
 		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_032c: stloc.s 10
-		IL_032e: ldloc.s 10
+		IL_032c: stloc.s 9
+		IL_032e: ldloc.s 9
 		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0335: stloc.s 10
+		IL_0335: stloc.s 9
 		IL_0337: ldloc.2
 		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_033d: stloc.s 12
+		IL_033d: stloc.s 11
 		IL_033f: ldstr "WeakSet"
 		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0349: stloc.s 11
-		IL_034b: ldloc.s 11
+		IL_0349: stloc.s 10
+		IL_034b: ldloc.s 10
 		IL_034d: ldstr "prototype"
 		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0357: stloc.s 11
-		IL_0359: ldloc.s 12
-		IL_035b: ldloc.s 11
+		IL_0357: stloc.s 10
+		IL_0359: ldloc.s 11
+		IL_035b: ldloc.s 10
 		IL_035d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0362: stloc.s 13
-		IL_0364: ldloc.s 13
+		IL_0362: stloc.s 12
+		IL_0364: ldloc.s 12
 		IL_0366: box [System.Runtime]System.Boolean
-		IL_036b: stloc.s 14
-		IL_036d: ldloc.s 10
+		IL_036b: stloc.s 13
+		IL_036d: ldloc.s 9
 		IL_036f: ldstr "log"
-		IL_0374: ldloc.s 14
+		IL_0374: ldloc.s 13
 		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_037b: pop
 		IL_037c: ldstr "console"
 		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0386: stloc.s 10
-		IL_0388: ldloc.s 10
+		IL_0386: stloc.s 9
+		IL_0388: ldloc.s 9
 		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_038f: stloc.s 10
+		IL_038f: stloc.s 9
 		IL_0391: ldloc.2
-		IL_0392: stloc.s 15
+		IL_0392: stloc.s 14
 		IL_0394: ldstr "WeakSet"
 		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_039e: stloc.s 11
-		IL_03a0: ldloc.s 15
-		IL_03a2: ldloc.s 11
+		IL_039e: stloc.s 10
+		IL_03a0: ldloc.s 14
+		IL_03a2: ldloc.s 10
 		IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_03a9: stloc.s 13
-		IL_03ab: ldloc.s 13
+		IL_03a9: stloc.s 12
+		IL_03ab: ldloc.s 12
 		IL_03ad: box [System.Runtime]System.Boolean
-		IL_03b2: stloc.s 14
-		IL_03b4: ldloc.s 10
+		IL_03b2: stloc.s 13
+		IL_03b4: ldloc.s 9
 		IL_03b6: ldstr "log"
-		IL_03bb: ldloc.s 14
+		IL_03bb: ldloc.s 13
 		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_03c2: pop
 		IL_03c3: ldstr "console"
 		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03cd: stloc.s 10
-		IL_03cf: ldloc.s 10
+		IL_03cd: stloc.s 9
+		IL_03cf: ldloc.s 9
 		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d6: stloc.s 10
+		IL_03d6: stloc.s 9
 		IL_03d8: ldloc.2
 		IL_03d9: ldstr "constructor"
 		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e3: stloc.s 11
+		IL_03e3: stloc.s 10
 		IL_03e5: ldstr "WeakSet"
 		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ef: stloc.s 12
-		IL_03f1: ldloc.s 11
-		IL_03f3: ldloc.s 12
+		IL_03ef: stloc.s 11
+		IL_03f1: ldloc.s 10
+		IL_03f3: ldloc.s 11
 		IL_03f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03fa: stloc.s 13
-		IL_03fc: ldloc.s 13
+		IL_03fa: stloc.s 12
+		IL_03fc: ldloc.s 12
 		IL_03fe: box [System.Runtime]System.Boolean
-		IL_0403: stloc.s 14
-		IL_0405: ldloc.s 10
+		IL_0403: stloc.s 13
+		IL_0405: ldloc.s 9
 		IL_0407: ldstr "log"
-		IL_040c: ldloc.s 14
+		IL_040c: ldloc.s 13
 		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_0413: pop
 		IL_0414: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0419: stloc.3
 		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_041f: stloc.s 10
-		IL_0421: ldloc.s 10
+		IL_041f: stloc.s 9
+		IL_0421: ldloc.s 9
 		IL_0423: ldstr "value"
 		IL_0428: ldloc.3
 		IL_0429: ldc.i4.0
@@ -428,19 +427,19 @@
 		IL_042f: pop
 		IL_0430: ldstr "WeakSet"
 		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043a: stloc.s 10
-		IL_043c: ldloc.s 10
+		IL_043a: stloc.s 9
+		IL_043c: ldloc.s 9
 		IL_043e: ldstr "prototype"
 		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0448: stloc.s 10
-		IL_044a: ldloc.s 10
+		IL_0448: stloc.s 9
+		IL_044a: ldloc.s 9
 		IL_044c: ldstr "add"
 		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0456: stloc.s 10
-		IL_0458: ldloc.s 10
+		IL_0456: stloc.s 9
+		IL_0458: ldloc.s 9
 		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_045f: stloc.s 10
-		IL_0461: ldloc.s 10
+		IL_045f: stloc.s 9
+		IL_0461: ldloc.s 9
 		IL_0463: ldstr "call"
 		IL_0468: ldloc.2
 		IL_0469: ldloc.3
@@ -448,33 +447,33 @@
 		IL_046f: pop
 		IL_0470: ldstr "console"
 		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_047a: stloc.s 10
-		IL_047c: ldloc.s 10
+		IL_047a: stloc.s 9
+		IL_047c: ldloc.s 9
 		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0483: stloc.s 10
+		IL_0483: stloc.s 9
 		IL_0485: ldstr "WeakSet"
 		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_048f: stloc.s 12
-		IL_0491: ldloc.s 12
+		IL_048f: stloc.s 11
+		IL_0491: ldloc.s 11
 		IL_0493: ldstr "prototype"
 		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_049d: stloc.s 12
-		IL_049f: ldloc.s 12
+		IL_049d: stloc.s 11
+		IL_049f: ldloc.s 11
 		IL_04a1: ldstr "has"
 		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ab: stloc.s 12
-		IL_04ad: ldloc.s 12
+		IL_04ab: stloc.s 11
+		IL_04ad: ldloc.s 11
 		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b4: stloc.s 12
-		IL_04b6: ldloc.s 12
+		IL_04b4: stloc.s 11
+		IL_04b6: ldloc.s 11
 		IL_04b8: ldstr "call"
 		IL_04bd: ldloc.2
 		IL_04be: ldloc.3
 		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_04c4: stloc.s 12
-		IL_04c6: ldloc.s 10
+		IL_04c4: stloc.s 11
+		IL_04c6: ldloc.s 9
 		IL_04c8: ldstr "log"
-		IL_04cd: ldloc.s 12
+		IL_04cd: ldloc.s 11
 		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_04d4: pop
 		.try
@@ -482,12 +481,12 @@
 			IL_04d5: nop
 			IL_04d6: ldstr "WeakSet"
 			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04e0: stloc.s 12
-			IL_04e2: ldloc.s 12
+			IL_04e0: stloc.s 11
+			IL_04e2: ldloc.s 11
 			IL_04e4: stloc.s 4
 			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_04eb: stloc.s 12
-			IL_04ed: ldloc.s 12
+			IL_04eb: stloc.s 11
+			IL_04ed: ldloc.s 11
 			IL_04ef: ldstr "weakSetCtor"
 			IL_04f4: ldloc.s 4
 			IL_04f6: ldc.i4.0
@@ -499,16 +498,16 @@
 			IL_0509: pop
 			IL_050a: ldstr "console"
 			IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0514: stloc.s 12
-			IL_0516: ldloc.s 12
+			IL_0514: stloc.s 11
+			IL_0516: ldloc.s 11
 			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_051d: stloc.s 12
-			IL_051f: ldloc.s 12
+			IL_051d: stloc.s 11
+			IL_051f: ldloc.s 11
 			IL_0521: ldstr "log"
 			IL_0526: ldstr "no-throw"
 			IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0530: pop
-			IL_0531: leave IL_05c9
+			IL_0531: leave IL_05c2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -534,40 +533,38 @@
 			IL_0562: stloc.s 6
 
 			IL_0564: ldloc.s 6
-			IL_0566: stloc.s 12
-			IL_0568: ldloc.s 12
+			IL_0566: stloc.s 11
+			IL_0568: ldloc.s 11
 			IL_056a: stloc.s 7
-			IL_056c: newobj instance void Modules.WeakSet_Constructor_Prototype_Surface/Scope/Block_L27C12::.ctor()
-			IL_0571: stloc.s 8
-			IL_0573: ldstr "console"
-			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_057d: stloc.s 12
-			IL_057f: ldloc.s 12
-			IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0586: stloc.s 12
-			IL_0588: ldloc.s 7
-			IL_058a: ldstr "name"
-			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0594: ldstr ": "
-			IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_059e: stloc.s 16
-			IL_05a0: ldloc.s 16
-			IL_05a2: ldloc.s 7
-			IL_05a4: ldstr "message"
-			IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05b3: stloc.s 16
-			IL_05b5: ldloc.s 12
-			IL_05b7: ldstr "log"
-			IL_05bc: ldloc.s 16
-			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05c3: pop
-			IL_05c4: leave IL_05c9
+			IL_056c: ldstr "console"
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0576: stloc.s 11
+			IL_0578: ldloc.s 11
+			IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_057f: stloc.s 11
+			IL_0581: ldloc.s 7
+			IL_0583: ldstr "name"
+			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_058d: ldstr ": "
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0597: stloc.s 15
+			IL_0599: ldloc.s 15
+			IL_059b: ldloc.s 7
+			IL_059d: ldstr "message"
+			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05ac: stloc.s 15
+			IL_05ae: ldloc.s 11
+			IL_05b0: ldstr "log"
+			IL_05b5: ldloc.s 15
+			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05bc: pop
+			IL_05bd: leave IL_05c2
 		} // end handler
 
-		IL_05c9: ldnull
-		IL_05ca: stloc.s 9
-		IL_05cc: ret
+		IL_05c2: ldnull
+		IL_05c3: stloc.s 8
+		IL_05c5: ret
 	} // end of method WeakSet_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.WeakSet_Constructor_Prototype_Surface
@@ -579,7 +576,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2657
+		// Method begins at RVA 0x264f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary

- materialize block lexical environments only when a binding needs runtime field storage
- keep scope instances for captured bindings and block-level functions
- apply the same predicate to HIR blocks, closure environment layouts, and per-iteration loop scopes
- update affected IL snapshots and add focused captured/uncaptured block regressions

`PrimeSieve.runSieve` no longer emits:

```il
newobj instance void .../Scope_runSieve/Block_L133C2::.ctor()
stloc.2
```

The captured loop-body closure regression still allocates its `Block_L4C49` environment, while its unrelated local-only loop-head environment is now elided.

## Validation

- `HIRBlockScopeElisionTests`
- focused execution/generator coverage for TDZ, switch/catch, loop closures, async/generator control flow, and Prime
- compiled and executed `tests\performance\PrimeJavaScript.js` successfully
