### PR TITLE
fix(scripts): retry decompile test with build

### DIFF
--- a/scripts/decompileGeneratorTest.js
+++ b/scripts/decompileGeneratorTest.js
@@ -134,9 +134,17 @@ function main() {
     }
   );
 
-  if (testResult.status !== 0) {
-    // Try with build
-    console.log('Test failed or not found, retrying with build...');
+  const assemblyFileBaseName = getAssemblyFileBaseName(testName);
+  let assemblyPath =
+    testResult.status === 0
+      ? tryFindLatestGeneratedAssembly(category, assemblyFileBaseName)
+      : null;
+
+  // `dotnet test --no-build` can exit successfully without running tests when
+  // the test project has not been built yet. Only skip the build retry when
+  // the requested test actually produced an assembly.
+  if (!assemblyPath) {
+    console.log('Test did not produce an assembly, retrying with build...');
     const retryResult = childProcess.spawnSync(
       'dotnet',
       ['test', testProject, '--filter', `FullyQualifiedName=${fullTestName}`],
@@ -151,6 +159,11 @@ function main() {
       console.error(`Test ${fullTestName} failed or not found.`);
       process.exit(1);
     }
+
+    assemblyPath = tryFindLatestGeneratedAssembly(
+      category,
+      assemblyFileBaseName
+    );
   }
 
   // Step 2: Find the generated assembly
@@ -158,11 +171,6 @@ function main() {
   //   %TEMP%/Jroc.Tests/{Category}.GeneratorTests/{runId}/{assemblyName}.dll
   //   %TEMP%/Jroc.Tests/{Category}.ExecutionTests/{runId}/{assemblyName}.dll
   // where assemblyName is the basename of the JS entry file.
-  const assemblyFileBaseName = getAssemblyFileBaseName(testName);
-  const assemblyPath =
-    tryFindLatestGeneratedAssembly(category, assemblyFileBaseName) ??
-    null;
-
   if (!assemblyPath) {
     console.error(`Assembly not found for category '${category}' and test '${testName}'.`);
     console.error('Looked under:');

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ea
+				// Method begins at RVA 0x310a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f3
+				// Method begins at RVA 0x3113
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -253,7 +253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x310e
+					// Method begins at RVA 0x312e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -277,7 +277,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3078
+				// Method begins at RVA 0x3098
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -313,7 +313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3117
+					// Method begins at RVA 0x3137
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,7 +338,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3098
+				// Method begins at RVA 0x30b8
 				// Header size: 12
 				// Code size: 61 (0x3d)
 				.maxstack 8
@@ -393,7 +393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3105
+					// Method begins at RVA 0x3125
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -414,7 +414,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30fc
+				// Method begins at RVA 0x311c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -442,7 +442,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3132
+						// Method begins at RVA 0x3152
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,7 +460,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3129
+					// Method begins at RVA 0x3149
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -478,7 +478,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3120
+				// Method begins at RVA 0x3140
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -774,7 +774,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3144
+					// Method begins at RVA 0x3164
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -792,7 +792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x313b
+				// Method begins at RVA 0x315b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1015,7 +1015,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x315f
+						// Method begins at RVA 0x317f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1033,7 +1033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3156
+					// Method begins at RVA 0x3176
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1051,7 +1051,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314d
+				// Method begins at RVA 0x316d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1246,7 +1246,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3168
+				// Method begins at RVA 0x3188
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1352,7 +1352,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x317a
+					// Method begins at RVA 0x319a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1365,18 +1365,18 @@
 
 			} // end of class Block_L110C23
 
-			.class nested public auto ansi beforefieldinit Block_L137C31
+			.class nested public auto ansi beforefieldinit Block_L146C21
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested public auto ansi beforefieldinit Block_L150C34
+				.class nested public auto ansi beforefieldinit Block_L158C34
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318c
+						// Method begins at RVA 0x31ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1385,16 +1385,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L150C34::.ctor
+					} // end of method Block_L158C34::.ctor
 
-				} // end of class Block_L150C34
+				} // end of class Block_L158C34
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3183
+					// Method begins at RVA 0x31a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1403,18 +1403,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L137C31::.ctor
+				} // end of method Block_L146C21::.ctor
 
