### PR TITLE
test(compiler): cover stable-load GetItem receivers

### DIFF
--- a/tests/Jroc.Tests/Array/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Array/ExecutionTests.cs
@@ -154,5 +154,8 @@ namespace Jroc.Tests.Array
 
         [Fact]
         public Task Array_NumericStorage_Basic() { var testName = nameof(Array_NumericStorage_Basic); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Array_StableLoadReceiver_EvaluationOrder() { var testName = nameof(Array_StableLoadReceiver_EvaluationOrder); return ExecutionTest(testName); }
     }
 }

--- a/tests/Jroc.Tests/Array/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Array/GeneratorTests.cs
@@ -150,5 +150,8 @@ namespace Jroc.Tests.Array
 
         [Fact]
         public Task Array_NumericStorage_Basic() { var testName = nameof(Array_NumericStorage_Basic); return GenerateTest(testName); }
+
+        [Fact]
+        public Task Array_StableLoadReceiver_EvaluationOrder() { var testName = nameof(Array_StableLoadReceiver_EvaluationOrder); return GenerateTest(testName); }
     }
 }

--- a/tests/Jroc.Tests/Array/JavaScript/Array_StableLoadReceiver_EvaluationOrder.js
+++ b/tests/Jroc.Tests/Array/JavaScript/Array_StableLoadReceiver_EvaluationOrder.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var order = [];
+var innerReadCount = 0;
+var outerReadCount = 0;
+var nested = {
+    get value() {
+        outerReadCount++;
+        order.push("outer");
+        return 42;
+    }
+};
+var values = [];
+
+Object.defineProperty(values, "0", {
+    get() {
+        innerReadCount++;
+        order.push("inner");
+        return nested;
+    }
+});
+
+console.log(values[0].value);
+console.log(order.join(","), innerReadCount, outerReadCount);

--- a/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
@@ -1,0 +1,2 @@
+﻿42
+inner,outer 1 1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
@@ -1,0 +1,354 @@
+﻿// IL code: Array_StableLoadReceiver_EvaluationOrder
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Array_StableLoadReceiver_EvaluationOrder
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_nested
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x227f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 05 00 00 02
+			)
+			// Method begins at RVA 0x21c8
+			// Header size: 12
+			// Code size: 78 (0x4e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: ldc.r8 1
+			IL_0014: add
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: ldloc.1
+			IL_001f: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
+			IL_0024: ldarg.0
+			IL_0025: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_002f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0034: ldstr "outer"
+			IL_0039: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_003e: pop
+			IL_003f: ldc.r8 42
+			IL_0048: box [System.Runtime]System.Double
+			IL_004d: ret
+		} // end of method FunctionExpression_nested::__js_call__
+
+	} // end of class FunctionExpression_nested
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L16C7
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2288
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 05 00 00 02
+			)
+			// Method begins at RVA 0x2224
+			// Header size: 12
+			// Code size: 70 (0x46)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: ldc.r8 1
+			IL_0014: add
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: ldloc.1
+			IL_001f: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
+			IL_0024: ldarg.0
+			IL_0025: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_002f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0034: ldstr "inner"
+			IL_0039: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_003e: pop
+			IL_003f: ldarg.0
+			IL_0040: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::'nested'
+			IL_0045: ret
+		} // end of method FunctionExpression_L16C7::__js_call__
+
+	} // end of class FunctionExpression_L16C7
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 66 53 63 6f 70 65 20 6f 72 64 65 72 3d 7b
+			6f 72 64 65 72 7d 2c 20 69 6e 6e 65 72 52 65 61
+			64 43 6f 75 6e 74 3d 7b 69 6e 6e 65 72 52 65 61
+			64 43 6f 75 6e 74 7d 2c 20 6f 75 74 65 72 52 65
+			61 64 43 6f 75 6e 74 3d 7b 6f 75 74 65 72 52 65
+			61 64 43 6f 75 6e 74 7d 2c 20 6e 65 73 74 65 64
+			3d 7b 6e 65 73 74 65 64 7d 00 00
+		)
+		// Fields
+		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
+		.field public object innerReadCount
+		.field public object outerReadCount
+		.field public object 'nested'
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2276
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 362 (0x16a)
+		.maxstack 10
+		.locals init (
+			[0] class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] object
+		)
+
+		IL_0000: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: nop
+		IL_0007: ldc.i4.0
+		IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_000d: stloc.2
+		IL_000e: ldloc.0
+		IL_000f: ldloc.2
+		IL_0010: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
+		IL_0015: ldloc.0
+		IL_0016: ldc.r8 0.0
+		IL_001f: box [System.Runtime]System.Double
+		IL_0024: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
+		IL_0029: ldloc.0
+		IL_002a: ldc.r8 0.0
+		IL_0033: box [System.Runtime]System.Double
+		IL_0038: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
+		IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0042: stloc.3
+		IL_0043: ldloc.0
+		IL_0044: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
+		IL_0049: ldftn object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
+		IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0054: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0059: ldc.i4.0
+		IL_005a: conv.r8
+		IL_005b: ldstr ""
+		IL_0060: ldc.i4.0
+		IL_0061: ldc.i4.1
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0067: stloc.s 4
+		IL_0069: ldloc.s 4
+		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.3
+		IL_0073: ldstr "value"
+		IL_0078: ldloc.s 4
+		IL_007a: ldnull
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_0080: pop
+		IL_0081: ldloc.0
+		IL_0082: ldloc.3
+		IL_0083: stfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::'nested'
+		IL_0088: ldc.i4.0
+		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_008e: stloc.1
+		IL_008f: ldloc.0
+		IL_0090: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
+		IL_0095: ldftn object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
+		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00a5: ldc.i4.0
+		IL_00a6: conv.r8
+		IL_00a7: ldstr ""
+		IL_00ac: ldc.i4.0
+		IL_00ad: ldc.i4.1
+		IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_00b3: stloc.s 4
+		IL_00b5: ldloc.s 4
+		IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_00bc: stloc.s 4
+		IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00c3: dup
+		IL_00c4: ldstr "get"
+		IL_00c9: ldloc.s 4
+		IL_00cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00d0: stloc.3
+		IL_00d1: ldloc.1
+		IL_00d2: ldstr "0"
+		IL_00d7: ldloc.3
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_00dd: pop
+		IL_00de: ldstr "console"
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ed: stloc.s 5
+		IL_00ef: ldloc.1
+		IL_00f0: ldc.r8 0.0
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00fe: ldstr "value"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0108: stloc.s 6
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "log"
+		IL_0111: ldloc.s 6
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0118: pop
+		IL_0119: ldstr "console"
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0128: stloc.s 6
+		IL_012a: ldloc.0
+		IL_012b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: ldstr "join"
+		IL_013a: ldstr ","
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0144: stloc.s 5
+		IL_0146: ldloc.0
+		IL_0147: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
+		IL_014c: stloc.s 7
+		IL_014e: ldloc.0
+		IL_014f: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
+		IL_0154: stloc.s 8
+		IL_0156: ldloc.s 6
+		IL_0158: ldstr "log"
+		IL_015d: ldloc.s 5
+		IL_015f: ldloc.s 7
+		IL_0161: ldloc.s 8
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0168: pop
+		IL_0169: ret
+	} // end of method Array_StableLoadReceiver_EvaluationOrder::__js_module_init__
+
+} // end of class Modules.Array_StableLoadReceiver_EvaluationOrder
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2291
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Array_StableLoadReceiver_EvaluationOrder::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/LIRStackSchedulerTests.cs
+++ b/tests/Jroc.Tests/LIRStackSchedulerTests.cs
@@ -674,6 +674,243 @@ public sealed class LIRStackSchedulerTests
     }
 
     [Fact]
