### PR TITLE
feat(runtime): implement encodeURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: implement global `encodeURI`, including covered UTF-8 percent encoding, reserved-character preservation, and malformed-surrogate `URIError`s. Ports ten upstream test262 cases.
 - tests/test262: port fifty non-eval numeric-literal conformance cases, covering decimal integer, decimal-point, and exponent forms.
 - tests/test262: port fifty non-eval ECMA-262 conformance cases across tail-position call semantics, fixed-length SharedArrayBuffer construction and prototype behavior, and Atomics validation/error paths. Proper tail-call optimization and multi-agent shared-memory semantics remain unsupported.
 - perf/runtime: store initialized prototype state directly in `JsObject` while retaining weak-table fallback storage for delegates, CLR types, and other targets. Prototype-bearing ordinary objects now allocate 48 B instead of 94 B, and Arrays allocate 80 B instead of 126 B. Hosted `array-stress`, `constructed-object`, and `dromaeo-object-array-modern` runs reduced allocation by 18.92%, 0.38%, and 21.13% respectively; a four-pair `plain-object` rerun reduced median allocation by 0.38% and median execution time by 1.81%, confirming no repeatable execution regression.

--- a/docs/ECMA262/19/Section19_2.json
+++ b/docs/ECMA262/19/Section19_2.json
@@ -78,7 +78,7 @@
     {
       "clause": "19.2.6.3",
       "title": "encodeURI ( uri )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-encodeuri-uri"
     },
     {
@@ -220,6 +220,37 @@
           "test/built-ins/parseInt/not-a-constructor.js"
         ],
         "notes": "Implemented by JavaScriptRuntime.GlobalThis.parseInt following ECMA-262 §19.2.5. Supports: leading/trailing whitespace, sign handling, radix coercion via ToInt32 (§7.1.6), hex prefix detection (0x/0X), digit scanning with stop-at-first-invalid, case-insensitive alphabetic digits (A-Z), ToString coercion including primitive values, Array join, and custom toString methods, and large numbers using double arithmetic. Checked-in coverage now also includes additional whitespace/radix edge cases plus non-constructibility."
+      },
+      {
+        "clause": "19.2.6.3",
+        "feature": "encodeURI(uri)",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-encodeuri-uri",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T2.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T2.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.3_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.1_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.2_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.3_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T1.js",
+          "tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T2.js"
+        ],
+        "test262Paths": [
+          "test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js",
+          "test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js"
+        ],
+        "notes": "Implements the covered ECMAScript UTF-8 percent-encoding behavior, preserves encodeURI reserved and unescaped characters, and throws URIError for malformed UTF-16 surrogate sequences. Broader coercion and metadata coverage remains to be added."
       }
     ]
   }

--- a/docs/ECMA262/19/Section19_2.md
+++ b/docs/ECMA262/19/Section19_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-27T12:25:27Z
+> Last generated (UTC): 2026-07-25T22:31:27Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -25,7 +25,7 @@
 | 19.2.6 | URI Handling Functions | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-uri-handling-functions) |
 | 19.2.6.1 | decodeURI ( encodedURI ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-decodeuri-encodeduri) |
 | 19.2.6.2 | decodeURIComponent ( encodedURIComponent ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-decodeuricomponent-encodeduricomponent) |
-| 19.2.6.3 | encodeURI ( uri ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-encodeuri-uri) |
+| 19.2.6.3 | encodeURI ( uri ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-encodeuri-uri) |
 | 19.2.6.4 | encodeURIComponent ( uriComponent ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent) |
 | 19.2.6.5 | Encode ( string , extraUnescaped ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-encode) |
 | 19.2.6.6 | Decode ( string , preserveEscapeSet ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-decode) |
