### PR TITLE
ci: improve release and Mitata workflow dispatch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -156,7 +156,7 @@ node scripts/runPhasedBenchmarkScenario.js dromaeo-object-regexp
 
 **Preferred (Automated):**
 
-Use the release automation script (handles branch → bump → commit → PR, and optionally merge + GitHub release/tag):
+Use the release automation script (handles branch → bump → commit/push → remote validation → PR, and optionally merge + GitHub release/tag):
 
 ```powershell
 # Patch / minor / major
@@ -195,24 +195,21 @@ Follow these steps IN ORDER:
    ```
    This updates CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj
 
-3. **Validate the coordinated release package set** (on the release branch):
-   ```powershell
-   npm run release:validate
-   ```
-
-4. **Commit version bump** (on the release branch):
+3. **Commit and push the release candidate**:
    ```powershell
    git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj
    git commit -m "chore(release): cut v0.x.y"
+   git push -u origin release/0.x.y
    ```
 
-5. **Push release branch and create PR**:
+4. **Validate the coordinated release package set** by dispatching `.github/workflows/release-validation.yml` against the pushed release branch. It runs `npm run release:validate` in GitHub Actions.
+
+5. **Create PR**:
    ```powershell
-   git push -u origin release/0.x.y
    gh pr create --title "chore(release): Release v0.x.y" --body-file <release-notes.md> --base master --head release/0.x.y
    ```
 
-5. **After PR is merged**, create the release (this creates the tag and triggers GitHub Actions):
+6. **After PR is merged**, create the release (this creates the tag and triggers GitHub Actions):
    create a release-notes.md file with the release notes copied from changelog.md for the new version.
 
    ```powershell

--- a/.github/workflows/mitata-suite.yml
+++ b/.github/workflows/mitata-suite.yml
@@ -8,6 +8,10 @@ on:
         description: 'Mitata benchmark suffix (for example string-width)'
         required: false
         default: 'runtime-baseline'
+      runtimes:
+        description: 'Comma-separated runtimes to benchmark'
+        required: false
+        default: 'node,jroc,clearscript,jint,yantrajs,okojo'
       jroc_package_version:
         description: 'Published jroc package version to benchmark (for example 0.9.31)'
         required: false
@@ -157,10 +161,18 @@ jobs:
         shell: bash
         env:
           BENCHMARK_NAME: ${{ github.event.inputs.benchmark || 'runtime-baseline' }}
+          RUNTIMES: ${{ github.event.inputs.runtimes || '' }}
         run: |
           set -euo pipefail
           cd tests/performance/mitata
-          node scripts/run-release-suite.mjs --bench "${BENCHMARK_NAME}" --output results.json
+          args=(--bench "${BENCHMARK_NAME}" --output results.json)
+          if [ -n "${RUNTIMES}" ]; then
+            IFS=',' read -r -a runtimes <<< "${RUNTIMES}"
+            for runtime in "${runtimes[@]}"; do
+              args+=(--runtime "${runtime}")
+            done
+          fi
+          node scripts/run-release-suite.mjs "${args[@]}"
           if [ ! -f "results.json" ]; then
             echo "Mitata runner produced no results.json output; failing workflow."
             exit 1

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,0 +1,35 @@
+name: Release Validation
+run-name: ${{ github.workflow }} - ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release package set
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Restore dependencies
+        run: |
+          dotnet restore
+          npm ci
+
+      - name: Validate coordinated release package set
+        run: npm run release:validate

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ What it does:
 - Validates you're on a clean, up-to-date `master`
 - Creates `release/<version>` branch
 - Runs the existing `scripts/bumpVersion.js` to update `CHANGELOG.md` + project versions
-- Runs `npm run release:validate` so the release candidate is validated as a coordinated package set before the release commit is created
-- Commits, pushes, and opens a PR
+- Commits and pushes the release candidate
+- Dispatches `.github/workflows/release-validation.yml` against that exact commit; it must pass before the PR is opened
+- Opens a PR after remote release validation succeeds
 - With `--merge`: waits for CI checks (if configured), merges the PR, then creates the GitHub release/tag using the `CHANGELOG.md` section
 
 Requirements: `git`, `gh` (authenticated), `node`/`npm`.
@@ -194,38 +195,38 @@ What the script does:
 - Resets the `## Unreleased` section to placeholder
 - Updates `samples/Directory.Build.props` plus the `<Version>` in `src/Cli/Jroc.csproj`, `src/Jroc.Core/Jroc.Core.csproj`, `src/Jroc.SDK/Jroc.SDK.csproj`, and `src/JavaScriptRuntime/JavaScriptRuntime.csproj`
 
