### PR TITLE
perf(runtime): consolidate ObjectRuntime helpers

### DIFF
--- a/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
@@ -1582,27 +1582,15 @@ namespace JavaScriptRuntime
             }
 
             var result = CreateOrdinaryObject();
-            if (getOwnPropertyNames(obj) is JavaScriptRuntime.Array names)
+            foreach (var key in GetOrderedOwnKeys(obj, includeEncodedSymbolKeys: true))
             {
-                foreach (var key in names)
+                var propertyKey = TryDecodeEncodedSymbolKey(key, out var symbol)
+                    ? (object)symbol
+                    : key;
+                var descriptor = getOwnPropertyDescriptor(obj, propertyKey);
+                if (descriptor is not null)
                 {
-                    var descriptor = getOwnPropertyDescriptor(obj, key);
-                    if (descriptor is not null)
-                    {
-                        ObjectRuntime.SetItem(result, key!, descriptor);
-                    }
-                }
-            }
-
-            if (getOwnPropertySymbols(obj) is JavaScriptRuntime.Array symbols)
-            {
-                foreach (var sym in symbols)
-                {
-                    var descriptor = getOwnPropertyDescriptor(obj, sym);
-                    if (descriptor is not null)
-                    {
-                        ObjectRuntime.SetItem(result, sym!, descriptor);
-                    }
+                    ObjectRuntime.SetItem(result, propertyKey, descriptor);
                 }
             }
 
@@ -1707,51 +1695,12 @@ namespace JavaScriptRuntime
         }
 
         public static object seal(object obj)
-        {
-            if (obj is null || obj is JsNull)
-            {
-                throw new TypeError("Cannot convert undefined or null to object");
-            }
-
-            if (IsPrimitiveObjectOperationTarget(obj))
-            {
-                return obj;
-            }
-
-            EnsureIntegrityDescriptorsForExistingOwnProperties(obj);
-            foreach (var key in GetOwnKeysForIntegrity(obj))
-            {
-                if (!PropertyDescriptorStore.TryGetOwn(obj, key, out var desc))
-                {
-                    continue;
-                }
-
-                desc = PropertyDescriptorStore.CloneDescriptor(desc);
-                desc.Configurable = false;
-                if (obj is JsObject jsObject)
-                {
-                    if (!jsObject.DefineOwnProperty(key, desc))
-                    {
-                        throw new TypeError($"Cannot define property: {key}");
-                    }
-                }
-                else
-                {
-                    PropertyDescriptorStore.DefineOrUpdate(obj, key, desc);
-                }
-            }
-
-            var state = GetIntegrityState(obj);
-            state.Extensible = false;
-            state.Sealed = true;
-            if (obj is Array array)
-            {
-                array.DisableDenseGrowthFastPath();
-            }
-            return obj;
-        }
+            => SetIntegrityLevel(obj, frozen: false);
 
         public static object freeze(object obj)
