### PR TITLE
feat(runtime): add Map insertion helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: implement `Map.prototype.getOrInsert` and `Map.prototype.getOrInsertComputed`, including SameValueZero lookup, negative-zero canonicalization, callback validation and ordering, mutation overwrite semantics, and built-in metadata. Ports ten upstream test262 cases.
 - runtime/hosting: remove DLR participation from `JsObject`; C# `dynamic` access remains available through hosting proxies, including object-typed contract returns.
 - runtime: implement global `decodeURI`, including strict UTF-8 percent decoding, malformed-escape `URIError`s, and reserved-character escape preservation. Ports ten upstream test262 cases.
 - runtime: implement global `encodeURI`, including covered UTF-8 percent encoding, reserved-character preservation, and malformed-surrogate `URIError`s. Ports ten upstream test262 cases.

--- a/docs/ECMA262/24/Section24_1.json
+++ b/docs/ECMA262/24/Section24_1.json
@@ -96,13 +96,13 @@
     {
       "clause": "24.1.3.7",
       "title": "Map.prototype.getOrInsert ( key , value )",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.getorinsert"
     },
     {
       "clause": "24.1.3.8",
       "title": "Map.prototype.getOrInsertComputed ( key , callback )",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed"
     },
     {
@@ -324,10 +324,37 @@
       },
       {
         "clause": "24.1.3.7",
-        "feature": "Map.prototype.getOrInsert / getOrInsertComputed",
-        "status": "Not Yet Supported",
+        "feature": "Map.prototype.getOrInsert",
+        "status": "Supported",
         "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.getorinsert",
-        "notes": "The newer getOrInsert APIs are still not implemented on JavaScriptRuntime.Map."
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/Map/prototype/getOrInsert/append-new-values.js",
+          "test/built-ins/Map/prototype/getOrInsert/append-new-values-normalizes-zero-key.js",
+          "test/built-ins/Map/prototype/getOrInsert/append-value-if-key-is-not-present-different-key-types.js",
+          "test/built-ins/Map/prototype/getOrInsert/returns-value-if-key-is-not-present-different-key-types.js",
+          "test/built-ins/Map/prototype/getOrInsert/returns-value-if-key-is-present-different-key-types.js",
+          "test/built-ins/Map/prototype/getOrInsert/returns-value-normalized-zero-key.js"
+        ],
+        "notes": "Returns an existing Map value or appends and returns the supplied value. SameValueZero key lookup, insertion order, key types, and negative-zero canonicalization are covered."
+      },
+      {
+        "clause": "24.1.3.8",
+        "feature": "Map.prototype.getOrInsertComputed",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/Map/prototype/getOrInsertComputed/canonical-key-passed-to-callback.js",
+          "test/built-ins/Map/prototype/getOrInsertComputed/different-types-function-callbackfn-does-not-throw.js",
+          "test/built-ins/Map/prototype/getOrInsertComputed/does-not-evaluate-callbackfn-if-key-present.js",
+          "test/built-ins/Map/prototype/getOrInsertComputed/overwrites-mutation-from-callbackfn.js"
+        ],
+        "notes": "Returns existing values without invoking the callback; otherwise calls a validated callback with the canonical key and stores its result, overwriting same-key callback mutations as required."
       },
       {
         "clause": "24.1.3.14",

--- a/docs/ECMA262/24/Section24_1.md
+++ b/docs/ECMA262/24/Section24_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section24](Section24.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-23T02:06:52Z
+> Last generated (UTC): 2026-07-27T04:46:16Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -28,8 +28,8 @@
 | 24.1.3.4 | Map.prototype.entries ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.entries) |
 | 24.1.3.5 | Map.prototype.forEach ( callback [ , thisArg ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.foreach) |
 | 24.1.3.6 | Map.prototype.get ( key ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.get) |
-| 24.1.3.7 | Map.prototype.getOrInsert ( key , value ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsert) |
-| 24.1.3.8 | Map.prototype.getOrInsertComputed ( key , callback ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed) |
+| 24.1.3.7 | Map.prototype.getOrInsert ( key , value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsert) |
+| 24.1.3.8 | Map.prototype.getOrInsertComputed ( key , callback ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed) |
 | 24.1.3.9 | Map.prototype.has ( key ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.has) |
 | 24.1.3.10 | Map.prototype.keys ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.keys) |
 | 24.1.3.11 | Map.prototype.set ( key , value ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-map.prototype.set) |
