### PR TITLE
perf(compiler): extend unboxed numeric locals to uninitialized let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler: extend unboxed numeric local specialization to uninitialized `let` declarations. Previously only `var` bindings were rescued by the definite-initialization pass, so uninitialized `let` fell back to boxed `object` locals and round-tripped every arithmetic and comparison through `ToNumber`/box. Modern `let`-based code such as the `dromaeo-3d-cube-modern` hot pixel loop now compiles to native `float64` locals. Temporal dead zone, conditional initialization, type-transition, captured-binding, and block-shadowing semantics are unchanged.
 
 ## v0.11.39 - 2026-07-29
 

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -86,8 +86,8 @@ public class BindingInfo
     public bool HasWrite { get; set; }
 
     /// <summary>
-    /// True when a non-captured <c>var</c> binding is proven numeric and definitely
-    /// initialized before every reachable read in its callable.
+    /// True when a non-captured <c>var</c> or <c>let</c> binding is proven numeric and
+    /// definitely initialized before every reachable read in its callable.
     /// </summary>
     public bool CanUseUnboxedLocal { get; set; }
 

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.NumericVarLocals.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.NumericVarLocals.cs
@@ -57,7 +57,7 @@ public partial class SymbolTableBuilder
             changed = false;
             foreach (var binding in scope.Bindings.Values)
             {
-                if (binding.Kind != BindingKind.Var
+                if (!IsUnboxedLocalCandidateKind(binding.Kind)
                     || binding.IsCaptured
                     || scope.Parameters.Contains(binding.Name)
                     || (scope.Kind == ScopeKind.Global
@@ -99,7 +99,7 @@ public partial class SymbolTableBuilder
         // local or callable-return fact.
         foreach (var binding in scope.Bindings.Values)
         {
-            if (binding.Kind != BindingKind.Var
+            if (!IsUnboxedLocalCandidateKind(binding.Kind)
                 || binding.CanUseUnboxedLocal
                 || binding.DeclarationNode is not VariableDeclarator { Init: Expression initializer })
             {
@@ -121,6 +121,27 @@ public partial class SymbolTableBuilder
             binding.IsStableType = false;
         }
     }
+
+    /// <summary>
+    /// Declaration kinds eligible for an unboxed numeric local.
+    /// <para>
+    /// <c>var</c> qualifies because the analyzer proves the binding is written with a number
+    /// before every reachable read, so its hoisted <c>undefined</c> state is never observable.
+    /// </para>
+    /// <para>
+    /// <c>let</c> qualifies for the same reason and is strictly safer: the analyzer only accepts
+    /// a binding when definite assignment dominates every read, which is exactly the condition
+    /// under which the temporal dead zone can never be entered. Uninitialized <c>let</c> otherwise
+    /// falls back to a boxed <see cref="object"/> local because
+    /// <c>InferVariableClrTypes</c> refuses value types for declarators without an initializer.
+    /// </para>
+    /// <para>
+    /// <c>const</c> is excluded: it always has an initializer, so ordinary initializer-based
+    /// inference already types it and this pass would add nothing.
+    /// </para>
+    /// </summary>
+    private static bool IsUnboxedLocalCandidateKind(BindingKind kind)
+        => kind is BindingKind.Var or BindingKind.Let;
 
     private static bool TryGetScopeStatements(Scope scope, out NodeList<Statement> body)
     {

--- a/tests/Jroc.Tests/Variable/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Variable/ExecutionTests.cs
@@ -21,6 +21,7 @@ namespace Jroc.Tests.Variable
         [Fact] public Task Variable_TemporalDeadZoneShadowing() { var testName = nameof(Variable_TemporalDeadZoneShadowing); return ExecutionTest(testName); }
         [Fact] public Task Variable_TemporalDeadZoneSwitchScope() { var testName = nameof(Variable_TemporalDeadZoneSwitchScope); return ExecutionTest(testName); }
         [Fact] public Task Variable_NumericVarLocalSpecialization() { var testName = nameof(Variable_NumericVarLocalSpecialization); return ExecutionTest(testName); }
+        [Fact] public Task Variable_NumericLetLocalSpecialization() { var testName = nameof(Variable_NumericLetLocalSpecialization); return ExecutionTest(testName); }
         [Fact] public Task Variable_TopLevelNumericVarSpecialization() { var testName = nameof(Variable_TopLevelNumericVarSpecialization); return ExecutionTest(testName); }
 
         // Object destructuring tests

--- a/tests/Jroc.Tests/Variable/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Variable/GeneratorTests.cs
@@ -21,6 +21,7 @@ namespace Jroc.Tests.Variable
         [Fact] public Task Variable_TemporalDeadZoneShadowing() { var testName = nameof(Variable_TemporalDeadZoneShadowing); return GenerateTest(testName); }
         [Fact] public Task Variable_TemporalDeadZoneSwitchScope() { var testName = nameof(Variable_TemporalDeadZoneSwitchScope); return GenerateTest(testName); }
         [Fact] public Task Variable_NumericVarLocalSpecialization() { var testName = nameof(Variable_NumericVarLocalSpecialization); return GenerateTest(testName); }
+        [Fact] public Task Variable_NumericLetLocalSpecialization() { var testName = nameof(Variable_NumericLetLocalSpecialization); return GenerateTest(testName); }
         [Fact] public Task Variable_TopLevelNumericVarSpecialization() { var testName = nameof(Variable_TopLevelNumericVarSpecialization); return GenerateTest(testName); }
 
         // Object destructuring generator tests

--- a/tests/Jroc.Tests/Variable/JavaScript/Variable_NumericLetLocalSpecialization.js
+++ b/tests/Jroc.Tests/Variable/JavaScript/Variable_NumericLetLocalSpecialization.js
@@ -1,0 +1,120 @@
+// Mirrors Variable_NumericVarLocalSpecialization for `let` declarations.
+// Uninitialized `let` bindings that are provably numeric before every read
+// must specialize to unboxed numeric locals without changing observable
+// semantics (temporal dead zone, undefined reads, type transitions).
+
+function calculate(limit) {
+    let total = 0;
+    for (let i = 0; i < limit; i++) {
+        total += i;
+    }
+
+    let direction;
+    if (total >= 0) {
+        direction = 1;
+    } else {
+        direction = -1;
+    }
+
+    return total + direction;
+}
+
+function drawLineShape(count) {
+    // Shape of the dromaeo 3d-cube inner loop: several uninitialized `let`
+    // numerics assigned on every path before the hot loop reads them.
+    let IncX1, IncY1;
+    let Den;
+    let Num;
+    let NumAdd;
+    let NumPix;
+
+    if (count >= 0) { IncX1 = 1; IncY1 = 1; }
+    else { IncX1 = -1; IncY1 = -1; }
+
+    Den = 7;
+    Num = 0;
+    NumAdd = 3;
+    NumPix = count;
+
+    let acc = 0;
+    for (let i = 0; i < NumPix; i++) {
+        Num += NumAdd;
+        if (Num >= Den) {
+            Num -= Den;
+            acc += IncX1;
+        }
+        acc += IncY1;
+    }
+    return acc;
+}
+
+function temporalDeadZoneRead() {
+    try {
+        return value;
+    } catch (error) {
+        return error.constructor.name;
+    }
+    // eslint-disable-next-line no-unreachable
+    let value = 1;
+}
+
+function conditionallyInitialized(flag) {
+    let value;
+    if (flag) {
+        value = 3;
+    }
+    return typeof value;
+}
+
+function mixedType(flag) {
+    let value;
+    value = 1;
+    if (flag) {
+        value = "text";
+    }
+    return value;
+}
+
+function captured() {
+    let value;
+    value = 1;
+    return function () {
+        return ++value;
+    };
+}
+
+function shadowedSource() {
+    let source = 1;
+    let target;
+    {
+        let inner = "text";
+        target = inner;
+    }
+    return target + source;
+}
+
+function loopCarried(limit) {
+    let previous;
+    let current;
+    previous = 0;
+    current = 1;
+    for (let i = 0; i < limit; i++) {
+        const next = previous + current;
+        previous = current;
+        current = next;
+    }
+    return current;
+}
+
+console.log(calculate(5));
+console.log(drawLineShape(10));
+console.log(temporalDeadZoneRead());
+console.log(conditionallyInitialized(false));
+console.log(conditionallyInitialized(true));
+console.log(mixedType(false));
+console.log(mixedType(true));
+const increment = captured();
+console.log(increment());
+console.log(increment());
+console.log(shadowedSource());
+console.log(loopCarried(10));

--- a/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_NumericLetLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_NumericLetLocalSpecialization.verified.txt
@@ -1,0 +1,11 @@
+﻿11
+14
+ReferenceError
+undefined
+number
+1
+text
+2
+3
+text1
+89

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
@@ -1,0 +1,1656 @@
+﻿// IL code: Variable_NumericLetLocalSpecialization
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Variable_NumericLetLocalSpecialization
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit calculate
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L13C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x285e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L13C20::.ctor
+
+			} // end of class Block_L13C20
+
+			.class nested public auto ansi beforefieldinit Block_L15C11
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2867
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L15C11::.ctor
+
+			} // end of class Block_L15C11
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2843
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_For_L8C9
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L8C36
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2855
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L8C36::.ctor
+
+			} // end of class Block_L8C36
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x284c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L8C9::.ctor
+
+		} // end of class Scope_For_L8C9
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericLetLocalSpecialization/Scope scope,
+				object newTarget,
+				float64 limit
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x241c
+			// Header size: 12
+			// Code size: 143 (0x8f)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: box [System.Runtime]System.Double
+			IL_000e: stloc.0
+			IL_000f: ldc.r8 0.0
+			IL_0018: stloc.1
+			// loop start (head: IL_0019)
+				IL_0019: ldloc.1
+				IL_001a: stloc.3
+				IL_001b: ldloc.3
+				IL_001c: ldarg.2
+				IL_001d: clt
+				IL_001f: brfalse IL_0041
+
+				IL_0024: ldloc.0
+				IL_0025: ldloc.1
+				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_002b: stloc.s 4
+				IL_002d: ldloc.s 4
+				IL_002f: stloc.0
+				IL_0030: ldloc.1
+				IL_0031: ldc.r8 1
+				IL_003a: add
+				IL_003b: stloc.1
+				IL_003c: br IL_0019
+			// end loop
+
+			IL_0041: nop
+			IL_0042: ldloc.0
+			IL_0043: stloc.s 4
+			IL_0045: ldloc.s 4
+			IL_0047: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_004c: stloc.3
+			IL_004d: ldloc.3
+			IL_004e: ldc.r8 0.0
+			IL_0057: clt
+			IL_0059: ldc.i4.0
+			IL_005a: ceq
+			IL_005c: brfalse IL_0072
+
+			IL_0061: ldc.r8 1
+			IL_006a: stloc.3
+			IL_006b: ldloc.3
+			IL_006c: stloc.2
+			IL_006d: br IL_007f
+
+			IL_0072: ldc.r8 1
+			IL_007b: neg
+			IL_007c: stloc.3
+			IL_007d: ldloc.3
+			IL_007e: stloc.2
+
+			IL_007f: ldloc.0
+			IL_0080: stloc.s 4
+			IL_0082: ldloc.s 4
+			IL_0084: ldloc.2
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_008a: stloc.s 4
+			IL_008c: ldloc.s 4
+			IL_008e: ret
+		} // end of method calculate::__js_call__
+
+	} // end of class calculate
+
+	.class nested public auto ansi abstract sealed beforefieldinit drawLineShape
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L31C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2879
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L31C20::.ctor
+
+			} // end of class Block_L31C20
+
+			.class nested public auto ansi beforefieldinit Block_L32C9
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2882
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L32C9::.ctor
+
+			} // end of class Block_L32C9
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2870
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_For_L40C9
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L40C37
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested public auto ansi beforefieldinit Block_L42C24
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x289d
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L42C24::.ctor
+
+				} // end of class Block_L42C24
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2894
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L40C37::.ctor
+
+			} // end of class Block_L40C37
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x288b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L40C9::.ctor
+
+		} // end of class Scope_For_L40C9
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericLetLocalSpecialization/Scope scope,
+				object newTarget,
+				float64 count
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x24b8
+			// Header size: 12
+			// Code size: 259 (0x103)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] float64,
+				[5] float64,
+				[6] float64,
+				[7] float64,
+				[8] float64,
+				[9] object
+			)
+
+			IL_0000: nop
+			IL_0001: nop
+			IL_0002: nop
+			IL_0003: nop
+			IL_0004: nop
+			IL_0005: ldarg.2
+			IL_0006: ldc.r8 0.0
+			IL_000f: clt
+			IL_0011: ldc.i4.0
+			IL_0012: ceq
+			IL_0014: brfalse IL_003a
+
+			IL_0019: ldc.r8 1
+			IL_0022: stloc.s 8
+			IL_0024: ldloc.s 8
+			IL_0026: stloc.0
+			IL_0027: ldc.r8 1
+			IL_0030: stloc.s 8
+			IL_0032: ldloc.s 8
+			IL_0034: stloc.1
+			IL_0035: br IL_0058
+
+			IL_003a: ldc.r8 1
+			IL_0043: neg
+			IL_0044: stloc.s 8
+			IL_0046: ldloc.s 8
+			IL_0048: stloc.0
+			IL_0049: ldc.r8 1
+			IL_0052: neg
+			IL_0053: stloc.s 8
+			IL_0055: ldloc.s 8
+			IL_0057: stloc.1
+
+			IL_0058: ldc.r8 7
+			IL_0061: stloc.s 8
+			IL_0063: ldloc.s 8
+			IL_0065: stloc.2
+			IL_0066: ldc.r8 0.0
+			IL_006f: stloc.s 8
+			IL_0071: ldloc.s 8
+			IL_0073: stloc.3
+			IL_0074: ldc.r8 3
+			IL_007d: stloc.s 8
+			IL_007f: ldloc.s 8
+			IL_0081: stloc.s 4
+			IL_0083: ldarg.2
+			IL_0084: stloc.s 8
+			IL_0086: ldloc.s 8
+			IL_0088: stloc.s 5
+			IL_008a: ldc.r8 0.0
+			IL_0093: stloc.s 6
+			IL_0095: ldc.r8 0.0
+			IL_009e: stloc.s 7
+			// loop start (head: IL_00a0)
+				IL_00a0: ldloc.s 7
+				IL_00a2: stloc.s 8
+				IL_00a4: ldloc.s 8
+				IL_00a6: ldloc.s 5
+				IL_00a8: clt
+				IL_00aa: brfalse IL_00f7
+
+				IL_00af: ldloc.3
+				IL_00b0: ldloc.s 4
+				IL_00b2: add
+				IL_00b3: stloc.s 8
+				IL_00b5: ldloc.s 8
+				IL_00b7: stloc.3
+				IL_00b8: ldloc.3
+				IL_00b9: stloc.s 8
+				IL_00bb: ldloc.s 8
+				IL_00bd: ldloc.2
+				IL_00be: clt
+				IL_00c0: ldc.i4.0
+				IL_00c1: ceq
+				IL_00c3: brfalse IL_00da
+
+				IL_00c8: ldloc.3
+				IL_00c9: ldloc.2
+				IL_00ca: sub
+				IL_00cb: stloc.s 8
+				IL_00cd: ldloc.s 8
+				IL_00cf: stloc.3
+				IL_00d0: ldloc.s 6
+				IL_00d2: ldloc.0
+				IL_00d3: add
+				IL_00d4: stloc.s 8
+				IL_00d6: ldloc.s 8
+				IL_00d8: stloc.s 6
+
+				IL_00da: ldloc.s 6
+				IL_00dc: ldloc.1
+				IL_00dd: add
+				IL_00de: stloc.s 8
+				IL_00e0: ldloc.s 8
+				IL_00e2: stloc.s 6
+				IL_00e4: ldloc.s 7
+				IL_00e6: ldc.r8 1
+				IL_00ef: add
+				IL_00f0: stloc.s 7
+				IL_00f2: br IL_00a0
+			// end loop
+
+			IL_00f7: ldloc.s 6
+			IL_00f9: box [System.Runtime]System.Double
+			IL_00fe: stloc.s 9
+			IL_0100: ldloc.s 9
+			IL_0102: ret
+		} // end of method drawLineShape::__js_call__
+
+	} // end of class drawLineShape
+
+	.class nested public auto ansi abstract sealed beforefieldinit temporalDeadZoneRead
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L52C8
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28af
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L52C8::.ctor
+
+			} // end of class Block_L52C8
+
+			.class nested public auto ansi beforefieldinit Block_L54C20
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28b8
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L54C20::.ctor
+
+			} // end of class Block_L54C20
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28a6
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x25c8
+			// Header size: 12
+			// Code size: 156 (0x9c)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
+				[3] object,
+				[4] float64,
+				[5] object
+			)
+
+			.try
+			{
+				IL_0000: nop
+				IL_0001: ldstr "Cannot access 'value' before initialization"
+				IL_0006: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+				IL_0010: isinst [System.Runtime]System.Exception
+				IL_0015: dup
+				IL_0016: brtrue IL_0031
+
+				IL_001b: pop
+				IL_001c: ldstr "Cannot access 'value' before initialization"
+				IL_0021: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+				IL_002b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0030: throw
+
+				IL_0031: throw
+
+				IL_0032: ldnull
+				IL_0033: stloc.0
+				IL_0034: ldnull
+				IL_0035: stloc.0
+				IL_0036: leave IL_009a
+
+				IL_003b: leave IL_008f
+			} // end .try
+			catch [System.Runtime]System.Exception
+			{
+				IL_0040: stloc.1
+				IL_0041: ldloc.1
+				IL_0042: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0047: dup
+				IL_0048: brtrue IL_005d
+
+				IL_004d: pop
+				IL_004e: ldloc.1
+				IL_004f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0054: dup
+				IL_0055: brtrue IL_0068
+
+				IL_005a: pop
+				IL_005b: rethrow
+
+				IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0062: stloc.2
+				IL_0063: br IL_0069
+
+				IL_0068: stloc.2
+
+				IL_0069: ldloc.2
+				IL_006a: stloc.s 5
+				IL_006c: ldloc.s 5
+				IL_006e: stloc.3
+				IL_006f: ldloc.3
+				IL_0070: ldstr "constructor"
+				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_007a: ldstr "name"
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0084: stloc.0
+				IL_0085: leave IL_009a
+
+				IL_008a: leave IL_008f
+			} // end handler
+
+			IL_008f: ldc.r8 1
+			IL_0098: stloc.s 4
+
+			IL_009a: ldloc.0
+			IL_009b: ret
+		} // end of method temporalDeadZoneRead::__js_call__
+
+	} // end of class temporalDeadZoneRead
+
+	.class nested public auto ansi abstract sealed beforefieldinit conditionallyInitialized
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L63C14
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28ca
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L63C14::.ctor
+
+			} // end of class Block_L63C14
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28c1
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				bool flag
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2680
+			// Header size: 12
+			// Code size: 32 (0x20)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: ldnull
+			IL_0001: stloc.0
+			IL_0002: ldarg.1
+			IL_0003: brfalse IL_0019
+
+			IL_0008: ldc.r8 3
+			IL_0011: box [System.Runtime]System.Double
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: stloc.0
+
+			IL_0019: ldloc.0
+			IL_001a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_001f: ret
+		} // end of method conditionallyInitialized::__js_call__
+
+	} // end of class conditionallyInitialized
+
+	.class nested public auto ansi abstract sealed beforefieldinit mixedType
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L72C14
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28dc
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L72C14::.ctor
+
+			} // end of class Block_L72C14
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28d3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				bool flag
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x26ac
+			// Header size: 12
+			// Code size: 35 (0x23)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] string
+			)
+
+			IL_0000: ldnull
+			IL_0001: stloc.0
+			IL_0002: ldc.r8 1
+			IL_000b: box [System.Runtime]System.Double
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: stloc.0
+			IL_0013: ldarg.1
+			IL_0014: brfalse IL_0021
+
+			IL_0019: ldstr "text"
+			IL_001e: stloc.2
+			IL_001f: ldloc.2
+			IL_0020: stloc.0
+
+			IL_0021: ldloc.0
+			IL_0022: ret
+		} // end of method mixedType::__js_call__
+
+	} // end of class mixedType
+
+	.class nested public auto ansi abstract sealed beforefieldinit captured
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L81C11
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28ee
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x27fc
+				// Header size: 12
+				// Code size: 50 (0x32)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Variable_NumericLetLocalSpecialization/captured/Scope
+				IL_0008: ldfld object Modules.Variable_NumericLetLocalSpecialization/captured/Scope::'value'
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: ldc.r8 1
+				IL_001b: add
+				IL_001c: box [System.Runtime]System.Double
+				IL_0021: stloc.0
+				IL_0022: ldarg.0
+				IL_0023: ldc.i4.1
+				IL_0024: ldelem.ref
+				IL_0025: castclass Modules.Variable_NumericLetLocalSpecialization/captured/Scope
+				IL_002a: ldloc.0
+				IL_002b: stfld object Modules.Variable_NumericLetLocalSpecialization/captured/Scope::'value'
+				IL_0030: ldloc.0
+				IL_0031: ret
+			} // end of method FunctionExpression_L81C11::__js_call__
+
+		} // end of class FunctionExpression_L81C11
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 13 53 63 6f 70 65 20 76 61 6c 75 65 3d 7b
+				76 61 6c 75 65 7d 00 00
+			)
+			// Fields
+			.field public object 'value'
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28e5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericLetLocalSpecialization/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x26dc
+			// Header size: 12
+			// Code size: 80 (0x50)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Variable_NumericLetLocalSpecialization/captured/Scope,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			)
+
+			IL_0000: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldloc.0
+			IL_0007: ldnull
+			IL_0008: stfld object Modules.Variable_NumericLetLocalSpecialization/captured/Scope::'value'
+			IL_000d: ldloc.0
+			IL_000e: ldc.r8 1
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: stfld object Modules.Variable_NumericLetLocalSpecialization/captured/Scope::'value'
+			IL_0021: ldc.i4.2
+			IL_0022: newarr [System.Runtime]System.Object
+			IL_0027: dup
+			IL_0028: ldc.i4.0
+			IL_0029: ldarg.0
+			IL_002a: stelem.ref
+			IL_002b: dup
+			IL_002c: ldc.i4.1
+			IL_002d: ldloc.0
+			IL_002e: stelem.ref
+			IL_002f: ldftn object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
+			IL_0035: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_003a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_003f: ldc.i4.0
+			IL_0040: conv.r8
+			IL_0041: ldstr ""
+			IL_0046: ldc.i4.0
+			IL_0047: ldc.i4.0
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_004d: stloc.1
+			IL_004e: ldloc.1
+			IL_004f: ret
+		} // end of method captured::__js_call__
+
+	} // end of class captured
+
+	.class nested public auto ansi abstract sealed beforefieldinit shadowedSource
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L89C4
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2900
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L89C4::.ctor
+
+			} // end of class Block_L89C4
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28f7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericLetLocalSpecialization/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x2738
+			// Header size: 12
+			// Code size: 37 (0x25)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object,
+				[2] string,
+				[3] string,
+				[4] object
+			)
+
+			IL_0000: ldc.r8 1
+			IL_0009: stloc.0
+			IL_000a: ldnull
+			IL_000b: stloc.1
+			IL_000c: nop
+			IL_000d: ldstr "text"
+			IL_0012: stloc.2
+			IL_0013: ldloc.2
+			IL_0014: stloc.3
+			IL_0015: ldloc.3
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: stloc.3
+			IL_0019: ldloc.3
+			IL_001a: ldloc.0
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0020: stloc.s 4
+			IL_0022: ldloc.s 4
+			IL_0024: ret
+		} // end of method shadowedSource::__js_call__
+
+	} // end of class shadowedSource
+
+	.class nested public auto ansi abstract sealed beforefieldinit loopCarried
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2909
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_For_L101C9
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L101C36
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x291b
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L101C36::.ctor
+
+			} // end of class Block_L101C36
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2912
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L101C9::.ctor
+
+		} // end of class Scope_For_L101C9
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_NumericLetLocalSpecialization/Scope scope,
+				object newTarget,
+				float64 limit
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x276c
+			// Header size: 12
+			// Code size: 131 (0x83)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] float64,
+				[3] float64,
+				[4] object,
+				[5] float64,
+				[6] float64
+			)
+
+			IL_0000: ldnull
+			IL_0001: stloc.0
+			IL_0002: ldnull
+			IL_0003: stloc.1
+			IL_0004: ldc.r8 0.0
+			IL_000d: box [System.Runtime]System.Double
+			IL_0012: stloc.s 4
+			IL_0014: ldloc.s 4
+			IL_0016: stloc.0
+			IL_0017: ldc.r8 1
+			IL_0020: box [System.Runtime]System.Double
+			IL_0025: stloc.s 4
+			IL_0027: ldloc.s 4
+			IL_0029: stloc.1
+			IL_002a: ldc.r8 0.0
+			IL_0033: stloc.2
+			// loop start (head: IL_0034)
+				IL_0034: ldloc.2
+				IL_0035: stloc.s 5
+				IL_0037: ldloc.s 5
+				IL_0039: ldarg.2
+				IL_003a: clt
+				IL_003c: brfalse IL_0081
+
+				IL_0041: ldloc.0
+				IL_0042: stloc.s 4
+				IL_0044: ldloc.s 4
+				IL_0046: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_004b: stloc.s 5
+				IL_004d: ldloc.1
+				IL_004e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0053: stloc.s 6
+				IL_0055: ldloc.s 5
+				IL_0057: ldloc.s 6
+				IL_0059: add
+				IL_005a: stloc.s 6
+				IL_005c: ldloc.s 6
+				IL_005e: stloc.3
+				IL_005f: ldloc.1
+				IL_0060: stloc.s 4
+				IL_0062: ldloc.s 4
+				IL_0064: stloc.0
+				IL_0065: ldloc.3
+				IL_0066: box [System.Runtime]System.Double
+				IL_006b: stloc.s 4
+				IL_006d: ldloc.s 4
+				IL_006f: stloc.1
+				IL_0070: ldloc.2
+				IL_0071: ldc.r8 1
+				IL_007a: add
+				IL_007b: stloc.2
+				IL_007c: br IL_0034
+			// end loop
+
+			IL_0081: ldloc.1
+			IL_0082: ret
+		} // end of method loopCarried::__js_call__
+
+	} // end of class loopCarried
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 81 04 53 63 6f 70 65 20 63 61 6c 63 75 6c
+			61 74 65 3d 7b 63 61 6c 63 75 6c 61 74 65 7d 2c
+			20 64 72 61 77 4c 69 6e 65 53 68 61 70 65 3d 7b
+			64 72 61 77 4c 69 6e 65 53 68 61 70 65 7d 2c 20
+			74 65 6d 70 6f 72 61 6c 44 65 61 64 5a 6f 6e 65
+			52 65 61 64 3d 7b 74 65 6d 70 6f 72 61 6c 44 65
+			61 64 5a 6f 6e 65 52 65 61 64 7d 2c 20 63 6f 6e
+			64 69 74 69 6f 6e 61 6c 6c 79 49 6e 69 74 69 61
+			6c 69 7a 65 64 3d 7b 63 6f 6e 64 69 74 69 6f 6e
+			61 6c 6c 79 49 6e 69 74 69 61 6c 69 7a 65 64 7d
+			2c 20 6d 69 78 65 64 54 79 70 65 3d 7b 6d 69 78
+			65 64 54 79 70 65 7d 2c 20 63 61 70 74 75 72 65
+			64 3d 7b 63 61 70 74 75 72 65 64 7d 2c 20 73 68
+			61 64 6f 77 65 64 53 6f 75 72 63 65 3d 7b 73 68
+			61 64 6f 77 65 64 53 6f 75 72 63 65 7d 2c 20 6c
+			6f 6f 70 43 61 72 72 69 65 64 3d 7b 6c 6f 6f 70
+			43 61 72 72 69 65 64 7d 00 00
+		)
+		// Fields
+		.field public object calculate
+		.field public object drawLineShape
+		.field public object temporalDeadZoneRead
+		.field public object conditionallyInitialized
+		.field public object mixedType
+		.field public object captured
+		.field public object shadowedSource
+		.field public object loopCarried
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x283a
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 957 (0x3bd)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Variable_NumericLetLocalSpecialization/Scope,
+			[1] class [System.Runtime]System.Func`3<object, float64, object>,
+			[2] class [System.Runtime]System.Func`3<object, float64, object>,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[4] class [System.Runtime]System.Func`3<object, bool, object>,
+			[5] class [System.Runtime]System.Func`3<object, bool, object>,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[8] class [System.Runtime]System.Func`3<object, float64, object>,
+			[9] object,
+			[10] class [System.Runtime]System.Func`3<object, float64, object>,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[12] class [System.Runtime]System.Func`3<object, bool, object>,
+			[13] object,
+			[14] object
+		)
+
+		IL_0000: newobj instance void Modules.Variable_NumericLetLocalSpecialization/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: ldc.i4.0
+		IL_0011: ldelem.ref
+		IL_0012: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_0017: ldftn object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+		IL_001d: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0022: castclass class [System.Runtime]System.Func`3<object, float64, object>
+		IL_0027: ldc.i4.1
+		IL_0028: conv.r8
+		IL_0029: ldstr "calculate"
+		IL_002e: ldc.i4.0
+		IL_002f: ldc.i4.0
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
+		IL_0035: stloc.s 10
+		IL_0037: ldloc.s 10
+		IL_0039: stloc.1
+		IL_003a: ldc.i4.1
+		IL_003b: newarr [System.Runtime]System.Object
+		IL_0040: dup
+		IL_0041: ldc.i4.0
+		IL_0042: ldloc.0
+		IL_0043: stelem.ref
+		IL_0044: ldc.i4.0
+		IL_0045: ldelem.ref
+		IL_0046: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_004b: ldftn object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+		IL_0051: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0056: castclass class [System.Runtime]System.Func`3<object, float64, object>
+		IL_005b: ldc.i4.1
+		IL_005c: conv.r8
+		IL_005d: ldstr "drawLineShape"
+		IL_0062: ldc.i4.0
+		IL_0063: ldc.i4.0
+		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
+		IL_0069: stloc.s 10
+		IL_006b: ldloc.s 10
+		IL_006d: stloc.2
+		IL_006e: ldnull
+		IL_006f: ldftn object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
+		IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_007a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_007f: ldc.i4.0
+		IL_0080: conv.r8
+		IL_0081: ldstr "temporalDeadZoneRead"
+		IL_0086: ldc.i4.0
+		IL_0087: ldc.i4.0
+		IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_008d: stloc.s 11
+		IL_008f: ldloc.s 11
+		IL_0091: stloc.3
+		IL_0092: ldnull
+		IL_0093: ldftn object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+		IL_0099: newobj instance void class [System.Runtime]System.Func`3<object, bool, object>::.ctor(object, native int)
+		IL_009e: castclass class [System.Runtime]System.Func`3<object, bool, object>
+		IL_00a3: ldc.i4.1
+		IL_00a4: conv.r8
+		IL_00a5: ldstr "conditionallyInitialized"
+		IL_00aa: ldc.i4.0
+		IL_00ab: ldc.i4.0
+		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, bool, object>>(!!0, float64, string, bool, bool)
+		IL_00b1: stloc.s 12
+		IL_00b3: ldloc.s 12
+		IL_00b5: stloc.s 4
+		IL_00b7: ldnull
+		IL_00b8: ldftn object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
+		IL_00be: newobj instance void class [System.Runtime]System.Func`3<object, bool, object>::.ctor(object, native int)
+		IL_00c3: castclass class [System.Runtime]System.Func`3<object, bool, object>
+		IL_00c8: ldc.i4.1
+		IL_00c9: conv.r8
+		IL_00ca: ldstr "mixedType"
+		IL_00cf: ldc.i4.0
+		IL_00d0: ldc.i4.0
+		IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, bool, object>>(!!0, float64, string, bool, bool)
+		IL_00d6: stloc.s 12
+		IL_00d8: ldloc.s 12
+		IL_00da: stloc.s 5
+		IL_00dc: ldc.i4.1
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldloc.0
+		IL_00e5: stelem.ref
+		IL_00e6: ldc.i4.0
+		IL_00e7: ldelem.ref
+		IL_00e8: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_00ed: ldftn object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+		IL_00f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00f8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00fd: ldc.i4.0
+		IL_00fe: conv.r8
+		IL_00ff: ldstr "captured"
+		IL_0104: ldc.i4.0
+		IL_0105: ldc.i4.0
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_010b: stloc.s 11
+		IL_010d: ldloc.s 11
+		IL_010f: stloc.s 6
+		IL_0111: ldc.i4.1
+		IL_0112: newarr [System.Runtime]System.Object
+		IL_0117: dup
+		IL_0118: ldc.i4.0
+		IL_0119: ldloc.0
+		IL_011a: stelem.ref
+		IL_011b: ldc.i4.0
+		IL_011c: ldelem.ref
+		IL_011d: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_0122: ldftn object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+		IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_012d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0132: ldc.i4.0
+		IL_0133: conv.r8
+		IL_0134: ldstr "shadowedSource"
+		IL_0139: ldc.i4.0
+		IL_013a: ldc.i4.0
+		IL_013b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0140: stloc.s 11
+		IL_0142: ldloc.s 11
+		IL_0144: stloc.s 7
+		IL_0146: ldc.i4.1
+		IL_0147: newarr [System.Runtime]System.Object
+		IL_014c: dup
+		IL_014d: ldc.i4.0
+		IL_014e: ldloc.0
+		IL_014f: stelem.ref
+		IL_0150: ldc.i4.0
+		IL_0151: ldelem.ref
+		IL_0152: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_0157: ldftn object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+		IL_015d: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0162: castclass class [System.Runtime]System.Func`3<object, float64, object>
+		IL_0167: ldc.i4.1
+		IL_0168: conv.r8
+		IL_0169: ldstr "loopCarried"
+		IL_016e: ldc.i4.0
+		IL_016f: ldc.i4.0
+		IL_0170: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
+		IL_0175: stloc.s 10
+		IL_0177: ldloc.s 10
+		IL_0179: stloc.s 8
+		IL_017b: nop
+		IL_017c: nop
+		IL_017d: nop
+		IL_017e: nop
+		IL_017f: nop
+		IL_0180: nop
+		IL_0181: nop
+		IL_0182: nop
+		IL_0183: ldstr "console"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018d: stloc.s 13
+		IL_018f: ldloc.s 13
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0196: stloc.s 13
+		IL_0198: ldloc.0
+		IL_0199: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_019e: ldnull
+		IL_019f: ldc.r8 5
+		IL_01a8: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+		IL_01ad: stloc.s 14
+		IL_01af: ldloc.s 13
+		IL_01b1: ldstr "log"
+		IL_01b6: ldloc.s 14
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bd: pop
+		IL_01be: ldstr "console"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c8: stloc.s 14
+		IL_01ca: ldloc.s 14
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d1: stloc.s 14
+		IL_01d3: ldloc.0
+		IL_01d4: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_01d9: ldnull
+		IL_01da: ldc.r8 10
+		IL_01e3: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+		IL_01e8: stloc.s 13
+		IL_01ea: ldloc.s 14
+		IL_01ec: ldstr "log"
+		IL_01f1: ldloc.s 13
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f8: pop
+		IL_01f9: ldstr "console"
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0203: stloc.s 13
+		IL_0205: ldloc.s 13
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020c: stloc.s 13
+		IL_020e: ldnull
+		IL_020f: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
+		IL_0214: stloc.s 14
+		IL_0216: ldloc.s 13
+		IL_0218: ldstr "log"
+		IL_021d: ldloc.s 14
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0224: pop
+		IL_0225: ldstr "console"
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_022f: stloc.s 14
+		IL_0231: ldloc.s 14
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0238: stloc.s 14
+		IL_023a: ldnull
+		IL_023b: ldc.i4.0
+		IL_023c: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+		IL_0241: stloc.s 13
+		IL_0243: ldloc.s 14
+		IL_0245: ldstr "log"
+		IL_024a: ldloc.s 13
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0251: pop
+		IL_0252: ldstr "console"
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_025c: stloc.s 13
+		IL_025e: ldloc.s 13
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0265: stloc.s 13
+		IL_0267: ldnull
+		IL_0268: ldc.i4.1
+		IL_0269: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+		IL_026e: stloc.s 14
+		IL_0270: ldloc.s 13
+		IL_0272: ldstr "log"
+		IL_0277: ldloc.s 14
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027e: pop
+		IL_027f: ldstr "console"
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0289: stloc.s 14
+		IL_028b: ldloc.s 14
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0292: stloc.s 14
+		IL_0294: ldnull
+		IL_0295: ldc.i4.0
+		IL_0296: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
+		IL_029b: stloc.s 13
+		IL_029d: ldloc.s 14
+		IL_029f: ldstr "log"
+		IL_02a4: ldloc.s 13
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ab: pop
+		IL_02ac: ldstr "console"
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b6: stloc.s 13
+		IL_02b8: ldloc.s 13
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02bf: stloc.s 13
+		IL_02c1: ldnull
+		IL_02c2: ldc.i4.1
+		IL_02c3: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
+		IL_02c8: stloc.s 14
+		IL_02ca: ldloc.s 13
+		IL_02cc: ldstr "log"
+		IL_02d1: ldloc.s 14
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d8: pop
+		IL_02d9: ldloc.0
+		IL_02da: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_02df: ldnull
+		IL_02e0: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+		IL_02e5: stloc.s 14
+		IL_02e7: ldloc.s 14
+		IL_02e9: stloc.s 9
+		IL_02eb: ldstr "console"
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f5: stloc.s 14
+		IL_02f7: ldloc.s 14
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fe: stloc.s 14
+		IL_0300: ldloc.s 9
+		IL_0302: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_030c: stloc.s 13
+		IL_030e: ldloc.s 14
+		IL_0310: ldstr "log"
+		IL_0315: ldloc.s 13
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031c: pop
+		IL_031d: ldstr "console"
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0327: stloc.s 13
+		IL_0329: ldloc.s 13
+		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0330: stloc.s 13
+		IL_0332: ldloc.s 9
+		IL_0334: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_033e: stloc.s 14
+		IL_0340: ldloc.s 13
+		IL_0342: ldstr "log"
+		IL_0347: ldloc.s 14
+		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034e: pop
+		IL_034f: ldstr "console"
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0359: stloc.s 14
+		IL_035b: ldloc.s 14
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0362: stloc.s 14
+		IL_0364: ldloc.0
+		IL_0365: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_036a: ldnull
+		IL_036b: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+		IL_0370: stloc.s 13
+		IL_0372: ldloc.s 14
+		IL_0374: ldstr "log"
+		IL_0379: ldloc.s 13
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0380: pop
+		IL_0381: ldstr "console"
+		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_038b: stloc.s 13
+		IL_038d: ldloc.s 13
+		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0394: stloc.s 13
+		IL_0396: ldloc.0
+		IL_0397: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
+		IL_039c: ldnull
+		IL_039d: ldc.r8 10
+		IL_03a6: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+		IL_03ab: stloc.s 14
+		IL_03ad: ldloc.s 13
+		IL_03af: ldstr "log"
+		IL_03b4: ldloc.s 14
+		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03bb: pop
+		IL_03bc: ret
+	} // end of method Variable_NumericLetLocalSpecialization::__js_module_init__
+
+} // end of class Modules.Variable_NumericLetLocalSpecialization
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2924
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Variable_NumericLetLocalSpecialization::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
Fixes #1607