@@ -58,4 +58,10 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | parseInt(string, radix) | Supported | [`IntrinsicCallables_ParseInt_Basic.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_ParseInt_Basic.js)<br>[`IntrinsicCallables_ParseInt_Spec.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_ParseInt_Spec.js)<br>[`IntrinsicCallables_GlobalFunctions_AsValues_Basic.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_GlobalFunctions_AsValues_Basic.js)<br>[`S15.1.2.2_A2_T2.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/S15.1.2.2_A2_T2.js)<br>[`15.1.2.2-2-1.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/15.1.2.2-2-1.js)<br>[`S15.1.2.2_A5.1_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/S15.1.2.2_A5.1_T1.js)<br>[`S15.1.2.2_A6.1_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/S15.1.2.2_A6.1_T1.js)<br>[`S15.1.2.2_A7.2_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/S15.1.2.2_A7.2_T1.js)<br>[`S15.1.2.2_A8.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/S15.1.2.2_A8.js)<br>[`not-a-constructor.js`](../../../tests/Jroc.Test262.Tests/built-ins/parseInt/JavaScript/not-a-constructor.js) | `test/built-ins/parseInt/S15.1.2.2_A2_T2.js`<br>`test/built-ins/parseInt/15.1.2.2-2-1.js`<br>`test/built-ins/parseInt/S15.1.2.2_A5.1_T1.js`<br>`test/built-ins/parseInt/S15.1.2.2_A6.1_T1.js`<br>`test/built-ins/parseInt/S15.1.2.2_A7.2_T1.js`<br>`test/built-ins/parseInt/S15.1.2.2_A8.js`<br>`test/built-ins/parseInt/not-a-constructor.js` | Implemented by JavaScriptRuntime.GlobalThis.parseInt following ECMA-262 §19.2.5. Supports: leading/trailing whitespace, sign handling, radix coercion via ToInt32 (§7.1.6), hex prefix detection (0x/0X), digit scanning with stop-at-first-invalid, case-insensitive alphabetic digits (A-Z), ToString coercion including primitive values, Array join, and custom toString methods, and large numbers using double arithmetic. Checked-in coverage now also includes additional whitespace/radix edge cases plus non-constructibility. |
+
+### 19.2.6.3 ([tc39.es](https://tc39.es/ecma262/#sec-encodeuri-uri))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| encodeURI(uri) | Supported with Limitations | [`S15.1.3.3_A1.1_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T1.js)<br>[`S15.1.3.3_A1.1_T2.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T2.js)<br>[`S15.1.3.3_A1.2_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T1.js)<br>[`S15.1.3.3_A1.2_T2.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T2.js)<br>[`S15.1.3.3_A1.3_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.3_T1.js)<br>[`S15.1.3.3_A2.1_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.1_T1.js)<br>[`S15.1.3.3_A2.2_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.2_T1.js)<br>[`S15.1.3.3_A2.3_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.3_T1.js)<br>[`S15.1.3.3_A2.4_T1.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T1.js)<br>[`S15.1.3.3_A2.4_T2.js`](../../../tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T2.js) | `test/built-ins/encodeURI/S15.1.3.3_A1.1_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A1.1_T2.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A1.2_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A1.2_T2.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A1.3_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A2.1_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A2.2_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A2.3_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A2.4_T1.js`<br>`test/built-ins/encodeURI/S15.1.3.3_A2.4_T2.js` | Implements the covered ECMAScript UTF-8 percent-encoding behavior, preserves encodeURI reserved and unescaped characters, and throws URIError for malformed UTF-16 surrogate sequences. Broader coercion and metadata coverage remains to be added. |
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using JavaScriptRuntime.DependencyInjection;
 
 namespace JavaScriptRuntime
@@ -137,6 +138,7 @@ namespace JavaScriptRuntime
         private static readonly Func<object?, double> _parseFloatValue = parseFloat;
         private static readonly Func<object?, bool> _isFiniteValue = isFinite;
         private static readonly Func<object?, bool> _isNaNValue = isNaN;
+        private static readonly Func<object?, string> _encodeURIValue = encodeURI;
         private static readonly Func<object?, bool> _numberIsFiniteValue = JavaScriptRuntime.Number.isFinite;
         private static readonly Func<object?, bool> _numberIsIntegerValue = JavaScriptRuntime.Number.isInteger;
         private static readonly Func<object?, bool> _numberIsNaNValue = JavaScriptRuntime.Number.isNaN;
@@ -619,10 +621,12 @@ namespace JavaScriptRuntime
             ConfigureBuiltinFunctionObject(_parseFloatValue);
             ConfigureBuiltinFunctionObject(_isFiniteValue);
             ConfigureBuiltinFunctionObject(_isNaNValue);