-			} // end of class Block_L137C31
+			} // end of class Block_L146C21
 
-			.class nested public auto ansi beforefieldinit Block_L166C21
+			.class nested public auto ansi beforefieldinit Block_L174C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3195
+					// Method begins at RVA 0x31b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1423,22 +1423,22 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L166C21::.ctor
+				} // end of method Block_L174C21::.ctor
 
-			} // end of class Block_L166C21
+			} // end of class Block_L174C21
 
-			.class nested public auto ansi beforefieldinit Scope_For_L170C9
+			.class nested public auto ansi beforefieldinit Scope_For_L178C9
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested public auto ansi beforefieldinit Block_L170C54
+				.class nested public auto ansi beforefieldinit Block_L178C54
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a7
+						// Method begins at RVA 0x31c7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1447,16 +1447,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L170C54::.ctor
+					} // end of method Block_L178C54::.ctor
 
-				} // end of class Block_L170C54
+				} // end of class Block_L178C54
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x319e
+					// Method begins at RVA 0x31be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1465,18 +1465,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Scope_For_L170C9::.ctor
+				} // end of method Scope_For_L178C9::.ctor
 
-			} // end of class Scope_For_L170C9
+			} // end of class Scope_For_L178C9
 
-			.class nested public auto ansi beforefieldinit Block_L180C6
+			.class nested public auto ansi beforefieldinit Block_L188C6
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b0
+					// Method begins at RVA 0x31d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1485,18 +1485,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L180C6::.ctor
+				} // end of method Block_L188C6::.ctor
 
-			} // end of class Block_L180C6
+			} // end of class Block_L188C6
 
-			.class nested public auto ansi beforefieldinit Block_L183C16
+			.class nested public auto ansi beforefieldinit Block_L191C16
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b9
+					// Method begins at RVA 0x31d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1505,16 +1505,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L183C16::.ctor
+				} // end of method Block_L191C16::.ctor
 
-			} // end of class Block_L183C16
+			} // end of class Block_L191C16
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3171
+				// Method begins at RVA 0x3191
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1542,7 +1542,7 @@
 			)
 			// Method begins at RVA 0x2954
 			// Header size: 12
-			// Code size: 1800 (0x708)
+			// Code size: 1830 (0x726)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1555,29 +1555,28 @@
 				[7] object,
 				[8] object,
 				[9] object,
-				[10] float64,
-				[11] class [System.Runtime]System.Exception,
-				[12] object,
+				[10] object,
+				[11] float64,
+				[12] class [System.Runtime]System.Exception,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] string,
-				[17] object,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[20] bool,
-				[21] object,
-				[22] object,
-				[23] float64,
-				[24] float64
+				[16] object,
+				[17] string,
+				[18] object,
+				[19] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[21] bool,
+				[22] float64,
+				[23] float64
 			)
 
 			IL_0000: ldstr "process"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: ldstr "argv"
 			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0014: stloc.s 15
-			IL_0016: ldloc.s 15
+			IL_0014: stloc.s 16
+			IL_0016: ldloc.s 16
 			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001d: ldstr "slice"
 			IL_0022: ldc.r8 2
@@ -1587,8 +1586,8 @@
 			IL_0036: ldloc.0
 			IL_0037: ldstr "length"
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 15
-			IL_0043: ldloc.s 15
+			IL_0041: stloc.s 16
+			IL_0043: ldloc.s 16
 			IL_0045: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_004a: ldc.r8 2
 			IL_0053: clt
@@ -1648,32 +1647,32 @@
 			IL_013c: stloc.2
 			IL_013d: ldloc.1
 			IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0143: stloc.s 16
+			IL_0143: stloc.s 17
 			IL_0145: ldstr "Jroc.Tests."
-			IL_014a: ldloc.s 16
+			IL_014a: ldloc.s 17
 			IL_014c: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0151: ldstr ".GeneratorTests."
 			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
 			IL_015b: ldloc.2
 			IL_015c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0161: stloc.s 16