@@ -95,7 +95,13 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Map.prototype.getOrInsert / getOrInsertComputed | Not Yet Supported |  |  | The newer getOrInsert APIs are still not implemented on JavaScriptRuntime.Map. |
+| Map.prototype.getOrInsert | Supported | `tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/ExecutionTests.cs` | `test/built-ins/Map/prototype/getOrInsert/append-new-values.js`<br>`test/built-ins/Map/prototype/getOrInsert/append-new-values-normalizes-zero-key.js`<br>`test/built-ins/Map/prototype/getOrInsert/append-value-if-key-is-not-present-different-key-types.js`<br>`test/built-ins/Map/prototype/getOrInsert/returns-value-if-key-is-not-present-different-key-types.js`<br>`test/built-ins/Map/prototype/getOrInsert/returns-value-if-key-is-present-different-key-types.js`<br>`test/built-ins/Map/prototype/getOrInsert/returns-value-normalized-zero-key.js` | Returns an existing Map value or appends and returns the supplied value. SameValueZero key lookup, insertion order, key types, and negative-zero canonicalization are covered. |
+
+### 24.1.3.8 ([tc39.es](https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Map.prototype.getOrInsertComputed | Supported | `tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/ExecutionTests.cs` | `test/built-ins/Map/prototype/getOrInsertComputed/canonical-key-passed-to-callback.js`<br>`test/built-ins/Map/prototype/getOrInsertComputed/different-types-function-callbackfn-does-not-throw.js`<br>`test/built-ins/Map/prototype/getOrInsertComputed/does-not-evaluate-callbackfn-if-key-present.js`<br>`test/built-ins/Map/prototype/getOrInsertComputed/overwrites-mutation-from-callbackfn.js` | Returns existing values without invoking the callback; otherwise calls a validated callback with the canonical key and stores its result, overwriting same-key callback mutations as required. |
 
 ### 24.1.3.14 ([tc39.es](https://tc39.es/ecma262/#sec-map.prototype-%symbol.iterator%))
 

--- a/src/JavaScriptRuntime/Closure.cs
+++ b/src/JavaScriptRuntime/Closure.cs
@@ -729,6 +729,20 @@ namespace JavaScriptRuntime
                         return trapResult!;
                     }
 
+                    if (proxyTarget is Delegate proxyTargetDelegate)
+                    {
+                        var previousThis = RuntimeServices.SetCurrentThis(
+                            Function.GetEffectiveThisArg(proxyTargetDelegate, RuntimeServices.GetCurrentThis()));
+                        try
+                        {
+                            return InvokeWithArgsCore(proxyTarget, scopes, newTarget, args);
+                        }
+                        finally
+                        {
+                            RuntimeServices.SetCurrentThis(previousThis);
+                        }
+                    }
+
                     return InvokeWithArgsCore(proxyTarget, scopes, newTarget, args);
                 }
 

--- a/src/JavaScriptRuntime/Map.cs
+++ b/src/JavaScriptRuntime/Map.cs
@@ -28,6 +28,8 @@ namespace JavaScriptRuntime
             DefinePrototypeMethod(exp, "values", PrototypeValues);
             DefinePrototypeMethod(exp, "entries", _prototypeEntriesValue);
             DefinePrototypeMethod(exp, "forEach", PrototypeForEach);
