### PR TITLE
fix(test): prune stale temp artifacts per run

### DIFF
--- a/scripts/cleanupTempTestArtifacts.js
+++ b/scripts/cleanupTempTestArtifacts.js
@@ -128,6 +128,7 @@ function isTopLevelCandidateName(name) {
   // Roots created by .NET tests
   if (name === 'Jroc.Tests') return true;
   if (name.startsWith('Jroc.Tests.')) return true; // e.g. Jroc.Tests.ILVerification
+  if (name === 'Jroc.Test262.Tests') return true;
   if (name === 'jroc-tests') return true;
 
   // Per-test roots created by CLI tests
@@ -150,8 +151,11 @@ function isTopLevelCandidateName(name) {
 }
 
 function isManagedRootName(name) {
-  // For these roots we clean their children (not just the root itself)
-  return name === 'Jroc.Tests' || name.startsWith('Jroc.Tests.') || name === 'jroc-tests';
+  // For these roots we clean individual artifacts instead of the root itself.
+  return name === 'Jroc.Tests'
+    || name.startsWith('Jroc.Tests.')
+    || name === 'Jroc.Test262.Tests'
+    || name === 'jroc-tests';
 }
 
 async function listTopLevelCandidates(tempRoot) {
@@ -164,10 +168,34 @@ async function listTopLevelCandidates(tempRoot) {
   return out;
 }
 
-async function listManagedRootChildren(rootPath) {
+async function listManagedRootArtifacts(rootPath) {
   try {
-    const entries = await fsp.readdir(rootPath, { withFileTypes: true });
-    return entries.map(e => ({ name: e.name, fullPath: path.join(rootPath, e.name), dirent: e }));
+    const roots = await fsp.readdir(rootPath, { withFileTypes: true });
+    const artifacts = [];
+
+    for (const root of roots) {
+      const rootItem = { name: root.name, fullPath: path.join(rootPath, root.name), dirent: root };
+      if (!root.isDirectory()) {
+        artifacts.push(rootItem);
+        continue;
+      }
+
+      const children = await fsp.readdir(rootItem.fullPath, { withFileTypes: true });
+      if (children.length === 0) {
+        artifacts.push(rootItem);
+        continue;
+      }
+
+      // Jroc.Tests stores artifacts as <category>.ExecutionTests/<run-id>.
+      // Check each artifact timestamp so a recent run does not retain older runs.
+      artifacts.push(...children.map(child => ({
+        name: child.name,
+        fullPath: path.join(rootItem.fullPath, child.name),
+        dirent: child,
+      })));
+    }
+
+    return artifacts;
   } catch {
     return [];
   }
@@ -201,11 +229,11 @@ async function main() {
 
   const top = await listTopLevelCandidates(tempRoot);
 
-  // Expand managed roots to their children for finer-grained cleanup
+  // Expand managed roots to individual artifacts for finer-grained cleanup.
   const expanded = [];
   for (const item of top) {
     if (isManagedRootName(item.name) && item.dirent.isDirectory()) {
-      expanded.push(...(await listManagedRootChildren(item.fullPath)));
+      expanded.push(...(await listManagedRootArtifacts(item.fullPath)));
       continue;
     }
     expanded.push(item);

--- a/scripts/cleanupTempTestArtifacts.test.js
+++ b/scripts/cleanupTempTestArtifacts.test.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const scriptPath = path.join(__dirname, 'cleanupTempTestArtifacts.js');
+const oneDayAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+
+async function createArtifact(root, parts, modifiedAt) {
+  const artifactPath = path.join(root, ...parts);
+  await fs.mkdir(artifactPath, { recursive: true });
+  await fs.writeFile(path.join(artifactPath, 'artifact.dll'), 'test artifact');
+  await fs.utimes(artifactPath, modifiedAt, modifiedAt);
+  return artifactPath;
+}
+
+test('removes old individual test artifacts while preserving recent runs', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'jroc-cleanup-test-'));
+
+  try {
+    const oldJrocRun = await createArtifact(
+      tempRoot,
+      ['Jroc.Tests', 'Array.ExecutionTests', 'old-run'],
+      oneDayAgo);
+    const recentJrocRun = await createArtifact(
+      tempRoot,
+      ['Jroc.Tests', 'Array.ExecutionTests', 'recent-run'],
+      new Date());
+    const oldTest262Run = await createArtifact(
+      tempRoot,
+      ['Jroc.Test262.Tests', 'CompilationFailure', 'old-run'],
+      oneDayAgo);
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--apply', '--older-than-hours', '24'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, TEMP: tempRoot, TMP: tempRoot },
+      });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(fs.access(oldJrocRun));
+    await assert.rejects(fs.access(oldTest262Run));
+    await fs.access(recentJrocRun);
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes stale JROC test artifact cleanup by pruning individual run directories instead of category directories, and adds the Test262 temp root. Includes a Node regression test covering old and recent runs.