### PR TITLE
feat(compiler): add identity LIR stack schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler: add the identity-mode foundation for the incremental LIR stack scheduler. The IL backend now emits through an explicit source-order schedule with temp residency, instruction disposition, atomic operation, metrics, and cumulative coverage models, while preserving legacy Stackify/local allocation decisions and byte-identical method bodies, local signatures, maxstack, exception regions, and Portable PDB mappings. Existing user-class and intrinsic constructor/field-store peepholes are represented as atomic schedule operations with their prior eligibility checks and ordinary-emission fallback unchanged.
 
 ## v0.11.40 - 2026-07-30
 

--- a/docs/compiler/LIRStackScheduler.md
+++ b/docs/compiler/LIRStackScheduler.md
@@ -1,0 +1,352 @@
+# LIR Stack Scheduler
+
+## Status
+
+The scheduler is being introduced incrementally under the umbrella tracked by
+[GitHub issue #1617](https://github.com/tomacox74/js2il/issues/1617).
+
+The implementation currently provides an **identity schedule only**:
+
+- LIR instructions are emitted in their original order.
+- No temp is made stack-resident by the scheduler.
+- Existing `Stackify`, branch fusion, rematerialization, and local allocation
+  behavior remains authoritative.
+- Existing constructor/field-store peepholes remain intact.
+- Generated method bodies and Portable PDB mappings are unchanged.
+
+The identity stage exists to establish a reviewable and testable emission-plan
+boundary before later stages make real scheduling decisions.
+
+## Why a scheduler is needed
+
+JROC LIR names intermediate values with `TempVariable` instances. A direct IL
+backend can materialize each live temp through a local:
+
+```text
+produce value
+stloc temp
+...
+ldloc temp
+consume value
+```
+
+CLR IL is a stack machine, so a single-use value can often stay on the
+evaluation stack:
+
+```text
+produce value
+...
+consume value
+```
+
+The existing [`Stackify`](Stackify.md) pass eliminates some locals by
+suppressing a definition and re-emitting it at the use site. That is
+rematerialization: it is appropriate for constants and other cheap, stable
+loads, but it cannot safely generalize to calls, allocations, observable
+property reads, or other instructions that must execute exactly once.
+
+The scheduler will eventually represent a different operation:
+
+1. emit the producer once at its legal evaluation point;
+2. leave its result on the CLR evaluation stack;
+3. preserve the required stack shape until its consumer;
+4. consume the value without `stloc`, `ldloc`, or re-execution.
+
+Stack scheduling and rematerialization are separate optimizations. During the
+migration they coexist; after scheduling coverage is complete, the useful
+rematerialization behavior will remain under an explicit policy.
+
+## Pipeline placement
+
+Semantic and type-directed LIR normalization runs in `JsMethodCompiler`:
+
+```text
+HIRToLIRLowerer
+  -> LIRIntrinsicNormalization
+  -> LIRMemberCallNormalization
+  -> LIRTypeNormalization
+  -> late intrinsic normalization
+  -> LIRCoercionCSE
+```
+
+The stack scheduler belongs to the IL backend because its decisions depend on
+CLR evaluation-stack order, local materialization, and emission details:
+
+```text
+normalized MethodBodyIR
+  -> LIRStackScheduler
+  -> legacy branch/Stackify materialization decisions
+  -> TempLocalAllocator
+  -> LIRToILCompiler
+  -> method body + Portable PDB metadata
+```
+
+Current integration is in:
+
+- `src/Compiler/IL/LIRStackSchedule.cs`
+- `src/Compiler/IL/LIRStackScheduler.cs`
+- `src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs`
+- `src/Compiler/CompilerOptions.cs`
+
+## Scheduler modes
+
+`LIRStackSchedulerMode` is cumulative:
+
+| Mode | Current behavior |
+|---|---|
+| `Disabled` | Bypass schedule construction and use the legacy raw LIR index path. |
+| `Identity` | Emit through an explicit source-order schedule. This is the default. |
+| `TypedNumeric` | Reserved for the first optimizing stage; currently rejected with `NotSupportedException`. |
+
+Later modes must include all behavior from preceding modes so adjacent levels
+remain useful for A/B diagnosis.
+
+The option is internal and testable. It is not currently a user-facing CLI
+switch.
+
+## Schedule model
+
+### Temp residency
+
+`TempResidency` separates three eventual storage behaviors:
+
+| Residency | Meaning |
+|---|---|
+| `MaterializedLocal` | Store/load the value through a variable or allocator temp slot. |
+| `StackResident` | Emit once and carry the value on the CLR evaluation stack. |
+| `Rematerialized` | Suppress the original definition and safely reproduce it at a use. |
+
+Identity mode reports `MaterializedLocal` for every temp and marks every
+`OwnedTemps` entry `false`. The `false` ownership is important: it delegates
+the actual decision to the existing Stackify/allocator pipeline. Identity mode
+does not force all values into locals.
+
+### Instruction disposition
+
+Temp residency does not say what to do with the instruction itself, especially
+when its result is unused. `InstructionDisposition` defines the eventual
+instruction-level choice:
+
+| Disposition | Meaning |
+|---|---|
+| `EmitNormally` | Emit through the normal instruction path. |
+| `EmitAndDiscardResult` | Execute exactly once and discard an unused result. |
+| `ElidePureUnused` | Omit a proven pure, non-throwing instruction whose result is unused. |
+| `FusedIntoEmissionUnit` | Emit an atomic group through one specialized operation. |
+
+Identity mode currently assigns `EmitNormally` except for the two existing
+constructor/field-store fusion candidates. Existing emitters still make their
+legacy unused-result decisions; later stages will move those decisions into
+canonical instruction metadata.
+
+### Scheduled operations
+
+`ScheduledOperation` owns a consecutive range of source LIR indexes:
+
+```csharp
+internal readonly record struct ScheduledOperation(
+    int StartLirIndex,
+    int InstructionCount,
+    InstructionDisposition Disposition);
+```
+
+The order of operations is the emission order. Identity scheduling uses
+source-order operations. Future scheduling may reorder whole operations within
+validated regions without mutating `MethodBodyIR.Instructions`.
+
+### Regions and metrics
+
+`ScheduledRegion` reserves the boundary for future straight-line scheduling.
+Identity mode creates no optimized regions and reports:
+
+```text
+ScheduledRegionCount = 0
+StackResidentTempCount = 0
+EliminatedSpillCount = 0
+MaxStackDepth = 0
+```
+
+The existing IL maxstack calculation remains authoritative in identity mode.
+
+### Effective last uses
+
+The schedule records the last LIR index that uses each temp. Identity mode
+matches raw source order and does not feed this data into allocation yet.
+
+The implementation supplements the legacy temp visitor for:
+
+- `LIRThrow.Value`
+- `LIRUnwrapCatchException.Exception`
+
+Those operands are consumed by the emitter but are missing from the legacy
+allocator visitor. Recording them makes the schedule metadata accurate without
+changing allocation or generated IL in this stage. A later stage will replace
+duplicated manual instruction inventories with canonical exhaustive metadata.
+
+## Identity operation construction
+
+Most instructions become one `EmitNormally` operation.
+
+Two existing source-adjacent patterns become atomic
+`FusedIntoEmissionUnit` candidates:
+
+```text
+LIRNewUserClass
+LIRStoreUserClassInstanceField(result)
+```
+
+and:
+
+```text
+LIRNewIntrinsicObject
+LIRStoreUserClassInstanceField(result)
+```
+
+The scheduler recognizes only the structural candidate. It does **not** move
+the runtime eligibility rules out of the emitter.
+
+For example, user-class fusion still depends on:
+
+- a non-derived constructor;
+- available class/callable metadata;
+- no constructor-return override field;
+- a declared constructor token;
+- a resolvable destination field;
+- compatible constructed and declared field types.
+
+If any eligibility check declines fusion, the identity cursor emits the first
+instruction normally and then emits the field store normally. This preserves
+the exact legacy fallback.
+
+## Plan-driven emission cursor
+
+`LIRToILCompiler.TryCompileMethodBodyToIL` has two cursor implementations:
+
+### Disabled mode
+
+The cursor advances raw source LIR indexes. A successful adjacent fusion
+advances by two indexes, matching the previous `for` loop's `i++` skip.
+
+### Identity mode
+
+The cursor advances through scheduled operations and offsets inside each
+operation:
+
+- ordinary instruction: advance one operation;
+- failed atomic fusion eligibility: advance to the second instruction inside
+  the same operation;
+- successful atomic fusion: consume the whole operation.
+
+Labels, branches, sequence points, `leave`, and `endfinally` explicitly advance
+the active cursor before continuing.
+
+This dual path is temporary but intentional: disabled-versus-identity
+equivalence isolates any problem in plan-driven emission before optimization
+coverage is added.
+
+## Current invariants
+
+Identity mode must preserve all of the following:
+
+- original LIR instruction order;
+- each instruction's existing execute/elide/discard behavior;
+- existing Stackify and branch-fusion ownership;
+- `TempLocalAllocator` decisions and compatible-slot reuse;
+- variable-slot and constructor-result forced materialization;
+- generated IL bytes for every method body;
+- local signature blobs;
+- maxstack and `InitLocals`;
+- exception regions;
+- sequence-point mappings and source local indexes;
+- constructor/field-store fusion and fallback behavior.
+
+The identity scheduler does not inspect `CompilerOptions.EmitPdb`; enabling
+symbols must not change schedule selection or operation order.
+
+## Tests
+
+`tests/Jroc.Tests/LIRStackSchedulerTests.cs` covers:
+
+- empty identity schedules;
+- source-order straight-line and control-flow plans;
+- raw effective last-use metadata;
+- throw and catch-unwrapping operands;
+- intrinsic and user-class atomic fusion candidates;
+- derived constructors remaining ordinary operations;
+- disabled-mode bypass;
+- rejection of not-yet-implemented coverage.
+
+Its integration fixture compiles with scheduler `Disabled` and `Identity`, with
+and without PDBs, and compares:
+
+- exact IL bytes for every method;
+- decoded local signature blobs;
+- maxstack and `InitLocals`;
+- exception regions;
+- PDB documents and sequence-point blobs;
+- local scopes, indexes, attributes, and names.
+
+Focused regression coverage also includes:
+
+- `StackifyTests`;
+- `TempLocalAllocatorTests`;
+- user/intrinsic constructor-field fusion generator snapshots;
+- Portable PDB sequence-point and locals tests.
+
+## What this stage does not do
+
+Identity scheduling does not:
+
+- reorder instructions;
+- create scheduling regions;
+- keep a temp on the stack;
+- remove a spill;
+- alter rematerialization;
+- change maxstack calculation;
+- replace the local allocator;
+- classify all LIR effects or stack signatures;
+- schedule across labels, branches, sequence points, EH, `yield`, or `await`.
+
+These limitations are deliberate. A no-change foundation makes later
+instruction-family PRs smaller and reviewable.
+
+## Planned expansion
+
+The ordered work is tracked under
+[issue #1617](https://github.com/tomacox74/js2il/issues/1617):
+
+1. Canonical LIR metadata and safe scheduling-region partitioning.
+2. Independent schedule validation and schedule-aware maxstack.
+3. Effective liveness/local allocation integration.
+4. Portable PDB preservation gate.
+5. Typed numeric binary expression trees.
+6. Typed unary/comparison/branch expressions.
+7. Conversions, stable loads, and explicit rematerialization.
+8. Literal and argument construction.
+9. Same-region single-use call results.
+10. General legal scheduling inside straight-line regions.
+11. Stackify scheduling retirement.
+12. Final obsolete-code audit and deletion.
+
+At each optimizing stage:
+
+- supported coverage is cumulative;
+- positive fixtures must prove the scheduler accepted the region;
+- negative fixtures must assert a documented rejection/fallback reason;
+- JavaScript evaluation order and exact expression grouping must be preserved;
+- broad regression coverage comes from PR CI.
+
+## Contributor checklist
+
+When changing the identity scheduler foundation:
+
+- Keep `Disabled` and `Identity` method bodies equivalent.
+- Do not make scheduler behavior depend on PDB emission.
+- Preserve ordinary fallback for atomic fusion candidates.
+- Keep effective last uses accurate for every newly-observed operand.
+- Add direct schedule assertions, not only execution tests.
+- Compare local signature contents, not only metadata row numbers.
+- Check decoded Portable PDB mappings, not raw PDB container bytes.
+- Run focused Stackify, allocator, fusion, and PDB regressions.
+- Do not enable a reserved coverage mode without its own issue's validation and
+  exit criteria.

--- a/docs/compiler/Stackify.md
+++ b/docs/compiler/Stackify.md
@@ -4,6 +4,12 @@ This document explains how **Stackify** works in JROC.
 
 **Goal:** teach you *why* Stackify exists, *what problem it solves*, and *how the algorithm decides* whether a temporary value (a “temp”) can stay on the .NET IL **evaluation stack** instead of being stored into an IL local variable.
 
+> **Migration note:** JROC now has an identity-mode IL-backend scheduling
+> foundation. Stackify remains the active legacy residency/rematerialization
+> analysis in this stage; no optimization behavior has moved yet. See
+> [LIR Stack Scheduler](LIRStackScheduler.md) for the new emission-plan model,
+> current invariants, and the incremental migration path.
+
 ---
 ## Table of Contents
 
@@ -526,4 +532,3 @@ Even if Stackify’s analysis says “stackable”, emission still needs to be c
 - Verify that stackified temps are marked non-materialized via `MarkStackifiableTemps` in `LIRToILCompiler`.
 - Confirm that non-materialized temps don’t get IL locals allocated (`TempLocalAllocator.Allocate`).
 - If you see unexpected `pop` emissions, it often means a temp got marked non-materialized but the surrounding instruction sequence didn’t actually consume the value as expected.
-

--- a/src/Compiler/CompilerOptions.cs
+++ b/src/Compiler/CompilerOptions.cs
@@ -12,6 +12,13 @@ public class CompilerOptions
     public bool EmitPdb { get; set; } = false;
 
     /// <summary>
+    /// Controls cumulative LIR stack-scheduler coverage. Identity mode is the
+    /// no-optimization foundation and must preserve legacy IL byte-for-byte.
+    /// </summary>
+    internal Jroc.IL.LIRStackSchedulerMode LIRStackSchedulerMode { get; set; } =
+        Jroc.IL.LIRStackSchedulerMode.Identity;
+
+    /// <summary>
     /// When true, JROC emits strongly-typed .NET contracts for CommonJS <c>module.exports</c>
     /// into the compiled assembly for hosting via <see cref="Jroc.Runtime.JsEngine"/>.
     /// </summary>

--- a/src/Compiler/IL/LIRStackSchedule.cs
+++ b/src/Compiler/IL/LIRStackSchedule.cs
@@ -1,0 +1,79 @@
+using Jroc.IR;
+
+namespace Jroc.IL;
+
+/// <summary>
+/// Cumulative scheduler coverage levels. New levels must include the behavior
+/// of every preceding level so adjacent modes remain useful for A/B diagnosis.
+/// </summary>
+internal enum LIRStackSchedulerMode
+{
+    Disabled = 0,
+    Identity = 1,
+    TypedNumeric = 2
+}
+
+internal enum TempResidency
+{
+    MaterializedLocal,
+    StackResident,
+    Rematerialized
+}
+
+internal enum InstructionDisposition
+{
+    EmitNormally,
+    EmitAndDiscardResult,
+    ElidePureUnused,
+    FusedIntoEmissionUnit
+}
+
+/// <summary>
+/// One atomic unit in the IL emission order. Identity scheduling uses
+/// consecutive source indexes; future schedulers may reorder these operations.
+/// </summary>
+internal readonly record struct ScheduledOperation(
+    int StartLirIndex,
+    int InstructionCount,
+    InstructionDisposition Disposition)
+{
+    internal int EndLirIndexExclusive => checked(StartLirIndex + InstructionCount);
+
+    internal int GetLirInstructionIndex(int operationOffset)
+    {
+        if ((uint)operationOffset >= (uint)InstructionCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(operationOffset));
+        }
+
+        return StartLirIndex + operationOffset;
+    }
+}
+
+internal readonly record struct ScheduledRegion(
+    int StartLirIndex,
+    int EndLirIndexExclusive,
+    IReadOnlyList<ScheduledOperation> Operations,
+    int MaxStackDepth);
+
+internal readonly record struct LIRStackScheduleMetrics(
+    int ScheduledRegionCount,
+    int StackResidentTempCount,
+    int EliminatedSpillCount);
+
+/// <summary>
+/// Immutable scheduler output consumed by local allocation and IL emission.
+/// Identity mode deliberately delegates all residency decisions to the legacy
+/// pipeline while making emission order and atomic operation ownership explicit.
+/// </summary>
+internal sealed record LIRStackSchedule(
+    LIRStackSchedulerMode Mode,
+    IReadOnlyList<ScheduledOperation> Operations,
+    IReadOnlyList<ScheduledRegion> Regions,
+    IReadOnlyList<TempResidency> TempResidencies,
+    IReadOnlyList<bool> OwnedTemps,
+    IReadOnlyList<int> EffectiveLastUses,
+    int MaxStackDepth,
+    LIRStackScheduleMetrics Metrics);
+
+internal readonly record struct LIRStackSchedulerOptions(LIRStackSchedulerMode Mode);

--- a/src/Compiler/IL/LIRStackSchedule.cs
+++ b/src/Compiler/IL/LIRStackSchedule.cs
@@ -53,7 +53,8 @@ internal readonly record struct ScheduledOperation(
 internal readonly record struct ScheduledRegion(
     int StartLirIndex,
     int EndLirIndexExclusive,
-    IReadOnlyList<ScheduledOperation> Operations,
+    int StartOperationIndex,
+    int OperationCount,
     int MaxStackDepth);
 
 internal readonly record struct LIRStackScheduleMetrics(
@@ -68,11 +69,11 @@ internal readonly record struct LIRStackScheduleMetrics(
 /// </summary>
 internal sealed record LIRStackSchedule(
     LIRStackSchedulerMode Mode,
-    IReadOnlyList<ScheduledOperation> Operations,
-    IReadOnlyList<ScheduledRegion> Regions,
-    IReadOnlyList<TempResidency> TempResidencies,
-    IReadOnlyList<bool> OwnedTemps,
-    IReadOnlyList<int> EffectiveLastUses,
+    ScheduledOperation[] Operations,
+    ScheduledRegion[] Regions,
+    TempResidency[] TempResidencies,
+    bool[] OwnedTemps,
+    int[] EffectiveLastUses,
     int MaxStackDepth,
     LIRStackScheduleMetrics Metrics);
 

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -1,0 +1,160 @@
+using Jroc.IR;
+
+namespace Jroc.IL;
+
+/// <summary>
+/// Builds an IL-backend emission plan over LIR. The initial identity mode owns
+/// no temp residency decisions and preserves the existing source-order output.
+/// </summary>
+internal static class LIRStackScheduler
+{
+    internal static LIRStackSchedule Build(
+        MethodBodyIR methodBody,
+        LIRStackSchedulerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(methodBody);
+
+        return options.Mode switch
+        {
+            LIRStackSchedulerMode.Identity => Identity(methodBody),
+            LIRStackSchedulerMode.Disabled => throw new InvalidOperationException(
+                "Disabled scheduler mode bypasses schedule construction."),
+            _ => throw new NotSupportedException(
+                $"LIR stack scheduler mode '{options.Mode}' is not implemented yet.")
+        };
+    }
+
+    internal static LIRStackSchedule Identity(MethodBodyIR methodBody)
+    {
+        ArgumentNullException.ThrowIfNull(methodBody);
+
+        var operations = BuildIdentityOperations(methodBody);
+        var tempResidencies = new TempResidency[methodBody.Temps.Count];
+        Array.Fill(tempResidencies, TempResidency.MaterializedLocal);
+
+        var ownedTemps = new bool[methodBody.Temps.Count];
+        var effectiveLastUses = ComputeIdentityLastUses(methodBody);
+
+        return new LIRStackSchedule(
+            LIRStackSchedulerMode.Identity,
+            operations,
+            Array.Empty<ScheduledRegion>(),
+            tempResidencies,
+            ownedTemps,
+            effectiveLastUses,
+            MaxStackDepth: 0,
+            new LIRStackScheduleMetrics(
+                ScheduledRegionCount: 0,
+                StackResidentTempCount: 0,
+                EliminatedSpillCount: 0));
+    }
+
+    private static ScheduledOperation[] BuildIdentityOperations(MethodBodyIR methodBody)
+    {
+        if (methodBody.Instructions.Count == 0)
+        {
+            return Array.Empty<ScheduledOperation>();
+        }
+
+        var operations = new List<ScheduledOperation>(methodBody.Instructions.Count);
+        for (var index = 0; index < methodBody.Instructions.Count;)
+        {
+            if (IsConstructorFieldStoreFusionCandidate(methodBody.Instructions, index))
+            {
+                operations.Add(new ScheduledOperation(
+                    index,
+                    InstructionCount: 2,
+                    InstructionDisposition.FusedIntoEmissionUnit));
+                index += 2;
+                continue;
+            }
+
+            operations.Add(new ScheduledOperation(
+                index,
+                InstructionCount: 1,
+                InstructionDisposition.EmitNormally));
+            index++;
+        }
+
+        return operations.ToArray();
+    }
+
+    private static bool IsConstructorFieldStoreFusionCandidate(
+        IReadOnlyList<LIRInstruction> instructions,
+        int index)
+    {
+        if (index + 1 >= instructions.Count
+            || instructions[index + 1] is not LIRStoreUserClassInstanceField storeField)
+        {
+            return false;
+        }
+
+        return instructions[index] switch
+        {
+            LIRNewUserClass newUserClass =>
+                !newUserClass.IsDerivedConstructor
+                && storeField.Value.Equals(newUserClass.Result),
+            LIRNewIntrinsicObject newIntrinsic =>
+                storeField.Value.Equals(newIntrinsic.Result),
+            _ => false
+        };
+    }
+
+    private static int[] ComputeIdentityLastUses(MethodBodyIR methodBody)
+    {
+        var lastUses = new int[methodBody.Temps.Count];
+        Array.Fill(lastUses, -1);
+
+        for (var instructionIndex = 0;
+             instructionIndex < methodBody.Instructions.Count;
+             instructionIndex++)
+        {
+            var visitor = new LastUseVisitor(lastUses, instructionIndex);
+            VisitIdentityUsedTemps(methodBody.Instructions[instructionIndex], ref visitor);
+        }
+
+        return lastUses;
+    }
+
+    private static void VisitIdentityUsedTemps<TVisitor>(
+        LIRInstruction instruction,
+        ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
+    {
+        // These exception operands are not yet present in the allocator's
+        // legacy visitor. Keep identity schedule metadata correct without
+        // changing legacy allocation/output in this no-IL-change stage.
+        switch (instruction)
+        {
+            case LIRThrow throwInstruction:
+                visitor.Visit(throwInstruction.Value);
+                return;
+            case LIRUnwrapCatchException unwrapCatch:
+                visitor.Visit(unwrapCatch.Exception);
+                return;
+            default:
+                TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
+                return;
+        }
+    }
+
+    private struct LastUseVisitor : ITempUseVisitor
+    {
+        private readonly int[] _lastUses;
+        private readonly int _instructionIndex;
+
+        internal LastUseVisitor(int[] lastUses, int instructionIndex)
+        {
+            _lastUses = lastUses;
+            _instructionIndex = instructionIndex;
+        }
+
+        public void Visit(TempVariable temp)
+        {
+            if ((uint)temp.Index < (uint)_lastUses.Length)
+            {
+                _lastUses[temp.Index] = _instructionIndex;
+            }
+        }
+    }
+}

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -56,27 +56,33 @@ internal static class LIRStackScheduler
             return Array.Empty<ScheduledOperation>();
         }
 
-        var operations = new List<ScheduledOperation>(methodBody.Instructions.Count);
+        var operations = new ScheduledOperation[methodBody.Instructions.Count];
+        var operationCount = 0;
         for (var index = 0; index < methodBody.Instructions.Count;)
         {
             if (IsConstructorFieldStoreFusionCandidate(methodBody.Instructions, index))
             {
-                operations.Add(new ScheduledOperation(
+                operations[operationCount++] = new ScheduledOperation(
                     index,
                     InstructionCount: 2,
-                    InstructionDisposition.FusedIntoEmissionUnit));
+                    InstructionDisposition.FusedIntoEmissionUnit);
                 index += 2;
                 continue;
             }
 
-            operations.Add(new ScheduledOperation(
+            operations[operationCount++] = new ScheduledOperation(
                 index,
                 InstructionCount: 1,
-                InstructionDisposition.EmitNormally));
+                InstructionDisposition.EmitNormally);
             index++;
         }
 
-        return operations.ToArray();
+        if (operationCount != operations.Length)
+        {
+            Array.Resize(ref operations, operationCount);
+        }
+
+        return operations;
     }
 
     private static bool IsConstructorFieldStoreFusionCandidate(

--- a/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
+++ b/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
@@ -118,13 +118,26 @@ internal sealed partial class LIRToILCompiler
         bool HasNextEmissionInstruction()
             => scheduledOperations is null
                 ? legacyInstructionIndex < MethodBody.Instructions.Count
-                : scheduledOperationIndex < scheduledOperations.Count;
+                : scheduledOperationIndex < scheduledOperations.Length;
 
         int GetCurrentEmissionInstructionIndex()
             => scheduledOperations is null
                 ? legacyInstructionIndex
                 : scheduledOperations[scheduledOperationIndex]
                     .GetLirInstructionIndex(scheduledOperationOffset);
+
+        bool CurrentEmissionOperationAllowsFusion(int instructionCount)
+        {
+            if (scheduledOperations is null)
+            {
+                return true;
+            }
+
+            var operation = scheduledOperations[scheduledOperationIndex];
+            return scheduledOperationOffset == 0
+                && operation.InstructionCount == instructionCount
+                && operation.Disposition == InstructionDisposition.FusedIntoEmissionUnit;
+        }
 
         void AdvanceOneEmissionInstruction()
         {
@@ -151,6 +164,18 @@ internal sealed partial class LIRToILCompiler
                 return;
             }
 
+            var operation = scheduledOperations[scheduledOperationIndex];
+            if (scheduledOperationOffset != 0
+                || operation.InstructionCount != legacyInstructionCount
+                || operation.Disposition != InstructionDisposition.FusedIntoEmissionUnit)
+            {
+                throw new InvalidOperationException(
+                    $"Emitter attempted to consume a {legacyInstructionCount}-instruction fusion "
+                    + $"from scheduled operation {scheduledOperationIndex} "
+                    + $"(offset={scheduledOperationOffset}, count={operation.InstructionCount}, "
+                    + $"disposition={operation.Disposition}).");
+            }
+
             scheduledOperationIndex++;
             scheduledOperationOffset = 0;
         }
@@ -166,7 +191,8 @@ internal sealed partial class LIRToILCompiler
             // then immediately `castclass`-ing it back to the declared user-class type for `stfld`.
             //
             // Only apply when we can preserve JS semantics without requiring PL5.4a ctor return override handling.
-            if (instruction is LIRNewUserClass newUserClass
+            if (CurrentEmissionOperationAllowsFusion(instructionCount: 2)
+                && instruction is LIRNewUserClass newUserClass
                 && !newUserClass.IsDerivedConstructor
                 && i + 1 < MethodBody.Instructions.Count
                 && MethodBody.Instructions[i + 1] is LIRStoreUserClassInstanceField storeInstanceField
@@ -280,7 +306,8 @@ internal sealed partial class LIRToILCompiler
             // `ldarg.0; newobj <Intrinsic>(..); stfld <field>`.
             // This avoids materializing the freshly-constructed intrinsic instance into an `object` local and
             // then immediately `castclass`-ing it back to the declared intrinsic type for `stfld`.
-            if (instruction is LIRNewIntrinsicObject newIntrinsic
+            if (CurrentEmissionOperationAllowsFusion(instructionCount: 2)
+                && instruction is LIRNewIntrinsicObject newIntrinsic
                 && i + 1 < MethodBody.Instructions.Count
                 && MethodBody.Instructions[i + 1] is LIRStoreUserClassInstanceField storeIntrinsicField
                 && storeIntrinsicField.Value.Equals(newIntrinsic.Result))

--- a/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
+++ b/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
@@ -29,7 +29,15 @@ internal sealed partial class LIRToILCompiler
         _localVariablesSignature = default;
         _ilLength = 0;
         _locals = null;
-        var emitPdb = _serviceProvider.GetService<CompilerOptions>()?.EmitPdb == true;
+        var compilerOptions = _serviceProvider.GetService<CompilerOptions>();
+        var emitPdb = compilerOptions?.EmitPdb == true;
+        var schedulerMode = compilerOptions?.LIRStackSchedulerMode
+            ?? LIRStackSchedulerMode.Identity;
+        var stackSchedule = schedulerMode == LIRStackSchedulerMode.Disabled
+            ? null
+            : LIRStackScheduler.Build(
+                MethodBody,
+                new LIRStackSchedulerOptions(schedulerMode));
 
         // All temps start as "needs materialization". Stackify will mark which ones can stay on stack.
         var shouldMaterialize = new bool[MethodBody.Temps.Count];
@@ -102,8 +110,54 @@ internal sealed partial class LIRToILCompiler
         // because we need the scope instance to be in local 0 first (either newly created or
         // loaded from arg.0[0] on resume). The state switch is emitted inline with that instruction.
 
-        for (int i = 0; i < MethodBody.Instructions.Count; i++)
+        var scheduledOperations = stackSchedule?.Operations;
+        var scheduledOperationIndex = 0;
+        var scheduledOperationOffset = 0;
+        var legacyInstructionIndex = 0;
+
+        bool HasNextEmissionInstruction()
+            => scheduledOperations is null
+                ? legacyInstructionIndex < MethodBody.Instructions.Count
+                : scheduledOperationIndex < scheduledOperations.Count;
+
+        int GetCurrentEmissionInstructionIndex()
+            => scheduledOperations is null
+                ? legacyInstructionIndex
+                : scheduledOperations[scheduledOperationIndex]
+                    .GetLirInstructionIndex(scheduledOperationOffset);
+
+        void AdvanceOneEmissionInstruction()
         {
+            if (scheduledOperations is null)
+            {
+                legacyInstructionIndex++;
+                return;
+            }
+
+            scheduledOperationOffset++;
+            if (scheduledOperationOffset
+                >= scheduledOperations[scheduledOperationIndex].InstructionCount)
+            {
+                scheduledOperationIndex++;
+                scheduledOperationOffset = 0;
+            }
+        }
+
+        void AdvanceCurrentEmissionOperation(int legacyInstructionCount)
+        {
+            if (scheduledOperations is null)
+            {
+                legacyInstructionIndex += legacyInstructionCount;
+                return;
+            }
+
+            scheduledOperationIndex++;
+            scheduledOperationOffset = 0;
+        }
+
+        while (HasNextEmissionInstruction())
+        {
+            var i = GetCurrentEmissionInstructionIndex();
             var instruction = MethodBody.Instructions[i];
 
             // Peephole optimization: fuse `new C(...); this.<field> = <temp>` into a single sequence
@@ -216,8 +270,8 @@ internal sealed partial class LIRToILCompiler
                     ilEncoder.OpCode(ILOpCode.Stfld);
                     ilEncoder.Token(fieldHandle);
 
-                    // Skip the following LIRStoreUserClassInstanceField (we just emitted it).
-                    i++;
+                    // Consume the following LIRStoreUserClassInstanceField (we just emitted it).
+                    AdvanceCurrentEmissionOperation(legacyInstructionCount: 2);
                     continue;
                 }
             }
@@ -260,8 +314,8 @@ internal sealed partial class LIRToILCompiler
                     ilEncoder.OpCode(ILOpCode.Stfld);
                     ilEncoder.Token(fieldHandle);
 
-                    // Skip the following LIRStoreUserClassInstanceField (we just emitted it).
-                    i++;
+                    // Consume the following LIRStoreUserClassInstanceField (we just emitted it).
+                    AdvanceCurrentEmissionOperation(legacyInstructionCount: 2);
                     continue;
                 }
             }
@@ -271,6 +325,7 @@ internal sealed partial class LIRToILCompiler
             {
                 case LIRLabel lirLabel:
                     ilEncoder.MarkLabel(labelMap[lirLabel.LabelId]);
+                    AdvanceOneEmissionInstruction();
                     continue;
 
                 case LIRSequencePoint sp:
@@ -288,28 +343,34 @@ internal sealed partial class LIRToILCompiler
                     // Marker emits no IL. Associate the next real IL instruction with this span.
                     // IL offset is the current method IL byte length.
                     _sequencePoints.Add(new MethodSequencePoint(methodBlob.Count, sp.Span));
+                    AdvanceOneEmissionInstruction();
                     continue;
 
                 case LIRBranch branch:
                     ilEncoder.Branch(ILOpCode.Br, labelMap[branch.TargetLabel]);
+                    AdvanceOneEmissionInstruction();
                     continue;
 
                 case LIRLeave leave:
                     ilEncoder.Branch(ILOpCode.Leave, labelMap[leave.TargetLabel]);
+                    AdvanceOneEmissionInstruction();
                     continue;
 
                 case LIRBranchIfFalse branchFalse:
                     EmitBranchCondition(branchFalse.Condition, ilEncoder, allocation, tempDefinitions, methodDescriptor);
                     ilEncoder.Branch(ILOpCode.Brfalse, labelMap[branchFalse.TargetLabel]);
+                    AdvanceOneEmissionInstruction();
                     continue;
 
                 case LIRBranchIfTrue branchTrue:
                     EmitBranchCondition(branchTrue.Condition, ilEncoder, allocation, tempDefinitions, methodDescriptor);
                     ilEncoder.Branch(ILOpCode.Brtrue, labelMap[branchTrue.TargetLabel]);
+                    AdvanceOneEmissionInstruction();
                     continue;
 
                 case LIREndFinally:
                     ilEncoder.OpCode(ILOpCode.Endfinally);
+                    AdvanceOneEmissionInstruction();
                     continue;
             }
 
@@ -319,6 +380,8 @@ internal sealed partial class LIRToILCompiler
                 IRPipelineMetrics.RecordFailureIfUnset($"IL compile failed: unsupported LIR instruction {instruction.GetType().Name}");
                 return false;
             }
+
+            AdvanceOneEmissionInstruction();
         }
 
         // Ensure the method body always ends with a return.

--- a/tests/Jroc.Tests/LIRStackSchedulerTests.cs
+++ b/tests/Jroc.Tests/LIRStackSchedulerTests.cs
@@ -1,0 +1,451 @@
+using Jroc.IL;
+using Jroc.IR;
+using Jroc.Services.TwoPhaseCompilation;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Jroc.Tests;
+
+public sealed class LIRStackSchedulerTests
+{
+    [Fact]
+    public void Identity_EmptyBody_ReturnsEmptyLegacyDelegatingPlan()
+    {
+        var schedule = LIRStackScheduler.Identity(new MethodBodyIR());
+
+        Assert.Equal(LIRStackSchedulerMode.Identity, schedule.Mode);
+        Assert.Empty(schedule.Operations);
+        Assert.Empty(schedule.Regions);
+        Assert.Empty(schedule.TempResidencies);
+        Assert.Empty(schedule.OwnedTemps);
+        Assert.Empty(schedule.EffectiveLastUses);
+        Assert.Equal(0, schedule.MaxStackDepth);
+        Assert.Equal(default, schedule.Metrics);
+    }
+
+    [Fact]
+    public void Identity_StraightLineBody_PreservesOrderAndRawLastUses()
+    {
+        var body = new MethodBodyIR();
+        var left = AddTemp(body);
+        var right = AddTemp(body);
+        var result = AddTemp(body);
+
+        body.Instructions.Add(new LIRLoadParameter(1, left));
+        body.Instructions.Add(new LIRConstNumber(2, right));
+        body.Instructions.Add(new LIRMulNumber(left, right, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Equal(
+            new[] { 0, 1, 2, 3 },
+            schedule.Operations.Select(operation => operation.StartLirIndex));
+        Assert.All(schedule.Operations, operation =>
+        {
+            Assert.Equal(1, operation.InstructionCount);
+            Assert.Equal(InstructionDisposition.EmitNormally, operation.Disposition);
+        });
+        Assert.Equal(
+            new[] { TempResidency.MaterializedLocal, TempResidency.MaterializedLocal, TempResidency.MaterializedLocal },
+            schedule.TempResidencies);
+        Assert.All(schedule.OwnedTemps, Assert.False);
+        Assert.Equal(new[] { 2, 2, 3 }, schedule.EffectiveLastUses);
+    }
+
+    [Fact]
+    public void Identity_ControlFlowBody_PreservesEverySourceIndex()
+    {
+        var body = new MethodBodyIR();
+        var condition = AddTemp(body);
+        var value = AddTemp(body);
+
+        body.Instructions.Add(new LIRLoadParameter(1, condition));
+        body.Instructions.Add(new LIRBranchIfFalse(condition, 1));
+        body.Instructions.Add(new LIRConstNumber(1, value));
+        body.Instructions.Add(new LIRReturn(value));
+        body.Instructions.Add(new LIRLabel(1));
+        body.Instructions.Add(new LIRReturnUndefinedImmediate());
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Equal(
+            Enumerable.Range(0, body.Instructions.Count),
+            schedule.Operations.Select(operation => operation.StartLirIndex));
+    }
+
+    [Fact]
+    public void Identity_ExceptionOperands_ContributeToRawLastUses()
+    {
+        var body = new MethodBodyIR();
+        var exception = AddTemp(body);
+        var value = AddTemp(body);
+
+        body.Instructions.Add(new LIRUnwrapCatchException(exception, value));
+        body.Instructions.Add(new LIRThrow(value));
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Equal(new[] { 0, 1 }, schedule.EffectiveLastUses);
+    }
+
+    [Fact]
+    public void Identity_IntrinsicConstructorFieldStore_GroupsAtomicFusionCandidate()
+    {
+        var body = new MethodBodyIR();
+        var result = AddTemp(body);
+
+        body.Instructions.Add(new LIRNewIntrinsicObject(
+            "Int32Array",
+            System.Array.Empty<TempVariable>(),
+            result));
+        body.Instructions.Add(new LIRStoreUserClassInstanceField(
+            "Example",
+            "buffer",
+            IsPrivateField: false,
+            result));
+        body.Instructions.Add(new LIRReturnUndefinedImmediate());
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Collection(
+            schedule.Operations,
+            operation =>
+            {
+                Assert.Equal(0, operation.StartLirIndex);
+                Assert.Equal(2, operation.InstructionCount);
+                Assert.Equal(InstructionDisposition.FusedIntoEmissionUnit, operation.Disposition);
+                Assert.Equal(0, operation.GetLirInstructionIndex(0));
+                Assert.Equal(1, operation.GetLirInstructionIndex(1));
+            },
+            operation =>
+            {
+                Assert.Equal(2, operation.StartLirIndex);
+                Assert.Equal(1, operation.InstructionCount);
+                Assert.Equal(InstructionDisposition.EmitNormally, operation.Disposition);
+            });
+    }
+
+    [Fact]
+    public void Identity_UserConstructorFieldStore_GroupsOnlyEligibleStructuralCandidate()
+    {
+        var body = new MethodBodyIR();
+        var result = AddTemp(body);
+        var callable = new CallableId
+        {
+            Kind = CallableKind.ClassConstructor,
+            DeclaringScopeName = "module",
+            Name = "Child",
+            JsParamCount = 0
+        };
+
+        body.Instructions.Add(new LIRNewUserClass(
+            "Child",
+            "Child",
+            callable,
+            NeedsScopes: false,
+            ScopesArray: null,
+            MinArgCount: 0,
+            MaxArgCount: 0,
+            IsDerivedConstructor: false,
+            ParameterClrTypes: System.Array.Empty<Type?>(),
+            Arguments: System.Array.Empty<TempVariable>(),
+            result));
+        body.Instructions.Add(new LIRStoreUserClassInstanceField(
+            "Parent",
+            "child",
+            IsPrivateField: false,
+            result));
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        var operation = Assert.Single(schedule.Operations);
+        Assert.Equal(2, operation.InstructionCount);
+        Assert.Equal(InstructionDisposition.FusedIntoEmissionUnit, operation.Disposition);
+    }
+
+    [Fact]
+    public void Identity_DerivedUserConstructor_DoesNotGroupFusionCandidate()
+    {
+        var body = new MethodBodyIR();
+        var result = AddTemp(body);
+        var callable = new CallableId
+        {
+            Kind = CallableKind.ClassConstructor,
+            DeclaringScopeName = "module",
+            Name = "Derived",
+            JsParamCount = 0
+        };
+
+        body.Instructions.Add(new LIRNewUserClass(
+            "Derived",
+            "Derived",
+            callable,
+            NeedsScopes: false,
+            ScopesArray: null,
+            MinArgCount: 0,
+            MaxArgCount: 0,
+            IsDerivedConstructor: true,
+            ParameterClrTypes: System.Array.Empty<Type?>(),
+            Arguments: System.Array.Empty<TempVariable>(),
+            result));
+        body.Instructions.Add(new LIRStoreUserClassInstanceField(
+            "Parent",
+            "child",
+            IsPrivateField: false,
+            result));
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Equal(2, schedule.Operations.Count);
+        Assert.All(
+            schedule.Operations,
+            operation => Assert.Equal(InstructionDisposition.EmitNormally, operation.Disposition));
+    }
+
+    [Fact]
+    public void Build_DisabledMode_RejectsScheduleConstruction()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            LIRStackScheduler.Build(
+                new MethodBodyIR(),
+                new LIRStackSchedulerOptions(LIRStackSchedulerMode.Disabled)));
+
+        Assert.Contains("bypasses schedule construction", exception.Message);
+    }
+
+    [Fact]
+    public void Build_UnimplementedCoverageMode_FailsExplicitly()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            LIRStackScheduler.Build(
+                new MethodBodyIR(),
+                new LIRStackSchedulerOptions(LIRStackSchedulerMode.TypedNumeric)));
+
+        Assert.Contains(nameof(LIRStackSchedulerMode.TypedNumeric), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Compiler_IdentityMode_ProducesByteIdenticalArtifactToDisabledMode(bool emitPdb)
+    {
+        const string source = """
+            "use strict";
+            function numeric(a, b) { return a * 2 + b; }
+            function control(a) { if (a) return 1; return 2; }
+            function call(a) { return Math.floor(a); }
+            class Bar { constructor(value) { this.value = value; } }
+            class Foo {
+              constructor() {
+                this.bar = new Bar(5);
+                this.buffer = new Int32Array(3);
+              }
+            }
+            class Getter { get value() { return 7; } }
+            new Foo();
+            Math.floor(1.5);
+            new Getter().value;
+            +true;
+            console.log(numeric(4, 3), control(0), call(3.5));
+            """;
+
+        var disabled = Compile(source, LIRStackSchedulerMode.Disabled, emitPdb);
+        var identity = Compile(source, LIRStackSchedulerMode.Identity, emitPdb);
+
+        AssertEquivalentMethodBodies(disabled.PeBytes, identity.PeBytes);
+        AssertEquivalentPortablePdb(disabled.PdbBytes, identity.PdbBytes);
+    }
+
+    private static TempVariable AddTemp(MethodBodyIR body)
+    {
+        var temp = new TempVariable(body.Temps.Count);
+        body.Temps.Add(temp);
+        return temp;
+    }
+
+    private static JrocCompiledAssemblyArtifact Compile(
+        string source,
+        LIRStackSchedulerMode mode,
+        bool emitPdb)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "LIRStackSchedulerIdentity");
+        var entryPath = Path.Combine(root, "identity.js");
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile(entryPath, source);
+
+        var options = new CompilerOptions
+        {
+            OutputDirectory = root,
+            EmitPdb = emitPdb,
+            LIRStackSchedulerMode = mode
+        };
+
+        var logger = new TestLogger();
+        using var services = CompilerServices.BuildServiceProvider(options, fileSystem, logger);
+        var compiler = services.GetRequiredService<Compiler>();
+        return compiler.CompileToArtifact(entryPath)
+            ?? throw new InvalidOperationException(
+                $"Compilation failed. Errors: {logger.Errors}\nWarnings: {logger.Warnings}");
+    }
+
+    private static void AssertEquivalentMethodBodies(byte[] expectedPe, byte[] actualPe)
+    {
+        using var expectedStream = new MemoryStream(expectedPe, writable: false);
+        using var actualStream = new MemoryStream(actualPe, writable: false);
+        using var expectedReader = new PEReader(expectedStream);
+        using var actualReader = new PEReader(actualStream);
+        var expectedMetadata = expectedReader.GetMetadataReader();
+        var actualMetadata = actualReader.GetMetadataReader();
+
+        Assert.Equal(
+            expectedMetadata.MethodDefinitions.Count,
+            actualMetadata.MethodDefinitions.Count);
+
+        foreach (var expectedHandle in expectedMetadata.MethodDefinitions)
+        {
+            var actualHandle = MetadataTokens.MethodDefinitionHandle(
+                MetadataTokens.GetRowNumber(expectedHandle));
+            var expectedDefinition = expectedMetadata.GetMethodDefinition(expectedHandle);
+            var actualDefinition = actualMetadata.GetMethodDefinition(actualHandle);
+
+            Assert.Equal(
+                expectedMetadata.GetString(expectedDefinition.Name),
+                actualMetadata.GetString(actualDefinition.Name));
+            Assert.Equal(
+                expectedDefinition.RelativeVirtualAddress == 0,
+                actualDefinition.RelativeVirtualAddress == 0);
+
+            if (expectedDefinition.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            var expectedBody = expectedReader.GetMethodBody(expectedDefinition.RelativeVirtualAddress);
+            var actualBody = actualReader.GetMethodBody(actualDefinition.RelativeVirtualAddress);
+
+            Assert.Equal(expectedBody.GetILBytes(), actualBody.GetILBytes());
+            Assert.Equal(expectedBody.MaxStack, actualBody.MaxStack);
+            AssertEquivalentLocalSignature(
+                expectedMetadata,
+                expectedBody.LocalSignature,
+                actualMetadata,
+                actualBody.LocalSignature);
+            Assert.Equal(
+                expectedBody.LocalVariablesInitialized,
+                actualBody.LocalVariablesInitialized);
+            Assert.Equal(
+                expectedBody.ExceptionRegions.ToArray(),
+                actualBody.ExceptionRegions.ToArray());
+        }
+    }
+
+    private static void AssertEquivalentLocalSignature(
+        MetadataReader expectedMetadata,
+        StandaloneSignatureHandle expectedHandle,
+        MetadataReader actualMetadata,
+        StandaloneSignatureHandle actualHandle)
+    {
+        Assert.Equal(expectedHandle.IsNil, actualHandle.IsNil);
+        if (expectedHandle.IsNil || actualHandle.IsNil)
+        {
+            return;
+        }
+
+        var expectedSignature = expectedMetadata.GetStandaloneSignature(expectedHandle);
+        var actualSignature = actualMetadata.GetStandaloneSignature(actualHandle);
+        Assert.Equal(
+            expectedMetadata.GetBlobBytes(expectedSignature.Signature),
+            actualMetadata.GetBlobBytes(actualSignature.Signature));
+    }
+
+    private static void AssertEquivalentPortablePdb(byte[]? expectedPdb, byte[]? actualPdb)
+    {
+        Assert.Equal(expectedPdb is null, actualPdb is null);
+        if (expectedPdb is null || actualPdb is null)
+        {
+            return;
+        }
+
+        using var expectedStream = new MemoryStream(expectedPdb, writable: false);
+        using var actualStream = new MemoryStream(actualPdb, writable: false);
+        using var expectedProvider = MetadataReaderProvider.FromPortablePdbStream(expectedStream);
+        using var actualProvider = MetadataReaderProvider.FromPortablePdbStream(actualStream);
+        var expectedReader = expectedProvider.GetMetadataReader();
+        var actualReader = actualProvider.GetMetadataReader();
+
+        Assert.Equal(
+            expectedReader.MethodDebugInformation.Count,
+            actualReader.MethodDebugInformation.Count);
+
+        foreach (var expectedHandle in expectedReader.MethodDebugInformation)
+        {
+            var actualHandle = MetadataTokens.MethodDebugInformationHandle(
+                MetadataTokens.GetRowNumber(expectedHandle));
+            var expectedInfo = expectedReader.GetMethodDebugInformation(expectedHandle);
+            var actualInfo = actualReader.GetMethodDebugInformation(actualHandle);
+
+            Assert.Equal(
+                MetadataTokens.GetToken(expectedInfo.Document),
+                MetadataTokens.GetToken(actualInfo.Document));
+            Assert.Equal(
+                expectedInfo.SequencePointsBlob.IsNil
+                    ? System.Array.Empty<byte>()
+                    : expectedReader.GetBlobBytes(expectedInfo.SequencePointsBlob),
+                actualInfo.SequencePointsBlob.IsNil
+                    ? System.Array.Empty<byte>()
+                    : actualReader.GetBlobBytes(actualInfo.SequencePointsBlob));
+        }
+
+        Assert.Equal(
+            GetDocuments(expectedReader),
+            GetDocuments(actualReader));
+        Assert.Equal(
+            GetLocalScopes(expectedReader),
+            GetLocalScopes(actualReader));
+    }
+
+    private static string[] GetDocuments(MetadataReader reader)
+        => reader.Documents
+            .Select(handle =>
+            {
+                var document = reader.GetDocument(handle);
+                var hash = document.Hash.IsNil
+                    ? string.Empty
+                    : Convert.ToHexString(reader.GetBlobBytes(document.Hash));
+                return string.Join(
+                    "|",
+                    reader.GetString(document.Name),
+                    reader.GetGuid(document.HashAlgorithm),
+                    hash,
+                    reader.GetGuid(document.Language));
+            })
+            .ToArray();
+
+    private static string[] GetLocalScopes(MetadataReader reader)
+        => reader.LocalScopes
+            .Select(handle =>
+            {
+                var scope = reader.GetLocalScope(handle);
+                var locals = scope.GetLocalVariables()
+                    .Select(localHandle =>
+                    {
+                        var local = reader.GetLocalVariable(localHandle);
+                        return string.Join(
+                            ":",
+                            local.Index,
+                            (int)local.Attributes,
+                            reader.GetString(local.Name));
+                    });
+
+                return string.Join(
+                    "|",
+                    MetadataTokens.GetToken(scope.Method),
+                    scope.StartOffset,
+                    scope.Length,
+                    string.Join(",", locals));
+            })
+            .ToArray();
+}