+    public void Build_ConversionsMode_CarriesStableArrayLoadIntoGenericGetItemReceiver()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.StackResident,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.True(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryMultiUseStableArrayLoad()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var property = AddTemp(body);
+        var first = AddTemp(body);
+        var second = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, first));
+        body.Instructions.Add(new LIRGetItem(receiver, property, second));
+        body.Instructions.Add(new LIRReturn(second));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.False(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryVariableSlotStableArrayLoad()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.TempVariableSlots.AddRange(
+            Enumerable.Repeat(-1, body.Temps.Count));
+        body.TempVariableSlots[receiver.Index] = 0;
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.False(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryStableArrayLoadAcrossScopeReplacement()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(
+            new LIRCreateLeafScopeInstance(new ScopeId("block")));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.False(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryStableArrayLoadAcrossSequencePoint()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(new LIRSequencePoint(
+            SourceSpan.Hidden("stable-load.js")));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.False(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryStableArrayLoadAcrossControlFlow()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(new LIRBranch(1));
+        body.Instructions.Add(new LIRLabel(1));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.False(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryStableArrayLoadAcrossEhEntry()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var receiver = AddTemp(body);
+        var exception = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, array));
+        body.Instructions.Add(new LIRLoadParameter(2, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, receiver));
+        body.Instructions.Add(new LIRLabel(10));
+        body.Instructions.Add(new LIRStoreException(exception));
+        body.Instructions.Add(new LIRConstString("value", property));
+        body.Instructions.Add(new LIRGetItem(receiver, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+        body.ExceptionRegions.Add(new ExceptionRegionInfo(
+            Jroc.IR.ExceptionRegionKind.Catch,
+            TryStartLabelId: 1,
+            TryEndLabelId: 2,
+            HandlerStartLabelId: 10,
+            HandlerEndLabelId: 11,
+            CatchType: typeof(Exception)));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[receiver.Index]);
+        Assert.False(schedule.OwnedTemps[receiver.Index]);
+    }
+
+    [Fact]
+    public void Build_ConversionsMode_DoesNotCarryStableArrayLoadAsGetItemIndex()
+    {
+        var body = new MethodBodyIR();
+        var target = AddTemp(body);
+        var array = AddTemp(body);
+        var index = AddTemp(body);
+        var property = AddTemp(body);
+        var result = AddTemp(body);
+        body.Instructions.Add(new LIRLoadParameter(1, target));
+        body.Instructions.Add(new LIRLoadParameter(2, array));
+        body.Instructions.Add(new LIRLoadParameter(3, index));
+        body.Instructions.Add(new LIRGetJsArrayElement(array, index, property));
+        body.Instructions.Add(new LIRGetItem(target, property, result));
+        body.Instructions.Add(new LIRReturn(result));
+
+        var schedule = LIRStackScheduler.Build(
+            body,
+            new LIRStackSchedulerOptions(
+                LIRStackSchedulerMode.ConversionsAndStableLoads));
+
+        Assert.Equal(
+            TempResidency.MaterializedLocal,
+            schedule.TempResidencies[property.Index]);
+        Assert.False(schedule.OwnedTemps[property.Index]);
+    }
+
+    [Fact]
     public void Build_CallResultsMode_CarriesCallResultIntoReceiverConsumer()
     {
         var body = new MethodBodyIR();


### PR DESCRIPTION
## Summary

- add direct scheduler coverage for stable Array loads consumed as generic `LIRGetItem` receivers
- cover multi-use, variable-slot, scope-replacement, sequence-point, control-flow, EH-entry, and invalid operand-order rejection
- verify nested observable property reads execute once in left-to-right order and retain spill-free generated IL

## Validation

- 64 focused scheduler, PDB, execution, and generator tests

Closes #1647