+            => SetIntegrityLevel(obj, frozen: true);
+
+        private static object SetIntegrityLevel(object obj, bool frozen)
         {
             if (obj is null || obj is JsNull)
             {
@@ -1773,10 +1722,11 @@ namespace JavaScriptRuntime
 
                 desc = PropertyDescriptorStore.CloneDescriptor(desc);
                 desc.Configurable = false;
-                if (desc.Kind == JsPropertyDescriptorKind.Data)
+                if (frozen && desc.Kind == JsPropertyDescriptorKind.Data)
                 {
                     desc.Writable = false;
                 }
+
                 if (obj is JsObject jsObject)
                 {
                     if (!jsObject.DefineOwnProperty(key, desc))
@@ -1793,7 +1743,10 @@ namespace JavaScriptRuntime
             var state = GetIntegrityState(obj);
             state.Extensible = false;
             state.Sealed = true;
-            state.Frozen = true;
+            if (frozen)
+            {
+                state.Frozen = true;
+            }
             if (obj is Array array)
             {
                 array.DisableDenseGrowthFastPath();
@@ -1802,6 +1755,12 @@ namespace JavaScriptRuntime
         }
 
         public static bool isSealed(object obj)
+            => TestIntegrityLevel(obj, frozen: false);
+
+        public static bool isFrozen(object obj)
+            => TestIntegrityLevel(obj, frozen: true);
+
+        private static bool TestIntegrityLevel(object obj, bool frozen)
         {
             if (obj is null || obj is JsNull)
             {
@@ -1820,40 +1779,9 @@ namespace JavaScriptRuntime
 
             foreach (var key in GetOwnKeysForIntegrity(obj))
             {
-                if (!PropertyDescriptorStore.TryGetOwn(obj, key, out var desc) || desc.Configurable)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        public static bool isFrozen(object obj)
-        {
-            if (obj is null || obj is JsNull)
-            {
-                throw new TypeError("Cannot convert undefined or null to object");
-            }
-
-            if (IsPrimitiveObjectOperationTarget(obj))
-            {
-                return true;
-            }
-
-            if (!isSealed(obj))
-            {
-                return false;
-            }
-
-            foreach (var key in GetOwnKeysForIntegrity(obj))
-            {
-                if (!PropertyDescriptorStore.TryGetOwn(obj, key, out var desc))
-                {
-                    return false;
-                }
-
-                if (desc.Kind == JsPropertyDescriptorKind.Data && desc.Writable)
+                if (!PropertyDescriptorStore.TryGetOwn(obj, key, out var desc)
+                    || desc.Configurable
+                    || frozen && desc.Kind == JsPropertyDescriptorKind.Data && desc.Writable)
                 {
                     return false;
                 }
@@ -2818,6 +2746,21 @@ namespace JavaScriptRuntime
             try
             {
                 return Closure.InvokeWithArgs0(member, System.Array.Empty<object>());
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
+        }
+
+        private static object InvokeMemberDelegate0PreservingContext(object receiver, Delegate member)
+        {
+            var previousThis = RuntimeServices.SetCurrentThis(receiver);
+            try
+            {
+                return Function.HasBoundWithObject(member)
+                    ? Closure.InvokeWithArgs(member, System.Array.Empty<object>(), System.Array.Empty<object>())
+                    : Closure.InvokeWithArgs0(member, System.Array.Empty<object>());
             }
             finally
             {
@@ -4525,24 +4468,16 @@ namespace JavaScriptRuntime
 
             if (iteratorMethod is Delegate del)
             {
-                var previousThis = RuntimeServices.SetCurrentThis(iterable);
-                try
+                var iteratorObj = InvokeMemberDelegate0PreservingContext(iterable, del);
+                if (iteratorObj is null)
                 {
-                    var iteratorObj = Closure.InvokeWithArgs(del, System.Array.Empty<object>(), System.Array.Empty<object>());
-                    if (iteratorObj is null)
-                    {
-                        throw new JavaScriptRuntime.TypeError("Iterator method returned null or undefined");
-                    }
-                    if (iteratorObj is IJavaScriptIterator native)
-                    {
-                        return native;
-                    }
-                    return new DynamicIterator(iteratorObj);
+                    throw new JavaScriptRuntime.TypeError("Iterator method returned null or undefined");
                 }
-                finally
+                if (iteratorObj is IJavaScriptIterator native)
                 {
-                    RuntimeServices.SetCurrentThis(previousThis);
+                    return native;
                 }
+                return new DynamicIterator(iteratorObj);
             }
 
             if (iteratorMethod != null || hasIteratorProperty)
@@ -4617,32 +4552,24 @@ namespace JavaScriptRuntime
 
             if (asyncIteratorMethod is Delegate asyncDel)
             {
-                var previousThis = RuntimeServices.SetCurrentThis(iterable);
-                try
+                var iteratorObj = InvokeMemberDelegate0PreservingContext(iterable, asyncDel);
+                if (iteratorObj is null)
                 {
-                    var iteratorObj = Closure.InvokeWithArgs(asyncDel, System.Array.Empty<object>(), System.Array.Empty<object>());
-                    if (iteratorObj is null)
-                    {
-                        throw new JavaScriptRuntime.TypeError("Async iterator method returned null or undefined");
-                    }
-
-                    if (iteratorObj is IJavaScriptAsyncIterator native)
-                    {
-                        return native;
-                    }
-
-                    // If the async iterator method returns a sync iterator, it is still valid: we will await its next() result.
-                    if (iteratorObj is IJavaScriptIterator sync)
-                    {
-                        return new AsyncFromSyncIterator(sync);
-                    }
-
-                    return new AsyncDynamicIterator(iteratorObj);
+                    throw new JavaScriptRuntime.TypeError("Async iterator method returned null or undefined");
                 }
-                finally
+
+                if (iteratorObj is IJavaScriptAsyncIterator native)
                 {
-                    RuntimeServices.SetCurrentThis(previousThis);
+                    return native;
                 }
+
+                // If the async iterator method returns a sync iterator, it is still valid: we will await its next() result.
+                if (iteratorObj is IJavaScriptIterator sync)
+                {
+                    return new AsyncFromSyncIterator(sync);
+                }
+
+                return new AsyncDynamicIterator(iteratorObj);
             }
 
             if (asyncIteratorMethod != null)
@@ -4819,17 +4746,8 @@ namespace JavaScriptRuntime
                     throw new JavaScriptRuntime.TypeError("Iterator.return is not a function");
                 }
 
-                var previousThis = RuntimeServices.SetCurrentThis(iterator);
-                try
-                {
-                    var result = Closure.InvokeWithArgs(del, System.Array.Empty<object>(), System.Array.Empty<object>());
-                    ValidateIteratorCloseResult(result);
-                    return;
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(previousThis);
-                }
+                ValidateIteratorCloseResult(InvokeMemberDelegate0PreservingContext(iterator, del));
+                return;
             }
 
             // Host object: look for a delegate-valued property.
@@ -4843,16 +4761,7 @@ namespace JavaScriptRuntime
                 throw new JavaScriptRuntime.TypeError("Iterator.return is not a function");
             }
 
-            var prev = RuntimeServices.SetCurrentThis(iterator);
-            try
-            {
-                var result = Closure.InvokeWithArgs(memberDel, System.Array.Empty<object>(), System.Array.Empty<object>());
-                ValidateIteratorCloseResult(result);
-            }
-            finally
-            {
-                RuntimeServices.SetCurrentThis(prev);
-            }
+            ValidateIteratorCloseResult(InvokeMemberDelegate0PreservingContext(iterator, memberDel));
         }
 
         private static void ValidateIteratorCloseResult(object? result)
@@ -5031,21 +4940,13 @@ namespace JavaScriptRuntime
 
             public object NextRaw()
             {
-                var previousThis = RuntimeServices.SetCurrentThis(_iterator);
-                try
+                var result = InvokeMemberDelegate0PreservingContext(_iterator, _next);
+                if (result is null || result is JsNull || !IsObjectLikeForPrototype(result))
                 {
-                    var result = Closure.InvokeWithArgs(_next, System.Array.Empty<object>(), System.Array.Empty<object>());
-                    if (result is null || result is JsNull || !IsObjectLikeForPrototype(result))
-                    {
-                        throw new JavaScriptRuntime.TypeError("Iterator.next result must be an object");
-                    }
+                    throw new JavaScriptRuntime.TypeError("Iterator.next result must be an object");
+                }
 
-                    return result;
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(previousThis);
-                }
+                return result;
             }
 
             public void Return()
@@ -5061,16 +4962,7 @@ namespace JavaScriptRuntime
                     throw new JavaScriptRuntime.TypeError("Iterator.return is not a function");
                 }
 
-                var previousThis = RuntimeServices.SetCurrentThis(_iterator);
-                try
-                {
-                    var result = Closure.InvokeWithArgs(del, System.Array.Empty<object>(), System.Array.Empty<object>());
-                    ValidateIteratorCloseResult(result);
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(previousThis);
-                }
+                ValidateIteratorCloseResult(InvokeMemberDelegate0PreservingContext(_iterator, del));
             }
         }
 
@@ -5124,17 +5016,7 @@ namespace JavaScriptRuntime
             public bool HasReturn => _return != null;
 
             public object? Next()
-            {
-                var previousThis = RuntimeServices.SetCurrentThis(_iterator);
-                try
-                {
-                    return Closure.InvokeWithArgs(_next, System.Array.Empty<object>(), System.Array.Empty<object>());
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(previousThis);
-                }
-            }
+                => InvokeMemberDelegate0PreservingContext(_iterator, _next);
 
             public object? Return()
             {
@@ -5148,15 +5030,7 @@ namespace JavaScriptRuntime
                     throw new JavaScriptRuntime.TypeError("Iterator.return is not a function");
                 }
 
-                var previousThis = RuntimeServices.SetCurrentThis(_iterator);
-                try
-                {
-                    return Closure.InvokeWithArgs(del, System.Array.Empty<object>(), System.Array.Empty<object>());
-                }
-                finally
-                {
-                    RuntimeServices.SetCurrentThis(previousThis);
-                }
+                return InvokeMemberDelegate0PreservingContext(_iterator, del);
             }
         }
 

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -443,6 +443,12 @@ namespace JavaScriptRuntime
         /// is not present, and throws for non-configurable own properties.
         /// </summary>
         public static bool DeleteProperty(object? receiver, object? propName)