--- a/tests/Jroc.Tests/LIRStackSchedulerTests.cs
+++ b/tests/Jroc.Tests/LIRStackSchedulerTests.cs
@@ -199,7 +199,7 @@ public sealed class LIRStackSchedulerTests
 
         var schedule = LIRStackScheduler.Identity(body);
 
-        Assert.Equal(2, schedule.Operations.Count);
+        Assert.Equal(2, schedule.Operations.Length);
         Assert.All(
             schedule.Operations,
             operation => Assert.Equal(InstructionDisposition.EmitNormally, operation.Disposition));


### PR DESCRIPTION
## Summary

Implements #1619, the first no-optimization foundation step of #1617.

The LIR-to-IL backend now has an explicit identity schedule and emits by
enumerating scheduled operations instead of directly incrementing the raw LIR
source index. This PR intentionally changes **no Stackify, temp allocation,
instruction order, method body, local signature, maxstack, exception region,
or Portable PDB behavior**.

## New scheduler model

Added `src/Compiler/IL/LIRStackSchedule.cs`:

- cumulative `LIRStackSchedulerMode`:
  - `Disabled` — exact legacy source-index path;
  - `Identity` — new plan-driven source-order path and current default;
  - `TypedNumeric` — reserved and explicitly rejected until #1624;