-			IL_0163: ldloc.s 16
+			IL_0161: stloc.s 17
+			IL_0163: ldloc.s 17
 			IL_0165: call string [System.Runtime]System.String::Concat(string, string)
 			IL_016a: stloc.3
 			IL_016b: ldarg.0
 			IL_016c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
 			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0176: stloc.s 15
+			IL_0176: stloc.s 16
 			IL_0178: ldarg.0
 			IL_0179: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_017e: stloc.s 17
-			IL_0180: ldloc.s 15
+			IL_017e: stloc.s 18
+			IL_0180: ldloc.s 16
 			IL_0182: ldstr "join"
 			IL_0187: ldc.i4.4
 			IL_0188: newarr [System.Runtime]System.Object
 			IL_018d: dup
 			IL_018e: ldc.i4.0
-			IL_018f: ldloc.s 17
+			IL_018f: ldloc.s 18
 			IL_0191: stelem.ref
 			IL_0192: dup
 			IL_0193: ldc.i4.1
@@ -1692,30 +1691,30 @@
 			IL_01b1: ldstr "console"
 			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c0: stloc.s 15
+			IL_01c0: stloc.s 16
 			IL_01c2: ldloc.3
 			IL_01c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c8: stloc.s 16
+			IL_01c8: stloc.s 17
 			IL_01ca: ldstr "Running test: "
-			IL_01cf: ldloc.s 16
+			IL_01cf: ldloc.s 17
 			IL_01d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d6: stloc.s 16
-			IL_01d8: ldloc.s 15
+			IL_01d6: stloc.s 17
+			IL_01d8: ldloc.s 16
 			IL_01da: ldstr "log"
-			IL_01df: ldloc.s 16
+			IL_01df: ldloc.s 17
 			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_01e6: pop
 			IL_01e7: ldarg.0
 			IL_01e8: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
 			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f2: stloc.s 15
+			IL_01f2: stloc.s 16
 			IL_01f4: ldloc.3
 			IL_01f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01fa: stloc.s 16
+			IL_01fa: stloc.s 17
 			IL_01fc: ldstr "FullyQualifiedName="
-			IL_0201: ldloc.s 16
+			IL_0201: ldloc.s 17
 			IL_0203: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0208: stloc.s 16
+			IL_0208: stloc.s 17
 			IL_020a: ldc.i4.5
 			IL_020b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0210: dup
@@ -1728,15 +1727,15 @@
 			IL_0224: ldstr "--filter"
 			IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_022e: dup
-			IL_022f: ldloc.s 16
+			IL_022f: ldloc.s 17
 			IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0236: dup
 			IL_0237: ldstr "--no-build"
 			IL_023c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0241: stloc.s 18
+			IL_0241: stloc.s 19
 			IL_0243: ldarg.0
 			IL_0244: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0249: stloc.s 17
+			IL_0249: stloc.s 18
 			IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0250: dup
 			IL_0251: ldstr "stdio"
@@ -1748,375 +1747,391 @@
 			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_026c: dup
 			IL_026d: ldstr "cwd"
-			IL_0272: ldloc.s 17
+			IL_0272: ldloc.s 18
 			IL_0274: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0279: stloc.s 19
-			IL_027b: ldloc.s 15
+			IL_0279: stloc.s 20
+			IL_027b: ldloc.s 16
 			IL_027d: ldstr "spawnSync"
 			IL_0282: ldstr "dotnet"
-			IL_0287: ldloc.s 18
-			IL_0289: ldloc.s 19
+			IL_0287: ldloc.s 19
+			IL_0289: ldloc.s 20
 			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
 			IL_0290: stloc.s 5
-			IL_0292: ldloc.s 5
-			IL_0294: ldstr "status"
-			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029e: stloc.s 15
-			IL_02a0: ldloc.s 15
-			IL_02a2: ldc.r8 0.0
-			IL_02ab: box [System.Runtime]System.Double
-			IL_02b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02b5: stloc.s 20
-			IL_02b7: ldloc.s 20
-			IL_02b9: brfalse IL_0411
+			IL_0292: ldarg.0
+			IL_0293: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_0298: ldc.i4.1
+			IL_0299: newarr [System.Runtime]System.Object
+			IL_029e: dup
+			IL_029f: ldc.i4.0
+			IL_02a0: ldarg.0
+			IL_02a1: stelem.ref
+			IL_02a2: ldloc.2
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_02a8: stloc.s 6
+			IL_02aa: ldloc.s 5
+			IL_02ac: ldstr "status"
+			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b6: stloc.s 16
+			IL_02b8: ldloc.s 16
+			IL_02ba: ldc.r8 0.0
+			IL_02c3: box [System.Runtime]System.Double
+			IL_02c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02cd: stloc.s 21
+			IL_02cf: ldloc.s 21
+			IL_02d1: brfalse IL_02f9
 