+            => DeletePropertyCore(receiver, propName, throwOnError: true);
+
+        public static bool DeletePropertyNonStrict(object? receiver, object? propName)
+            => DeletePropertyCore(receiver, propName, throwOnError: false);
+
+        private static bool DeletePropertyCore(object? receiver, object? propName, bool throwOnError)
         {
             if (receiver is null || receiver is JsNull)
             {
@@ -464,7 +470,17 @@ namespace JavaScriptRuntime
             if (PropertyDescriptorStore.TryGetOwn(receiver, key, out var ownDescriptor)
                 && !ownDescriptor.Configurable)
             {
-                throw new JavaScriptRuntime.TypeError($"Cannot delete property '{key}' of object");
+                if (throwOnError)
+                {
+                    throw new JavaScriptRuntime.TypeError($"Cannot delete property '{key}' of object");
+                }
+
+                return false;
+            }
+
+            if (!throwOnError && receiver is JsObject nonStrictObject)
+            {
+                return nonStrictObject.DeleteOwnProperty(key);
             }
 
             RuntimeServices.MarkLazyClassMethodPropertyDeleted(receiver, key);
@@ -533,39 +549,6 @@ namespace JavaScriptRuntime
             return true;
         }
 
-        public static bool DeletePropertyNonStrict(object? receiver, object? propName)
-        {
-            if (receiver is null || receiver is JsNull)
-            {
-                throw new JavaScriptRuntime.TypeError("Cannot convert undefined or null to object");
-            }
-
-            var key = ToPropertyKeyString(propName);
-
-            if (receiver is JavaScriptRuntime.Proxy proxy)
-            {
-                if (proxy.TryInvokeTrap("deleteProperty", "deleteProperty", new object?[] { proxy.GetTarget("deleteProperty"), key }, out var trapResult))
-                {
-                    return TypeUtilities.ToBoolean(trapResult);
-                }
-
-                receiver = proxy.GetTarget("deleteProperty");
-            }
-
-            if (PropertyDescriptorStore.TryGetOwn(receiver, key, out var ownDescriptor)
-                && !ownDescriptor.Configurable)
-            {
-                return false;
-            }
-
-            if (receiver is JsObject jsObject)
-            {
-                return jsObject.DeleteOwnProperty(key);
-            }
-
-            return DeleteProperty(receiver, key);
-        }
-
         /// <summary>
         /// Implements the JavaScript <c>delete obj[index]</c> runtime semantics (minimal).
         /// </summary>
@@ -629,6 +612,24 @@ namespace JavaScriptRuntime
 
         internal static bool TryParseCanonicalArrayIndexUInt(string s, out uint parsed)
             => CanonicalArrayIndex.TryParse(s, out parsed);
+
+        [System.Runtime.CompilerServices.MethodImpl(
+            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static bool TryGetCanonicalInt32Index(double index, out int intIndex)
+        {
+            if (!double.IsNaN(index)
+                && !double.IsInfinity(index)
+                && index % 1.0 == 0.0
+                && index >= 0
+                && index <= int.MaxValue)
+            {
+                intIndex = (int)index;
+                return true;
+            }
+
+            intIndex = 0;
+            return false;
+        }
 
         // Array branches in the numeric overloads below are intentional: they
         // preserve dense element access without allocating or parsing string keys.
@@ -749,13 +750,10 @@ namespace JavaScriptRuntime
                 return GetProperty(obj, propName)!;
             }
 
-            // Coerce index to int (JS ToInt32-ish truncation)
-            int intIndex = (int)index;
-
             // String: return character at index as a 1-length string
             if (obj is string str)
             {
-                if (double.IsNaN(index) || double.IsInfinity(index) || index < 0 || index > int.MaxValue || index % 1.0 != 0.0)
+                if (!TryGetCanonicalInt32Index(index, out var intIndex))
                 {
                     return GetProperty(obj, ToPropertyKeyString(index))!;
                 }
@@ -769,11 +767,7 @@ namespace JavaScriptRuntime
 
             if (obj is Array array)
             {
-                if (!double.IsNaN(index)
-                    && !double.IsInfinity(index)
-                    && index % 1.0 == 0.0
-                    && index >= 0
-                    && index <= int.MaxValue)
+                if (TryGetCanonicalInt32Index(index, out var intIndex))
                 {
                     if (PropertyDescriptorStore.HasAny(array))
                     {
@@ -799,6 +793,7 @@ namespace JavaScriptRuntime
                     return array[intIndex]!;
                 }
 
+                intIndex = (int)index;
                 var propName = ToPropertyKeyString(index);
                 if (PropertyDescriptorStore.GetOwnLookupCore(array, propName, out _) != PropertyDescriptorLookup.None)
                 {
@@ -822,14 +817,14 @@ namespace JavaScriptRuntime
             }
             else if (obj is JavaScriptRuntime.Node.Buffer buffer)
             {
-                if (double.IsNaN(index) || double.IsInfinity(index) || index % 1.0 != 0.0)
+                if (!TryGetCanonicalInt32Index(index, out _))
                 {
-                    var propName = ToPropertyKeyString(index);
-                    return GetProperty(buffer, propName)!;
-                }
+                    if (!double.IsInteger(index))
+                    {
+                        var propName = ToPropertyKeyString(index);
+                        return GetProperty(buffer, propName)!;
+                    }
 
-                if (index < 0 || index > int.MaxValue)
-                {
                     return null!;
                 }
 
@@ -1081,12 +1076,7 @@ namespace JavaScriptRuntime
                 throw new JavaScriptRuntime.TypeError("Cannot set properties of null");
             }
 
-            var isCanonicalArrayIndex = !double.IsNaN(index)
-                && !double.IsInfinity(index)
-                && index % 1.0 == 0.0
-                && index >= 0
-                && index <= int.MaxValue;
-            var intIndex = isCanonicalArrayIndex ? (int)index : 0;
+            var isCanonicalArrayIndex = TryGetCanonicalInt32Index(index, out var intIndex);
 
             if (obj is JavaScriptRuntime.Proxy)
             {
@@ -1347,12 +1337,7 @@ namespace JavaScriptRuntime
                 throw new JavaScriptRuntime.TypeError("Cannot set properties of null");
             }
 
-            var isCanonicalArrayIndex = !double.IsNaN(index)
-                && !double.IsInfinity(index)
-                && index % 1.0 == 0.0
-                && index >= 0
-                && index <= int.MaxValue;
-            var intIndex = isCanonicalArrayIndex ? (int)index : 0;
+            var isCanonicalArrayIndex = TryGetCanonicalInt32Index(index, out var intIndex);
 
             // Strings are immutable in JS; silently ignore and return value.
             if (obj is string)
@@ -1391,23 +1376,13 @@ namespace JavaScriptRuntime
             // Buffer: only use element write path if index is finite, integer, and in-bounds.
             if (obj is JavaScriptRuntime.Node.Buffer buffer)
             {
-                // Check if index is a valid integer index
-                if (!double.IsNaN(index) && !double.IsInfinity(index) && (index % 1.0 == 0.0))
+                if (isCanonicalArrayIndex)
                 {
-                    // Validate index is within int32 range before casting
-                    if (index >= 0 && index <= int.MaxValue)
+                    if (intIndex < (int)buffer.length)
                     {
-                        int bufferIndex = (int)index;
-                        // Only write if in bounds [0, length)
-                        if (bufferIndex < (int)buffer.length)
-                        {
-                            buffer[(double)bufferIndex] = value;
-                        }
-                        // Out-of-bounds: no-op (buffers don't expand)
+                        buffer[(double)intIndex] = value;
                     }
-                    // Negative or too large: no-op
                 }
-                // NaN/Infinity/fractional: no-op (do not treat as element 0 or property)
                 return;
             }
 

--- a/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
+++ b/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
@@ -265,6 +265,49 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
     }
 
     [Fact]
+    public void NumericGetItem_PreservesNonCanonicalArrayProperties()
+    {
+        var target = new JavaScriptRuntime.Array(new object?[] { "zero" });
+        ObjectRuntime.SetProperty(target, "1.5", "fractional");
+        ObjectRuntime.SetProperty(target, "NaN", "not-a-number");
+        ObjectRuntime.SetProperty(target, "-1", "negative");
+
+        Assert.Equal("fractional", ObjectRuntime.GetItem(target, 1.5d));
+        Assert.Equal("not-a-number", ObjectRuntime.GetItem(target, double.NaN));
+        Assert.Equal("negative", ObjectRuntime.GetItem(target, -1d));
+    }
+
+    [Fact]
+    public void IteratorProtocolInvocation_PreservesWithBindingContext()
+    {
+        var withObject = new JsObject();
+        ObjectRuntime.SetProperty(withObject, "marker", "bound");
+
+        var iterator = new JsObject();
+        ObjectRuntime.SetProperty(
+            iterator,
+            "next",
+            (Func<object[], object?[]?, object?>)((_, _) => IteratorResult.Create(null, done: true)));
+
+        object? observed = null;
+        Func<object[], object?[]?, object?> iteratorMethod = (_, _) =>
+        {
+            observed = RuntimeServices.ResolveWithBindingOrDefault("marker", "fallback");
+            return iterator;
+        };
+        JavaScriptRuntime.Function.BindWithObject(iteratorMethod, withObject);
+
+        var iterable = new JsObject();
+        ObjectRuntime.DefineObjectLiteralDataProperty(
+            iterable,
+            Symbol.iterator,
+            iteratorMethod);
+
+        _ = ObjectRuntime.GetIterator(iterable);
+        Assert.Equal("bound", observed);
+    }
+
+    [Fact]
     public void ExoticSubclass_UsesInternalOperationsAcrossGenericObjectSemantics()
     {
         var runtime = RuntimeServices.BuildServiceProvider();

--- a/tests/performance/Benchmarks/ObjectInternalOperationsBenchmarks.cs
+++ b/tests/performance/Benchmarks/ObjectInternalOperationsBenchmarks.cs
@@ -21,6 +21,11 @@ public class ObjectInternalOperationsBenchmarks : IDisposable
 {
     private readonly JavaScriptRuntime.JsObject _readTarget = new();
     private readonly JavaScriptRuntime.JsObject _writeTarget = new();
+    private readonly JavaScriptRuntime.JsObject _deleteTarget = new();
+    private readonly JavaScriptRuntime.JsObject _descriptorTarget = new();
+    private readonly JavaScriptRuntime.JsObject _frozenTarget = new();
+    private readonly JavaScriptRuntime.Array _indexedTarget = new(new object?[] { 42d });
+    private readonly JavaScriptRuntime.JsObject _iterableTarget = new();
     private JrocInMemoryModule? _hostedModule;
     private dynamic _hostedTarget = null!;
 
@@ -29,6 +34,22 @@ public class ObjectInternalOperationsBenchmarks : IDisposable
     {
         JavaScriptRuntime.ObjectRuntime.SetProperty(_readTarget, "value", 42d);
         JavaScriptRuntime.ObjectRuntime.SetProperty(_writeTarget, "value", 0d);
+        for (var i = 0; i < 16; i++)
+        {
+            JavaScriptRuntime.ObjectRuntime.SetProperty(_descriptorTarget, $"value{i}", (double)i);
+            JavaScriptRuntime.ObjectRuntime.SetProperty(_frozenTarget, $"value{i}", (double)i);
+        }
+        JavaScriptRuntime.ObjectRuntime.freeze(_frozenTarget);
+
+        var iterator = new JavaScriptRuntime.JsObject();
+        JavaScriptRuntime.ObjectRuntime.SetProperty(
+            iterator,
+            "next",
+            (Func<object[], object?[]?, object?>)((_, _) => JavaScriptRuntime.IteratorResult.Create(null, done: true)));
+        JavaScriptRuntime.ObjectRuntime.DefineObjectLiteralDataProperty(
+            _iterableTarget,
+            JavaScriptRuntime.Symbol.iterator,
+            (Func<object[], object?[]?, object?>)((_, _) => iterator));
 
         var request = new JrocInMemoryCompileRequest(
             Path.Combine(Path.GetTempPath(), "jroc-hosted-object-operations.js"))
@@ -58,4 +79,24 @@ public class ObjectInternalOperationsBenchmarks : IDisposable
     [Benchmark(Description = "Hosted dynamic proxy write")]
     public void HostedWrite()
         => _hostedTarget.value = 42d;
+
+    [Benchmark(Description = "Delete missing property (non-strict)")]
+    public bool DeleteMissingNonStrict()
+        => JavaScriptRuntime.ObjectRuntime.DeletePropertyNonStrict(_deleteTarget, "missing");
+
+    [Benchmark(Description = "Get own property descriptors")]
+    public object GetOwnPropertyDescriptors()
+        => JavaScriptRuntime.ObjectRuntime.getOwnPropertyDescriptors(_descriptorTarget);
+
+    [Benchmark(Description = "Test frozen object")]
+    public bool IsFrozen()
+        => JavaScriptRuntime.ObjectRuntime.isFrozen(_frozenTarget);
+
+    [Benchmark(Description = "Numeric indexed read")]
+    public object GetNumericIndex()
+        => JavaScriptRuntime.ObjectRuntime.GetItem(_indexedTarget, 0d);
+
+    [Benchmark(Description = "Resolve custom iterator")]
+    public object GetIterator()
+        => JavaScriptRuntime.ObjectRuntime.GetIterator(_iterableTarget);
 }


### PR DESCRIPTION
## Summary

- consolidate `seal` / `freeze` and `isSealed` / `isFrozen` through shared integrity-level helpers
- enumerate `Object.getOwnPropertyDescriptors` in one ordered own-key pass
- share strict and non-strict delete logic without repeated property conversion or descriptor probes
- reuse an inlinable canonical numeric-index predicate while preserving specialized indexed-access paths
- centralize context-preserving zero-argument iterator protocol invocation
- add focused behavior coverage and ObjectRuntime microbenchmarks

## Performance

Paired BenchmarkDotNet runs used the same benchmark build and environment:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| `Object.isFrozen` (16 properties) | 5.141 us, 6 KB | 2.607 us, 3 KB | 49.3% faster, 50% less allocation |
| `Object.getOwnPropertyDescriptors` (16 properties) | 33.073 us, 29.33 KB | 30.389 us, 25.91 KB | 8.1% faster, 11.7% less allocation |
| Non-strict missing-property delete | 71.43 ns | 66.16 ns | 7.4% faster |
| Custom iterator resolution | 2,947.21 ns | 2,798.90 ns | 5.0% faster |
| Numeric indexed read | 32.23 ns | 29.10 ns | 9.7% faster |

## Validation

- solution build: 0 warnings, 0 errors
- 956 GeneratorTests
- 1,010 ExecutionTests passed; 2 child-process tests skipped
- 18 focused ObjectRuntime tests
- 262 test262 `built_ins.Object` tests
- Release benchmark project build