+            DefinePrototypeMethod(exp, "getOrInsert", PrototypeGetOrInsert, 2);
+            DefinePrototypeMethod(exp, "getOrInsertComputed", PrototypeGetOrInsertComputed, 2);
             PropertyDescriptorStore.DefineOrUpdate(exp, Symbol.iterator.DebugId, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
@@ -81,6 +83,17 @@ namespace JavaScriptRuntime
                 Writable = true,
                 Value = method
             });
+        }
+
+        private static void DefinePrototypeMethod(
+            JsObject prototype,
+            string name,
+            Func<object[], object?[]?, object?> method,
+            double length)
+        {
+            Function.InitializeFunctionInstance(method, length, name);
+            Function.MarkUndefinedPrototype(method);
+            DefinePrototypeMethod(prototype, name, method);
         }
 
         private static Map GetMapReceiver(string methodName)
@@ -151,6 +164,22 @@ namespace JavaScriptRuntime
             var thisArg = args != null && args.Length > 1 ? args[1] : null;
             map.forEach(callback, thisArg);
             return null;
+        }
+
+        private static object? PrototypeGetOrInsert(object[] scopes, object?[]? args)
+        {
+            var map = GetMapReceiver("getOrInsert");
+            var key = args != null && args.Length > 0 ? args[0] : null;
+            var value = args != null && args.Length > 1 ? args[1] : null;
+            return map.getOrInsert(key, value);
+        }
+
+        private static object? PrototypeGetOrInsertComputed(object[] scopes, object?[]? args)
+        {
+            var map = GetMapReceiver("getOrInsertComputed");
+            var key = args != null && args.Length > 0 ? args[0] : null;
+            var callback = args != null && args.Length > 1 ? args[1] : null;
+            return map.getOrInsertComputed(key, callback);
         }
 
         private static object? PrototypeSizeGetter(object[] scopes, object?[]? args)
@@ -353,6 +382,40 @@ namespace JavaScriptRuntime
             return null; // JavaScript undefined, represented as null in .NET
         }
 
+        public object? getOrInsert(object? key, object? value)
+        {
+            var normalizedKey = NormalizeKey(key);
+            if (_keyIndex.TryGetValue(normalizedKey, out var index))
+            {
+                return _entries[index][1];
+            }
+
+            set(key, value);
+            return value;
+        }
+
+        public object? getOrInsertComputed(object? key, object? callback)
+        {
+            if (!Proxy.IsCallableValue(callback))
+            {
+                throw new TypeError("Map.prototype.getOrInsertComputed callback must be a function");
+            }
+
+            var canonicalKey = CanonicalizeKeyedCollectionKey(key);
+            var normalizedKey = NormalizeKey(canonicalKey);
+            if (_keyIndex.TryGetValue(normalizedKey, out var index))
+            {
+                return _entries[index][1];
+            }
+
+            var value = Closure.InvokeFunctionCallWithArgs1(
+                callback!,
+                System.Array.Empty<object>(),
+                canonicalKey);
+            set(canonicalKey, value);
+            return value;
+        }
+
         public bool has(object? key)
         {
             return _keyIndex.ContainsKey(NormalizeKey(key));
@@ -424,13 +487,8 @@ namespace JavaScriptRuntime
         // JavaScript Map.prototype.entries()
         public IJavaScriptIterator entries() => new MapIterator(this, MapIteratorKind.Entries);
 
-        private static object NormalizeKey(object? key)
+        private static object? CanonicalizeKeyedCollectionKey(object? key)
         {
-            if (key is null)
-            {
-                return NullKeySentinel;
-            }
-
             return key switch
             {
                 byte value => (double)value,
@@ -447,6 +505,11 @@ namespace JavaScriptRuntime
                 decimal value => (double)value,
                 _ => key
             };
+        }
+
+        private static object NormalizeKey(object? key)
+        {
+            return CanonicalizeKeyedCollectionKey(key) ?? NullKeySentinel;
         }
 
         private enum MapIteratorKind

--- a/src/JavaScriptRuntime/Proxy.cs
+++ b/src/JavaScriptRuntime/Proxy.cs
@@ -28,7 +28,7 @@ namespace JavaScriptRuntime
                 return proxy.IsCallableTarget;
             }
 