-			IL_02be: ldstr "console"
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02cd: ldstr "log"
-			IL_02d2: ldstr "Test failed or not found, retrying with build..."
-			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02dc: pop
-			IL_02dd: ldarg.0
-			IL_02de: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e8: stloc.s 15
-			IL_02ea: ldloc.3
-			IL_02eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f0: stloc.s 16
-			IL_02f2: ldstr "FullyQualifiedName="
-			IL_02f7: ldloc.s 16
-			IL_02f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02fe: stloc.s 16
-			IL_0300: ldc.i4.4
-			IL_0301: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0306: dup
-			IL_0307: ldstr "test"
-			IL_030c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0311: dup
-			IL_0312: ldloc.s 4
-			IL_0314: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0319: dup
-			IL_031a: ldstr "--filter"
-			IL_031f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0324: dup
-			IL_0325: ldloc.s 16
-			IL_0327: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_032c: stloc.s 18
-			IL_032e: ldarg.0
-			IL_032f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0334: stloc.s 17
-			IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_033b: dup
-			IL_033c: ldstr "stdio"
-			IL_0341: ldstr "inherit"
-			IL_0346: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_034b: dup
-			IL_034c: ldstr "shell"
-			IL_0351: ldc.i4.1
-			IL_0352: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0357: dup
-			IL_0358: ldstr "cwd"
-			IL_035d: ldloc.s 17
-			IL_035f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0364: stloc.s 19
-			IL_0366: ldloc.s 15
-			IL_0368: ldstr "spawnSync"
-			IL_036d: ldstr "dotnet"
-			IL_0372: ldloc.s 18
-			IL_0374: ldloc.s 19
-			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_037b: stloc.s 6
-			IL_037d: ldloc.s 6
-			IL_037f: ldstr "status"
-			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0389: stloc.s 15
-			IL_038b: ldloc.s 15
-			IL_038d: ldc.r8 0.0
-			IL_0396: box [System.Runtime]System.Double
-			IL_039b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03a0: stloc.s 20
-			IL_03a2: ldloc.s 20
-			IL_03a4: brfalse IL_0411
+			IL_02d6: ldarg.0
+			IL_02d7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_02dc: ldc.i4.1
+			IL_02dd: newarr [System.Runtime]System.Object
+			IL_02e2: dup
+			IL_02e3: ldc.i4.0
+			IL_02e4: ldarg.0
+			IL_02e5: stelem.ref
+			IL_02e6: ldloc.1
+			IL_02e7: ldloc.s 6
+			IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02ee: stloc.s 16
+			IL_02f0: ldloc.s 16
+			IL_02f2: stloc.s 7
+			IL_02f4: br IL_0301
 
-			IL_03a9: ldstr "console"
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b8: stloc.s 15
-			IL_03ba: ldloc.3
-			IL_03bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03c0: stloc.s 16
-			IL_03c2: ldstr "Test "
-			IL_03c7: ldloc.s 16
-			IL_03c9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03ce: ldstr " failed or not found."
-			IL_03d3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03d8: stloc.s 16
-			IL_03da: ldloc.s 15
-			IL_03dc: ldstr "error"
-			IL_03e1: ldloc.s 16
-			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03e8: pop
-			IL_03e9: ldstr "process"
-			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f8: ldstr "exit"
-			IL_03fd: ldc.r8 1
-			IL_0406: box [System.Runtime]System.Double
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0410: pop
+			IL_02f9: ldc.i4.0
+			IL_02fa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02ff: stloc.s 7
 