- `TempResidency`:
  - `MaterializedLocal`;
  - `StackResident`;
  - `Rematerialized`;
- `InstructionDisposition`:
  - `EmitNormally`;
  - `EmitAndDiscardResult`;
  - `ElidePureUnused`;
  - `FusedIntoEmissionUnit`;
- `ScheduledOperation`, `ScheduledRegion`, metrics, effective last uses, and
  explicit ownership arrays.

Identity mode delegates every residency/materialization decision to the legacy
pipeline: all temp residencies are `MaterializedLocal`, no temp is
scheduler-owned, and metrics report zero scheduled regions/stack residents/
eliminated spills.

## Identity schedule construction

Added `src/Compiler/IL/LIRStackScheduler.cs`.

The identity schedule:

- preserves source LIR order;
- computes raw-order effective last uses without changing allocation;
- represents the existing structural fusion candidates atomically:
  - non-derived `LIRNewUserClass` + matching instance-field store;
  - `LIRNewIntrinsicObject` + matching instance-field store;
- keeps the existing runtime eligibility checks in the emitter, so a structural
  candidate that cannot fuse still emits both instructions normally;
- records exception operand uses (`LIRThrow`,
  `LIRUnwrapCatchException`) that the legacy allocator visitor currently omits,
  without changing that visitor or legacy allocation in this no-change stage.

