### PR TITLE
ci: skip YantraJS for string-width benchmark

### DIFF
--- a/.github/workflows/mitata-suite.yml
+++ b/.github/workflows/mitata-suite.yml
@@ -169,6 +169,10 @@ jobs:
           if [ -n "${RUNTIMES}" ]; then
             IFS=',' read -r -a runtimes <<< "${RUNTIMES}"
             for runtime in "${runtimes[@]}"; do
+              if [ "${BENCHMARK_NAME}" = "string-width" ] && [ "${runtime}" = "yantrajs" ]; then
+                echo "Skipping yantrajs for string-width because this benchmark currently crashes."
+                continue
+              fi
               args+=(--runtime "${runtime}")
             done
           fi


### PR DESCRIPTION
## Summary
- skip YantraJS only for the `string-width` Mitata benchmark because it currently crashes
- keep YantraJS enabled for all other requested benchmarks

## Validation
- workflow YAML parsing