-			IL_0411: ldarg.0
-			IL_0412: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_0417: ldc.i4.1
-			IL_0418: newarr [System.Runtime]System.Object
-			IL_041d: dup
-			IL_041e: ldc.i4.0
-			IL_041f: ldarg.0
-			IL_0420: stelem.ref
-			IL_0421: ldloc.2
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0427: stloc.s 7
-			IL_0429: ldarg.0
-			IL_042a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_042f: ldc.i4.1
-			IL_0430: newarr [System.Runtime]System.Object
-			IL_0435: dup
-			IL_0436: ldc.i4.0
-			IL_0437: ldarg.0
-			IL_0438: stelem.ref
-			IL_0439: ldloc.1
-			IL_043a: ldloc.s 7
-			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0441: stloc.s 15
-			IL_0443: ldloc.s 15
-			IL_0445: brfalse IL_045f
+			IL_0301: ldloc.s 7
+			IL_0303: stloc.s 8
+			IL_0305: ldloc.s 8
+			IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_030c: ldc.i4.0
+			IL_030d: ceq
+			IL_030f: stloc.s 21
+			IL_0311: ldloc.s 21
+			IL_0313: brfalse IL_0489
 
-			IL_044a: ldloc.s 15
-			IL_044c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0451: brtrue IL_045f
+			IL_0318: ldstr "console"
+			IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0327: ldstr "log"
+			IL_032c: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0336: pop
+			IL_0337: ldarg.0
+			IL_0338: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0342: stloc.s 16
+			IL_0344: ldloc.3
+			IL_0345: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_034a: stloc.s 17
+			IL_034c: ldstr "FullyQualifiedName="
+			IL_0351: ldloc.s 17
+			IL_0353: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0358: stloc.s 17
+			IL_035a: ldc.i4.4
+			IL_035b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0360: dup
+			IL_0361: ldstr "test"
+			IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_036b: dup
+			IL_036c: ldloc.s 4
+			IL_036e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0373: dup
+			IL_0374: ldstr "--filter"
+			IL_0379: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_037e: dup
+			IL_037f: ldloc.s 17
+			IL_0381: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0386: stloc.s 19
+			IL_0388: ldarg.0
+			IL_0389: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_038e: stloc.s 18
+			IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0395: dup
+			IL_0396: ldstr "stdio"
+			IL_039b: ldstr "inherit"
+			IL_03a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03a5: dup
+			IL_03a6: ldstr "shell"
+			IL_03ab: ldc.i4.1
+			IL_03ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03b1: dup
+			IL_03b2: ldstr "cwd"
+			IL_03b7: ldloc.s 18
+			IL_03b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03be: stloc.s 20
+			IL_03c0: ldloc.s 16
+			IL_03c2: ldstr "spawnSync"
+			IL_03c7: ldstr "dotnet"
+			IL_03cc: ldloc.s 19
+			IL_03ce: ldloc.s 20
+			IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_03d5: stloc.s 9
+			IL_03d7: ldloc.s 9
+			IL_03d9: ldstr "status"
+			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e3: stloc.s 16
+			IL_03e5: ldloc.s 16
+			IL_03e7: ldc.r8 0.0
+			IL_03f0: box [System.Runtime]System.Double
+			IL_03f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03fa: stloc.s 21
+			IL_03fc: ldloc.s 21
+			IL_03fe: brfalse IL_046b
 
-			IL_0456: ldloc.s 15
-			IL_0458: stloc.s 22
-			IL_045a: br IL_0467
+			IL_0403: ldstr "console"
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0412: stloc.s 16
+			IL_0414: ldloc.3
+			IL_0415: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_041a: stloc.s 17
+			IL_041c: ldstr "Test "
+			IL_0421: ldloc.s 17
+			IL_0423: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0428: ldstr " failed or not found."
+			IL_042d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0432: stloc.s 17
+			IL_0434: ldloc.s 16
+			IL_0436: ldstr "error"
+			IL_043b: ldloc.s 17
+			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0442: pop
+			IL_0443: ldstr "process"
+			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0452: ldstr "exit"
+			IL_0457: ldc.r8 1
+			IL_0460: box [System.Runtime]System.Double
+			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_046a: pop
 