+            ConfigureBuiltinFunctionObject(_encodeURIValue);
             DefineUndefinedPrototypeProperty(_parseIntValue);
             DefineUndefinedPrototypeProperty(_parseFloatValue);
             DefineUndefinedPrototypeProperty(_isFiniteValue);
             DefineUndefinedPrototypeProperty(_isNaNValue);
+            DefineUndefinedPrototypeProperty(_encodeURIValue);
 
             // Provide Error.prototype for patterns like `Error.prototype` and error-subclassing libraries.
             ConfigureErrorIntrinsicSurface(_errorConstructorValue, _errorPrototypeValue, "Error", parentPrototype: _objectPrototypeValue);
@@ -1210,6 +1214,9 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.isNaN), _isNaNValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.isNaN), dict[nameof(GlobalThis.isNaN)]);
 
+            dict.TryAdd(nameof(GlobalThis.encodeURI), _encodeURIValue);
+            DefineNonEnumerableDataProperty(nameof(GlobalThis.encodeURI), dict[nameof(GlobalThis.encodeURI)]);
+
             ApplyHostGlobalBindings(dict);
         }
 
@@ -1637,6 +1644,67 @@ namespace JavaScriptRuntime
             return double.IsNaN(TypeUtilities.ToNumber(number));
         }
 