## Plan-driven emission

`LIRToILCompiler.TryCompileMethodBodyToIL` now selects:

- `Disabled`: the original raw source-index behavior;
- `Identity`: enumeration of `ScheduledOperation`s.

Control flow, sequence points, ordinary instructions, and both constructor
fusion paths explicitly advance the active emission cursor. A successful
fusion consumes its whole atomic operation; a failed eligibility check advances
one instruction and then processes the field store normally.

All existing Stackify/branch-fusion/materialization/local-allocation behavior
is unchanged.

## Equivalence coverage

Added `LIRStackSchedulerTests` covering:

- empty and straight-line identity plans;
- labels/branches preserving source order;
- raw effective last uses, including catch unwrap/throw operands;
- intrinsic and user-class atomic fusion candidates;
- derived constructors remaining ordinary operations;
- disabled mode bypass and unimplemented-mode failure;
- compilation with scheduler `Disabled` versus `Identity`, both with and
  without PDBs.

The compiler equivalence test compares:

- exact IL bytes for every method body;
- maxstack;
- decoded standalone local-signature blobs;
- `InitLocals`;
- exception regions;
- Portable PDB documents;
- method sequence-point blobs;
- local scopes, source-local indexes, attributes, and names.

The fixture includes numeric/control-flow/call code, both constructor-field
fusion shapes, unused constructor/call/getter results, a pure unused
conversion, and execution entry code.