-			IL_045f: ldc.i4.0
-			IL_0460: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0465: stloc.s 22
+			IL_046b: ldarg.0
+			IL_046c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_0471: ldc.i4.1
+			IL_0472: newarr [System.Runtime]System.Object
+			IL_0477: dup
+			IL_0478: ldc.i4.0
+			IL_0479: ldarg.0
+			IL_047a: stelem.ref
+			IL_047b: ldloc.1
+			IL_047c: ldloc.s 6
+			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0483: stloc.s 16
+			IL_0485: ldloc.s 16
+			IL_0487: stloc.s 8
 
-			IL_0467: ldloc.s 22
-			IL_0469: stloc.s 8
-			IL_046b: ldloc.s 8
-			IL_046d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0472: ldc.i4.0
-			IL_0473: ceq
-			IL_0475: stloc.s 20
-			IL_0477: ldloc.s 20
-			IL_0479: brfalse IL_05d1
+			IL_0489: ldloc.s 8
+			IL_048b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0490: ldc.i4.0
+			IL_0491: ceq
+			IL_0493: stloc.s 21
+			IL_0495: ldloc.s 21
+			IL_0497: brfalse IL_05ef
 
-			IL_047e: ldstr "console"
-			IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_048d: stloc.s 15
-			IL_048f: ldloc.1
-			IL_0490: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0495: stloc.s 16
-			IL_0497: ldstr "Assembly not found for category '"
-			IL_049c: ldloc.s 16
-			IL_049e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04a3: ldstr "' and test '"
-			IL_04a8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04ad: ldloc.2
+			IL_049c: ldstr "console"
+			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ab: stloc.s 16
+			IL_04ad: ldloc.1
 			IL_04ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04b3: stloc.s 16
-			IL_04b5: ldloc.s 16
-			IL_04b7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04bc: ldstr "'."
-			IL_04c1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04c6: stloc.s 16
-			IL_04c8: ldloc.s 15
-			IL_04ca: ldstr "error"
-			IL_04cf: ldloc.s 16
-			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04d6: pop
-			IL_04d7: ldstr "console"
-			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04e6: ldstr "error"
-			IL_04eb: ldstr "Looked under:"
-			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04f5: pop
-			IL_04f6: ldarg.0
-			IL_04f7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_04fc: ldc.i4.1
-			IL_04fd: newarr [System.Runtime]System.Object
-			IL_0502: dup
-			IL_0503: ldc.i4.0
-			IL_0504: ldarg.0
-			IL_0505: stelem.ref
-			IL_0506: ldloc.1
-			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_050c: stloc.s 9
-			IL_050e: ldc.r8 0.0
-			IL_0517: stloc.s 10
-			// loop start (head: IL_0519)
-				IL_0519: ldloc.s 10
-				IL_051b: stloc.s 23
-				IL_051d: ldloc.s 9
-				IL_051f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_0524: stloc.s 24
-				IL_0526: ldloc.s 23
-				IL_0528: ldloc.s 24
-				IL_052a: clt
-				IL_052c: brfalse IL_058a
+			IL_04b3: stloc.s 17
+			IL_04b5: ldstr "Assembly not found for category '"
+			IL_04ba: ldloc.s 17
+			IL_04bc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c1: ldstr "' and test '"
+			IL_04c6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04cb: ldloc.2
+			IL_04cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04d1: stloc.s 17
+			IL_04d3: ldloc.s 17
+			IL_04d5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04da: ldstr "'."
+			IL_04df: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04e4: stloc.s 17
+			IL_04e6: ldloc.s 16
+			IL_04e8: ldstr "error"
+			IL_04ed: ldloc.s 17
+			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04f4: pop
+			IL_04f5: ldstr "console"
+			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0504: ldstr "error"
+			IL_0509: ldstr "Looked under:"
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0513: pop
+			IL_0514: ldarg.0
+			IL_0515: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_051a: ldc.i4.1
+			IL_051b: newarr [System.Runtime]System.Object
+			IL_0520: dup
+			IL_0521: ldc.i4.0
+			IL_0522: ldarg.0
+			IL_0523: stelem.ref
+			IL_0524: ldloc.1
+			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_052a: stloc.s 10
+			IL_052c: ldc.r8 0.0
+			IL_0535: stloc.s 11
+			// loop start (head: IL_0537)
+				IL_0537: ldloc.s 11
+				IL_0539: stloc.s 22
+				IL_053b: ldloc.s 10
+				IL_053d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+				IL_0542: stloc.s 23
+				IL_0544: ldloc.s 22
+				IL_0546: ldloc.s 23
+				IL_0548: clt
+				IL_054a: brfalse IL_05a8
 