## Problem

`dromaeo-3d-cube-modern` runs ~48% slower than `dromaeo-3d-cube` under JROC, even though the two scripts are the same algorithm. Every other engine (jint, okojo, clearscript, yantrajs) treats them as equivalent — only JROC regresses, so this is a codegen issue rather than a workload difference.

| Engine | `dromaeo-3d-cube` | `dromaeo-3d-cube-modern` | Delta |
|---|---|---|---|
| **jroc** | **6.54 ms** | **9.70 ms** | **+48%** |
| jint | 7.60 ms | 7.65 ms | +0.7% |
| okojo | 8.68 ms | 8.86 ms | +2% |
| clearscript | 6.43 ms | 6.33 ms | -1.6% |
| yantrajs | 4.28 ms | 4.15 ms | -3% |

## Root cause

The unboxed-numeric-local optimization was gated on `BindingKind.Var`, so **uninitialized `let` bindings fell back to boxed `object` locals**. Two gates combined:

1. `SymbolTableBuilder.InferTypes.cs` — any declarator with `Init == null` is denied a CLR type (a value type can't also hold `undefined`).
2. `SymbolTableBuilder.NumericVarLocals.cs` — the definite-assignment pass that *rescues* such declarations bailed on `binding.Kind != BindingKind.Var`.

Net effect: uninitialized `var` gets rescued into an unboxed `float64` local; uninitialized `let` does not.

`dromaeo-3d-cube-modern` declares `IncX1, IncY1, IncX2, IncY2, Den, Num, NumAdd, NumPix` as bare uninitialized `let` inside the hot `DrawLine` function — exactly the variables driving the innermost pixel loop. That loop grew from 66 to 84 IL instructions, with `ToNumber` calls going 2 → 7 and `box System.Double` 1 → 2, because every compare and arithmetic op round-tripped through box/unbox:

```
base:                             modern:
ldloc.0                           ldloc.0
ldc.r8 3                          ldc.r8 3
add                               call Operators::Add(object, float64)
...
ldloc.0                           ldloc.0
ldloc.1                           call TypeUtilities::ToNumber(object)
clt                               ldloc.1
                                  call TypeUtilities::ToNumber(object)
                                  clt
```

Minimal repro — identical function, only the declaration keyword changed:

| Source | IL instrs | Locals |
|---|---|---|
| `var Num; ... Num = 0;` | 56 | all `float64` |
| `let Num; ... Num = 0;` | **77** | `object`, boxing throughout |
| `let Num = 0; ...` | **50** | all `float64` |

The trigger is *uninitialized* `let`, not `let` itself.

## The fix

Extend the pass to accept `BindingKind.Let` via a new `IsUnboxedLocalCandidateKind` predicate, replacing the two `binding.Kind != BindingKind.Var` checks.

**Why this is safe.** `let` is strictly *easier* to prove than `var`. `NumericVarDefiniteAssignmentAnalyzer` only marks a binding when definite assignment dominates every read — exactly the condition under which the temporal dead zone can never be entered. There is no hoisted-`undefined` window to preserve. The analyzer is already binding-kind-agnostic; only the caller's filter needed changing.

`const` is deliberately excluded: it always has an initializer, so ordinary initializer-based inference already types it and this pass would add nothing.

## Testing

New `Variable_NumericLetLocalSpecialization` execution + generator test covering:

- TDZ read before `let` declaration → `ReferenceError`
- conditional initialization → `undefined` on the unassigned path
- numeric → string type transition
- captured `let` (closure over a mutable binding)
- block shadowing
- loop-carried dependencies
- the dromaeo `DrawLine` loop shape

The generator snapshot confirms all 8 uninitialized `let` numerics in the `DrawLine` loop shape now compile to `float64` locals. Execution output matches Node.js exactly (`11 / 14 / ReferenceError / undefined / number / 1 / text / 2 / 3 / text1 / 89`).

`dotnet test tests/Jroc.Tests --filter "FullyQualifiedName~Variable"` → 138/138 passing. Local full-suite runs were impractically slow on this machine, so **CI is relied on for full-suite and snapshot validation.**

## Follow-up (not addressed here)

A pre-existing, unrelated bug was found while validating:

```js
function letHoistVarHazard() { let y = z; var z = 1; return y; }
```

Node returns `undefined`; JROC returns `NaN`. Confirmed present on `master` with this change stashed. Worth a separate issue.

Perf confirmation should be done via the `Benchmark branch comparison` workflow (`private_branch: perf/unboxed-numeric-let-locals`, `scenario_name: dromaeo-3d-cube-modern`, `benchmark_suite: dromaeo`) rather than local timings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