## Documentation

Added `docs/compiler/LIRStackScheduler.md`, covering:

- why scheduling is distinct from Stackify rematerialization;
- exact placement in the normalized-LIR-to-IL pipeline;
- disabled/identity/reserved cumulative modes;
- temp residency and instruction disposition;
- scheduled operations, regions, metrics, and effective last uses;
- atomic constructor/field-store fusion candidates and fallback;
- the plan-driven emission cursor;
- current no-change invariants and equivalence coverage;
- non-goals, ordered expansion path, and contributor checklist.

`docs/compiler/Stackify.md` now links to the scheduler documentation and
clarifies that Stackify remains the active legacy analysis during identity
mode.

## Performance design review

A dedicated performance review found no measurable current regression:

- representative compile-time benchmark: master **2.104s average** versus
  branch **2.098s average** across five runs (within noise);
- generated assemblies differ only in normal PE timestamp/MVID bytes;
- method IL remains exactly equivalent.

The review prompted two foundation refinements included in this PR:

1. Schedule storage now uses dense arrays rather than `IReadOnlyList<T>`
   interfaces in the hot emission cursor. `ScheduledRegion` references a window
   in the single flat operation array instead of duplicating operation lists.
   Identity operation construction also avoids `List<T>` plus `ToArray()`
   allocation/copy.