-				IL_0531: ldstr "console"
-				IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0540: stloc.s 15
-				IL_0542: ldloc.s 9
-				IL_0544: ldloc.s 10
-				IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_054b: stloc.s 17
-				IL_054d: ldloc.s 17
-				IL_054f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0554: stloc.s 16
-				IL_0556: ldstr "  - "
-				IL_055b: ldloc.s 16
-				IL_055d: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0562: stloc.s 16
-				IL_0564: ldloc.s 15
-				IL_0566: ldstr "error"
-				IL_056b: ldloc.s 16
-				IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0572: pop
-				IL_0573: ldloc.s 10
-				IL_0575: ldc.r8 1
-				IL_057e: add
-				IL_057f: stloc.s 24
-				IL_0581: ldloc.s 24
-				IL_0583: stloc.s 10
-				IL_0585: br IL_0519
+				IL_054f: ldstr "console"
+				IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_055e: stloc.s 16
+				IL_0560: ldloc.s 10
+				IL_0562: ldloc.s 11
+				IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0569: stloc.s 18
+				IL_056b: ldloc.s 18
+				IL_056d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0572: stloc.s 17
+				IL_0574: ldstr "  - "
+				IL_0579: ldloc.s 17
+				IL_057b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0580: stloc.s 17
+				IL_0582: ldloc.s 16
+				IL_0584: ldstr "error"
+				IL_0589: ldloc.s 17
+				IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0590: pop
+				IL_0591: ldloc.s 11
+				IL_0593: ldc.r8 1
+				IL_059c: add
+				IL_059d: stloc.s 23
+				IL_059f: ldloc.s 23
+				IL_05a1: stloc.s 11
+				IL_05a3: br IL_0537
 			// end loop
 
-			IL_058a: ldstr "console"
-			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0599: ldstr "error"
-			IL_059e: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05a8: pop
-			IL_05a9: ldstr "process"
-			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05b8: ldstr "exit"
-			IL_05bd: ldc.r8 1
-			IL_05c6: box [System.Runtime]System.Double
-			IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05d0: pop
+			IL_05a8: ldstr "console"
+			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b7: ldstr "error"
+			IL_05bc: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05c6: pop
+			IL_05c7: ldstr "process"
+			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05d6: ldstr "exit"
+			IL_05db: ldc.r8 1
+			IL_05e4: box [System.Runtime]System.Double
+			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05ee: pop
 