-            return value is Delegate;
+            return value is Delegate or ClassConstructorValue;
         }
 
         public Proxy(object? target, object? handler)

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/ExecutionTests.cs
@@ -1,0 +1,33 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.Map.prototype.getOrInsert;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.Map.prototype.getOrInsert") { }
+
+    [Fact(DisplayName = "append-new-values")]
+    public Task append_new_values()
+        => ExecutionTestFromFile("append-new-values");
+
+    [Fact(DisplayName = "append-new-values-normalizes-zero-key")]
+    public Task append_new_values_normalizes_zero_key()
+        => ExecutionTestFromFile("append-new-values-normalizes-zero-key");
+
+    [Fact(DisplayName = "append-value-if-key-is-not-present-different-key-types")]
+    public Task append_value_if_key_is_not_present_different_key_types()
+        => ExecutionTestFromFile("append-value-if-key-is-not-present-different-key-types");
+
+    [Fact(DisplayName = "returns-value-if-key-is-not-present-different-key-types")]
+    public Task returns_value_if_key_is_not_present_different_key_types()
+        => ExecutionTestFromFile("returns-value-if-key-is-not-present-different-key-types");
+
+    [Fact(DisplayName = "returns-value-if-key-is-present-different-key-types")]
+    public Task returns_value_if_key_is_present_different_key_types()
+        => ExecutionTestFromFile("returns-value-if-key-is-present-different-key-types");
+
+    [Fact(DisplayName = "returns-value-normalized-zero-key")]
+    public Task returns_value_normalized_zero_key()
+        => ExecutionTestFromFile("returns-value-normalized-zero-key");
+}
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/append-new-values-normalizes-zero-key.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/append-new-values-normalizes-zero-key.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2024 Jonas Haukenes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsert
+description: |
+  Append a new value in the map normalizing +0 and -0.
+info: |
+  Map.prototype.getOrInsert ( key , value )
+
+  ...
+  3. Set key to CanonicalizeKeyedCollectionKey(key).
+  4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+    a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+  5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+  6. Append p to M.[[MapData]].
+  ...
+features: [Symbol, upsert]
+---*/
+var map = new Map();
+map.getOrInsert(-0, 42);
+assert.sameValue(map.get(0), 42);
+
+map = new Map();
+map.getOrInsert(+0, 43);
+assert.sameValue(map.get(0), 43);
+assert.sameValue(map.get(-0), 43);

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/append-new-values.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/append-new-values.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2024 Jonas Haukenes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsert
+description: |
+  Append a new value as the last element of entries.
+info: |
+  Map.prototype.getOrInsert ( key , value )
+
+  ...
+  3. Set key to CanonicalizeKeyedCollectionKey(key).
+  4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+    a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+  5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+  6. Append p to M.[[MapData]].
+  ...
+features: [Symbol, upsert]
+---*/
+var s = Symbol(2);
+var map = new Map([[4, 4], ['foo3', 3], [s, 2]]);
+
+map.getOrInsert(null, 42);
+map.getOrInsert(1, 'valid');
+
+assert.sameValue(map.size, 5);
+assert.sameValue(map.get(1), 'valid');
+
+var results = [];
+
+map.forEach(function(value, key) {
+  results.push({
+    value: value,
+    key: key
+  });
+});
+
+var result = results.pop();
+assert.sameValue(result.value, 'valid');
+assert.sameValue(result.key, 1);
+
+result = results.pop();
+assert.sameValue(result.value, 42);
+assert.sameValue(result.key, null);
+
+result = results.pop();
+assert.sameValue(result.value, 2);
+assert.sameValue(result.key, s);
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/append-value-if-key-is-not-present-different-key-types.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/append-value-if-key-is-not-present-different-key-types.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2024 Sune Eriksson Lianes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsert
+description: |
+  Inserts the value for the specified key on different types, when key not present.
+info: |
+  Map.prototype.getOrInsert ( key , value )
+
+  ...
+  5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+  6. Append p to M.[[MapData]].
+  ...
+features: [Symbol, upsert]
+---*/
+var map = new Map();
+
+map.getOrInsert('bar', 0);
+assert.sameValue(map.get('bar'), 0);
+
+map.getOrInsert(1, 42);
+assert.sameValue(map.get(1), 42);
+
+map.getOrInsert(NaN, 1);
+assert.sameValue(map.get(NaN), 1);
+
+var item = {};
+map.getOrInsert(item, 2);
+assert.sameValue(map.get(item), 2);
+
+item = [];
+map.getOrInsert(item, 3);
+assert.sameValue(map.get(item), 3);
+
+item = Symbol('item');
+map.getOrInsert(item, 4);
+assert.sameValue(map.get(item), 4);
+
+item = null;
+map.getOrInsert(item, 5);
+assert.sameValue(map.get(item), 5);
+
+item = undefined;
+map.getOrInsert(item, 6);
+assert.sameValue(map.get(item), 6);
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/returns-value-if-key-is-not-present-different-key-types.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/returns-value-if-key-is-not-present-different-key-types.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2024 Jonas Haukenes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsert
+description: |
+  Returns the value from the specified key on different types, when key not present.
+info: |
+  Map.prototype.getOrInsert ( key , value )
+
+  ...
+  5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+  6. Append p to M.[[MapData]].
+  7. Return p.[[Value]].
+  ...
+features: [Symbol, upsert]
+---*/
+var map = new Map();
+
+assert.sameValue(map.getOrInsert('bar', 0), 0);
+
+assert.sameValue(map.getOrInsert(1, 42), 42);
+
+assert.sameValue(map.getOrInsert(NaN, 1), 1);
+
+var item = {};
+assert.sameValue(map.getOrInsert(item, 2), 2);
+
+item = [];
+assert.sameValue(map.getOrInsert(item, 3), 3);
+
+item = Symbol('item');
+assert.sameValue(map.getOrInsert(item, 4), 4);
+
+item = null;
+assert.sameValue(map.getOrInsert(item, 5), 5);
+
+item = undefined;
+assert.sameValue(map.getOrInsert(item, 6), 6);
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/returns-value-if-key-is-present-different-key-types.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/returns-value-if-key-is-present-different-key-types.js
@@ -1,0 +1,55 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2024 Sune Eriksson Lianes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsert
+description: |
+  Returns the value set before getOrInsert from the specified key on different types.
+info: |
+  Map.prototype.getOrInsert ( key , value )
+
+  ...
+  4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+    a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+  ...
+features: [Symbol, upsert]
+---*/
+var map = new Map();
+
+map.set('bar', 0);
+assert.sameValue(map.get('bar'), map.getOrInsert('bar', 1));
+assert.sameValue(0, map.getOrInsert('bar', 1));
+
+map.set(1, 42);
+assert.sameValue(map.get(1), map.getOrInsert(1, 43));
+assert.sameValue(42, map.getOrInsert(1, 43));
+
+map.set(NaN, 1);
+assert.sameValue(map.get(NaN), map.getOrInsert(NaN, 2));
+assert.sameValue(1, map.getOrInsert(NaN, 2));
+
+var item = {};
+map.set(item, 2);
+assert.sameValue(map.get(item), map.getOrInsert(item, 3));
+assert.sameValue(2, map.getOrInsert(item, 3));
+
+item = [];
+map.set(item, 3);
+assert.sameValue(map.get(item), map.getOrInsert(item, 4));
+assert.sameValue(3, map.getOrInsert(item, 4));
+
+item = Symbol('item');
+map.set(item, 4);
+assert.sameValue(map.get(item), map.getOrInsert(item, 5));
+assert.sameValue(4, map.getOrInsert(item, 5));
+
+item = null;
+map.set(item, 5);
+assert.sameValue(map.get(item), map.getOrInsert(item, 6));
+assert.sameValue(5, map.getOrInsert(item, 6));
+
+item = undefined;
+map.set(item, 6);
+assert.sameValue(map.get(item), map.getOrInsert(item, 7));
+assert.sameValue(6, map.getOrInsert(item, 7));
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/returns-value-normalized-zero-key.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/JavaScript/returns-value-normalized-zero-key.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// Copyright (C) 2024 Jonas Haukenes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsert
+description: |
+  Returns the value from the specified key normalizing +0 and -0.
+info: |
+  Map.prototype.getOrInsert ( key , value )
+
+  5. Set key to CanonicalizeKeyedCollectionKey(key).
+  4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+    a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+  ...
+features: [upsert]
+---*/
+var map = new Map();
+
+map.set(+0, 42);
+assert.sameValue(map.getOrInsert(-0, 1), 42);
+
+map = new Map();
+map.set(-0, 43);
+assert.sameValue(map.getOrInsert(+0, 1), 43);
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.append_new_values.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.append_new_values.verified.txt
@@ -1,0 +1,8 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.append_new_values_normalizes_zero_key.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.append_new_values_normalizes_zero_key.verified.txt
@@ -1,0 +1,3 @@
+﻿true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.append_value_if_key_is_not_present_different_key_types.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.append_value_if_key_is_not_present_different_key_types.verified.txt
@@ -1,0 +1,8 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.returns_value_if_key_is_not_present_different_key_types.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.returns_value_if_key_is_not_present_different_key_types.verified.txt
@@ -1,0 +1,8 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.returns_value_if_key_is_present_different_key_types.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.returns_value_if_key_is_present_different_key_types.verified.txt
@@ -1,0 +1,16 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.returns_value_normalized_zero_key.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsert/Snapshots/ExecutionTests.returns_value_normalized_zero_key.verified.txt
@@ -1,0 +1,2 @@
+﻿true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/ExecutionTests.cs
@@ -1,0 +1,24 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.Map.prototype.getOrInsertComputed;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.Map.prototype.getOrInsertComputed") { }
+
+    [Fact(DisplayName = "canonical-key-passed-to-callback")]
+    public Task canonical_key_passed_to_callback()
+        => ExecutionTestFromFile("canonical-key-passed-to-callback");
+
+    [Fact(DisplayName = "different-types-function-callbackfn-does-not-throw")]
+    public Task different_types_function_callbackfn_does_not_throw()
+        => ExecutionTestFromFile("different-types-function-callbackfn-does-not-throw");
+
+    [Fact(DisplayName = "does-not-evaluate-callbackfn-if-key-present")]
+    public Task does_not_evaluate_callbackfn_if_key_present()
+        => ExecutionTestFromFile("does-not-evaluate-callbackfn-if-key-present");
+
+    [Fact(DisplayName = "overwrites-mutation-from-callbackfn")]
+    public Task overwrites_mutation_from_callbackfn()
+        => ExecutionTestFromFile("overwrites-mutation-from-callbackfn");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/canonical-key-passed-to-callback.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/canonical-key-passed-to-callback.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-map.prototype.getorinsertcomputed
+description: |
+  Ensure the canonical key is passed to the callback function.
+info: |
+  Map.prototype.getOrInsertComputed ( key, callbackfn )
+
+  ...
+  4. Set key to CanonicalizeKeyedCollectionKey(key).
+  ...
+  6. Let value be ? Call(callbackfn, key).
+  ...
+
+  CanonicalizeKeyedCollectionKey ( key )
+
+  1. If key is -0𝔽, return +0𝔽.
+  2. Return key.
+features: [upsert]
+---*/
+
+for (var key of [-0, +0]) {
+  var map = new Map();
+
+  var canonicalKey;
+  map.getOrInsertComputed(key, function(keyArg) {
+    canonicalKey = keyArg;
+  });
+
+  assert.sameValue(+0, canonicalKey);
+}

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/different-types-function-callbackfn-does-not-throw.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/different-types-function-callbackfn-does-not-throw.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2024 Mathias Ness. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsertcomputed
+description: |
+  Does not throw if `callbackfn` is callable.
+info: |
+  Map.prototype.getOrInsertComputed ( key , callbackfn )
+
+   ...
+  3. If IsCallable(callbackfn) is false, throw a TypeError exception.
+  ...
+
+features: [arrow-function, upsert]
+---*/
+var m = new Map();
+
+assert.sameValue(m.getOrInsertComputed(1, function () { return 1; }), 1);
+assert.sameValue(m.get(1), 1);
+
+assert.sameValue(m.getOrInsertComputed(2, () => 2), 2);
+assert.sameValue(m.get(2), 2);
+
+function three() { return 3; }
+assert.sameValue(m.getOrInsertComputed(3, three), 3);
+assert.sameValue(m.get(3), 3);
+
+assert.sameValue(m.getOrInsertComputed(4, new Function()), undefined);
+assert.sameValue(m.get(4), undefined);
+
+assert.sameValue(m.getOrInsertComputed(5, (function () { return 5; }).bind(m)), 5);
+assert.sameValue(m.get(5), 5);

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/does-not-evaluate-callbackfn-if-key-present.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/does-not-evaluate-callbackfn-if-key-present.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 Jonas Haukenes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsertcomputed
+description: |
+  Does not evaluate the callback function if the key is already in the map.
+info: |
+  WeakMap.prototype.getOrInsertComputed ( key, callbackfn )
+
+  ...
+  5. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+    a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
+  6. Let value be ? Call(callbackfn, undefined, « key »).
+  ...
+features: [WeakMap, upsert]
+---*/
+var map = new Map([
+  [1, 0]
+]);
+
+var callbackCalls = 0;
+function callback() {
+    callbackCalls += 1;
+    throw new Error('Callbackfn should not be evaluated if key is present');
+}
+
+assert.sameValue(map.getOrInsertComputed(1, callback), 0);
+
+map.set(2, 1);
+assert.sameValue(map.getOrInsertComputed(2, callback), 1);
+
+map.set(3, 2);
+assert.sameValue(map.getOrInsertComputed(3, callback), 2);
+
+assert.throws(Error, function() {
+  map.getOrInsertComputed(4, callback)}
+, Error);
+
+assert.sameValue(callbackCalls, 1);

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/overwrites-mutation-from-callbackfn.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/JavaScript/overwrites-mutation-from-callbackfn.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Jonas Haukenes. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-map.prototype.getorinsertcomputed
+description: |
+  If the callbackfn inserts a value on the given key, the value is overwritten.
+info: |
+  WeakMap.prototype.set ( key, value )
+
+  ...
+  6. Let value be ? Call(callbackfn, undefined, « key »).
+  7. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
+    a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
+      i. Set p.[[Value]] to value.
+      ii. Return value.
+  8. Let p be the Record { [[Key]]: key, [[Value]]: value }.
+  9. Append p to M.[[WeakMapData]].
+  ...
+features: [upsert]
+---*/
+var map = new Map();
+var foo = 1;
+var bar = 2;
+var baz = 3;
+
+map.getOrInsertComputed(foo, () => {map.set(foo, 0); return 3;});
+map.getOrInsertComputed(bar, () => {map.set(bar, 1)});
+map.getOrInsertComputed(baz, () => {map.set(baz, 2); return 'string';});
+
+assert.sameValue(map.get(foo), 3);
+assert.sameValue(map.get(bar), undefined);
+assert.sameValue(map.get(baz), 'string');
+

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.canonical_key_passed_to_callback.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.canonical_key_passed_to_callback.verified.txt
@@ -1,0 +1,2 @@
+﻿true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.different_types_function_callbackfn_does_not_throw.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.different_types_function_callbackfn_does_not_throw.verified.txt
@@ -1,0 +1,10 @@
+﻿true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.does_not_evaluate_callbackfn_if_key_present.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.does_not_evaluate_callbackfn_if_key_present.verified.txt
@@ -1,0 +1,5 @@
+﻿true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.overwrites_mutation_from_callbackfn.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Map/prototype/getOrInsertComputed/Snapshots/ExecutionTests.overwrites_mutation_from_callbackfn.verified.txt
@@ -1,0 +1,3 @@
+﻿true
+true
+true

