### PR TITLE
feat(compiler): classify LIR scheduling boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler: add exhaustive scheduler-facing metadata for every concrete LIR instruction, including ordered def/use access, semantic stack signatures, conservative mutable-state/call/throw/allocation effects, catch-entry stack input, await/yield resume-result definitions, hidden-control-flow classification, and fail-closed unknown handling. Identity scheduling now discovers straight-line candidate regions split by control flow, EH, sequence points, suspension, scope replacement, internal control flow, and unsupported instructions without changing emission order, Stackify, allocation, method IL, or PDB output. Final LIR validation now also runs after all normalization passes at the actual pre-scheduler boundary.
 - compiler: add the identity-mode foundation for the incremental LIR stack scheduler. The IL backend now emits through an explicit source-order schedule with temp residency, instruction disposition, atomic operation, metrics, and cumulative coverage models, while preserving legacy Stackify/local allocation decisions and byte-identical method bodies, local signatures, maxstack, exception regions, and Portable PDB mappings. Existing user-class and intrinsic constructor/field-store peepholes are represented as atomic schedule operations with their prior eligibility checks and ordinary-emission fallback unchanged.
 
 ## v0.11.40 - 2026-07-30

--- a/docs/compiler/LIRStackScheduler.md
+++ b/docs/compiler/LIRStackScheduler.md
@@ -5,13 +5,18 @@
 The scheduler is being introduced incrementally under the umbrella tracked by
 [GitHub issue #1617](https://github.com/tomacox74/js2il/issues/1617).
 
-The implementation currently provides an **identity schedule only**:
+The implementation currently provides an **identity schedule with conservative
+region discovery**:
 
 - LIR instructions are emitted in their original order.
 - No temp is made stack-resident by the scheduler.
 - Existing `Stackify`, branch fusion, rematerialization, and local allocation
   behavior remains authoritative.
 - Existing constructor/field-store peepholes remain intact.
+- Every concrete LIR instruction type is inventoried by canonical
+  scheduler-facing metadata.
+- Straight-line candidate regions are identified between conservative
+  boundaries, but their instructions are not reordered.
 - Generated method bodies and Portable PDB mappings are unchanged.
 
 The identity stage exists to establish a reviewable and testable emission-plan
@@ -85,6 +90,7 @@ Current integration is in:
 
 - `src/Compiler/IL/LIRStackSchedule.cs`
 - `src/Compiler/IL/LIRStackScheduler.cs`
+- `src/Compiler/IL/LIRInstructionInfo.cs`
 - `src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs`
 - `src/Compiler/CompilerOptions.cs`
 
@@ -154,13 +160,66 @@ The order of operations is the emission order. Identity scheduling uses
 source-order operations. Future scheduling may reorder whole operations within
 validated regions without mutating `MethodBodyIR.Instructions`.
 
+### Canonical instruction metadata
+
+`LIRInstructionInfo` is the scheduler-facing source for:
+
+- ordered temp definitions and uses;
+- implicit catch/await/yield definition semantics;
+- semantic stack signatures;
+- default instruction disposition;
+- conservative effect flags;
+- internal-control-flow and scheduling-boundary classification.
+
+`KnownInstructionTypes` explicitly inventories every concrete
+`LIRInstruction` subtype. A reflection-based test compares that inventory with
+the compiler assembly, so adding a new LIR instruction fails until it is
+classified. A runtime instruction absent from the inventory fails closed as an
+`UnsupportedBarrier`.
+
+Effects distinguish:
+
+- mutable slot, scope, and heap reads/writes;
+- calls, allocations, and may-throw behavior;
+- explicit control flow;
+- suspension;
+- scope replacement;
+- hidden IL control flow;
+- unsupported barriers.
+
+Typed numeric constants/operators are explicitly pure. Calls and dynamic
+operations receive conservative read/write/may-throw effects.
+TDZ-checked scope loads are marked `MayThrow`.
+
+Catch handler entry is represented by
+`LIRImplicitStackInput.CatchException`: the CLR supplies one exception object,
+and `LIRStoreException` consumes it into a materialized result. `LIRAwait` and
+`LIRYield` use `ResumeResult` definitions and remain opaque suspension
+boundaries. `LIRUnwrapCatchException` is an opaque internal-control-flow
+boundary because its emitter expands into branches.
+
+The allocator keeps its legacy def/use switches in this stage to guarantee no
+IL change. Scheduler and final-LIR validation use canonical metadata; allocator
+liveness migration is isolated to its dedicated later stage.
+
 ### Regions and metrics
 
-`ScheduledRegion` reserves the boundary for future straight-line scheduling.
-Identity mode creates no optimized regions and reports:
+`ScheduledRegion` identifies a source-order window in the flat operation array.
+Regions contain only instructions that may participate in future scheduling.
+They are split around:
+
+- labels, branches, `leave`, return, throw, and `endfinally`;
+- sequence points;
+- EH catch entry and hidden-control-flow instructions;
+- `yield`, `await`, and state-machine operations;
+- scope replacement;
+- unknown/unsupported instructions.
+
+Identity mode still performs no optimization. It reports the number of
+discovered regions while leaving the optimization metrics at zero:
 
 ```text
-ScheduledRegionCount = 0
+ScheduledRegionCount = <discovered straight-line region count>
 StackResidentTempCount = 0
 EliminatedSpillCount = 0
 MaxStackDepth = 0
@@ -173,15 +232,15 @@ The existing IL maxstack calculation remains authoritative in identity mode.
 The schedule records the last LIR index that uses each temp. Identity mode
 matches raw source order and does not feed this data into allocation yet.
 
-The implementation supplements the legacy temp visitor for:
+Canonical metadata supplements the legacy temp visitor for:
 
 - `LIRThrow.Value`
 - `LIRUnwrapCatchException.Exception`
 
 Those operands are consumed by the emitter but are missing from the legacy
-allocator visitor. Recording them makes the schedule metadata accurate without
-changing allocation or generated IL in this stage. A later stage will replace
-duplicated manual instruction inventories with canonical exhaustive metadata.
+allocator visitor. Recording them makes scheduler metadata accurate without
+changing allocation or generated IL. The allocator deliberately stays on its
+legacy visitor until schedule-effective liveness is integrated.
 
 ## Identity operation construction
 
@@ -259,6 +318,12 @@ Identity mode must preserve all of the following:
 - exception regions;
 - sequence-point mappings and source local indexes;
 - constructor/field-store fusion and fallback behavior.
+- every concrete compiler LIR subtype is present in the canonical inventory;
+- unclassified runtime instructions become unsupported boundaries;
+- candidate regions never include explicit control, sequence-point, scope,
+  suspension, EH-entry, hidden-CFG, or unsupported boundaries;
+- catch entry consumes exactly one implicit exception stack input;
+- await/yield results are identified as resume-time definitions.
 
 The identity scheduler does not inspect `CompilerOptions.EmitPdb`; enabling
 symbols must not change schedule selection or operation order.
@@ -298,7 +363,7 @@ Focused regression coverage also includes:
 Identity scheduling does not:
 
 - reorder instructions;
-- create scheduling regions;
+- optimize or reorder discovered scheduling regions;
 - keep a temp on the stack;
 - remove a spill;
 - alter rematerialization;
@@ -315,18 +380,17 @@ instruction-family PRs smaller and reviewable.
 The ordered work is tracked under
 [issue #1617](https://github.com/tomacox74/js2il/issues/1617):
 
-1. Canonical LIR metadata and safe scheduling-region partitioning.
-2. Independent schedule validation and schedule-aware maxstack.
-3. Effective liveness/local allocation integration.
-4. Portable PDB preservation gate.
-5. Typed numeric binary expression trees.
-6. Typed unary/comparison/branch expressions.
-7. Conversions, stable loads, and explicit rematerialization.
-8. Literal and argument construction.
-9. Same-region single-use call results.
-10. General legal scheduling inside straight-line regions.
-11. Stackify scheduling retirement.
-12. Final obsolete-code audit and deletion.
+1. Independent schedule validation and schedule-aware maxstack.
+2. Effective liveness/local allocation integration.
+3. Portable PDB preservation gate.
+4. Typed numeric binary expression trees.
+5. Typed unary/comparison/branch expressions.
+6. Conversions, stable loads, and explicit rematerialization.
+7. Literal and argument construction.
+8. Same-region single-use call results.
+9. General legal scheduling inside straight-line regions.
+10. Stackify scheduling retirement.
+11. Final obsolete-code audit and deletion.
 
 At each optimizing stage:
 
@@ -344,6 +408,10 @@ When changing the identity scheduler foundation:
 - Do not make scheduler behavior depend on PDB emission.
 - Preserve ordinary fallback for atomic fusion candidates.
 - Keep effective last uses accurate for every newly-observed operand.
+- Add every new concrete LIR subtype to canonical metadata and classify it
+  conservatively before enabling scheduling.
+- Keep hidden-control-flow, catch-entry, suspension, scope-replacement, and
+  sequence-point instructions outside candidate regions.
 - Add direct schedule assertions, not only execution tests.
 - Compare local signature contents, not only metadata row numbers.
 - Check decoded Portable PDB mappings, not raw PDB container bytes.

--- a/docs/compiler/Stackify.md
+++ b/docs/compiler/Stackify.md
@@ -8,7 +8,8 @@ This document explains how **Stackify** works in JROC.
 > foundation. Stackify remains the active legacy residency/rematerialization
 > analysis in this stage; no optimization behavior has moved yet. See
 > [LIR Stack Scheduler](LIRStackScheduler.md) for the new emission-plan model,
-> current invariants, and the incremental migration path.
+> canonical LIR metadata, conservative region boundaries, current invariants,
+> and the incremental migration path.
 
 ---
 ## Table of Contents

--- a/src/Compiler/IL/LIRBodyValidator.cs
+++ b/src/Compiler/IL/LIRBodyValidator.cs
@@ -56,7 +56,7 @@ internal static class LIRBodyValidator
         }
 
         // Build the set of temps that are defined by at least one instruction.
-        var definedTemps = new HashSet<int>(capacity: methodBody.Instructions.Count);
+        var definedTemps = new HashSet<int>(capacity: methodBody.Temps.Count);
         foreach (var instr in methodBody.Instructions)
         {
             if (LIRInstructionInfo.TryGetDefinedTemp(instr, out var defined)

--- a/src/Compiler/IL/LIRBodyValidator.cs
+++ b/src/Compiler/IL/LIRBodyValidator.cs
@@ -24,8 +24,8 @@ namespace Jroc.IL;
 ///     <c>EnsureNumber()</c> before being fed to these instructions.
 ///   </description></item>
 /// </list>
-/// Registered in the pipeline via <c>#if DEBUG</c> guards in
-/// <see cref="HIRToLIRLowerer.TryLower"/>.
+/// Registered in the pipeline via <c>#if DEBUG</c> guards after lowering and
+/// again at the final normalized-LIR boundary immediately before scheduling.
 /// </remarks>
 internal static class LIRBodyValidator
 {
@@ -59,7 +59,8 @@ internal static class LIRBodyValidator
         var definedTemps = new HashSet<int>(capacity: methodBody.Instructions.Count);
         foreach (var instr in methodBody.Instructions)
         {
-            if (TryGetDefinedTempExtended(instr, out var defined) && defined.Index >= 0)
+            if (LIRInstructionInfo.TryGetDefinedTemp(instr, out var defined)
+                && defined.Index >= 0)
             {
                 definedTemps.Add(defined.Index);
             }
@@ -210,27 +211,4 @@ internal static class LIRBodyValidator
         return new ValueStorage(ValueStorageKind.Unknown);
     }
 
-    /// <summary>
-    /// Like <see cref="TempLocalAllocator.TryGetDefinedTemp"/> but also covers instruction types
-    /// that define result temps without being listed in the allocator's switch
-    /// (e.g., <see cref="LIRStoreException"/> and <see cref="LIRUnwrapCatchException"/>
-    /// which populate their result from the CLR evaluation stack rather than via a prior LIR operand).
-    /// </summary>
-    private static bool TryGetDefinedTempExtended(LIRInstruction instruction, out TempVariable defined)
-    {
-        // Handle instructions that define a temp but are not in TempLocalAllocator.TryGetDefinedTemp.
-        if (instruction is LIRStoreException storeEx)
-        {
-            defined = storeEx.Result;
-            return true;
-        }
-
-        if (instruction is LIRUnwrapCatchException unwrap)
-        {
-            defined = unwrap.Result;
-            return true;
-        }
-
-        return TempLocalAllocator.TryGetDefinedTemp(instruction, out defined);
-    }
 }

--- a/src/Compiler/IL/LIRInstructionInfo.cs
+++ b/src/Compiler/IL/LIRInstructionInfo.cs
@@ -1,0 +1,598 @@
+using Jroc.IR;
+
+namespace Jroc.IL;
+
+[Flags]
+internal enum LIRInstructionEffects
+{
+    None = 0,
+    ReadsMutableSlot = 1 << 0,
+    WritesMutableSlot = 1 << 1,
+    ReadsScope = 1 << 2,
+    WritesScope = 1 << 3,
+    ReadsHeap = 1 << 4,
+    WritesHeap = 1 << 5,
+    Calls = 1 << 6,
+    MayThrow = 1 << 7,
+    Allocates = 1 << 8,
+    ControlFlow = 1 << 9,
+    Suspension = 1 << 10,
+    ScopeReplacement = 1 << 11,
+    EmitsInternalControlFlow = 1 << 12,
+    UnsupportedBarrier = 1 << 13
+}
+
+internal enum LIRImplicitStackInput
+{
+    None,
+    CatchException
+}
+
+internal enum LIRDefinitionKind
+{
+    None,
+    InstructionResult,
+    CatchException,
+    ResumeResult
+}
+
+internal readonly record struct LIRStackSignature(int Pops, int Pushes);
+
+internal readonly record struct LIRInstructionMetadata(
+    LIRInstructionEffects Effects,
+    InstructionDisposition DefaultDisposition,
+    LIRImplicitStackInput ImplicitStackInput,
+    LIRDefinitionKind DefinitionKind,
+    LIRStackSignature StackSignature,
+    bool IsSchedulingBoundary);
+
+/// <summary>
+/// Canonical scheduler-facing metadata for every concrete LIR instruction.
+/// Unknown or newly-added instructions fail closed until added to the explicit
+/// inventory and classified.
+/// </summary>
+internal static class LIRInstructionInfo
+{
+    private const LIRInstructionEffects CallEffects =
+        LIRInstructionEffects.Calls
+        | LIRInstructionEffects.MayThrow
+        | LIRInstructionEffects.ReadsHeap
+        | LIRInstructionEffects.WritesHeap;
+
+    private const LIRInstructionEffects HeapReadEffects =
+        LIRInstructionEffects.ReadsHeap
+        | LIRInstructionEffects.MayThrow;
+
+    private const LIRInstructionEffects HeapWriteEffects =
+        LIRInstructionEffects.ReadsHeap
+        | LIRInstructionEffects.WritesHeap
+        | LIRInstructionEffects.MayThrow;
+
+    private static readonly Type[] _knownInstructionTypes =
+    {
+        typeof(LIRAddAndToNumber),
+        typeof(LIRAddDynamic),
+        typeof(LIRAddDynamicDoubleObject),
+        typeof(LIRAddDynamicObjectDouble),
+        typeof(LIRAddNumber),
+        typeof(LIRArrayAdd),
+        typeof(LIRArrayPushRange),
+        typeof(LIRAsyncCallMoveNext),
+        typeof(LIRAsyncInitialize),
+        typeof(LIRAsyncLoadAwaitedResult),
+        typeof(LIRAsyncLoadState),
+        typeof(LIRAsyncReject),
+        typeof(LIRAsyncResolve),
+        typeof(LIRAsyncReturnPromise),
+        typeof(LIRAsyncStateSwitch),
+        typeof(LIRAsyncStoreAwaitedResult),
+        typeof(LIRAsyncStoreState),
+        typeof(LIRAwait),
+        typeof(LIRBinaryDynamicOperator),
+        typeof(LIRBitwiseAnd),
+        typeof(LIRBitwiseNotDynamic),
+        typeof(LIRBitwiseNotNumber),
+        typeof(LIRBitwiseOr),
+        typeof(LIRBitwiseXor),
+        typeof(LIRBranch),
+        typeof(LIRBranchIfFalse),
+        typeof(LIRBranchIfTrue),
+        typeof(LIRBuildArray),
+        typeof(LIRBuildScopesArray),
+        typeof(LIRCallDeclaredCallable),
+        typeof(LIRCallFunction),
+        typeof(LIRCallFunctionBaseConstructor),
+        typeof(LIRCallFunctionValue),
+        typeof(LIRCallFunctionValue0),
+        typeof(LIRCallFunctionValue1),
+        typeof(LIRCallFunctionValue2),
+        typeof(LIRCallFunctionValue3),
+        typeof(LIRCallFunctionWithArgsArray),
+        typeof(LIRCallImport),
+        typeof(LIRCallInstanceMethod),
+        typeof(LIRCallIntrinsic),
+        typeof(LIRCallIntrinsicBaseConstructor),
+        typeof(LIRCallIntrinsicGlobalFunction),
+        typeof(LIRCallIntrinsicStatic),
+        typeof(LIRCallIntrinsicStaticVoid),
+        typeof(LIRCallIntrinsicStaticVoidWithArgsArray),
+        typeof(LIRCallIntrinsicStaticWithArgsArray),
+        typeof(LIRCallIsTruthy),
+        typeof(LIRCallIsTruthyBool),
+        typeof(LIRCallIsTruthyDouble),
+        typeof(LIRCallMember),
+        typeof(LIRCallMember0),
+        typeof(LIRCallMember1),
+        typeof(LIRCallMember2),
+        typeof(LIRCallMember3),
+        typeof(LIRCallRequire),
+        typeof(LIRCallRuntimeServicesStatic),
+        typeof(LIRCallTypedMember),
+        typeof(LIRCallTypedMemberWithFallback),
+        typeof(LIRCallUserClassBaseConstructor),
+        typeof(LIRCallUserClassBaseInstanceMethod),
+        typeof(LIRCallUserClassInstanceMethod),
+        typeof(LIRCompareBooleanEqual),
+        typeof(LIRCompareBooleanNotEqual),
+        typeof(LIRCompareNumberEqual),
+        typeof(LIRCompareNumberGreaterThan),
+        typeof(LIRCompareNumberGreaterThanOrEqual),
+        typeof(LIRCompareNumberLessThan),
+        typeof(LIRCompareNumberLessThanOrEqual),
+        typeof(LIRCompareNumberNotEqual),
+        typeof(LIRConcatStrings),
+        typeof(LIRConstBoolean),
+        typeof(LIRConstNull),
+        typeof(LIRConstNumber),
+        typeof(LIRConstructValue),
+        typeof(LIRConstString),
+        typeof(LIRConstUndefined),
+        typeof(LIRConvertToBoolean),
+        typeof(LIRConvertToNumber),
+        typeof(LIRConvertToNumberDiscard),
+        typeof(LIRConvertToObject),
+        typeof(LIRConvertToString),
+        typeof(LIRCopyTemp),
+        typeof(LIRCreateBoundArrowFunction),
+        typeof(LIRCreateBoundFunctionExpression),
+        typeof(LIRCreateLeafScopeInstance),
+        typeof(LIRCreateScopeInstance),
+        typeof(LIRDivNumber),
+        typeof(LIREndFinally),
+        typeof(LIREqualDynamic),
+        typeof(LIRExpNumber),
+        typeof(LIRGeneratorStateSwitch),
+        typeof(LIRGetInferredMember),
+        typeof(LIRGetInt32ArrayElement),
+        typeof(LIRGetInt32ArrayLength),
+        typeof(LIRGetIntrinsicGlobal),
+        typeof(LIRGetIntrinsicGlobalFunction),
+        typeof(LIRGetItem),
+        typeof(LIRGetItemAsNumber),
+        typeof(LIRGetItemAsNumberString),
+        typeof(LIRGetJsArrayElement),
+        typeof(LIRGetJsArrayLength),
+        typeof(LIRGetLength),
+        typeof(LIRGetStringLength),
+        typeof(LIRGetUserClassType),
+        typeof(LIRInOperator),
+        typeof(LIRInstanceOfOperator),
+        typeof(LIRIsInstanceOf),
+        typeof(LIRLabel),
+        typeof(LIRLeave),
+        typeof(LIRLeftShift),
+        typeof(LIRLoadLeafScopeField),
+        typeof(LIRLoadNewTarget),
+        typeof(LIRLoadParameter),
+        typeof(LIRLoadParentScopeField),
+        typeof(LIRLoadScopeField),
+        typeof(LIRLoadScopeFieldByName),
+        typeof(LIRLoadScopesArgument),
+        typeof(LIRLoadThis),
+        typeof(LIRLoadUserClassInstanceField),
+        typeof(LIRLoadUserClassStaticField),
+        typeof(LIRLogicalNot),
+        typeof(LIRModNumber),
+        typeof(LIRMulDynamic),
+        typeof(LIRMulNumber),
+        typeof(LIRNegateNumber),
+        typeof(LIRNegateNumberDynamic),
+        typeof(LIRNewBuiltInError),
+        typeof(LIRNewInferredJsObject),
+        typeof(LIRNewIntrinsicObject),
+        typeof(LIRNewJsArray),
+        typeof(LIRNewJsObject),
+        typeof(LIRNewUserClass),
+        typeof(LIRNotEqualDynamic),
+        typeof(LIRReturn),
+        typeof(LIRReturnUndefinedImmediate),
+        typeof(LIRRightShift),
+        typeof(LIRSequencePoint),
+        typeof(LIRSetInferredMember),
+        typeof(LIRSetInt32ArrayElement),
+        typeof(LIRSetItem),
+        typeof(LIRSetJsArrayElement),
+        typeof(LIRSetJsArrayLength),
+        typeof(LIRStoreException),
+        typeof(LIRStoreLeafScopeField),
+        typeof(LIRStoreParameter),
+        typeof(LIRStoreParentScopeField),
+        typeof(LIRStoreScopeField),
+        typeof(LIRStoreScopeFieldByName),
+        typeof(LIRStoreUserClassInstanceField),
+        typeof(LIRStoreUserClassStaticField),
+        typeof(LIRStrictEqualDynamic),
+        typeof(LIRStrictNotEqualDynamic),
+        typeof(LIRSubNumber),
+        typeof(LIRTailCallFunctionReturn),
+        typeof(LIRThrow),
+        typeof(LIRThrowNewTypeError),
+        typeof(LIRTypeof),
+        typeof(LIRUnsignedRightShift),
+        typeof(LIRUnwrapCatchException),
+        typeof(LIRYield)
+    };
+
+    private static readonly HashSet<Type> _knownInstructionTypeSet =
+        new(_knownInstructionTypes);
+
+    internal static IReadOnlyList<Type> KnownInstructionTypes => _knownInstructionTypes;
+
+    internal static bool IsKnownInstructionType(Type type)
+        => _knownInstructionTypeSet.Contains(type);
+
+    internal static LIRInstructionMetadata GetMetadata(LIRInstruction instruction)
+    {
+        ArgumentNullException.ThrowIfNull(instruction);
+
+        var instructionType = instruction.GetType();
+        if (!_knownInstructionTypeSet.Contains(instructionType))
+        {
+            return new LIRInstructionMetadata(
+                LIRInstructionEffects.UnsupportedBarrier,
+                InstructionDisposition.EmitNormally,
+                LIRImplicitStackInput.None,
+                LIRDefinitionKind.None,
+                new LIRStackSignature(Pops: 0, Pushes: 0),
+                IsSchedulingBoundary: true);
+        }
+
+        var effects = GetEffects(instruction);
+        var implicitInput = instruction is LIRStoreException
+            ? LIRImplicitStackInput.CatchException
+            : LIRImplicitStackInput.None;
+        var definitionKind = instruction switch
+        {
+            LIRStoreException => LIRDefinitionKind.CatchException,
+            LIRAwait or LIRYield => LIRDefinitionKind.ResumeResult,
+            _ when TryGetDefinedTemp(instruction, out _) =>
+                LIRDefinitionKind.InstructionResult,
+            _ => LIRDefinitionKind.None
+        };
+        var stackSignature = GetStackSignature(instruction, implicitInput);
+        var isBoundary = implicitInput != LIRImplicitStackInput.None
+            || instruction is LIRSequencePoint
+            || (effects & (
+                LIRInstructionEffects.ControlFlow
+                | LIRInstructionEffects.Suspension
+                | LIRInstructionEffects.ScopeReplacement
+                | LIRInstructionEffects.EmitsInternalControlFlow
+                | LIRInstructionEffects.UnsupportedBarrier)) != 0;
+
+        return new LIRInstructionMetadata(
+            effects,
+            InstructionDisposition.EmitNormally,
+            implicitInput,
+            definitionKind,
+            stackSignature,
+            isBoundary);
+    }
+
+    internal static bool TryGetDefinedTemp(
+        LIRInstruction instruction,
+        out TempVariable defined)
+    {
+        switch (instruction)
+        {
+            case LIRStoreException storeException:
+                defined = storeException.Result;
+                return true;
+            case LIRUnwrapCatchException unwrapCatch:
+                defined = unwrapCatch.Result;
+                return true;
+            default:
+                return TempLocalAllocator.TryGetDefinedTemp(instruction, out defined);
+        }
+    }
+
+    internal static void VisitUsedTemps<TVisitor>(
+        LIRInstruction instruction,
+        ref TVisitor visitor)
+        where TVisitor : struct, ITempUseVisitor
+    {
+        switch (instruction)
+        {
+            case LIRThrow throwInstruction:
+                visitor.Visit(throwInstruction.Value);
+                return;
+            case LIRUnwrapCatchException unwrapCatch:
+                visitor.Visit(unwrapCatch.Exception);
+                return;
+            default:
+                TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
+                return;
+        }
+    }
+
+    internal static bool UsesTemp(LIRInstruction instruction, TempVariable target)
+    {
+        var visitor = new TempMatchVisitor(target.Index);
+        VisitUsedTemps(instruction, ref visitor);
+        return visitor.Found;
+    }
+
+    private static LIRStackSignature GetStackSignature(
+        LIRInstruction instruction,
+        LIRImplicitStackInput implicitInput)
+    {
+        var visitor = new TempCountVisitor();
+        VisitUsedTemps(instruction, ref visitor);
+        var pops = visitor.Count
+            + (implicitInput == LIRImplicitStackInput.CatchException ? 1 : 0);
+        var pushes = instruction is LIRStoreException or LIRAwait or LIRYield
+            ? 0
+            : TryGetDefinedTemp(instruction, out _) ? 1 : 0;
+        return new LIRStackSignature(pops, pushes);
+    }
+
+    private static LIRInstructionEffects GetEffects(LIRInstruction instruction)
+        => instruction switch
+        {
+            // Native constants and typed operators are pure and non-throwing.
+            LIRConstNumber
+                or LIRConstString
+                or LIRConstBoolean
+                or LIRConstUndefined
+                or LIRConstNull
+                or LIRAddNumber
+                or LIRSubNumber
+                or LIRMulNumber
+                or LIRDivNumber
+                or LIRModNumber
+                or LIRExpNumber
+                or LIRBitwiseAnd
+                or LIRBitwiseOr
+                or LIRBitwiseXor
+                or LIRLeftShift
+                or LIRRightShift
+                or LIRUnsignedRightShift
+                or LIRCompareNumberLessThan
+                or LIRCompareNumberGreaterThan
+                or LIRCompareNumberLessThanOrEqual
+                or LIRCompareNumberGreaterThanOrEqual
+                or LIRCompareNumberEqual
+                or LIRCompareNumberNotEqual
+                or LIRCompareBooleanEqual
+                or LIRCompareBooleanNotEqual
+                or LIRNegateNumber
+                or LIRBitwiseNotNumber
+                or LIRIsInstanceOf
+                or LIRTypeof
+                or LIRCopyTemp
+                => LIRInstructionEffects.None,
+
+            LIRLoadParameter
+                or LIRLoadThis
+                or LIRLoadScopesArgument
+                or LIRLoadNewTarget
+                => LIRInstructionEffects.ReadsMutableSlot,
+
+            LIRStoreParameter
+                => LIRInstructionEffects.WritesMutableSlot,
+
+            LIRLoadLeafScopeField loadLeaf =>
+                LIRInstructionEffects.ReadsScope
+                | (loadLeaf.Binding.RequiresRuntimeTemporalDeadZoneChecks
+                    ? LIRInstructionEffects.MayThrow
+                    : LIRInstructionEffects.None),
+            LIRLoadParentScopeField loadParent =>
+                LIRInstructionEffects.ReadsScope
+                | (loadParent.Binding.RequiresRuntimeTemporalDeadZoneChecks
+                    ? LIRInstructionEffects.MayThrow
+                    : LIRInstructionEffects.None),
+            LIRLoadScopeField loadScope =>
+                LIRInstructionEffects.ReadsScope
+                | (loadScope.Binding.RequiresRuntimeTemporalDeadZoneChecks
+                    ? LIRInstructionEffects.MayThrow
+                    : LIRInstructionEffects.None),
+            LIRLoadScopeFieldByName => LIRInstructionEffects.ReadsScope,
+
+            LIRStoreLeafScopeField
+                or LIRStoreParentScopeField
+                or LIRStoreScopeField
+                or LIRStoreScopeFieldByName
+                => LIRInstructionEffects.WritesScope,
+
+            LIRCreateLeafScopeInstance
+                or LIRCreateScopeInstance
+                => LIRInstructionEffects.ScopeReplacement
+                    | LIRInstructionEffects.Allocates,
+
+            LIRLabel
+                or LIRBranch
+                or LIRBranchIfFalse
+                or LIRBranchIfTrue
+                or LIRLeave
+                or LIREndFinally
+                or LIRReturn
+                or LIRReturnUndefinedImmediate
+                => LIRInstructionEffects.ControlFlow,
+
+            LIRThrow
+                or LIRThrowNewTypeError
+                => LIRInstructionEffects.ControlFlow
+                    | LIRInstructionEffects.MayThrow,
+
+            LIRSequencePoint => LIRInstructionEffects.None,
+            LIRStoreException => LIRInstructionEffects.None,
+            LIRUnwrapCatchException =>
+                LIRInstructionEffects.EmitsInternalControlFlow
+                | LIRInstructionEffects.MayThrow,
+
+            LIRAwait
+                or LIRYield
+                => LIRInstructionEffects.Suspension
+                    | LIRInstructionEffects.EmitsInternalControlFlow
+                    | CallEffects,
+
+            LIRGeneratorStateSwitch
+                or LIRAsyncInitialize
+                or LIRAsyncCallMoveNext
+                or LIRAsyncReturnPromise
+                or LIRAsyncLoadState
+                or LIRAsyncStoreState
+                or LIRAsyncResolve
+                or LIRAsyncReject
+                or LIRAsyncStateSwitch
+                or LIRAsyncStoreAwaitedResult
+                or LIRAsyncLoadAwaitedResult
+                => LIRInstructionEffects.EmitsInternalControlFlow
+                    | CallEffects,
+
+            LIRGetItem
+                or LIRGetItemAsNumber
+                or LIRGetItemAsNumberString
+                or LIRGetJsArrayElement
+                or LIRGetInt32ArrayElement
+                or LIRGetLength
+                or LIRGetJsArrayLength
+                or LIRGetInt32ArrayLength
+                or LIRGetStringLength
+                or LIRGetInferredMember
+                or LIRLoadUserClassInstanceField
+                or LIRLoadUserClassStaticField
+                or LIRGetIntrinsicGlobal
+                or LIRGetIntrinsicGlobalFunction
+                or LIRGetUserClassType
+                => HeapReadEffects,
+
+            LIRSetItem
+                or LIRSetJsArrayLength
+                or LIRSetJsArrayElement
+                or LIRSetInt32ArrayElement
+                or LIRSetInferredMember
+                or LIRArrayPushRange
+                or LIRArrayAdd
+                or LIRStoreUserClassInstanceField
+                or LIRStoreUserClassStaticField
+                => HeapWriteEffects,
+
+            LIRBuildArray
+                or LIRBuildScopesArray
+                or LIRNewJsArray
+                or LIRNewJsObject
+                or LIRNewInferredJsObject
+                => LIRInstructionEffects.Allocates
+                    | LIRInstructionEffects.MayThrow,
+
+            LIRNewBuiltInError
+                or LIRNewIntrinsicObject
+                or LIRNewUserClass
+                or LIRConstructValue
+                or LIRCreateBoundArrowFunction
+                or LIRCreateBoundFunctionExpression
+                => CallEffects
+                    | LIRInstructionEffects.Allocates,
+
+            LIRCallIntrinsic
+                or LIRCallIntrinsicGlobalFunction
+                or LIRCallIntrinsicStatic
+                or LIRCallIntrinsicStaticWithArgsArray
+                or LIRCallIntrinsicStaticVoid
+                or LIRCallIntrinsicStaticVoidWithArgsArray
+                or LIRCallIntrinsicBaseConstructor
+                or LIRCallInstanceMethod
+                or LIRCallFunction
+                or LIRTailCallFunctionReturn
+                or LIRCallFunctionWithArgsArray
+                or LIRCallFunctionValue
+                or LIRCallFunctionValue0
+                or LIRCallFunctionValue1
+                or LIRCallFunctionValue2
+                or LIRCallFunctionValue3
+                or LIRCallRequire
+                or LIRCallImport
+                or LIRCallMember
+                or LIRCallMember0
+                or LIRCallMember1
+                or LIRCallMember2
+                or LIRCallMember3
+                or LIRCallTypedMember
+                or LIRCallTypedMemberWithFallback
+                or LIRCallUserClassInstanceMethod
+                or LIRCallUserClassBaseConstructor
+                or LIRCallUserClassBaseInstanceMethod
+                or LIRCallFunctionBaseConstructor
+                or LIRCallDeclaredCallable
+                or LIRCallRuntimeServicesStatic
+                => CallEffects,
+
+            LIRConcatStrings
+                => LIRInstructionEffects.Allocates
+                    | LIRInstructionEffects.MayThrow,
+
+            LIRAddAndToNumber
+                or LIRAddDynamic
+                or LIRAddDynamicDoubleObject
+                or LIRAddDynamicObjectDouble
+                or LIRMulDynamic
+                or LIRBinaryDynamicOperator
+                or LIREqualDynamic
+                or LIRNotEqualDynamic
+                or LIRStrictEqualDynamic
+                or LIRStrictNotEqualDynamic
+                or LIRInOperator
+                or LIRInstanceOfOperator
+                or LIRConvertToObject
+                or LIRConvertToNumber
+                or LIRConvertToNumberDiscard
+                or LIRConvertToBoolean
+                or LIRConvertToString
+                or LIRNegateNumberDynamic
+                or LIRBitwiseNotDynamic
+                or LIRLogicalNot
+                or LIRCallIsTruthy
+                or LIRCallIsTruthyDouble
+                or LIRCallIsTruthyBool
+                => CallEffects,
+
+            _ => LIRInstructionEffects.UnsupportedBarrier
+        };
+
+    private struct TempCountVisitor : ITempUseVisitor
+    {
+        internal int Count { get; private set; }
+
+        public void Visit(TempVariable temp)
+        {
+            Count++;
+        }
+    }
+
+    private struct TempMatchVisitor : ITempUseVisitor
+    {
+        private readonly int _targetIndex;
+
+        internal TempMatchVisitor(int targetIndex)
+        {
+            _targetIndex = targetIndex;
+        }
+
+        internal bool Found { get; private set; }
+
+        public void Visit(TempVariable temp)
+        {
+            Found |= temp.Index == _targetIndex;
+        }
+    }
+}

--- a/src/Compiler/IL/LIRInstructionInfo.cs
+++ b/src/Compiler/IL/LIRInstructionInfo.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using Jroc.IR;
 
 namespace Jroc.IL;
@@ -236,7 +238,47 @@ internal static class LIRInstructionInfo
     private static readonly HashSet<Type> _knownInstructionTypeSet =
         new(_knownInstructionTypes);
 
-    internal static IReadOnlyList<Type> KnownInstructionTypes => _knownInstructionTypes;
+    private static readonly ReadOnlyCollection<Type> _readOnlyKnownInstructionTypes =
+        Array.AsReadOnly(_knownInstructionTypes);
+
+    private static readonly HashSet<Type> _schedulingBoundaryTypeSet =
+    [
+        typeof(LIRLabel),
+        typeof(LIRBranch),
+        typeof(LIRBranchIfFalse),
+        typeof(LIRBranchIfTrue),
+        typeof(LIRLeave),
+        typeof(LIREndFinally),
+        typeof(LIRReturn),
+        typeof(LIRReturnUndefinedImmediate),
+        typeof(LIRTailCallFunctionReturn),
+        typeof(LIRThrow),
+        typeof(LIRThrowNewTypeError),
+        typeof(LIRSequencePoint),
+        typeof(LIRStoreException),
+        typeof(LIRUnwrapCatchException),
+        typeof(LIRAwait),
+        typeof(LIRYield),
+        typeof(LIRGeneratorStateSwitch),
+        typeof(LIRAsyncInitialize),
+        typeof(LIRAsyncCallMoveNext),
+        typeof(LIRAsyncReturnPromise),
+        typeof(LIRAsyncLoadState),
+        typeof(LIRAsyncStoreState),
+        typeof(LIRAsyncResolve),
+        typeof(LIRAsyncReject),
+        typeof(LIRAsyncStateSwitch),
+        typeof(LIRAsyncStoreAwaitedResult),
+        typeof(LIRAsyncLoadAwaitedResult),
+        typeof(LIRCreateLeafScopeInstance),
+        typeof(LIRCreateScopeInstance)
+    ];
+
+    private static readonly ConcurrentDictionary<Type, LIRInstructionEffects>
+        _staticEffectsByType = new();
+
+    internal static IReadOnlyList<Type> KnownInstructionTypes =>
+        _readOnlyKnownInstructionTypes;
 
     internal static bool IsKnownInstructionType(Type type)
         => _knownInstructionTypeSet.Contains(type);
@@ -261,23 +303,18 @@ internal static class LIRInstructionInfo
         var implicitInput = instruction is LIRStoreException
             ? LIRImplicitStackInput.CatchException
             : LIRImplicitStackInput.None;
+        var hasDefinition = TryGetDefinedTemp(instruction, out _);
         var definitionKind = instruction switch
         {
             LIRStoreException => LIRDefinitionKind.CatchException,
             LIRAwait or LIRYield => LIRDefinitionKind.ResumeResult,
-            _ when TryGetDefinedTemp(instruction, out _) =>
-                LIRDefinitionKind.InstructionResult,
+            _ when hasDefinition => LIRDefinitionKind.InstructionResult,
             _ => LIRDefinitionKind.None
         };
-        var stackSignature = GetStackSignature(instruction, implicitInput);
-        var isBoundary = implicitInput != LIRImplicitStackInput.None
-            || instruction is LIRSequencePoint
-            || (effects & (
-                LIRInstructionEffects.ControlFlow
-                | LIRInstructionEffects.Suspension
-                | LIRInstructionEffects.ScopeReplacement
-                | LIRInstructionEffects.EmitsInternalControlFlow
-                | LIRInstructionEffects.UnsupportedBarrier)) != 0;
+        var stackSignature = GetStackSignature(
+            instruction,
+            implicitInput,
+            hasDefinition);
 
         return new LIRInstructionMetadata(
             effects,
@@ -285,7 +322,16 @@ internal static class LIRInstructionInfo
             implicitInput,
             definitionKind,
             stackSignature,
-            isBoundary);
+            IsSchedulingBoundary(instruction));
+    }
+
+    internal static bool IsSchedulingBoundary(LIRInstruction instruction)
+    {
+        ArgumentNullException.ThrowIfNull(instruction);
+
+        var instructionType = instruction.GetType();
+        return !_knownInstructionTypeSet.Contains(instructionType)
+            || _schedulingBoundaryTypeSet.Contains(instructionType);
     }
 
     internal static bool TryGetDefinedTemp(
@@ -333,7 +379,8 @@ internal static class LIRInstructionInfo
 
     private static LIRStackSignature GetStackSignature(
         LIRInstruction instruction,
-        LIRImplicitStackInput implicitInput)
+        LIRImplicitStackInput implicitInput,
+        bool hasDefinition)
     {
         var visitor = new TempCountVisitor();
         VisitUsedTemps(instruction, ref visitor);
@@ -341,11 +388,45 @@ internal static class LIRInstructionInfo
             + (implicitInput == LIRImplicitStackInput.CatchException ? 1 : 0);
         var pushes = instruction is LIRStoreException or LIRAwait or LIRYield
             ? 0
-            : TryGetDefinedTemp(instruction, out _) ? 1 : 0;
+            : hasDefinition ? 1 : 0;
         return new LIRStackSignature(pops, pushes);
     }
 
     private static LIRInstructionEffects GetEffects(LIRInstruction instruction)
+    {
+        // Runtime TDZ requirements are binding-instance data, so these three
+        // instruction families cannot use the otherwise type-stable cache.
+        if (instruction is LIRLoadLeafScopeField loadLeaf)
+        {
+            return LIRInstructionEffects.ReadsScope
+                | (loadLeaf.Binding.RequiresRuntimeTemporalDeadZoneChecks
+                    ? LIRInstructionEffects.MayThrow
+                    : LIRInstructionEffects.None);
+        }
+
+        if (instruction is LIRLoadParentScopeField loadParent)
+        {
+            return LIRInstructionEffects.ReadsScope
+                | (loadParent.Binding.RequiresRuntimeTemporalDeadZoneChecks
+                    ? LIRInstructionEffects.MayThrow
+                    : LIRInstructionEffects.None);
+        }
+
+        if (instruction is LIRLoadScopeField loadScope)
+        {
+            return LIRInstructionEffects.ReadsScope
+                | (loadScope.Binding.RequiresRuntimeTemporalDeadZoneChecks
+                    ? LIRInstructionEffects.MayThrow
+                    : LIRInstructionEffects.None);
+        }
+
+        return _staticEffectsByType.GetOrAdd(
+            instruction.GetType(),
+            static (_, value) => GetStaticEffects(value),
+            instruction);
+    }
+
+    private static LIRInstructionEffects GetStaticEffects(LIRInstruction instruction)
         => instruction switch
         {
             // Native constants and typed operators are pure and non-throwing.
@@ -390,21 +471,10 @@ internal static class LIRInstructionInfo
             LIRStoreParameter
                 => LIRInstructionEffects.WritesMutableSlot,
 
-            LIRLoadLeafScopeField loadLeaf =>
-                LIRInstructionEffects.ReadsScope
-                | (loadLeaf.Binding.RequiresRuntimeTemporalDeadZoneChecks
-                    ? LIRInstructionEffects.MayThrow
-                    : LIRInstructionEffects.None),
-            LIRLoadParentScopeField loadParent =>
-                LIRInstructionEffects.ReadsScope
-                | (loadParent.Binding.RequiresRuntimeTemporalDeadZoneChecks
-                    ? LIRInstructionEffects.MayThrow
-                    : LIRInstructionEffects.None),
-            LIRLoadScopeField loadScope =>
-                LIRInstructionEffects.ReadsScope
-                | (loadScope.Binding.RequiresRuntimeTemporalDeadZoneChecks
-                    ? LIRInstructionEffects.MayThrow
-                    : LIRInstructionEffects.None),
+            LIRLoadLeafScopeField
+                or LIRLoadParentScopeField
+                or LIRLoadScopeField
+                => LIRInstructionEffects.ReadsScope,
             LIRLoadScopeFieldByName => LIRInstructionEffects.ReadsScope,
 
             LIRStoreLeafScopeField

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -134,7 +134,7 @@ internal static class LIRStackScheduler
             return Array.Empty<ScheduledRegion>();
         }
 
-        var regions = new ScheduledRegion[operations.Length];
+        var regions = new ScheduledRegion[(operations.Length / 2) + 1];
         var regionCount = 0;
         var regionStartOperation = -1;
 
@@ -146,7 +146,7 @@ internal static class LIRStackScheduler
             {
                 var instruction = methodBody.Instructions[
                     operation.GetLirInstructionIndex(offset)];
-                if (LIRInstructionInfo.GetMetadata(instruction).IsSchedulingBoundary)
+                if (LIRInstructionInfo.IsSchedulingBoundary(instruction))
                 {
                     isBoundary = true;
                     break;

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -29,6 +29,7 @@ internal static class LIRStackScheduler
         ArgumentNullException.ThrowIfNull(methodBody);
 
         var operations = BuildIdentityOperations(methodBody);
+        var regions = BuildSchedulingRegions(methodBody, operations);
         var tempResidencies = new TempResidency[methodBody.Temps.Count];
         Array.Fill(tempResidencies, TempResidency.MaterializedLocal);
 
@@ -38,13 +39,13 @@ internal static class LIRStackScheduler
         return new LIRStackSchedule(
             LIRStackSchedulerMode.Identity,
             operations,
-            Array.Empty<ScheduledRegion>(),
+            regions,
             tempResidencies,
             ownedTemps,
             effectiveLastUses,
             MaxStackDepth: 0,
             new LIRStackScheduleMetrics(
-                ScheduledRegionCount: 0,
+                ScheduledRegionCount: regions.Length,
                 StackResidentTempCount: 0,
                 EliminatedSpillCount: 0));
     }
@@ -116,31 +117,79 @@ internal static class LIRStackScheduler
              instructionIndex++)
         {
             var visitor = new LastUseVisitor(lastUses, instructionIndex);
-            VisitIdentityUsedTemps(methodBody.Instructions[instructionIndex], ref visitor);
+             LIRInstructionInfo.VisitUsedTemps(
+                 methodBody.Instructions[instructionIndex],
+                 ref visitor);
         }
 
         return lastUses;
     }
 
-    private static void VisitIdentityUsedTemps<TVisitor>(
-        LIRInstruction instruction,
-        ref TVisitor visitor)
-        where TVisitor : struct, ITempUseVisitor
+    private static ScheduledRegion[] BuildSchedulingRegions(
+        MethodBodyIR methodBody,
+        ScheduledOperation[] operations)
     {
-        // These exception operands are not yet present in the allocator's
-        // legacy visitor. Keep identity schedule metadata correct without
-        // changing legacy allocation/output in this no-IL-change stage.
-        switch (instruction)
+        if (operations.Length == 0)
         {
-            case LIRThrow throwInstruction:
-                visitor.Visit(throwInstruction.Value);
+            return Array.Empty<ScheduledRegion>();
+        }
+
+        var regions = new ScheduledRegion[operations.Length];
+        var regionCount = 0;
+        var regionStartOperation = -1;
+
+        for (var operationIndex = 0; operationIndex < operations.Length; operationIndex++)
+        {
+            var operation = operations[operationIndex];
+            var isBoundary = false;
+            for (var offset = 0; offset < operation.InstructionCount; offset++)
+            {
+                var instruction = methodBody.Instructions[
+                    operation.GetLirInstructionIndex(offset)];
+                if (LIRInstructionInfo.GetMetadata(instruction).IsSchedulingBoundary)
+                {
+                    isBoundary = true;
+                    break;
+                }
+            }
+
+            if (isBoundary)
+            {
+                AppendRegionBeforeBoundary(operationIndex);
+                continue;
+            }
+
+            if (regionStartOperation < 0)
+            {
+                regionStartOperation = operationIndex;
+            }
+        }
+
+        AppendRegionBeforeBoundary(operations.Length);
+
+        if (regionCount != regions.Length)
+        {
+            Array.Resize(ref regions, regionCount);
+        }
+
+        return regions;
+
+        void AppendRegionBeforeBoundary(int endOperationIndexExclusive)
+        {
+            if (regionStartOperation < 0)
+            {
                 return;
-            case LIRUnwrapCatchException unwrapCatch:
-                visitor.Visit(unwrapCatch.Exception);
-                return;
-            default:
-                TempLocalAllocator.VisitUsedTemps(instruction, ref visitor);
-                return;
+            }
+
+            var firstOperation = operations[regionStartOperation];
+            var lastOperation = operations[endOperationIndexExclusive - 1];
+            regions[regionCount++] = new ScheduledRegion(
+                firstOperation.StartLirIndex,
+                lastOperation.EndLirIndexExclusive,
+                regionStartOperation,
+                endOperationIndexExclusive - regionStartOperation,
+                MaxStackDepth: 0);
+            regionStartOperation = -1;
         }
     }
 

--- a/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
+++ b/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
@@ -33,6 +33,12 @@ internal sealed partial class LIRToILCompiler
         var emitPdb = compilerOptions?.EmitPdb == true;
         var schedulerMode = compilerOptions?.LIRStackSchedulerMode
             ?? LIRStackSchedulerMode.Identity;
+
+#if DEBUG
+        // Validate the actual scheduler input after all LIR normalization passes.
+        LIRBodyValidator.Validate(MethodBody);
+#endif
+
         var stackSchedule = schedulerMode == LIRStackSchedulerMode.Disabled
             ? null
             : LIRStackScheduler.Build(

--- a/tests/Jroc.Tests/LIRInstructionInfoTests.cs
+++ b/tests/Jroc.Tests/LIRInstructionInfoTests.cs
@@ -1,0 +1,197 @@
+using Acornima.Ast;
+using Jroc.DebugSymbols;
+using Jroc.IL;
+using Jroc.IR;
+using Jroc.Services;
+using Jroc.SymbolTables;
+
+namespace Jroc.Tests;
+
+public sealed class LIRInstructionInfoTests
+{
+    [Fact]
+    public void KnownInstructionTypes_ExhaustivelyMatchConcreteLirTypes()
+    {
+        var actual = typeof(LIRInstruction).Assembly
+            .GetTypes()
+            .Where(type =>
+                type is { IsAbstract: false }
+                && typeof(LIRInstruction).IsAssignableFrom(type))
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToArray();
+        var known = LIRInstructionInfo.KnownInstructionTypes
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(actual, known);
+        Assert.Equal(known.Length, known.Distinct().Count());
+    }
+
+    [Fact]
+    public void TypedNumericInstructions_ArePureAndNonBoundary()
+    {
+        var metadata = LIRInstructionInfo.GetMetadata(new LIRAddNumber(
+            new TempVariable(0),
+            new TempVariable(1),
+            new TempVariable(2)));
+
+        Assert.Equal(LIRInstructionEffects.None, metadata.Effects);
+        Assert.Equal(InstructionDisposition.EmitNormally, metadata.DefaultDisposition);
+        Assert.Equal(LIRImplicitStackInput.None, metadata.ImplicitStackInput);
+        Assert.Equal(LIRDefinitionKind.InstructionResult, metadata.DefinitionKind);
+        Assert.Equal(new LIRStackSignature(Pops: 2, Pushes: 1), metadata.StackSignature);
+        Assert.False(metadata.IsSchedulingBoundary);
+    }
+
+    [Fact]
+    public void CallInstructions_HaveConservativeCallEffects()
+    {
+        var metadata = LIRInstructionInfo.GetMetadata(new LIRCallMember0(
+            new TempVariable(0),
+            "method",
+            new TempVariable(1)));
+
+        AssertEffects(
+            metadata,
+            LIRInstructionEffects.Calls
+                | LIRInstructionEffects.MayThrow
+                | LIRInstructionEffects.ReadsHeap
+                | LIRInstructionEffects.WritesHeap);
+        Assert.False(metadata.IsSchedulingBoundary);
+    }
+
+    [Fact]
+    public void MutableAndHeapStores_AreClassifiedAsWrites()
+    {
+        var parameterStore = LIRInstructionInfo.GetMetadata(
+            new LIRStoreParameter(1, new TempVariable(0)));
+        var itemStore = LIRInstructionInfo.GetMetadata(new LIRSetItem(
+            new TempVariable(0),
+            new TempVariable(1),
+            new TempVariable(2),
+            new TempVariable(3)));
+
+        AssertEffects(parameterStore, LIRInstructionEffects.WritesMutableSlot);
+        AssertEffects(
+            itemStore,
+            LIRInstructionEffects.ReadsHeap
+                | LIRInstructionEffects.WritesHeap
+                | LIRInstructionEffects.MayThrow);
+    }
+
+    [Fact]
+    public void TdzCheckedScopeLoad_IsMayThrowAndOrderingSensitive()
+    {
+        var parser = new JavaScriptParser();
+        var program = parser.ParseJavaScript("let value;", "tdz.js");
+        var declaration = Assert.IsType<VariableDeclaration>(Assert.Single(program.Body));
+        var scope = new Scope("global", ScopeKind.Global, parent: null, program);
+        var binding = new BindingInfo("value", BindingKind.Let, scope, declaration)
+        {
+            RequiresRuntimeTemporalDeadZoneChecks = true
+        };
+        var metadata = LIRInstructionInfo.GetMetadata(new LIRLoadLeafScopeField(
+            binding,
+            default,
+            new ScopeId("global"),
+            new TempVariable(0)));
+
+        AssertEffects(
+            metadata,
+            LIRInstructionEffects.ReadsScope | LIRInstructionEffects.MayThrow);
+        Assert.False(metadata.IsSchedulingBoundary);
+    }
+
+    [Fact]
+    public void ScopeCreation_IsReplacementBoundary()
+    {
+        var metadata = LIRInstructionInfo.GetMetadata(
+            new LIRCreateLeafScopeInstance(new ScopeId("block")));
+
+        AssertEffects(
+            metadata,
+            LIRInstructionEffects.ScopeReplacement | LIRInstructionEffects.Allocates);
+        Assert.True(metadata.IsSchedulingBoundary);
+    }
+
+    [Fact]
+    public void CatchStore_ConsumesImplicitExceptionAndDefinesMaterializedResult()
+    {
+        var instruction = new LIRStoreException(new TempVariable(0));
+        var metadata = LIRInstructionInfo.GetMetadata(instruction);
+
+        Assert.Equal(
+            LIRImplicitStackInput.CatchException,
+            metadata.ImplicitStackInput);
+        Assert.Equal(LIRDefinitionKind.CatchException, metadata.DefinitionKind);
+        Assert.Equal(new LIRStackSignature(Pops: 1, Pushes: 0), metadata.StackSignature);
+        Assert.True(metadata.IsSchedulingBoundary);
+        Assert.True(LIRInstructionInfo.TryGetDefinedTemp(instruction, out var defined));
+        Assert.Equal(0, defined.Index);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AwaitAndYield_DefineResumeResultsAndAreOpaqueBoundaries(bool isAwait)
+    {
+        var input = new TempVariable(0);
+        var result = new TempVariable(1);
+        LIRInstruction instruction = isAwait
+            ? new LIRAwait(input, AwaitId: 0, ResumeStateId: 1, ResumeLabelId: 10, result)
+            : new LIRYield(input, ResumeStateId: 1, ResumeLabelId: 10, result);
+
+        var metadata = LIRInstructionInfo.GetMetadata(instruction);
+
+        Assert.Equal(LIRDefinitionKind.ResumeResult, metadata.DefinitionKind);
+        Assert.True(metadata.Effects.HasFlag(LIRInstructionEffects.Suspension));
+        Assert.True(metadata.Effects.HasFlag(LIRInstructionEffects.EmitsInternalControlFlow));
+        Assert.True(metadata.IsSchedulingBoundary);
+        Assert.True(LIRInstructionInfo.TryGetDefinedTemp(instruction, out var defined));
+        Assert.Equal(result, defined);
+        Assert.True(LIRInstructionInfo.UsesTemp(instruction, input));
+    }
+
+    [Fact]
+    public void CatchUnwrap_UsesExceptionDefinesResultAndEmitsInternalControlFlow()
+    {
+        var exception = new TempVariable(0);
+        var result = new TempVariable(1);
+        var instruction = new LIRUnwrapCatchException(exception, result);
+        var metadata = LIRInstructionInfo.GetMetadata(instruction);
+
+        Assert.True(LIRInstructionInfo.UsesTemp(instruction, exception));
+        Assert.True(LIRInstructionInfo.TryGetDefinedTemp(instruction, out var defined));
+        Assert.Equal(result, defined);
+        Assert.True(metadata.Effects.HasFlag(LIRInstructionEffects.EmitsInternalControlFlow));
+        Assert.True(metadata.IsSchedulingBoundary);
+    }
+
+    [Fact]
+    public void UnknownInstruction_FailsClosedAsUnsupportedBoundary()
+    {
+        var metadata = LIRInstructionInfo.GetMetadata(new UnknownInstruction());
+
+        Assert.Equal(
+            LIRInstructionEffects.UnsupportedBarrier,
+            metadata.Effects);
+        Assert.True(metadata.IsSchedulingBoundary);
+        Assert.False(LIRInstructionInfo.IsKnownInstructionType(typeof(UnknownInstruction)));
+    }
+
+    [Fact]
+    public void SequencePoint_IsAlwaysSchedulingBoundary()
+    {
+        var metadata = LIRInstructionInfo.GetMetadata(
+            new LIRSequencePoint(SourceSpan.Hidden("source.js")));
+
+        Assert.True(metadata.IsSchedulingBoundary);
+    }
+
+    private static void AssertEffects(
+        LIRInstructionMetadata metadata,
+        LIRInstructionEffects expected)
+        => Assert.Equal(expected, metadata.Effects);
+
+    private sealed record UnknownInstruction : LIRInstruction;
+}

--- a/tests/Jroc.Tests/LIRStackSchedulerTests.cs
+++ b/tests/Jroc.Tests/LIRStackSchedulerTests.cs
@@ -1,3 +1,4 @@
+using Jroc.DebugSymbols;
 using Jroc.IL;
 using Jroc.IR;
 using Jroc.Services.TwoPhaseCompilation;
@@ -53,6 +54,12 @@ public sealed class LIRStackSchedulerTests
             schedule.TempResidencies);
         Assert.All(schedule.OwnedTemps, Assert.False);
         Assert.Equal(new[] { 2, 2, 3 }, schedule.EffectiveLastUses);
+        var region = Assert.Single(schedule.Regions);
+        Assert.Equal(0, region.StartLirIndex);
+        Assert.Equal(3, region.EndLirIndexExclusive);
+        Assert.Equal(0, region.StartOperationIndex);
+        Assert.Equal(3, region.OperationCount);
+        Assert.Equal(1, schedule.Metrics.ScheduledRegionCount);
     }
 
     [Fact]
@@ -74,6 +81,75 @@ public sealed class LIRStackSchedulerTests
         Assert.Equal(
             Enumerable.Range(0, body.Instructions.Count),
             schedule.Operations.Select(operation => operation.StartLirIndex));
+        Assert.Collection(
+            schedule.Regions,
+            region =>
+            {
+                Assert.Equal(0, region.StartLirIndex);
+                Assert.Equal(1, region.EndLirIndexExclusive);
+            },
+            region =>
+            {
+                Assert.Equal(2, region.StartLirIndex);
+                Assert.Equal(3, region.EndLirIndexExclusive);
+            });
+    }
+
+    [Fact]
+    public void Identity_SequencePointAndScopeCreation_SplitRegions()
+    {
+        var body = new MethodBodyIR();
+        var first = AddTemp(body);
+        var second = AddTemp(body);
+
+        body.Instructions.Add(new LIRConstNumber(1, first));
+        body.Instructions.Add(new LIRSequencePoint(SourceSpan.Hidden("source.js")));
+        body.Instructions.Add(new LIRConstNumber(2, second));
+        body.Instructions.Add(new LIRCreateLeafScopeInstance(new ScopeId("block")));
+        body.Instructions.Add(new LIRCopyTemp(second, first));
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Collection(
+            schedule.Regions,
+            region =>
+            {
+                Assert.Equal(0, region.StartLirIndex);
+                Assert.Equal(1, region.EndLirIndexExclusive);
+            },
+            region =>
+            {
+                Assert.Equal(2, region.StartLirIndex);
+                Assert.Equal(3, region.EndLirIndexExclusive);
+            },
+            region =>
+            {
+                Assert.Equal(4, region.StartLirIndex);
+                Assert.Equal(5, region.EndLirIndexExclusive);
+            });
+    }
+
+    [Fact]
+    public void Identity_InternalControlFlowAndUnknownInstructions_AreOpaqueBoundaries()
+    {
+        var body = new MethodBodyIR();
+        var exception = AddTemp(body);
+        var result = AddTemp(body);
+        var value = AddTemp(body);
+
+        body.Instructions.Add(new LIRConstUndefined(exception));
+        body.Instructions.Add(new LIRUnwrapCatchException(exception, result));
+        body.Instructions.Add(new LIRConstNumber(1, value));
+        body.Instructions.Add(new UnknownInstruction());
+        body.Instructions.Add(new LIRCopyTemp(value, result));
+
+        var schedule = LIRStackScheduler.Identity(body);
+
+        Assert.Collection(
+            schedule.Regions,
+            region => Assert.Equal((0, 1), (region.StartLirIndex, region.EndLirIndexExclusive)),
+            region => Assert.Equal((2, 3), (region.StartLirIndex, region.EndLirIndexExclusive)),
+            region => Assert.Equal((4, 5), (region.StartLirIndex, region.EndLirIndexExclusive)));
     }
 
     [Fact]
@@ -237,6 +313,13 @@ public sealed class LIRStackSchedulerTests
             function numeric(a, b) { return a * 2 + b; }
             function control(a) { if (a) return 1; return 2; }
             function call(a) { return Math.floor(a); }
+            function eh(a) {
+              try { return a + 1; }
+              catch (e) { return 0; }
+              finally { Math.floor(a); }
+            }
+            function* gen(a) { yield a + 1; return a + 2; }
+            async function af(a) { return (await a) + 1; }
             class Bar { constructor(value) { this.value = value; } }
             class Foo {
               constructor() {
@@ -290,6 +373,8 @@ public sealed class LIRStackSchedulerTests
             ?? throw new InvalidOperationException(
                 $"Compilation failed. Errors: {logger.Errors}\nWarnings: {logger.Warnings}");
     }
+
+    private sealed record UnknownInstruction : LIRInstruction;
 
     private static void AssertEquivalentMethodBodies(byte[] expectedPe, byte[] actualPe)
     {


### PR DESCRIPTION
## Summary

Implements #1620, the second foundation step of #1617.

This PR gives the identity scheduler a canonical, exhaustive view of LIR
semantics and partitions source-order operations into conservative
straight-line candidate regions. It intentionally performs **no instruction
reordering and no new stack-residency optimization**.

Generated IL, Stackify behavior, allocator decisions, constructor fusion,
maxstack, and Portable PDB output remain unchanged.

## Canonical LIR instruction metadata

Added `src/Compiler/IL/LIRInstructionInfo.cs`, which explicitly inventories
every current concrete `LIRInstruction` subtype and provides scheduler-facing:

- ordered temp definitions and uses;
- semantic LIR stack signatures;
- default instruction disposition;
- mutable-slot, scope, and heap read/write effects;
- call, allocation, and may-throw effects;
- control-flow, suspension, scope-replacement, and hidden internal-CFG flags;
- scheduling-boundary classification;
- catch-handler implicit stack input;
- catch, await, and yield definition kinds.

A reflection test compares the inventory against every concrete LIR subtype in
the compiler assembly. Adding a new instruction now fails the test until it is
classified.

Unknown runtime instruction types fail closed as `UnsupportedBarrier`.

### Implicit definitions and stack inputs

- `LIRStoreException` declares `CatchException` input and consumes the CLR
  exception object supplied at catch entry.
- `LIRAwait` and `LIRYield` declare `ResumeResult` definitions rather than
  ordinary producer results.
- `LIRUnwrapCatchException` is classified as an opaque internal-control-flow
  boundary because its emitter expands into branches.

## Conservative scheduling regions

`LIRStackScheduler.Identity` now discovers source-order candidate regions in
the flat operation array. Regions contain only operations between conservative
boundaries.

Boundaries include:

- labels, branches, `leave`, return, throw, and `endfinally`;
- `LIRSequencePoint`;
- catch entry and hidden EH control flow;
- `yield`, `await`, and async/generator state-machine operations;
- scope creation/replacement;
- unknown or unsupported instructions.

Identity emission still enumerates the original operations in the original
order. `StackResidentTempCount`, `EliminatedSpillCount`, and schedule maxstack
remain zero.

## Final normalized-LIR validation

`LIRBodyValidator` now uses canonical definition metadata and runs again in
DEBUG at the actual scheduler input boundary:

```text
all normalization passes
  -> final LIRBodyValidator.Validate
  -> LIRStackScheduler
```

This catches normalization-induced invariant violations that the earlier
post-lowering validation point cannot see.

## Allocation remains intentionally unchanged

The allocator and legacy Stackify still use their existing def/use switches in
this PR. Routing allocator liveness through newly complete catch metadata
changed generator/EH snapshots, which belongs to schedule-aware liveness issue
#1622.

The scheduler and validator use canonical metadata now; allocator migration is
kept isolated so this PR maintains its no-IL-change contract.

## Tests

Added `LIRInstructionInfoTests` covering:

- exhaustive concrete-type inventory;
- pure typed numeric classification;
- conservative call, mutable-slot, heap-store, TDZ, and scope-replacement
  effects;
- catch implicit input/definition;
- await/yield resume-result definitions and opaque suspension boundaries;
- catch-unwrapping def/use/internal-CFG behavior;
- unknown-instruction fail-closed behavior;
- sequence-point boundaries.

Expanded `LIRStackSchedulerTests` with:

- exact candidate-region windows;
- branch/control boundaries;
- sequence-point and scope-replacement splits;
- opaque internal-control-flow and unknown barriers;
- EH, generator, and async constructs in disabled-versus-identity method-body
  and PDB equivalence coverage.

## Documentation

Updated:

- `docs/compiler/LIRStackScheduler.md`
- `docs/compiler/Stackify.md`
- `CHANGELOG.md`

The scheduler guide now documents canonical metadata, effects, implicit
definitions, conservative regions, allocator migration boundaries, and the
remaining rollout order.

## Performance and scalability review

A dedicated performance review measured end-to-end compilation on synthetic
single-function workloads containing 500-4000 statements:

| Workload | master | PR before tuning |
|---|---:|---:|
| 2000 statements, Release | 6.15s | 6.20s |
| 2000 statements, Debug | 8.25s | 8.28s |
| 4000 statements, Release | 20.44s | 20.77s |

The PR is within measurement noise end to end; the repository's existing
superlinear behavior on very large functions dominates.

The review did identify metadata-layer constants that would compound as later
stages add consumers. This PR now also:

- uses a direct type-based scheduling-boundary lookup, so region discovery no
  longer constructs the full metadata record or walks def/use switches just to
  read one boundary bit;
- caches type-stable effect classification, with only binding-instance TDZ
  behavior evaluated per instruction;
- computes a definition once per full metadata request instead of twice;
- exposes the concrete-type inventory through a read-only wrapper;
- sizes the region buffer to its theoretical maximum
  (`operations / 2 + 1`) instead of one region per operation;
- sizes `LIRBodyValidator`'s defined-temp set by temp count instead of
  instruction count.

All scheduler work remains O(instructions + temps). Identity scheduling still
performs separate operation, region, and last-use scans; consolidating them is
intentionally deferred until schedule-aware liveness (#1622), because current
end-to-end overhead is below noise and premature fusion would couple two staged
migrations.

## Validation

- `dotnet build src/Jroc.Core/Jroc.Core.csproj` — succeeds with zero warnings.
- Focused metadata/region/validator/allocator/Stackify/PDB suite:
  **65/65 pass**.
- Focused catch/finally, async-generator, generator-resume, and class-throw
  execution cases: **4/4 pass**.
- No `.received.*` snapshot files were produced.

Broader regression coverage is delegated to PR CI per the repository workflow.

## Review notes

The highest-value review area is `LIRInstructionInfo.GetEffects`: classifications
are deliberately conservative. Misclassifying an operation as effectful only
reduces a future scheduling region; misclassifying an effectful operation as
pure could eventually permit unsafe movement.

Closes #1620.
