### PR TITLE
refactor(runtime): isolate DLR hosting interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/hosting: remove DLR participation from `JsObject`; C# `dynamic` access remains available through hosting proxies, including object-typed contract returns.
 - runtime: implement global `decodeURI`, including strict UTF-8 percent decoding, malformed-escape `URIError`s, and reserved-character escape preservation. Ports ten upstream test262 cases.
 - runtime: implement global `encodeURI`, including covered UTF-8 percent encoding, reserved-character preservation, and malformed-surrogate `URIError`s. Ports ten upstream test262 cases.
 - tests/test262: port fifty non-eval numeric-literal conformance cases, covering decimal integer, decimal-point, and exponent forms.

--- a/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
+++ b/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
@@ -73,6 +73,13 @@ internal static class JsReturnConverter
             return returnType.IsValueType ? Activator.CreateInstance(returnType) : null;
         }
 
+        if (returnType == typeof(object))
+        {
+            // An object-typed host contract erases whether the value is a JS reference.
+            // Keep runtime objects behind the dynamic hosting boundary instead of leaking them.
+            return JsDynamicValueProxy.Wrap(runtime, value);
+        }
+
         if (returnType.IsInstanceOfType(value))
         {
             return value;

--- a/src/JavaScriptRuntime/JsObject.cs
+++ b/src/JavaScriptRuntime/JsObject.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Dynamic;
 
 namespace JavaScriptRuntime;
 
@@ -182,7 +181,7 @@ internal interface IExoticJsObject
 /// for object literal property initialization to avoid the <c>box</c> instruction.
 /// </para>
 /// </summary>
-public class JsObject : DynamicObject, IDictionary<string, object?>
+public class JsObject : IDictionary<string, object?>
 {
     private JsValue[] _properties = System.Array.Empty<JsValue>();
 
@@ -649,21 +648,6 @@ public class JsObject : DynamicObject, IDictionary<string, object?>
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    public override bool TryGetMember(GetMemberBinder binder, out object? result)
-        => TryGetValue(binder.Name, out result);
-
-    public override bool TrySetMember(SetMemberBinder binder, object? value)
-    {
-        this[binder.Name] = value;
-        return true;
-    }
-
-    public override bool TryDeleteMember(DeleteMemberBinder binder)
-        => Remove(binder.Name);
-
-    public override IEnumerable<string> GetDynamicMemberNames()
-        => GetOwnPropertyNames();
 
     // -------------------------------------------------------------------------
     // Helpers

--- a/tests/Jroc.Tests/GlobalThisTests.cs
+++ b/tests/Jroc.Tests/GlobalThisTests.cs
@@ -1,3 +1,4 @@
+using System.Dynamic;
 using JavaScriptRuntime;
 
 namespace Jroc.Tests;
@@ -20,19 +21,26 @@ public class GlobalThisTests
     }
 
     [Fact]
-    public void GlobalObject_PreservesDynamicHostPropertyAccess()
+    public void JsObject_DoesNotParticipateInDlrDispatch()
+    {
+        Assert.False(typeof(DynamicObject).IsAssignableFrom(typeof(JsObject)));
+        Assert.False(typeof(IDynamicMetaObjectProvider).IsAssignableFrom(typeof(JsObject)));
+    }
+
+    [Fact]
+    public void GlobalObject_PreservesExplicitRuntimePropertyAccess()
     {
         var serviceProvider = RuntimeServices.BuildServiceProvider();
 
         try
         {
             GlobalThis.ServiceProvider = serviceProvider;
-            dynamic globalObject = GlobalThis.globalThis;
+            var globalObject = Assert.IsType<GlobalThis>(GlobalThis.globalThis);
 
-            globalObject.hostValue = 42d;
+            ObjectRuntime.SetItem(globalObject, "hostValue", 42d);
 
-            Assert.Equal(42d, globalObject.hostValue);
-            Assert.Equal(42d, ((GlobalThis)globalObject)["hostValue"]);
+            Assert.Equal(42d, ObjectRuntime.GetItem(globalObject, "hostValue"));
+            Assert.Equal(42d, globalObject["hostValue"]);
         }
         finally
         {

--- a/tests/Jroc.Tests/Hosting/JavaScript/nestedReturn.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/nestedReturn.js
@@ -1,11 +1,30 @@
 "use strict";
 
-exports.getWindow = function () {
-  return {
-    document: {
+class Window {
+  constructor() {
+    this.document = {
       title: "Hello"
-    }
-  };
+    };
+  }
+
+  get title() {
+    return this.document.title;
+  }
+
+  setTitle(title) {
+    this.document.title = title;
+    return this.document.title;
+  }
+
+  fail() {
+    throw new Error("nested boom");
+  }
+}
+
+const windowValue = new Window();
+
+exports.getWindow = function () {
+  return windowValue;
 };
 
 exports.getTitleViaHost = function () {
@@ -15,4 +34,8 @@ exports.getTitleViaHost = function () {
 
 exports.getTitle = function (win) {
   return win.document.title;
+};
+
+exports.getHostValue = function (win) {
+  return win.hostValue;
 };

--- a/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
+++ b/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
@@ -20,6 +20,13 @@ public class ModuleLoadTests
         double Add(double x, double y);
     }
 
+    public interface IObjectReturnExports : IDisposable
+    {
+        object GetWindow();
+        string GetTitle(object win);
+        double GetHostValue(object win);
+    }
+
     private sealed class CompiledModuleAssembly : IDisposable
     {
         private readonly string _outputDir;
@@ -240,8 +247,54 @@ public class ModuleLoadTests
 
         dynamic win = exports.getWindow();
         Assert.Equal("Hello", (string)win.document.title);
+        Assert.Equal("Hello", (string)win.title);
         Assert.Equal("Hello", (string)exports.getTitle(win));
         Assert.Equal("Hello", (string)exports.getTitleViaHost());
+
+        win.hostValue = 17;
+        Assert.Equal(17.0, (double)exports.getHostValue(win));
+
+        Assert.Equal("Updated", (string)win.setTitle("Updated"));
+        Assert.Equal("Updated", (string)win.document.title);
+        Assert.Equal("Updated", (string)win.title);
+    }
+
+    [Fact]
+    public void JsEngine_LoadModule_Typed_ObjectReturn_UsesDynamicBoundaryProxy()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource("nestedReturn", "nestedReturn.js");
+        using var exports = Jroc.Runtime.JsEngine.LoadModule<IObjectReturnExports>(module.Assembly, "nestedReturn");
+
+        var returnedValue = exports.GetWindow();
+        Assert.IsNotType<JsObject>(returnedValue);
+
+        dynamic win = returnedValue;
+        Assert.Equal("Hello", (string)win.title);
+
+        win.hostValue = 23;
+        Assert.Equal(23.0, exports.GetHostValue(win));
+        Assert.Equal("Hello", exports.GetTitle(win));
+    }
+
+    [Fact]
+    public async Task JsEngine_LoadModule_Dynamic_ReturnedObject_MarshalsAndTranslatesCalls()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource("nestedReturn", "nestedReturn.js");
+
+        using var exportsObj = Jroc.Runtime.JsEngine.LoadModule(module.Assembly, "nestedReturn");
+        dynamic exports = exportsObj;
+        dynamic win = exports.getWindow();
+
+        var title = await Task.Run(() => (string)win.title);
+        Assert.Equal("Hello", title);
+
+        var ex = Assert.Throws<JsInvocationException>(() => win.fail());
+        Assert.Equal("nestedReturn", ex.ModuleId);
+        Assert.Equal("fail", ex.MemberName);
+
+        var jsError = Assert.IsType<JsErrorException>(ex.InnerException);
+        Assert.Equal("Error", jsError.JsName);
+        Assert.Contains("nested boom", jsError.JsMessage ?? jsError.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/performance/Benchmarks/ObjectInternalOperationsBenchmarks.cs
+++ b/tests/performance/Benchmarks/ObjectInternalOperationsBenchmarks.cs
@@ -3,12 +3,13 @@ using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Order;
+using Jroc;
 
 namespace Benchmarks;
 
 /// <summary>
 /// Tracks the steady-state cost of ordinary-object reads and writes through the
-/// generic runtime dispatch used by extensible JsObject internal operations.
+/// generic runtime dispatch and through the hosted C# dynamic boundary.
 /// </summary>
 [MemoryDiagnoser]
 [Config(typeof(FullParamsConfig))]
@@ -16,17 +17,31 @@ namespace Benchmarks;
 [RankColumn]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [HideColumns("Error", "StdDev")]
-public class ObjectInternalOperationsBenchmarks
+public class ObjectInternalOperationsBenchmarks : IDisposable
 {
     private readonly JavaScriptRuntime.JsObject _readTarget = new();
     private readonly JavaScriptRuntime.JsObject _writeTarget = new();
+    private JrocInMemoryModule? _hostedModule;
+    private dynamic _hostedTarget = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         JavaScriptRuntime.Object.SetProperty(_readTarget, "value", 42d);
         JavaScriptRuntime.Object.SetProperty(_writeTarget, "value", 0d);
+
+        var request = new JrocInMemoryCompileRequest(
+            Path.Combine(Path.GetTempPath(), "jroc-hosted-object-operations.js"))
+        {
+            SourceText = "\"use strict\"; module.exports = { target: { value: 42 } };"
+        };
+        _hostedModule = JrocInMemoryCompiler.CompileAndLoadModule(request);
+        dynamic exports = _hostedModule.Exports;
+        _hostedTarget = exports.target;
     }
+
+    [GlobalCleanup]
+    public void Dispose() => _hostedModule?.Dispose();
 
     [Benchmark(Description = "Ordinary JsObject read")]
     public object? Read()
@@ -35,4 +50,12 @@ public class ObjectInternalOperationsBenchmarks
     [Benchmark(Description = "Ordinary JsObject write")]
     public object? Write()
         => JavaScriptRuntime.Object.SetProperty(_writeTarget, "value", 42d);
+
+    [Benchmark(Description = "Hosted dynamic proxy read")]
+    public object? HostedRead()
+        => _hostedTarget.value;
+
+    [Benchmark(Description = "Hosted dynamic proxy write")]
+    public void HostedWrite()
+        => _hostedTarget.value = 42d;
 }

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -177,6 +177,18 @@ Notes:
 - This benchmark is intentionally narrow: it measures representative CLR receiver dispatch, not full JavaScript prototype semantics.
 - It is useful for feasibility/performance investigations, not for validating JS compatibility.
 
+#### Object Operation Boundaries
+
+Compares internal ordinary-object reads and writes through JROC runtime operations with
+hosted C# `dynamic` access through `JsDynamicValueProxy`:
+
+```powershell
+dotnet run -c Release -- --object-operations
+```
+
+The hosted cases include runtime-thread marshalling and DLR boundary dispatch. Core
+JavaScript objects do not participate in DLR dispatch.
+
 #### Prototype Storage
 Measures the time and managed allocation required to construct an Array or ordinary `JsObject` with an initialized prototype:
 


### PR DESCRIPTION
## Summary

- remove `DynamicObject` and DLR member overrides from core `JsObject`
- route object-typed hosted contract returns through `JsDynamicValueProxy`
- preserve hosted dynamic reads, writes, accessors, prototype methods, receiver identity, runtime-thread marshalling, argument unwrapping, and exception translation
- add a guard that `JsObject` does not implement `IDynamicMetaObjectProvider`
- extend object-operation benchmarks to distinguish internal runtime operations from hosted dynamic access

## Validation

- `dotnet build jroc.sln -c Debug --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Tests.Hosting.ModuleLoadTests'`
- 62 representative core object/runtime tests
- 48 representative global-object and `Object.entries` test262 tests
- hosted dynamic benchmark smoke test

## Performance

Same-machine `ObjectInternalOperationsBenchmarks` short runs:

| Operation | master | branch |
|---|---:|---:|
| Ordinary `JsObject` read | 28.02 ns | 27.94 ns |
| Ordinary `JsObject` write | 250.75 ns | 247.23 ns |

The new hosted-boundary cases measured 1,420.05 ns/read and 2,340.98 ns/write, keeping DLR and runtime-thread marshalling costs isolated to explicit hosted `dynamic` access.

Closes #1461