-#### 3. Validate the Release Package Set
+#### 3. Commit and Push the Release Candidate
 
-Before committing, validate the coordinated package set:
+Commit the version bump and push the release branch:
 
 ```powershell
-npm run release:validate
+git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj
+git commit -m "chore(release): cut v0.x.y"
+git push -u origin release/0.x.y
 ```
 
-This command currently does two things:
+#### 4. Validate the Release Package Set
+
+Dispatch `.github/workflows/release-validation.yml` on the pushed release branch. It runs `npm run release:validate`, which:
 
 - runs the PR canary suite against a freshly packed local `jroc` tool
 - runs the focused `JrocSdkPackageTests` suite, which packs `Jroc.Runtime`, `Jroc.Core`, and `Jroc.SDK` into a local feed and verifies the SDK consumption path
+
+```powershell
+gh workflow run release-validation.yml --ref release/0.x.y
+```
+
+Wait for the dispatched workflow to succeed before creating the PR.
 
 After the GitHub release is published, the `windows-smoke` and `linux-smoke` workflows install the tagged `jroc` tool from NuGet and build/run the `Domino`, `Picocolors`, `Basic`, and `Typed` samples against the matching `Jroc.SDK` / `Jroc.Runtime` version.
 
 For the full restore/build/post-publish validation matrix used to close issues `#850` and `#439`, see [docs/sdk/PackagingValidation.md](docs/sdk/PackagingValidation.md).
 
-#### 4. Commit Version Bump
-
-Commit the changes on the release branch:
-
-```powershell
-git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj
-git commit -m "chore(release): cut v0.x.y"
-```
-
 #### 5. Push and Create PR
 
-Push the release branch and create a pull request:
+Create a pull request after remote validation succeeds:
 
 ```powershell
-git push -u origin release/0.x.y
 gh pr create --title "chore(release): Release v0.x.y" --base master --head release/0.x.y
 ```
 

--- a/docs/sdk/PackagingValidation.md
+++ b/docs/sdk/PackagingValidation.md
@@ -13,14 +13,14 @@ The package split is considered release-ready only when the following package fl
 
 ### Coordinated release gate
 
-`npm run release:validate` is the required local gate before a release commit is created.
+`.github/workflows/release-validation.yml` is the required remote gate after the release candidate is committed and pushed. `scripts\release.js` dispatches it against the exact release-branch commit and only opens the PR after it succeeds.
 
-It currently runs:
+The workflow runs `npm run release:validate`, which:
 
 - `npm run diff:test:canary:packed`
 - `dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocSdkPackageTests" --nologo`
 
-`scripts\release.js` invokes this command before it creates the release commit, so coordinated package regressions fail before the tag is cut.
+This ensures coordinated package regressions fail in the same Linux GitHub Actions environment used for release validation, before the tag is cut.
 
 ### `Jroc.Core` restore/consumption coverage
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "release:validate": "npm run diff:test:canary:packed && dotnet test ./tests/Jroc.Tests/Jroc.Tests.csproj -c Release --filter \"FullyQualifiedName~JrocSdkPackageTests\" --nologo",
     "perf:phased:cube": "node scripts/runCubePhasedGuardrails.js",
     "perf:compare:dispatch": "node scripts/dispatchBenchmarkBranchComparisonWorkflow.js",
+    "perf:mitata:dispatch": "node scripts/dispatchMitataBenchmarkWorkflow.js",
     "perf:profile": "node scripts/profileBenchmarkScenario.js",
     "test:perf-ingestion": "node --test tests/performance/ingestPerfToSupabase.test.js",
     "perf:phased:cube:dry": "node scripts/runCubePhasedGuardrails.js --dry",

