### PR TITLE
feat(runtime): add String.prototype.concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: add `String.prototype.concat` with generic receiver coercion and ordered argument conversion. Ports ten upstream test262 cases for built-in metadata, invalid receivers, and primitive arguments.
 - runtime: add standards-compatible `Uint8Array.fromHex` and `Uint8Array.prototype.toHex`, including strict input validation, lowercase hexadecimal output, non-constructible built-in metadata, property descriptors, and typed receiver validation. Ports ten test262 cases for hexadecimal Uint8Array conversion.
 
 ## v0.11.35 - 2026-07-21

--- a/docs/ECMA262/22/Section22_1.json
+++ b/docs/ECMA262/22/Section22_1.json
@@ -84,7 +84,7 @@
     {
       "clause": "22.1.3.5",
       "title": "String.prototype.concat ( ... args )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.concat"
     },
     {
@@ -467,9 +467,24 @@
       {
         "clause": "22.1.3.5",
         "feature": "String.prototype.concat",
-        "status": "Not Yet Supported",
+        "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-string.prototype.concat",
-        "notes": "No dedicated concat method is wired; string concatenation is handled via operators/ToString coercion only."
+        "test262Suites": [
+          "built_ins.String.prototype.concat"
+        ],
+        "test262Paths": [
+          "test/built-ins/String/prototype/concat/name.js",
+          "test/built-ins/String/prototype/concat/not-a-constructor.js",
+          "test/built-ins/String/prototype/concat/this-value-not-obj-coercible.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T1.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T2.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T4.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T5.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T6.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T7.js",
+          "test/built-ins/String/prototype/concat/S15.5.4.6_A1_T8.js"
+        ],
+        "notes": "Implemented with a generic receiver and left-to-right argument string coercion. Ten upstream test262 cases cover built-in metadata, receiver validation, no-argument behavior, and common primitive coercions."
       },
       {
         "clause": "22.1.3.6",

--- a/docs/ECMA262/22/Section22_1.md
+++ b/docs/ECMA262/22/Section22_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section22](Section22.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-12T04:40:20Z
+> Last generated (UTC): 2026-07-22T23:36:32Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -26,7 +26,7 @@
 | 22.1.3.2 | String.prototype.charAt ( pos ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.charat) |
 | 22.1.3.3 | String.prototype.charCodeAt ( pos ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.charcodeat) |
 | 22.1.3.4 | String.prototype.codePointAt ( pos ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.codepointat) |
-| 22.1.3.5 | String.prototype.concat ( ... args ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.concat) |
+| 22.1.3.5 | String.prototype.concat ( ... args ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.concat) |
 | 22.1.3.6 | String.prototype.constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.constructor) |
 | 22.1.3.7 | String.prototype.endsWith ( searchString [ , endPosition ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.endswith) |
 | 22.1.3.8 | String.prototype.includes ( searchString [ , position ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-string.prototype.includes) |
@@ -139,7 +139,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| String.prototype.concat | Not Yet Supported |  |  | No dedicated concat method is wired; string concatenation is handled via operators/ToString coercion only. |
+| String.prototype.concat | Supported with Limitations |  | suite `built_ins.String.prototype.concat`<br>`test/built-ins/String/prototype/concat/name.js`<br>`test/built-ins/String/prototype/concat/not-a-constructor.js`<br>`test/built-ins/String/prototype/concat/this-value-not-obj-coercible.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T1.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T2.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T4.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T5.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T6.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T7.js`<br>`test/built-ins/String/prototype/concat/S15.5.4.6_A1_T8.js` | Implemented with a generic receiver and left-to-right argument string coercion. Ten upstream test262 cases cover built-in metadata, receiver validation, no-argument behavior, and common primitive coercions. |
 
 ### 22.1.3.6 ([tc39.es](https://tc39.es/ecma262/#sec-string.prototype.constructor))
 

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -2624,6 +2624,16 @@ namespace JavaScriptRuntime
                     return stringResult;
                 }
 
+                if (JavaScriptRuntime.String.TryGetPrototypeProperty(receiver, methodName, out var prototypeMember))
+                {
+                    if (prototypeMember is Delegate memberDelegate)
+                    {
+                        return InvokeMemberDelegate(receiver, memberDelegate, callArgs);
+                    }
+
+                    throw new TypeError($"{methodName} is not a function");
+                }
+
                 return CallStringMemberViaReflection(input, methodName, callArgs);
             }
 
@@ -3063,12 +3073,6 @@ namespace JavaScriptRuntime
 
         private static bool TryCallStringMemberFastPath(string input, string methodName, object[] callArgs, out object? result)
         {
-            if (string.Equals(methodName, "concat", StringComparison.Ordinal))
-            {
-                result = JavaScriptRuntime.String.Concat(input, callArgs);
-                return true;
-            }
-
             var argCount = callArgs.Length;
             var a0 = argCount > 0 ? callArgs[0] : null;
             var a1 = argCount > 1 ? callArgs[1] : null;
@@ -3159,16 +3163,6 @@ namespace JavaScriptRuntime
         {
             switch (methodName)
             {
-                case "concat":
-                    result = argCount switch
-                    {
-                        <= 0 => JavaScriptRuntime.String.Concat(input, null),
-                        1 => JavaScriptRuntime.String.Concat(input, new object?[] { a0 }),
-                        2 => JavaScriptRuntime.String.Concat(input, new object?[] { a0, a1 }),
-                        _ => JavaScriptRuntime.String.Concat(input, new object?[] { a0, a1, a2 })
-                    };
-                    return true;
-
                 case "charAt":
                     result = argCount <= 0
                         ? JavaScriptRuntime.String.CharAt(input)

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -3063,6 +3063,12 @@ namespace JavaScriptRuntime
 
         private static bool TryCallStringMemberFastPath(string input, string methodName, object[] callArgs, out object? result)
         {
+            if (string.Equals(methodName, "concat", StringComparison.Ordinal))
+            {
+                result = JavaScriptRuntime.String.Concat(input, callArgs);
+                return true;
+            }
+
             var argCount = callArgs.Length;
             var a0 = argCount > 0 ? callArgs[0] : null;
             var a1 = argCount > 1 ? callArgs[1] : null;
@@ -3153,6 +3159,16 @@ namespace JavaScriptRuntime
         {
             switch (methodName)
             {
+                case "concat":
+                    result = argCount switch
+                    {
+                        <= 0 => JavaScriptRuntime.String.Concat(input, null),
+                        1 => JavaScriptRuntime.String.Concat(input, new object?[] { a0 }),
+                        2 => JavaScriptRuntime.String.Concat(input, new object?[] { a0, a1 }),
+                        _ => JavaScriptRuntime.String.Concat(input, new object?[] { a0, a1, a2 })
+                    };
+                    return true;
+
                 case "charAt":
                     result = argCount <= 0
                         ? JavaScriptRuntime.String.CharAt(input)

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -2624,16 +2624,6 @@ namespace JavaScriptRuntime
                     return stringResult;
                 }
 
-                if (JavaScriptRuntime.String.TryGetPrototypeProperty(receiver, methodName, out var prototypeMember))
-                {
-                    if (prototypeMember is Delegate memberDelegate)
-                    {
-                        return InvokeMemberDelegate(receiver, memberDelegate, callArgs);
-                    }
-
-                    throw new TypeError($"{methodName} is not a function");
-                }
-
                 return CallStringMemberViaReflection(input, methodName, callArgs);
             }
 
@@ -3100,13 +3090,23 @@ namespace JavaScriptRuntime
 
             int jsArgCount = callArgs.Length;
             var exact = candidates
-                .Where(m => m.GetParameters().Length == 1 + jsArgCount)
+                .Where(m =>
+                {
+                    var parameters = m.GetParameters();
+                    return !IsParamArray(parameters[^1]) && parameters.Length == 1 + jsArgCount;
+                })
                 .ToList();
 
             var viable = exact.Count > 0
                 ? exact
                 : candidates
-                    .Where(m => m.GetParameters().Length >= 1 + jsArgCount)
+                    .Where(m =>
+                    {
+                        var parameters = m.GetParameters();
+                        return IsParamArray(parameters[^1])
+                            ? jsArgCount >= parameters.Length - 2
+                            : parameters.Length >= 1 + jsArgCount;
+                    })
                     .OrderBy(m => m.GetParameters().Length)
                     .ToList();
             var chosen = viable
@@ -3121,8 +3121,10 @@ namespace JavaScriptRuntime
             var ps = chosen.GetParameters();
             var invokeArgs = new object?[ps.Length];
             invokeArgs[0] = input;
+            var hasParamArray = IsParamArray(ps[^1]);
+            var fixedArgumentCount = hasParamArray ? ps.Length - 2 : jsArgCount;
 
-            for (int i = 0; i < jsArgCount && (i + 1) < ps.Length; i++)
+            for (int i = 0; i < fixedArgumentCount; i++)
             {
                 var target = ps[i + 1].ParameterType;
                 var src = callArgs[i];
@@ -3140,7 +3142,12 @@ namespace JavaScriptRuntime
                 }
             }
 
-            for (int pi = 1 + jsArgCount; pi < ps.Length; pi++)
+            if (hasParamArray)
+            {
+                invokeArgs[^1] = callArgs.Skip(fixedArgumentCount).Cast<object?>().ToArray();
+            }
+
+            for (int pi = 1 + fixedArgumentCount; pi < ps.Length - (hasParamArray ? 1 : 0); pi++)
             {
                 invokeArgs[pi] = ps[pi].ParameterType == typeof(bool) ? (object)false : null;
             }
@@ -3155,6 +3162,9 @@ namespace JavaScriptRuntime
                 throw; // unreachable
             }
         }
+
+        private static bool IsParamArray(ParameterInfo parameter)
+            => parameter.GetCustomAttribute<ParamArrayAttribute>() != null;
 
         // Keep this switch intentionally limited to hot-path members.
         // Any method not listed here is still handled by CallStringMemberViaReflection,

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -539,7 +539,7 @@ namespace JavaScriptRuntime
             => CodePointAt(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
 
         private static object? PrototypeConcat(object[] scopes, object?[]? args)
-            => Concat(ThisStringValue(RuntimeServices.GetCurrentThis()), args);
+            => Concat(ThisStringValue(RuntimeServices.GetCurrentThis()), args ?? System.Array.Empty<object?>());
 
         private static object? PrototypeEndsWith(object[] scopes, object?[]? args)
         {
@@ -701,20 +701,17 @@ namespace JavaScriptRuntime
             return Substring(input, start, null);
         }
 
-        private static string Concat(string input, object?[]? args)
+        public static string Concat(string input, params object?[] args)
         {
             var builder = new StringBuilder(input);
-            if (args != null)
+            foreach (var argument in args)
             {
-                foreach (var argument in args)
+                if (argument is Symbol)
                 {
-                    if (argument is Symbol)
-                    {
-                        throw new TypeError("Cannot convert a Symbol value to a string");
-                    }
-
-                    builder.Append(DotNet2JSConversions.ToString(argument));
+                    throw new TypeError("Cannot convert a Symbol value to a string");
                 }
+
+                builder.Append(DotNet2JSConversions.ToString(argument));
             }
 
             return builder.ToString();

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -701,7 +701,7 @@ namespace JavaScriptRuntime
             return Substring(input, start, null);
         }
 
-        public static string Concat(string input, object?[]? args)
+        private static string Concat(string input, object?[]? args)
         {
             var builder = new StringBuilder(input);
             if (args != null)

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -57,6 +57,7 @@ namespace JavaScriptRuntime
             DefinePrototypeMethod(prototype, "charAt", (Func<object[], object?[]?, object?>)PrototypeCharAt, 1);
             DefinePrototypeMethod(prototype, "charCodeAt", (Func<object[], object?[]?, object?>)PrototypeCharCodeAt, 1);
             DefinePrototypeMethod(prototype, "codePointAt", (Func<object[], object?[]?, object?>)PrototypeCodePointAt, 1);
+            DefinePrototypeMethod(prototype, "concat", (Func<object[], object?[]?, object?>)PrototypeConcat, 1);
             DefinePrototypeMethod(prototype, "endsWith", (Func<object[], object?[]?, object?>)PrototypeEndsWith, 1);
             DefinePrototypeMethod(prototype, "includes", (Func<object[], object?[]?, object?>)PrototypeIncludes, 1);
             DefinePrototypeMethod(prototype, "indexOf", (Func<object[], object?[]?, object?>)PrototypeIndexOf, 1);
@@ -537,6 +538,9 @@ namespace JavaScriptRuntime
         private static object? PrototypeCodePointAt(object[] scopes, object?[]? args)
             => CodePointAt(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
 
+        private static object? PrototypeConcat(object[] scopes, object?[]? args)
+            => Concat(ThisStringValue(RuntimeServices.GetCurrentThis()), args);
+
         private static object? PrototypeEndsWith(object[] scopes, object?[]? args)
         {
             var input = ThisStringValue(RuntimeServices.GetCurrentThis());
@@ -695,6 +699,25 @@ namespace JavaScriptRuntime
         public static string Substring(string input, object? start)
         {
             return Substring(input, start, null);
+        }
+
+        public static string Concat(string input, object?[]? args)
+        {
+            var builder = new StringBuilder(input);
+            if (args != null)
+            {
+                foreach (var argument in args)
+                {
+                    if (argument is Symbol)
+                    {
+                        throw new TypeError("Cannot convert a Symbol value to a string");
+                    }
+
+                    builder.Append(DotNet2JSConversions.ToString(argument));
+                }
+            }
+
+            return builder.ToString();
         }
 
         public static string Substring(string input, object? start, object? end)

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/ExecutionTests.cs
@@ -1,0 +1,48 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.String.prototype.concat;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.String.prototype.concat") { }
+
+    [Fact(DisplayName = "name")]
+    public Task name()
+        => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "not-a-constructor")]
+    public Task not_a_constructor()
+        => ExecutionTestFromFile("not-a-constructor");
+
+    [Fact(DisplayName = "this-value-not-obj-coercible")]
+    public Task this_value_not_obj_coercible()
+        => ExecutionTestFromFile("this-value-not-obj-coercible");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T1")]
+    public Task S15_5_4_6_A1_T1()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T1");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T2")]
+    public Task S15_5_4_6_A1_T2()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T2");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T4")]
+    public Task S15_5_4_6_A1_T4()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T4");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T5")]
+    public Task S15_5_4_6_A1_T5()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T5");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T6")]
+    public Task S15_5_4_6_A1_T6()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T6");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T7")]
+    public Task S15_5_4_6_A1_T7()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T7");
+
+    [Fact(DisplayName = "S15.5.4.6_A1_T8")]
+    public Task S15_5_4_6_A1_T8()
+        => ExecutionTestFromFile("S15.5.4.6_A1_T8");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T1.js
@@ -1,0 +1,20 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T1
+description: Arguments are false and true, and instance is object
+---*/
+
+var __instance = new Object(42);
+
+__instance.concat = String.prototype.concat;
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+if (__instance.concat(false, true) !== "42falsetrue") {
+  throw new Test262Error('#1: __instance = new Object(42); __instance.concat = String.prototype.concat;  __instance.concat(false,true) === "42falsetrue". Actual: ' + __instance.concat(false, true));
+}
+//
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T2.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T2.js
@@ -1,0 +1,22 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T2
+description: >
+    Arguments are equation with false and true, and instance is
+    Boolean object
+---*/
+
+var __instance = new Boolean;
+
+__instance.concat = String.prototype.concat;
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+if (__instance.concat("\u0041", true, true + 1) !== "falseAtrue2") {
+  throw new Test262Error('#1: __instance = new Boolean; __instance.concat = String.prototype.concat;  __instance.concat("\\u0041",true,true+1) === "falseAtrue2". Actual: ' + __instance.concat("\u0041", true, true + 1));
+}
+//
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T4.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T4.js
@@ -1,0 +1,17 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T4
+description: Call concat([,[...]]) function without argument of string object
+---*/
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+//since ToString() evaluates to "" concat() evaluates to concat("")
+if ("lego".concat() !== "lego") {
+  throw new Test262Error('#1: "lego".concat() === "lego". Actual: ' + ("lego".concat()));
+}
+//
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T5.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T5.js
@@ -1,0 +1,23 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T5
+description: >
+    Call concat([,[...]]) function with null argument of function
+    object
+---*/
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+//since ToString(null) evaluates to "null" concat(null) evaluates to concat("null")
+if (function() {
+    return "lego"
+  }().concat(null) !== "legonull") {
+  throw new Test262Error('#1: function(){return "lego"}().concat(null) === "legonull". Actual: ' + function() {
+    return "lego"
+  }().concat(null));
+}
+//
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T6.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T6.js
@@ -1,0 +1,21 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T6
+description: >
+    Call concat([,[...]]) function with x argument of new String
+    object, where x is undefined variable
+---*/
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+//since ToString(undefined) evaluates to "undefined" concat(undefined) evaluates to concat("undefined")
+if (new String("lego").concat(x) !== "legoundefined") {
+  throw new Test262Error('#1: var x; new String("lego").concat(x) === "legoundefined". Actual: ' + new String("lego").concat(x));
+}
+//
+//////////////////////////////////////////////////////////////////////////////
+
+var x;

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T7.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T7.js
@@ -1,0 +1,19 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T7
+description: >
+    Call concat([,[...]]) function with undefined argument of string
+    object
+---*/
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+//since ToString(undefined) evaluates to "undefined" concat(undefined) evaluates to concat("undefined")
+if (String("lego").concat(undefined) !== "legoundefined") {
+  throw new Test262Error('#1: String("lego").concat(undefined) === "legoundefined". Actual: ' + String("lego").concat(undefined));
+}
+//
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T8.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/S15.5.4.6_A1_T8.js
@@ -1,0 +1,19 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: String.prototype.concat([,[...]])
+es5id: 15.5.4.6_A1_T8
+description: >
+    Call concat([,[...]]) function with void 0 argument of string
+    object
+---*/
+
+//////////////////////////////////////////////////////////////////////////////
+//CHECK#1
+//since ToString(void 0) evaluates to "undefined" concat(void 0) evaluates to concat("undefined")
+if (String(42).concat(void 0) !== "42undefined") {
+  throw new Test262Error('#1: String(42).concat(void 0) === "42undefined". Actual: ' + String(42).concat(void 0));
+}
+//
+//////////////////////////////////////////////////////////////////////////////

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/name.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+es6id: 21.1.3.4
+description: >
+  String.prototype.concat.name is "concat".
+info: |
+  String.prototype.concat ( ...args )
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, that is not
+    identified as an anonymous function has a name property whose value
+    is a String.
+
+    Unless otherwise specified, the name property of a built-in Function
+    object, if it exists, has the attributes { [[Writable]]: false,
+    [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(String.prototype.concat, "name", {
+  value: "concat",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/not-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  String.prototype.concat does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(String.prototype.concat),
+  false,
+  'isConstructor(String.prototype.concat) must return false'
+);
+
+assert.throws(TypeError, () => {
+  new String.prototype.concat();
+});
+

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/this-value-not-obj-coercible.js
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/JavaScript/this-value-not-obj-coercible.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-string.prototype.concat
+description: The "this" value must be object-coercible
+info: |
+  1. Let O be ? RequireObjectCoercible(this value).
+---*/
+
+var concat = String.prototype.concat;
+
+assert.sameValue(typeof concat, 'function');
+
+assert.throws(TypeError, function() {
+  concat.call(undefined, '');
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  concat.call(null, '');
+}, 'null');

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T2.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T2.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T4.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T4.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T5.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T5.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T6.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T6.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T7.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T7.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T8.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.S15_5_4_6_A1_T8.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.name.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.name.verified.txt
@@ -1,0 +1,8 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.not_a_constructor.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.not_a_constructor.verified.txt
@@ -1,0 +1,2 @@
+﻿true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.this_value_not_obj_coercible.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/String/prototype/concat/Snapshots/ExecutionTests.this_value_not_obj_coercible.verified.txt
@@ -1,0 +1,3 @@
+﻿true
+true
+true


### PR DESCRIPTION
## Summary

- Add the ECMA-262 `String.prototype.concat` intrinsic and variadic String-helper binding.
- Port ten byte-identical upstream test262 cases covering metadata, construction, receiver validation, and coercion.
- Mark §22.1.3.5 as supported with limitations and add test262 evidence.

## Validation

- `dotnet test tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj --filter "FullyQualifiedName~built_ins.String.prototype.concat" --nologo`
- `dotnet test tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj --filter "FullyQualifiedName~built_ins.String.prototype" --nologo`

## Hosted benchmark comparison

`Benchmark branch comparison` compared `master` with this branch using precompiled jroc execution. Lower is better.

| Scenario | Mean: master | Mean: PR | Time delta | Allocated: master | Allocated: PR | Allocation delta |
|---|---:|---:|---:|---:|---:|---:|
| [`dromaeo-object-string`](https://github.com/tomacox74/js2il/actions/runs/29968249316) | 41.97 ms | 41.46 ms | -1.22% | 52.05 MB | 52.13 MB | +0.15% |
| [`dromaeo-object-string-modern`](https://github.com/tomacox74/js2il/actions/runs/29968250318) | 44.85 ms | 44.22 ms | -1.41% | 52.22 MB | 52.21 MB | -0.02% |
| [`dromaeo-string-base64`](https://github.com/tomacox74/js2il/actions/runs/29968251452) | 9.50 ms | 9.48 ms | -0.28% | 8.63 MB | 8.63 MB | +0.00% |
| [`dromaeo-string-base64-modern`](https://github.com/tomacox74/js2il/actions/runs/29968252686) | 10.82 ms | 10.06 ms | -6.95% | 7.18 MB | 7.18 MB | -0.04% |
| [`dromaeo-object-regexp`](https://github.com/tomacox74/js2il/actions/runs/29968253773) | 100.29 ms | 103.74 ms | +3.44% | 172.76 MB | 171.16 MB | -0.92% |
| [`dromaeo-object-regexp-modern`](https://github.com/tomacox74/js2il/actions/runs/29968255040) | 254.36 ms | 248.59 ms | -2.27% | 180.45 MB | 176.75 MB | -2.05% |

The direct String and Base64 scenarios are flat-to-faster with effectively unchanged allocation. RegExp timing is mixed within the measured standard deviation, while allocation is flat-to-lower; the comparison shows no consistent performance regression.