2. Fused emission now consults and validates the scheduled operation's
   `FusedIntoEmissionUnit` disposition, offset, and instruction count before
   consuming it. This prevents a future fusion-predicate change from silently
   advancing the cursor over the wrong operation.

The remaining forward-looking performance work is intentionally assigned to
later sub-issues:

- identity mode currently performs one extra O(instructions) effective-last-use
  pass; measured overhead is below noise and #1620/#1622 will consolidate it
  into canonical metadata/schedule-aware allocation;
- `LIRStackSchedule.MaxStackDepth` remains zero in identity mode and the legacy
  estimator remains authoritative; #1621 must replace/validate maxstack before
  any mode can produce `StackResident` temps.

## Validation

- `dotnet build src/Jroc.Core/Jroc.Core.csproj` — succeeds with zero warnings.
- Focused `Jroc.Tests` — **38/38 pass**:
  - new identity scheduler suite;
  - legacy `StackifyTests`;
  - `TempLocalAllocatorTests`;
  - user/intrinsic constructor-field fusion snapshots;
  - Portable PDB sequence-point and locals suites.
- No `.received.*` snapshot files were produced.

Broader regression coverage is delegated to PR CI per the established workflow
for this repository.

## Review notes

The highest-value review point is
`LIRToILCompiler.MethodBodyCompilation.cs`: the new cursor has both a legacy
source-index implementation and an identity scheduled-operation implementation.
The equivalence suite is intended to make any divergence visible before later
sub-issues add actual scheduling.

Closes #1619.