--- a/scripts/dispatchMitataBenchmarkWorkflow.js
+++ b/scripts/dispatchMitataBenchmarkWorkflow.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("node:child_process");
+
+const WORKFLOW_FILE = "mitata-suite.yml";
+const ALL_RUNTIMES = "node,jroc,clearscript,jint,yantrajs,okojo";
+
+function printUsage() {
+  console.log("Usage: node scripts/dispatchMitataBenchmarkWorkflow.js <benchmark-name> [options]");
+  console.log("");
+  console.log("Options:");
+  console.log("  --ref <branch>        Branch/ref containing the workflow (default: master).");
+  console.log("  --repo <owner/name>   Repository override (defaults to the current repository).");
+  console.log("  --runtimes <names>    Comma-separated runtime names (default: all supported runtimes).");
+  console.log("  --dry-run             Print the gh command without dispatching.");
+  console.log("  --help, -h            Show this help.");
+  console.log("");
+  console.log("Example:");
+  console.log("  node scripts/dispatchMitataBenchmarkWorkflow.js runtime-baseline");
+}
+
+function parseArgs(argv) {
+  const args = {
+    benchmark: null,
+    ref: "master",
+    repo: null,
+    runtimes: ALL_RUNTIMES,
+    dryRun: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    switch (current) {
+      case "--ref":
+        args.ref = argv[++index] ?? null;
+        break;
+      case "--repo":
+        args.repo = argv[++index] ?? null;
+        break;
+      case "--runtimes":
+        args.runtimes = argv[++index] ?? null;
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        if (!current.startsWith("-") && !args.benchmark) {
+          args.benchmark = current;
+        } else {
+          throw new Error(`Unknown argument: ${current}`);
+        }
+        break;
+    }
+  }
+
+  if (!args.benchmark?.trim()) {
+    throw new Error("A Mitata benchmark name is required.");
+  }
+  if (!args.ref?.trim()) {
+    throw new Error("--ref requires a value.");
+  }
+  if (args.repo !== null && !args.repo.trim()) {
+    throw new Error("--repo requires a value.");
+  }
+  if (!args.runtimes?.trim()) {
+    throw new Error("--runtimes requires at least one runtime.");
+  }
+
+  return args;
+}
+
+function quoteForDisplay(value) {
+  return /^[A-Za-z0-9_./:=@-]+$/.test(value)
+    ? value
+    : `"${value.replaceAll('"', '\\"')}"`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.dryRun && ["true", "1", "yes"].includes(process.env.npm_config_dry_run)) {
+    args.dryRun = true;
+  }
+
+  const workflowArgs = [
+    "workflow",
+    "run",
+    WORKFLOW_FILE,
+    "--ref",
+    args.ref,
+    "--raw-field",
+    `benchmark=${args.benchmark}`,
+    "--raw-field",
+    `runtimes=${args.runtimes}`,
+  ];
+
+  if (args.repo) {
+    workflowArgs.push("--repo", args.repo);
+  }
+
+  if (args.dryRun) {
+    console.log(`gh ${workflowArgs.map(quoteForDisplay).join(" ")}`);
+    return;
+  }
+
+  const result = childProcess.spawnSync("gh", workflowArgs, {
+    stdio: "inherit",
+    shell: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -9,9 +9,9 @@
  *  2) Compute next version (patch/minor/major)
  *  3) Create release/<version> branch
  *  4) Run version bump (CHANGELOG + csproj versions)
- *  5) Run coordinated release-package validation
- *  6) Commit
- *  7) Push + open PR
+ *  5) Commit + push the version bump
+ *  6) Run coordinated release-package validation in GitHub Actions
+ *  7) Open PR after validation succeeds
  *  8) Optionally wait for checks, merge PR, and create GitHub release/tag
  *
  * Usage:
@@ -119,6 +119,7 @@ const CORE_CSPROJ_PATH = path.join(ROOT, 'src', 'Jroc.Core', 'Jroc.Core.csproj')
 const SDK_CSPROJ_PATH = path.join(ROOT, 'src', 'Jroc.SDK', 'Jroc.SDK.csproj');
 const RUNTIME_CSPROJ_PATH = path.join(ROOT, 'src', 'JavaScriptRuntime', 'JavaScriptRuntime.csproj');
 const SAMPLES_PROPS_PATH = path.join(ROOT, 'samples', 'Directory.Build.props');