--- a/tests/Jroc.Tests/Map/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Map/ExecutionTests.cs
@@ -50,5 +50,8 @@ namespace Jroc.Tests.Map
 
         [Fact]
         public Task Map_Symbol_Iterator() { var testName = nameof(Map_Symbol_Iterator); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Map_GetOrInsertComputed_CallableEdgeCases() { var testName = nameof(Map_GetOrInsertComputed_CallableEdgeCases); return ExecutionTest(testName); }
     }
 }

--- a/tests/Jroc.Tests/Map/JavaScript/Map_GetOrInsertComputed_CallableEdgeCases.js
+++ b/tests/Jroc.Tests/Map/JavaScript/Map_GetOrInsertComputed_CallableEdgeCases.js
@@ -1,0 +1,50 @@
+const existing = new Map([[1, "existing"]]);
+class Callback {}
+
+console.log(existing.getOrInsertComputed(1, Callback));
+
+try {
+  new Map().getOrInsertComputed(1, Callback);
+} catch (error) {
+  console.log(error instanceof TypeError);
+}
+
+let sloppyThis;
+function sloppyCallback(key) {
+  sloppyThis = this;
+  return key;
+}
+
+const sloppyResult = new Map().getOrInsertComputed(
+  "sloppy",
+  new Proxy(sloppyCallback, {})
+);
+console.log(sloppyResult);
+console.log(sloppyThis === globalThis);
+
+let strictThis;
+function strictCallback(key) {
+  "use strict";
+  strictThis = this;
+  return key;
+}
+
+const strictResult = new Map().getOrInsertComputed(
+  "strict",
+  new Proxy(strictCallback, {})
+);
+console.log(strictResult);
+console.log(strictThis === undefined);
+
+let trappedThis;
+const trappedResult = new Map().getOrInsertComputed(
+  "trapped",
+  new Proxy(sloppyCallback, {
+    apply(target, thisArg, args) {
+      trappedThis = thisArg;
+      return args[0];
+    },
+  })
+);
+console.log(trappedResult);
+console.log(trappedThis === undefined);

--- a/tests/Jroc.Tests/Map/Snapshots/ExecutionTests.Map_GetOrInsertComputed_CallableEdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/ExecutionTests.Map_GetOrInsertComputed_CallableEdgeCases.verified.txt
@@ -1,0 +1,8 @@
+existing
+true
+sloppy
+true
+strict
+true
+trapped
+true


### PR DESCRIPTION
## Summary

- implement `Map.prototype.getOrInsert` and `Map.prototype.getOrInsertComputed`
- preserve SameValueZero lookup, canonical `-0` handling, callback ordering, and callback mutation overwrite semantics
- support ordinary, strict, class-constructor, and callable Proxy callbacks with correct `this` behavior
- port ten upstream test262 cases verbatim
- mark ECMA-262 clauses 24.1.3.7 and 24.1.3.8 as supported

## Validation

- `dotnet build --no-restore --nologo`
- 47 `Jroc.Tests` Map and Proxy tests
- 133 checked-in test262 Map tests
- all 28 upstream `getOrInsert` cases
- all 37 upstream `getOrInsertComputed` cases