+        /// <summary>
+        /// Encodes a URI using the percent-encoding algorithm specified for the global
+        /// <c>encodeURI</c> function.
+        /// </summary>
+        public static string encodeURI(object? uri)
+        {
+            var input = DotNet2JSConversions.ToString(uri);
+            var result = new StringBuilder(input.Length);
+
+            for (var index = 0; index < input.Length; index++)
+            {
+                var codeUnit = input[index];
+                if (char.IsHighSurrogate(codeUnit))
+                {
+                    if (index + 1 >= input.Length || !char.IsLowSurrogate(input[index + 1]))
+                    {
+                        throw new URIError("URI malformed");
+                    }
+
+                    AppendUriEncodedCodePoint(result, char.ConvertToUtf32(codeUnit, input[++index]));
+                    continue;
+                }
+
+                if (char.IsLowSurrogate(codeUnit))
+                {
+                    throw new URIError("URI malformed");
+                }
+
+                if (IsEncodeUriUnescaped(codeUnit))
+                {
+                    result.Append(codeUnit);
+                }
+                else
+                {
+                    AppendUriEncodedCodePoint(result, codeUnit);
+                }
+            }
+
+            return result.ToString();
+        }
+
+        private static bool IsEncodeUriUnescaped(char value)
+        {
+            return value is >= 'A' and <= 'Z'
+                or >= 'a' and <= 'z'
+                or >= '0' and <= '9'
+                or '-' or '_' or '.' or '!' or '~' or '*' or '\'' or '(' or ')'
+                or ';' or '/' or '?' or ':' or '@' or '&' or '=' or '+' or '$' or ',' or '#';
+        }
+
+        private static void AppendUriEncodedCodePoint(StringBuilder result, int codePoint)
+        {
+            Span<byte> utf8 = stackalloc byte[4];
+            var count = new System.Text.Rune(codePoint).EncodeToUtf8(utf8);
+            for (var index = 0; index < count; index++)
+            {
+                result.Append('%');
+                result.Append(utf8[index].ToString("X2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+        }
+
         private static Timers GetTimers()
         {
             return _serviceProvider.Value!.Resolve<Timers>();
@@ -1837,6 +1905,7 @@ namespace JavaScriptRuntime
                 || functionValue.Method == _parseIntValue.Method
                 || functionValue.Method == _isFiniteValue.Method
                 || functionValue.Method == _isNaNValue.Method
+                || functionValue.Method == _encodeURIValue.Method
                 || functionValue.Method == _numberIsIntegerValue.Method
                 || JavaScriptRuntime.Function.HasUndefinedPrototype(functionValue);
         }

--- a/src/JavaScriptRuntime/RuntimeIntrinsicCatalog.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsicCatalog.cs
@@ -147,6 +147,7 @@ public sealed class RuntimeIntrinsicCatalog : IRuntimeIntrinsicCatalog
         AddBuiltInGlobalFunction(globals, nameof(GlobalThis.parseFloat), () => (Func<object?, double>)GlobalThis.parseFloat, builtInGlobalAttributes);
         AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isFinite), () => (Func<object?, bool>)GlobalThis.isFinite, builtInGlobalAttributes);
         AddBuiltInGlobalFunction(globals, nameof(GlobalThis.isNaN), () => (Func<object?, bool>)GlobalThis.isNaN, builtInGlobalAttributes);
+        AddBuiltInGlobalFunction(globals, nameof(GlobalThis.encodeURI), () => (Func<object?, string>)GlobalThis.encodeURI, builtInGlobalAttributes);
 
         return globals;
     }

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/ExecutionTests.cs
@@ -1,0 +1,48 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.encodeURI;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.encodeURI") { }
+
+    [Fact(DisplayName = "S15.1.3.3_A1.1_T1")]
+    public Task S15_1_3_3_A1_1_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A1.1_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A1.1_T2")]
+    public Task S15_1_3_3_A1_1_T2()
+        => ExecutionTestFromFile("S15.1.3.3_A1.1_T2");
+
+    [Fact(DisplayName = "S15.1.3.3_A1.2_T1")]
+    public Task S15_1_3_3_A1_2_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A1.2_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A1.2_T2")]
+    public Task S15_1_3_3_A1_2_T2()
+        => ExecutionTestFromFile("S15.1.3.3_A1.2_T2");
+
+    [Fact(DisplayName = "S15.1.3.3_A1.3_T1")]
+    public Task S15_1_3_3_A1_3_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A1.3_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A2.1_T1")]
+    public Task S15_1_3_3_A2_1_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A2.1_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A2.2_T1")]
+    public Task S15_1_3_3_A2_2_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A2.2_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A2.3_T1")]
+    public Task S15_1_3_3_A2_3_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A2.3_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A2.4_T1")]
+    public Task S15_1_3_3_A2_4_T1()
+        => ExecutionTestFromFile("S15.1.3.3_A2.4_T1");
+
+    [Fact(DisplayName = "S15.1.3.3_A2.4_T2")]
+    public Task S15_1_3_3_A2_4_T2()
+        => ExecutionTestFromFile("S15.1.3.3_A2.4_T2");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T1.js
@@ -1,0 +1,53 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: If string.charAt(k) in [0xDC00 - 0xDFFF], throw URIError
+esid: sec-encodeuri-uri
+description: Complex tests
+includes: [decimalToHexString.js]
+---*/
+
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
+  count++;
+  try {
+    encodeURI(String.fromCharCode(index));
+  } catch (e) {
+    if ((e instanceof URIError) === true) continue;
+  }
+  if (indexO === 0) {
+    indexO = index;
+  } else {
+    if ((index - indexP) !== 1) {
+      if ((indexP - indexO) !== 0) {
+        var hexP = decimalToHexString(indexP);
+        var hexO = decimalToHexString(indexO);
+        throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+      }
+      else {
+        var hexP = decimalToHexString(indexP);
+        throw new Test262Error('#' + hexP + ' ');
+      }
+      indexO = index;
+    }
+  }
+  indexP = index;
+  errorCount++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T2.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.1_T2.js
@@ -1,0 +1,53 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: If string.charAt(k) in [0xDC00 - 0xDFFF], throw URIError
+esid: sec-encodeuri-uri
+description: Complex tests
+includes: [decimalToHexString.js]
+---*/
+
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
+  count++;
+  try {
+    encodeURI(String.fromCharCode(index, 0x0041));
+  } catch (e) {
+    if ((e instanceof URIError) === true) continue;
+  }
+  if (indexO === 0) {
+    indexO = index;
+  } else {
+    if ((index - indexP) !== 1) {
+      if ((indexP - indexO) !== 0) {
+        var hexP = decimalToHexString(indexP);
+        var hexO = decimalToHexString(indexO);
+        throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+      }
+      else {
+        var hexP = decimalToHexString(indexP);
+        throw new Test262Error('#' + hexP + ' ');
+      }
+      indexO = index;
+    }
+  }
+  indexP = index;
+  errorCount++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T1.js
@@ -1,0 +1,55 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0xD800 - 0xDBFF] and string.length = k + 1, throw
+    URIError
+esid: sec-encodeuri-uri
+description: Complex tests
+includes: [decimalToHexString.js]
+---*/
+
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+
+for (var index = 0xD800; index <= 0xDBFF; index++) {
+  count++;
+  try {
+    encodeURI(String.fromCharCode(index));
+  } catch (e) {
+    if ((e instanceof URIError) === true) continue;
+  }
+  if (indexO === 0) {
+    indexO = index;
+  } else {
+    if ((index - indexP) !== 1) {
+      if ((indexP - indexO) !== 0) {
+        var hexP = decimalToHexString(indexP);
+        var hexO = decimalToHexString(indexO);
+        throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+      }
+      else {
+        var hexP = decimalToHexString(indexP);
+        throw new Test262Error('#' + hexP + ' ');
+      }
+      indexO = index;
+    }
+  }
+  indexP = index;
+  errorCount++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T2.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.2_T2.js
@@ -1,0 +1,55 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0xD800 - 0xDBFF] and string.length = k + 1, throw
+    URIError
+esid: sec-encodeuri-uri
+description: Complex tests
+includes: [decimalToHexString.js]
+---*/
+
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+
+for (var index = 0xD800; index <= 0xDBFF; index++) {
+  count++;
+  try {
+    encodeURI(String.fromCharCode(0x0041, index));
+  } catch (e) {
+    if ((e instanceof URIError) === true) continue;
+  }
+  if (indexO === 0) {
+    indexO = index;
+  } else {
+    if ((index - indexP) !== 1) {
+      if ((indexP - indexO) !== 0) {
+        var hexP = decimalToHexString(indexP);
+        var hexO = decimalToHexString(indexO);
+        throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+      }
+      else {
+        var hexP = decimalToHexString(indexP);
+        throw new Test262Error('#' + hexP + ' ');
+      }
+      indexO = index;
+    }
+  }
+  indexP = index;
+  errorCount++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.3_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A1.3_T1.js
@@ -1,0 +1,64 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0xD800 - 0xDBFF] and string.charAt(k+1) not in
+    [0xDC00 - 0xDFFF], throw URIError
+esid: sec-encodeuri-uri
+description: >
+    Complex tests, string.charAt(k+1) in [0x0000, 0xD7FF, 0xD800,
+    0xDBFE, 0xDBFF, 0xE000, 0xFFFF]
+includes: [decimalToHexString.js]
+---*/
+
+var chars = [0x0000, 0xD7FF, 0xD800, 0xDBFE, 0xDBFF, 0xE000, 0xFFFF];
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+
+for (var index = 0xD800; index <= 0xDBFF; index++) {
+  count++;
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    try {
+      encodeURI(String.fromCharCode(index, chars[indexC]));
+    } catch (e) {
+      if ((e instanceof URIError) === true) continue;
+    }
+    res = false;
+  }
+  if (res !== true) {
+    if (indexO === 0) {
+      indexO = index;
+    } else {
+      if ((index - indexP) !== 1) {
+        if ((indexP - indexO) !== 0) {
+          var hexP = decimalToHexString(indexP);
+          var hexO = decimalToHexString(indexO);
+          throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+        }
+        else {
+          var hexP = decimalToHexString(indexP);
+          throw new Test262Error('#' + hexP + ' ');
+        }
+        indexO = index;
+      }
+    }
+    indexP = index;
+    errorCount++;
+  }
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.1_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.1_T1.js
@@ -1,0 +1,63 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0x0000 - 0x007F]\[uriReserved, uriUnescaped, #],
+    return 1 octet (00000000 0zzzzzzz -> 0zzzzzzz)
+esid: sec-encodeuri-uri
+description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
+---*/
+
+var uriReserved = [";", "/", "?", ":", "@", "&", "=", "+", "$", ","];
+var uriUnescaped = ["-", "_", ".", "!", "~", "*", "'", "(", ")", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+
+l:
+  for (var index = 0x0000; index <= 0x007F; index++) {
+    count++;
+    var str = String.fromCharCode(index);
+    for (var indexC = 0; indexC < uriReserved.length; indexC++) {
+      if (uriReserved[indexC] === str) continue l;
+    }
+    for (indexC = 0; indexC < uriUnescaped.length; indexC++) {
+      if (uriUnescaped[indexC] === str) continue l;
+    }
+    if ("#" === str) continue l;
+    if (encodeURI(str).toUpperCase() === decimalToPercentHexString(index)) continue l;
+
+    if (indexO === 0) {
+      indexO = index;
+    } else {
+      if ((index - indexP) !== 1) {
+        if ((indexP - indexO) !== 0) {
+          var hexP = decimalToHexString(indexP);
+          var hexO = decimalToHexString(indexO);
+          throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+        }
+        else {
+          var hexP = decimalToHexString(indexP);
+          throw new Test262Error('#' + hexP + ' ');
+        }
+        indexO = index;
+      }
+    }
+    indexP = index;
+    errorCount++;
+  }
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.2_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.2_T1.js
@@ -1,0 +1,55 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0x0080 - 0x07FF], return 2 octets (00000yyy
+    yyzzzzzz -> 110yyyyy 10zzzzzz)
+esid: sec-encodeuri-uri
+description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
+---*/
+
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+l:
+  for (var index = 0x0080; index <= 0x07FF; index++) {
+    count++;
+    var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+    var hex2 = decimalToPercentHexString(0x00C0 + (index & 0x07C0) / 0x0040);
+    var str = String.fromCharCode(index);
+    if (encodeURI(str).toUpperCase() === hex2 + hex1) continue;
+
+    if (indexO === 0) {
+      indexO = index;
+    } else {
+      if ((index - indexP) !== 1) {
+        if ((indexP - indexO) !== 0) {
+          var hexP = decimalToHexString(indexP);
+          var hexO = decimalToHexString(indexO);
+          throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+        }
+        else {
+          var hexP = decimalToHexString(indexP);
+          throw new Test262Error('#' + hexP + ' ');
+        }
+        indexO = index;
+      }
+    }
+    indexP = index;
+    errorCount++;
+  }
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.3_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.3_T1.js
@@ -1,0 +1,55 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0x0800 - 0xD7FF], return 3 octets (xxxxyyyy
+    yyzzzzzz -> 1110xxxx 10yyyyyy 10zzzzzz)
+esid: sec-encodeuri-uri
+description: Complex tests, use RFC 3629
+includes: [decimalToHexString.js]
+---*/
+
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+for (var index = 0x0800; index <= 0xD7FF; index++) {
+  count++;
+  var hex1 = decimalToPercentHexString(0x0080 + (index & 0x003F));
+  var hex2 = decimalToPercentHexString(0x0080 + (index & 0x0FC0) / 0x0040);
+  var hex3 = decimalToPercentHexString(0x00E0 + (index & 0xF000) / 0x1000);
+  var str = String.fromCharCode(index);
+  if (encodeURI(str).toUpperCase() === hex3 + hex2 + hex1) continue;
+
+  if (indexO === 0) {
+    indexO = index;
+  } else {
+    if ((index - indexP) !== 1) {
+      if ((indexP - indexO) !== 0) {
+        var hexP = decimalToHexString(indexP);
+        var hexO = decimalToHexString(indexO);
+        throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+      }
+      else {
+        var hexP = decimalToHexString(indexP);
+        throw new Test262Error('#' + hexP + ' ');
+      }
+      indexO = index;
+    }
+  }
+  indexP = index;
+  errorCount++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T1.js
@@ -1,0 +1,67 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0xD800 - 0xDBFF] and string.charAt(k+1) in
+    [0xDC00 � 0xDFFF], return 4 octets (000wwwxx xxxxyyyy yyzzzzzz ->
+    11110www 10xxxxxx 10yyyyyy 10zzzzzz)
+esid: sec-encodeuri-uri
+description: >
+    Complex tests, use RFC 3629, string.charAt(k+1) in [0xDC00,
+    0xDDFF, 0xDFFF]
+includes: [decimalToHexString.js]
+---*/
+
+var chars = [0xDC00, 0xDDFF, 0xDFFF];
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+for (var index = 0xD800; index <= 0xDBFF; index++) {
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var index1 = (index - 0xD800) * 0x400 + (chars[indexC] - 0xDC00) + 0x10000;
+    var hex1 = decimalToPercentHexString(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToPercentHexString(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
+    var str = String.fromCharCode(index, chars[indexC]);
+    if (encodeURI(str).toUpperCase() === hex4 + hex3 + hex2 + hex1) continue;
+
+    res = false;
+  }
+  if (res !== true) {
+    if (indexO === 0) {
+      indexO = index;
+    } else {
+      if ((index - indexP) !== 1) {
+        if ((indexP - indexO) !== 0) {
+          var hexP = decimalToHexString(indexP);
+          var hexO = decimalToHexString(indexO);
+          throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+        }
+        else {
+          var hexP = decimalToHexString(indexP);
+          throw new Test262Error('#' + hexP + ' ');
+        }
+        indexO = index;
+      }
+    }
+    indexP = index;
+    errorCount++;
+  }
+  count++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T2.js
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/JavaScript/S15.1.3.3_A2.4_T2.js
@@ -1,0 +1,67 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    If string.charAt(k) in [0xD800 - 0xDBFF] and string.charAt(k+1) in
+    [0xDC00 � 0xDFFF], return 4 octets (000wwwxx xxxxyyyy yyzzzzzz ->
+    11110www 10xxxxxx 10yyyyyy 10zzzzzz)
+esid: sec-encodeuri-uri
+description: >
+    Complex tests, use RFC 3629, string.charAt(k) in [0xD800, 0xDBFF,
+    0xD9FF]
+includes: [decimalToHexString.js]
+---*/
+
+var chars = [0xD800, 0xDBFF, 0xD9FF];
+var errorCount = 0;
+var count = 0;
+var indexP;
+var indexO = 0;
+for (var index = 0xDC00; index <= 0xDFFF; index++) {
+  var res = true;
+  for (var indexC = 0; indexC < chars.length; indexC++) {
+    var index1 = (chars[indexC] - 0xD800) * 0x400 + (index - 0xDC00) + 0x10000;
+    var hex1 = decimalToPercentHexString(0x0080 + (index1 & 0x003F));
+    var hex2 = decimalToPercentHexString(0x0080 + (index1 & 0x0FC0) / 0x0040);
+    var hex3 = decimalToPercentHexString(0x0080 + (index1 & 0x3F000) / 0x1000);
+    var hex4 = decimalToPercentHexString(0x00F0 + (index1 & 0x1C0000) / 0x40000);
+    var str = String.fromCharCode(chars[indexC], index);
+    if (encodeURI(str).toUpperCase() === hex4 + hex3 + hex2 + hex1) continue;
+
+    res = false;
+  }
+  if (res !== true) {
+    if (indexO === 0) {
+      indexO = index;
+    } else {
+      if ((index - indexP) !== 1) {
+        if ((indexP - indexO) !== 0) {
+          var hexP = decimalToHexString(indexP);
+          var hexO = decimalToHexString(indexO);
+          throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+        }
+        else {
+          var hexP = decimalToHexString(indexP);
+          throw new Test262Error('#' + hexP + ' ');
+        }
+        indexO = index;
+      }
+    }
+    indexP = index;
+    errorCount++;
+  }
+  count++;
+}
+
+if (errorCount > 0) {
+  if ((indexP - indexO) !== 0) {
+    var hexP = decimalToHexString(indexP);
+    var hexO = decimalToHexString(indexO);
+    throw new Test262Error('#' + hexO + '-' + hexP + ' ');
+  } else {
+    var hexP = decimalToHexString(indexP);
+    throw new Test262Error('#' + hexP + ' ');
+  }
+  throw new Test262Error('Total error: ' + errorCount + ' bad Unicode character in ' + count + ' ');
+}

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_1_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_1_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_1_T2.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_1_T2.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_2_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_2_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_2_T2.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_2_T2.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_3_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A1_3_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_1_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_1_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_2_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_2_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_3_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_3_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_4_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_4_T1.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_4_T2.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/encodeURI/Snapshots/ExecutionTests.S15_1_3_3_A2_4_T2.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString


### PR DESCRIPTION
Implements global `encodeURI` with ECMAScript UTF-8 percent encoding, reserved-character preservation, and malformed-surrogate URIError handling.\n\nPorts ten previously failing, non-eval test262 cases for ECMA-262 §19.2.6.3 and updates the matching support documentation.