-			IL_05d1: ldstr "console"
-			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05e0: stloc.s 15
-			IL_05e2: ldloc.s 8
-			IL_05e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05e9: stloc.s 16
-			IL_05eb: ldstr "Found assembly: "
-			IL_05f0: ldloc.s 16
-			IL_05f2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05f7: stloc.s 16
-			IL_05f9: ldloc.s 15
-			IL_05fb: ldstr "log"
-			IL_0600: ldloc.s 16
-			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0607: pop
+			IL_05ef: ldstr "console"
+			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05fe: stloc.s 16
+			IL_0600: ldloc.s 8
+			IL_0602: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0607: stloc.s 17
+			IL_0609: ldstr "Found assembly: "
+			IL_060e: ldloc.s 17
+			IL_0610: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0615: stloc.s 17
+			IL_0617: ldloc.s 16
+			IL_0619: ldstr "log"
+			IL_061e: ldloc.s 17
+			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0625: pop
 			.try
 			{
-				IL_0608: nop
-				IL_0609: ldstr "console"
-				IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0618: ldstr "log"
-				IL_061d: ldstr "Opening in ILSpy..."
-				IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0627: pop
-				IL_0628: ldarg.0
-				IL_0629: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_062e: stloc.s 15
-				IL_0630: ldloc.s 15
-				IL_0632: ldc.i4.1
-				IL_0633: newarr [System.Runtime]System.Object
-				IL_0638: dup
-				IL_0639: ldc.i4.0
-				IL_063a: ldarg.0
-				IL_063b: stelem.ref
-				IL_063c: ldloc.s 8
-				IL_063e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0643: pop
-				IL_0644: leave IL_06e3
+				IL_0626: nop
+				IL_0627: ldstr "console"
+				IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0636: ldstr "log"
+				IL_063b: ldstr "Opening in ILSpy..."
+				IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0645: pop
+				IL_0646: ldarg.0
+				IL_0647: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_064c: stloc.s 16
+				IL_064e: ldloc.s 16
+				IL_0650: ldc.i4.1
+				IL_0651: newarr [System.Runtime]System.Object
+				IL_0656: dup
+				IL_0657: ldc.i4.0
+				IL_0658: ldarg.0
+				IL_0659: stelem.ref
+				IL_065a: ldloc.s 8
+				IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0661: pop
+				IL_0662: leave IL_0701
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0649: stloc.s 11
-				IL_064b: ldloc.s 11
-				IL_064d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0652: dup
-				IL_0653: brtrue IL_0669
+				IL_0667: stloc.s 12
+				IL_0669: ldloc.s 12
+				IL_066b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0670: dup
+				IL_0671: brtrue IL_0687
 
-				IL_0658: pop
-				IL_0659: ldloc.s 11
-				IL_065b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0660: dup
-				IL_0661: brtrue IL_0675
-
-				IL_0666: pop
-				IL_0667: rethrow
-
-				IL_0669: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_066e: stloc.s 12
-				IL_0670: br IL_0677
-
-				IL_0675: stloc.s 12
-
+				IL_0676: pop
 				IL_0677: ldloc.s 12
-				IL_0679: stloc.s 13
-				IL_067b: ldstr "console"
-				IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_068a: ldstr "error"
-				IL_068f: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0699: pop
-				IL_069a: ldstr "console"
-				IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06a9: ldstr "error"
-				IL_06ae: ldloc.s 13
-				IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06b5: pop
-				IL_06b6: ldstr "process"
-				IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06c5: ldstr "exit"
-				IL_06ca: ldc.r8 1
-				IL_06d3: box [System.Runtime]System.Double
-				IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06dd: pop
-				IL_06de: leave IL_06e3
+				IL_0679: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_067e: dup
+				IL_067f: brtrue IL_0693
+
+				IL_0684: pop
+				IL_0685: rethrow
+
+				IL_0687: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_068c: stloc.s 13
+				IL_068e: br IL_0695
+
+				IL_0693: stloc.s 13
+
+				IL_0695: ldloc.s 13
+				IL_0697: stloc.s 14
+				IL_0699: ldstr "console"
+				IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06a8: ldstr "error"
+				IL_06ad: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_06b7: pop
+				IL_06b8: ldstr "console"
+				IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06c7: ldstr "error"
+				IL_06cc: ldloc.s 14
+				IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_06d3: pop
+				IL_06d4: ldstr "process"
+				IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06e3: ldstr "exit"
+				IL_06e8: ldc.r8 1
+				IL_06f1: box [System.Runtime]System.Double
+				IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_06fb: pop
+				IL_06fc: leave IL_0701
 			} // end handler
 
-			IL_06e3: ldstr "console"
-			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06f2: ldstr "log"
-			IL_06f7: ldstr "Done!"
-			IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0701: pop
-			IL_0702: ldnull
-			IL_0703: stloc.s 14
-			IL_0705: ldloc.s 14
-			IL_0707: ret
+			IL_0701: ldstr "console"
+			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0710: ldstr "log"
+			IL_0715: ldstr "Done!"
+			IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_071f: pop
+			IL_0720: ldnull
+			IL_0721: stloc.s 15
+			IL_0723: ldloc.s 15
+			IL_0725: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2165,7 +2180,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30e1
+			// Method begins at RVA 0x3101
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2365,7 +2380,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31c2
+		// Method begins at RVA 0x31e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
Fixes the decompile helper when dotnet test --no-build exits successfully without producing a test assembly. The helper now retries with a build unless the requested assembly exists.