+const RELEASE_VALIDATION_WORKFLOW = 'release-validation.yml';
 
 function sleep(ms) {
   // Synchronous sleep without additional deps.
@@ -410,6 +411,65 @@ function waitForRequiredCheck(prNumber, repo, checkName, { timeoutMs = 10 * 60 *
   throw new Error(`Timed out waiting for required status check "${checkName}" to complete.`);
 }
 
+function waitForReleaseValidation(repo, releaseBranch, headSha, args, { timeoutMs = 30 * 60 * 1000, pollMs = 5000 } = {}) {
+  run(`gh workflow run ${RELEASE_VALIDATION_WORKFLOW} --repo ${repo} --ref ${releaseBranch}`, args);
+  if (args.dryRun) {
+    return;
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const raw = run(
+      `gh run list --repo ${repo} --workflow ${RELEASE_VALIDATION_WORKFLOW} --branch ${releaseBranch} --event workflow_dispatch --limit 20 --json databaseId,headSha,status,conclusion,url`,
+      { ...args, allowFailure: true }
+    );
+
+    let runs;
+    try {
+      runs = JSON.parse(raw);
+    } catch {
+      sleep(pollMs);
+      continue;
+    }
+
+    if (!Array.isArray(runs)) {
+      sleep(pollMs);
+      continue;
+    }
+
+    let validationRun;
+    for (const candidate of runs) {
+      if (candidate && candidate.headSha === headSha) {
+        validationRun = candidate;
+        break;
+      }
+    }
+
+    if (!validationRun) {
+      sleep(pollMs);
+      continue;
+    }
+
+    const status = String(validationRun.status || '').toUpperCase();
+    const conclusion = String(validationRun.conclusion || '').toUpperCase();
+    if (status !== 'COMPLETED' || !conclusion) {
+      sleep(pollMs);
+      continue;
+    }
+
+    if (conclusion === 'SUCCESS') {
+      writeStdout(`\nRelease validation passed: ${validationRun.url}\n`);
+      return;
+    }
+
+    throw new Error(
+      `Release validation failed (conclusion: ${conclusion}). ${validationRun.url || `Run ID: ${validationRun.databaseId}`}`
+    );
+  }
+
+  throw new Error(`Timed out waiting for release validation workflow on ${releaseBranch}.`);
+}
+
 function main() {
   const effectiveArgv = getEffectiveArgv(process.argv);
   const args = parseArgs(effectiveArgv);
@@ -478,17 +538,12 @@ function main() {
   if (args.skipEmpty) bumpArgs.push('--skip-empty');
   run(`node scripts/bumpVersion.js ${bumpArgs.join(' ')}`, args);
 
-  // Validate the coordinated package set before the release commit is created.
-  run('npm run release:validate', args);
-
-  // Commit
+  // Commit and push before remote validation so the workflow tests the exact release candidate.
   run(
     `git add "${path.relative(ROOT, CHANGELOG_PATH)}" "${path.relative(ROOT, SAMPLES_PROPS_PATH)}" "${path.relative(ROOT, CSPROJ_PATH)}" "${path.relative(ROOT, CORE_CSPROJ_PATH)}" "${path.relative(ROOT, SDK_CSPROJ_PATH)}" "${path.relative(ROOT, RUNTIME_CSPROJ_PATH)}"`,
     args
   );
   run(`git commit -m "chore(release): cut v${nextVersion}"`, args);
-
-  // Push + PR
   run(`git push -u origin ${releaseBranch}`, args);
 
   const repo = args.repo || inferRepoFromGitRemote();
@@ -496,6 +551,10 @@ function main() {
     throw new Error('Could not infer GitHub repo from origin remote. Provide --repo owner/name');
   }
 
+  const releaseHeadSha = run('git rev-parse HEAD', args);
+  waitForReleaseValidation(repo, releaseBranch, releaseHeadSha, args);
+
+  // Create the PR only after the remote validation passes.
   const prTitle = `chore(release): Release v${nextVersion}`;
   const prBody = `Patch release v${nextVersion}.\n\n- Version bump + changelog updates.`;
   const prBodyPath = path.join(ROOT, 'pr-body.md');


### PR DESCRIPTION
## Summary
- validate release candidates with a dispatchable GitHub Actions workflow before opening the release PR
- add a helper for dispatching Mitata benchmarks and run all managed runtimes by default
- document the updated release validation flow

## Validation
- `node --check scripts/release.js`
- `node --check scripts/dispatchMitataBenchmarkWorkflow.js`
- dry-run release and Mitata workflow dispatches
- workflow YAML parsing