### PR TITLE
fix(ci): show PR number in snapshot workflow runs

### DIFF
--- a/.github/workflows/update-generator-snapshots.yml
+++ b/.github/workflows/update-generator-snapshots.yml
@@ -1,5 +1,5 @@
 name: Update generator snapshots
-run-name: ${{ github.workflow }} - PR #${{ github.event.inputs.pr_number }}
+run-name: "${{ github.workflow }} - PR #${{ inputs.pr_number }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Quotes the generator snapshot workflow run name so YAML preserves the PR number after the literal # marker. Uses the workflow-dispatch inputs context for the number.