### PR TITLE
perf: optimize binary calls and captured constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler: infer typed callable parameters from conservative binary-expression
+  call arguments and numeric update-only parameters, removing boxing and numeric
+  coercion from hot loops. Propagate safe captured primitive `const` bindings
+  across callable boundaries, fold supported constant arithmetic, and eliminate
+  their unused scope fields while preserving TDZ, shadowing, and assignment
+  semantics.
 
 ## v0.12.0 - 2026-08-01
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.CompileTimeConstants.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.CompileTimeConstants.cs
@@ -1,0 +1,223 @@
+using Jroc.HIR;
+using Jroc.Services;
+using Jroc.SymbolTables;
+
+namespace Jroc.IR;
+
+public sealed partial class HIRToLIRLowerer
+{
+    private bool TryEmitCompileTimeConstant(BindingInfo binding, out TempVariable result)
+    {
+        result = default;
+        if (!CanPropagateCompileTimeConstant(binding))
+        {
+            return false;
+        }
+
+        result = CreateTempVariable();
+        EmitCompileTimeConstant(
+            binding.CompileTimeConstantType,
+            binding.CompileTimeConstantValue,
+            result);
+        return true;
+    }
+
+    private bool CanPropagateCompileTimeConstant(BindingInfo binding)
+    {
+        if (!binding.IsCompileTimeConstant)
+        {
+            return false;
+        }
+
+        // Reads in the declaring callable remain flow-sensitive so a pre-declaration read
+        // still takes the existing TDZ path.
+        if (ReferenceEquals(_scope, binding.DeclaringScope)
+            || _scope == null
+            || !IsDescendantOf(_scope, binding.DeclaringScope))
+        {
+            return _variableMap.ContainsKey(binding);
+        }
+
+        return true;
+    }
+
+    private static bool IsDescendantOf(Scope scope, Scope ancestor)
+    {
+        for (var current = scope.Parent; current != null; current = current.Parent)
+        {
+            if (ReferenceEquals(current, ancestor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryFoldCompileTimeConstantExpression(
+        HIRBinaryExpression expression,
+        TempVariable result)
+    {
+        if (_activeWithObjects.Count > 0 || _scope?.MayUseBoundWithObject == true)
+        {
+            return false;
+        }
+
+        if (!TryEvaluateCompileTimeConstant(
+                expression,
+                out var type,
+                out var value,
+                out var usesBinding)
+            || !usesBinding)
+        {
+            return false;
+        }
+
+        EmitCompileTimeConstant(type, value, result);
+        return true;
+    }
+
+    private bool TryEvaluateCompileTimeConstant(
+        HIRExpression expression,
+        out JavascriptType type,
+        out object? value,
+        out bool usesBinding)
+    {
+        switch (expression)
+        {
+            case HIRLiteralExpression literal
+                when literal.Kind is JavascriptType.Number
+                    or JavascriptType.String
+                    or JavascriptType.Boolean
+                    or JavascriptType.Null:
+                type = literal.Kind;
+                value = literal.Value;
+                usesBinding = false;
+                return true;
+
+            case HIRVariableExpression variable
+                when CanPropagateCompileTimeConstant(variable.Name.BindingInfo):
+                type = variable.Name.BindingInfo.CompileTimeConstantType;
+                value = variable.Name.BindingInfo.CompileTimeConstantValue;
+                usesBinding = true;
+                return true;
+
+            case HIRBinaryExpression binary:
+                if (!TryEvaluateCompileTimeConstant(
+                        binary.Left,
+                        out var leftType,
+                        out var leftValue,
+                        out var leftUsesBinding)
+                    || !TryEvaluateCompileTimeConstant(
+                        binary.Right,
+                        out var rightType,
+                        out var rightValue,
+                        out var rightUsesBinding)
+                    || !TryFoldBinaryConstant(
+                        binary.Operator,
+                        leftType,
+                        leftValue,
+                        rightType,
+                        rightValue,
+                        out type,
+                        out value))
+                {
+                    usesBinding = false;
+                    type = JavascriptType.Unknown;
+                    value = null;
+                    return false;
+                }
+
+                usesBinding = leftUsesBinding || rightUsesBinding;
+                return true;
+
+            default:
+                type = JavascriptType.Unknown;
+                value = null;
+                usesBinding = false;
+                return false;
+        }
+    }
+
+    private static bool TryFoldBinaryConstant(
+        Acornima.Operator op,
+        JavascriptType leftType,
+        object? leftValue,
+        JavascriptType rightType,
+        object? rightValue,
+        out JavascriptType resultType,
+        out object? resultValue)
+    {
+        if (leftType == JavascriptType.Number
+            && rightType == JavascriptType.Number
+            && leftValue is double left
+            && rightValue is double right)
+        {
+            resultType = JavascriptType.Number;
+            switch (op)
+            {
+                case Acornima.Operator.Addition:
+                    resultValue = left + right;
+                    return true;
+                case Acornima.Operator.Subtraction:
+                    resultValue = left - right;
+                    return true;
+                case Acornima.Operator.Multiplication:
+                    resultValue = left * right;
+                    return true;
+                case Acornima.Operator.Division:
+                    resultValue = left / right;
+                    return true;
+                case Acornima.Operator.Remainder:
+                    resultValue = left % right;
+                    return true;
+            }
+        }
+
+        if (op == Acornima.Operator.Addition
+            && leftType == JavascriptType.String
+            && rightType == JavascriptType.String
+            && leftValue is string leftString
+            && rightValue is string rightString)
+        {
+            resultType = JavascriptType.String;
+            resultValue = leftString + rightString;
+            return true;
+        }
+
+        resultType = JavascriptType.Unknown;
+        resultValue = null;
+        return false;
+    }
+
+    private void EmitCompileTimeConstant(
+        JavascriptType type,
+        object? value,
+        TempVariable result)
+    {
+        switch (type)
+        {
+            case JavascriptType.Number:
+                _methodBodyIR.Instructions.Add(new LIRConstNumber((double)value!, result));
+                DefineTempStorage(result, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)));
+                break;
+            case JavascriptType.String:
+                _methodBodyIR.Instructions.Add(new LIRConstString((string)value!, result));
+                DefineTempStorage(result, new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+                break;
+            case JavascriptType.Boolean:
+                _methodBodyIR.Instructions.Add(new LIRConstBoolean((bool)value!, result));
+                DefineTempStorage(result, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)));
+                break;
+            case JavascriptType.Null:
+                _methodBodyIR.Instructions.Add(new LIRConstNull(result));
+                DefineTempStorage(
+                    result,
+                    new ValueStorage(ValueStorageKind.UnboxedValue, typeof(JavaScriptRuntime.JsNull)));
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported compile-time constant type '{type}'.");
+        }
+    }
+}

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.Binary.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.Binary.cs
@@ -14,6 +14,11 @@ public sealed partial class HIRToLIRLowerer
     {
         resultTempVar = CreateTempVariable();
 
+        if (TryFoldCompileTimeConstantExpression(binaryExpr, resultTempVar))
+        {
+            return true;
+        }
+
         if (binaryExpr.Operator == Acornima.Operator.Division
             && TryFoldStableMathPiOver180(binaryExpr, resultTempVar))
         {

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAccess.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAccess.cs
@@ -714,7 +714,7 @@ public sealed partial class HIRToLIRLowerer
                         {
                             result = CreateTempVariable();
                             _methodBodyIR.Instructions.Add(new LIRLoadParameter(storage.JsParameterIndex, result));
-                            DefineTempStorage(result, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+                            DefineTempStorage(result, GetPreferredBindingReadStorage(binding));
                             _tempBindingOrigin[result] = binding;
                             return true;
                         }
@@ -762,7 +762,7 @@ public sealed partial class HIRToLIRLowerer
         {
             result = CreateTempVariable();
             _methodBodyIR.Instructions.Add(new LIRLoadParameter(paramIndex, result));
-            DefineTempStorage(result, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            DefineTempStorage(result, GetPreferredBindingReadStorage(binding));
             _tempBindingOrigin[result] = binding;
             return true;
         }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.UpdateAndAssignment.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.UpdateAndAssignment.cs
@@ -89,6 +89,10 @@ public sealed partial class HIRToLIRLowerer
         if (isEnvironmentStored)
         {
             // Note: if we're in this branch and not using an active scope temp, updateStorage must be non-null.
+            var isTypedNumericParameter =
+                updateStorage?.Kind == BindingStorageKind.IlArgument
+                && updateBinding.IsStableType
+                && updateBinding.ClrType == typeof(double);
 
             var currentNumber = EnsureNumber(currentValue);
 
@@ -97,10 +101,16 @@ public sealed partial class HIRToLIRLowerer
             TempVariable? originalSnapshotForPostfix = null;
             if (needsPostfixValue)
             {
-                var snapshotValue = EnsureObject(currentNumber);
+                var snapshotValue = isTypedNumericParameter
+                    ? currentNumber
+                    : EnsureObject(currentNumber);
                 var snapshot = CreateTempVariable();
                 _methodBodyIR.Instructions.Add(new LIRCopyTemp(snapshotValue, snapshot));
-                DefineTempStorage(snapshot, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+                DefineTempStorage(
+                    snapshot,
+                    isTypedNumericParameter
+                        ? GetTempStorage(snapshotValue)
+                        : new ValueStorage(ValueStorageKind.Reference, typeof(object)));
                 originalSnapshotForPostfix = snapshot;
             }
 
@@ -119,11 +129,13 @@ public sealed partial class HIRToLIRLowerer
             }
             DefineTempStorage(updatedNumber, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)));
 
-            var updatedBoxed = EnsureObject(updatedNumber);
+            var storedValue = isTypedNumericParameter
+                ? updatedNumber
+                : EnsureObject(updatedNumber);
 
             if (isActiveScopeStored)
             {
-                _methodBodyIR.Instructions.Add(new LIRStoreScopeField(activeScopeTemp, updateBinding, activeFieldId, activeScopeId, updatedBoxed));
+                _methodBodyIR.Instructions.Add(new LIRStoreScopeField(activeScopeTemp, updateBinding, activeFieldId, activeScopeId, storedValue));
             }
             else
             {
@@ -134,7 +146,7 @@ public sealed partial class HIRToLIRLowerer
                         {
                             return false;
                         }
-                        _methodBodyIR.Instructions.Add(new LIRStoreParameter(updateStorage.JsParameterIndex, updatedBoxed));
+                        _methodBodyIR.Instructions.Add(new LIRStoreParameter(updateStorage.JsParameterIndex, storedValue));
                         break;
 
                     case BindingStorageKind.LeafScopeField:
@@ -142,7 +154,7 @@ public sealed partial class HIRToLIRLowerer
                         {
                             return false;
                         }
-                        _methodBodyIR.Instructions.Add(new LIRStoreLeafScopeField(updateBinding, updateStorage.Field, updateStorage.DeclaringScope, updatedBoxed));
+                        _methodBodyIR.Instructions.Add(new LIRStoreLeafScopeField(updateBinding, updateStorage.Field, updateStorage.DeclaringScope, storedValue));
                         break;
 
                     case BindingStorageKind.ParentScopeField:
@@ -152,7 +164,7 @@ public sealed partial class HIRToLIRLowerer
                         }
                         {
                             var parentIndex = AdjustParentScopeFieldIndexForCurrentMethod(updateStorage.ParentScopeIndex);
-                            _methodBodyIR.Instructions.Add(new LIRStoreParentScopeField(updateBinding, updateStorage.Field, updateStorage.DeclaringScope, parentIndex, updatedBoxed));
+                            _methodBodyIR.Instructions.Add(new LIRStoreParentScopeField(updateBinding, updateStorage.Field, updateStorage.DeclaringScope, parentIndex, storedValue));
                         }
                         break;
 
@@ -163,16 +175,16 @@ public sealed partial class HIRToLIRLowerer
             }
 
             // Update SSA map for subsequent reads.
-            _variableMap[updateBinding] = updatedBoxed;
+            _variableMap[updateBinding] = storedValue;
             _numericRefinements.Remove(updateBinding);
 
             if (updateExpr.Prefix)
             {
-                resultTempVar = updatedBoxed;
+                resultTempVar = storedValue;
                 return true;
             }
 
-            resultTempVar = needsPostfixValue ? originalSnapshotForPostfix!.Value : updatedBoxed;
+            resultTempVar = needsPostfixValue ? originalSnapshotForPostfix!.Value : storedValue;
             return true;
         }
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -418,6 +418,12 @@ public sealed partial class HIRToLIRLowerer
                 var binding = varExpr.Name.BindingInfo;
                 EmitWithBindingProbe(binding.Name);
 
+                if (TryEmitCompileTimeConstant(binding, out resultTempVar))
+                {
+                    resultTempVar = EmitResolveWithBindingOrDefault(binding, resultTempVar);
+                    return true;
+                }
+
                 // Class declarations are compiled separately (as CLR types) and are not SSA-assigned.
                 // Always lower a class identifier to a runtime System.Type so it can cross module boundaries
                 // (e.g., `module.exports = { Counter }`).

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.cs
@@ -145,7 +145,7 @@ public sealed partial class HIRToLIRLowerer
     {
         if (string.IsNullOrEmpty(block.ScopeName))
         {
-            return block.Statements.All(TryLowerStatement);
+            return TryLowerBlockStatements(block);
         }
 
         var scopeName = block.ScopeName!;
@@ -158,7 +158,7 @@ public sealed partial class HIRToLIRLowerer
         _activeScopeTempsByScopeName[scopeName] = blockScopeTemp;
         try
         {
-            return block.Statements.All(TryLowerStatement);
+            return TryLowerBlockStatements(block);
         }
         finally
         {
@@ -171,6 +171,28 @@ public sealed partial class HIRToLIRLowerer
                 _activeScopeTempsByScopeName.Remove(scopeName);
             }
         }
+    }
+
+    private bool TryLowerBlockStatements(HIRBlock block)
+    {
+        for (var index = 0; index < block.Statements.Length; index++)
+        {
+            var statement = block.Statements[index];
+            if (statement is HIRSequencePointStatement
+                && index + 1 < block.Statements.Length
+                && block.Statements[index + 1] is HIRVariableDeclaration declaration
+                && declaration.Name.BindingInfo.IsCompileTimeConstant)
+            {
+                continue;
+            }
+
+            if (!TryLowerStatement(statement))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private bool TryLowerAsyncTryCatchWithAwait(HIRTryStatement tryStmt)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementVariableDeclarations.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementVariableDeclarations.cs
@@ -197,6 +197,12 @@ public sealed partial class HIRToLIRLowerer
             && GetTempStorage(value).Kind == ValueStorageKind.UnboxedValue
             && GetTempStorage(value).ClrType == typeof(bool);
 
+        if (binding.IsCompileTimeConstant)
+        {
+            _variableMap[binding] = value;
+            return true;
+        }
+
         // Per-iteration environments: if this binding lives in an active materialized scope instance
         // (e.g., `for (let/const ...)` loop-head scope), store directly into that scope field.
         if (TryGetActiveScopeFieldStorage(binding, out var activeScopeTemp, out var activeScopeId, out var activeFieldId))

--- a/src/Compiler/IR/LIR/LIRMemberCallNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRMemberCallNormalization.cs
@@ -501,15 +501,25 @@ internal static class LIRMemberCallNormalization
             ? new ValueStorage(ValueStorageKind.UnboxedValue, parameterClrType)
             : new ValueStorage(ValueStorageKind.Reference, parameterClrType);
 
-        if (!ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage))
+        if (!IsStableAlreadyEvaluatedTemp(
+                methodBody,
+                convertToObject.Source,
+                convertInstructionIndex,
+                callInstructionIndex))
         {
             return false;
         }
 
-        // Keep this rewrite to stable, already-evaluated values. The old LIRBuildArray
-        // materialized arguments before dispatch; forwarding an effectful source could
-        // otherwise move evaluation into the direct/fallback call branches.
-        return IsStableAlreadyEvaluatedTemp(methodBody, convertToObject.Source, convertInstructionIndex, callInstructionIndex);
+        if (ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage))
+        {
+            return true;
+        }
+
+        return convertToObject.Source.Index >= 0
+            && convertToObject.Source.Index < methodBody.TempStorages.Count
+            && ValueStorageFacts.CanFlowTo(
+                methodBody.TempStorages[convertToObject.Source.Index],
+                targetStorage);
     }
 
     private static bool IsStableAlreadyEvaluatedTemp(
@@ -525,6 +535,11 @@ internal static class LIRMemberCallNormalization
                 || !IsVariableSlotWrittenBetween(methodBody, variableSlot, snapshotInstructionIndex, useInstructionIndex);
         }
 
+        if (IsStableNumericProducer(methodBody, temp))
+        {
+            return true;
+        }
+
         return TryFindDefInstruction(methodBody, temp) switch
         {
             LIRConstNumber or LIRConstString or LIRConstBoolean or LIRConstUndefined or LIRConstNull => true,
@@ -532,6 +547,23 @@ internal static class LIRMemberCallNormalization
             LIRCopyTemp copyTemp => IsStableAlreadyEvaluatedTemp(methodBody, copyTemp.Source, snapshotInstructionIndex, useInstructionIndex),
             _ => false
         };
+    }
+
+    private static bool IsStableNumericProducer(MethodBodyIR methodBody, TempVariable temp)
+    {
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (TempLocalAllocator.TryGetDefinedTemp(instruction, out var defined)
+                && defined.Index == temp.Index)
+            {
+                return instruction is
+                    LIRAddNumber or LIRSubNumber or LIRMulNumber or LIRDivNumber or LIRModNumber or LIRExpNumber
+                    or LIRBitwiseAnd or LIRBitwiseOr or LIRBitwiseXor
+                    or LIRLeftShift or LIRRightShift or LIRUnsignedRightShift;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsVariableSlotWrittenBetween(MethodBodyIR methodBody, int variableSlot, int startInstructionIndex, int endInstructionIndex)

--- a/src/Compiler/IR/LIR/LIRTypeNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRTypeNormalization.cs
@@ -692,8 +692,43 @@ internal static class LIRTypeNormalization
             ? new ValueStorage(ValueStorageKind.UnboxedValue, parameterClrType)
             : new ValueStorage(ValueStorageKind.Reference, parameterClrType);
 
-        return ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage)
-            && IsStableAlreadyEvaluatedTemp(methodBody, convertToObject.Source, convertInstructionIndex, callInstructionIndex);
+        var isStable = IsStableAlreadyEvaluatedTemp(
+                methodBody,
+                convertToObject.Source,
+                convertInstructionIndex,
+                callInstructionIndex);
+        if (!isStable)
+        {
+            return false;
+        }
+
+        if (ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage))
+        {
+            return true;
+        }
+
+        return convertToObject.Source.Index >= 0
+            && convertToObject.Source.Index < methodBody.TempStorages.Count
+            && ValueStorageFacts.CanFlowTo(
+                methodBody.TempStorages[convertToObject.Source.Index],
+                targetStorage);
+    }
+
+    private static bool IsStableNumericProducer(MethodBodyIR methodBody, TempVariable temp)
+    {
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (TempLocalAllocator.TryGetDefinedTemp(instruction, out var defined)
+                && defined.Index == temp.Index)
+            {
+                return instruction is
+                    LIRAddNumber or LIRSubNumber or LIRMulNumber or LIRDivNumber or LIRModNumber or LIRExpNumber
+                    or LIRBitwiseAnd or LIRBitwiseOr or LIRBitwiseXor
+                    or LIRLeftShift or LIRRightShift or LIRUnsignedRightShift;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsStableAlreadyEvaluatedTemp(
@@ -707,6 +742,11 @@ internal static class LIRTypeNormalization
         {
             return methodBody.SingleAssignmentSlots.Contains(variableSlot)
                 || !IsVariableSlotWrittenBetween(methodBody, variableSlot, snapshotInstructionIndex, useInstructionIndex);
+        }
+
+        if (IsStableNumericProducer(methodBody, temp))
+        {
+            return true;
         }
 
         return TryFindInstructionDefiningTemp(methodBody, temp, out var definitionIndex)

--- a/src/Compiler/Services/ScopesAbi/EnvironmentLayoutBuilder.cs
+++ b/src/Compiler/Services/ScopesAbi/EnvironmentLayoutBuilder.cs
@@ -187,7 +187,9 @@ public class EnvironmentLayoutBuilder
             {
                 // Check if this binding is captured (referenced by this or child scopes)
                 // and we haven't already added it
-                if (binding.IsCaptured && !storage.ContainsKey(binding))
+                if (binding.IsCaptured
+                    && !binding.IsCompileTimeConstant
+                    && !storage.ContainsKey(binding))
                 {
                     // This is a parent scope field
                     var parentIndex = scopeChain.IndexOf(GetRegistryScopeName(current));
@@ -222,6 +224,11 @@ public class EnvironmentLayoutBuilder
         ScopeChainLayout scopeChain,
         CallableKind kind)
     {
+        if (binding.IsCompileTimeConstant)
+        {
+            return BindingStorage.ForLocal(-1);
+        }
+
         // Check if it's a parameter (and not destructured)
         if (scope.Parameters.Contains(name) && !scope.DestructuredParameters.Contains(name))
         {

--- a/src/Compiler/Services/TypeGenerator.cs
+++ b/src/Compiler/Services/TypeGenerator.cs
@@ -275,6 +275,11 @@ namespace Jroc.Services
                 bool isParameter = scope.Parameters.Contains(variableName);
                 bool isFunction = binding.Kind == BindingKind.Function;
                 bool isDestructuredParameter = scope.DestructuredParameters.Contains(variableName);
+
+                if (binding.IsCompileTimeConstant)
+                {
+                    continue;
+                }
                 
                 // Skip field creation for parameters that:
                 // - Are NOT captured (not referenced by child scopes)
@@ -1248,7 +1253,9 @@ namespace Jroc.Services
                 // Fields are created for: parameters (with some exceptions), functions, captured variables
                 // Fields are NOT created for: uncaptured non-parameter non-function variables
                 // (shadowed variables no longer need fields - each scope gets its own local slot)
-                bool fieldCreatedForThisBinding = isParameter || isFunction || bindingInfo.IsCaptured;
+                bool fieldCreatedForThisBinding =
+                    !bindingInfo.IsCompileTimeConstant
+                    && (isParameter || isFunction || bindingInfo.IsCaptured);
                 
                 // Parameters without fields: simple uncaptured params that aren't destructured or in arrow functions
                 if (isParameter && !bindingInfo.IsCaptured)

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -1,4 +1,5 @@
 using Acornima.Ast;
+using Jroc.Services;
 
 namespace Jroc.SymbolTables;
 
@@ -86,6 +87,11 @@ public class BindingInfo
     public bool HasWrite { get; set; }
 
     /// <summary>
+    /// True when source code explicitly assigns to or updates this binding after declaration.
+    /// </summary>
+    public bool HasNonInitializationWrite { get; set; }
+
+    /// <summary>
     /// True when a non-captured <c>var</c> or <c>let</c> binding is proven numeric and
     /// definitely initialized before every reachable read in its callable.
     /// </summary>
@@ -107,6 +113,22 @@ public class BindingInfo
     /// observed before initialization.
     /// </summary>
     public bool RequiresRuntimeTemporalDeadZoneChecks { get; set; }
+
+    /// <summary>
+    /// True when this captured binding is a <c>const</c> initialized from a primitive
+    /// literal and all reads are known to occur after initialization.
+    /// </summary>
+    public bool IsCompileTimeConstant { get; set; }
+
+    /// <summary>
+    /// The JavaScript type of <see cref="CompileTimeConstantValue"/>.
+    /// </summary>
+    public JavascriptType CompileTimeConstantType { get; set; } = JavascriptType.Unknown;
+
+    /// <summary>
+    /// The primitive value substituted at eligible read sites.
+    /// </summary>
+    public object? CompileTimeConstantValue { get; set; }
 
     /// <summary>
     /// Shape analysis result when this binding is declared with an object literal initializer.

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -181,7 +181,8 @@ public class Scope
     public bool RequiresRuntimeBlockScopeInstance
         => Kind == ScopeKind.Block
            && Bindings.Values.Any(binding =>
-               binding.IsCaptured || binding.Kind == BindingKind.Function);
+               (binding.IsCaptured && !binding.IsCompileTimeConstant)
+               || binding.Kind == BindingKind.Function);
 
     /// <summary>
     /// True when source code in this module referenced the ECMAScript globalThis binding.

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.CompileTimeConstants.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.CompileTimeConstants.cs
@@ -1,0 +1,218 @@
+using Acornima.Ast;
+using Jroc.Services;
+
+namespace Jroc.SymbolTables;
+
+public partial class SymbolTableBuilder
+{
+    private void AnalyzeCompileTimeConstants(Scope scope)
+        => AnalyzeCompileTimeConstants(scope, BuildNodeScopeMap(scope));
+
+    private void AnalyzeCompileTimeConstants(
+        Scope scope,
+        IReadOnlyDictionary<Node, Scope> nodeScopes)
+    {
+        foreach (var binding in scope.Bindings.Values)
+        {
+            if (binding.Kind != BindingKind.Const
+                || !binding.IsCaptured
+                || binding.HasNonInitializationWrite
+                || HasNonInitializationWrite(scope, binding, nodeScopes)
+                || binding.DeclarationNode is not VariableDeclarator
+                {
+                    Id: Identifier declaredIdentifier,
+                    Init: { } initializer
+                }
+                || !string.Equals(declaredIdentifier.Name, binding.Name, StringComparison.Ordinal)
+                || !IsDirectUnconditionalDeclaration(scope, binding.DeclarationNode)
+                || !TryGetPrimitiveConstant(initializer, out var type, out var value))
+            {
+                continue;
+            }
+
+            if (!TryGetBindingInitializationBoundary(binding, out var initializationBoundary))
+            {
+                continue;
+            }
+
+            if (HasReferenceBeforeInitialization(scope, binding, initializationBoundary, nodeScopes))
+            {
+                binding.RequiresRuntimeTemporalDeadZoneChecks = true;
+                continue;
+            }
+
+            if (!CanEliminateCapturedConstantStorage(scope, binding, initializationBoundary))
+            {
+                continue;
+            }
+
+            binding.IsCompileTimeConstant = true;
+            binding.CompileTimeConstantType = type;
+            binding.CompileTimeConstantValue = value;
+        }
+
+        foreach (var child in scope.Children)
+        {
+            AnalyzeCompileTimeConstants(child, nodeScopes);
+        }
+    }
+
+    private bool HasReferenceBeforeInitialization(
+        Scope scope,
+        BindingInfo binding,
+        int initializationBoundary,
+        IReadOnlyDictionary<Node, Scope> nodeScopes)
+    {
+        var hasReference = false;
+        var declaredIdentifier = (binding.DeclarationNode as VariableDeclarator)?.Id;
+        var walker = new Jroc.Utilities.AstWalker();
+        walker.Visit(scope.AstNode, node =>
+        {
+            if (hasReference
+                || node is not Identifier identifier
+                || identifier.Start >= initializationBoundary
+                || ReferenceEquals(identifier, declaredIdentifier)
+                || !string.Equals(identifier.Name, binding.Name, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            nodeScopes.TryGetValue(node, out var currentScope);
+            currentScope ??= scope;
+            hasReference = ReferenceEquals(TryResolveBinding(currentScope, identifier.Name), binding);
+        });
+        return hasReference;
+    }
+
+    private bool HasNonInitializationWrite(
+        Scope scope,
+        BindingInfo binding,
+        IReadOnlyDictionary<Node, Scope> nodeScopes)
+    {
+        var hasWrite = false;
+        var walker = new Jroc.Utilities.AstWalker();
+        walker.Visit(scope.AstNode, node =>
+        {
+            nodeScopes.TryGetValue(node, out var currentScope);
+            currentScope ??= scope;
+
+            hasWrite |= node switch
+            {
+                UpdateExpression update =>
+                    IsBindingWriteTarget(update.Argument, currentScope, binding),
+                AssignmentExpression assignment =>
+                    IsBindingWriteTarget(assignment.Left, currentScope, binding),
+                ForOfStatement forOf =>
+                    IsLoopBindingWriteTarget(forOf.Left, currentScope, binding),
+                ForInStatement forIn =>
+                    IsLoopBindingWriteTarget(forIn.Left, currentScope, binding),
+                _ => false
+            };
+        });
+        return hasWrite;
+    }
+
+    private static bool IsDirectUnconditionalDeclaration(Scope scope, Node declarationNode)
+    {
+        IEnumerable<Statement> statements = scope.AstNode switch
+        {
+            Program program => program.Body,
+            BlockStatement block => block.Body,
+            FunctionDeclaration { Body: BlockStatement body } => body.Body,
+            FunctionExpression { Body: BlockStatement body } => body.Body,
+            ArrowFunctionExpression { Body: BlockStatement body } => body.Body,
+            _ => Array.Empty<Statement>()
+        };
+
+        return statements
+            .OfType<VariableDeclaration>()
+            .SelectMany(declaration => declaration.Declarations)
+            .Any(declarator => ReferenceEquals(declarator, declarationNode));
+    }
+
+    private bool CanEliminateCapturedConstantStorage(
+        Scope declaringScope,
+        BindingInfo binding,
+        int initializationBoundary)
+    {
+        foreach (var child in declaringScope.Children)
+        {
+            if (!DoesScopeSubtreeReferenceBinding(child, declaringScope, binding))
+            {
+                continue;
+            }
+
+            if (!IsCapturedConstantBoundarySafe(child, declaringScope, binding, initializationBoundary))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool IsCapturedConstantBoundarySafe(
+        Scope candidate,
+        Scope declaringScope,
+        BindingInfo binding,
+        int initializationBoundary)
+    {
+        if (candidate.Kind == ScopeKind.Block)
+        {
+            foreach (var child in candidate.Children)
+            {
+                if (DoesScopeSubtreeReferenceBinding(child, declaringScope, binding)
+                    && !IsCapturedConstantBoundarySafe(child, declaringScope, binding, initializationBoundary))
+                {
+                    return false;
+                }
+            }
+
+            // Blocks execute in the declaring callable, where lowering remains flow-sensitive.
+            return true;
+        }
+
+        if (candidate.AstNode.Start < initializationBoundary)
+        {
+            return false;
+        }
+
+        return candidate.AstNode switch
+        {
+            // Function declarations are hoisted and can run before their source position.
+            FunctionDeclaration => false,
+            FunctionExpression or ArrowFunctionExpression or ClassDeclaration or ClassExpression => true,
+            _ => false
+        };
+    }
+
+    private static bool TryGetPrimitiveConstant(
+        Expression initializer,
+        out JavascriptType type,
+        out object? value)
+    {
+        switch (initializer)
+        {
+            case NumericLiteral numeric:
+                type = JavascriptType.Number;
+                value = numeric.Value;
+                return true;
+            case StringLiteral text:
+                type = JavascriptType.String;
+                value = text.Value;
+                return true;
+            case BooleanLiteral boolean:
+                type = JavascriptType.Boolean;
+                value = boolean.Value;
+                return true;
+            case NullLiteral:
+                type = JavascriptType.Null;
+                value = null;
+                return true;
+            default:
+                type = JavascriptType.Unknown;
+                value = null;
+                return false;
+        }
+    }
+}

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -64,10 +64,11 @@ public partial class SymbolTableBuilder
 
     private bool InferCallableParameterClrTypesOnce(Scope root)
     {
+        var nodeScopes = BuildNodeScopeMap(root);
         var candidatesByScope = new Dictionary<Scope, ParameterInferenceCandidate>();
         foreach (var scope in EnumerateScopes(root).Where(s => s.Kind == ScopeKind.Function))
         {
-            if (TryCreateParameterInferenceCandidate(scope, out var candidate))
+            if (TryCreateParameterInferenceCandidate(scope, nodeScopes, out var candidate))
             {
                 candidatesByScope[scope] = candidate;
             }
@@ -94,7 +95,6 @@ public partial class SymbolTableBuilder
             .GroupBy(c => c.Scope.Name, StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.Ordinal);
 
-        var nodeScopes = BuildNodeScopeMap(root);
         var walker = new Jroc.Utilities.AstWalker();
 
         walker.Visit(root.AstNode, node =>
@@ -233,10 +233,12 @@ public partial class SymbolTableBuilder
         public ParameterInferenceCandidate(
             Scope scope,
             IReadOnlyList<string> parameterNames,
-            IReadOnlyList<bool> hasDefaultValue)
+            IReadOnlyList<bool> hasDefaultValue,
+            IReadOnlyList<bool> requiresNumericType)
         {
             Scope = scope;
             ParameterNames = parameterNames;
+            RequiresNumericType = requiresNumericType;
             InferredTypes = new Type?[parameterNames.Count];
             HasEvidence = new bool[parameterNames.Count];
             IsParameterUnsafe = new bool[parameterNames.Count];
@@ -250,6 +252,7 @@ public partial class SymbolTableBuilder
 
         public Scope Scope { get; }
         public IReadOnlyList<string> ParameterNames { get; }
+        public IReadOnlyList<bool> RequiresNumericType { get; }
         public Type?[] InferredTypes { get; }
         public bool[] HasEvidence { get; }
         public bool[] IsParameterUnsafe { get; }
@@ -289,6 +292,12 @@ public partial class SymbolTableBuilder
                     continue;
                 }
 
+                if (RequiresNumericType[i] && argType != typeof(double))
+                {
+                    MarkParameterUnsafe(i);
+                    continue;
+                }
+
                 if (!HasEvidence[i])
                 {
                     HasEvidence[i] = true;
@@ -322,15 +331,96 @@ public partial class SymbolTableBuilder
             NewExpression newExpression => InferStableNewArgumentClrType(newExpression, callScope),
             CallExpression callExpression => InferStableCallArgumentClrType(callExpression, callScope),
             NonUpdateUnaryExpression unaryExpression => InferStableUnaryArgumentClrType(unaryExpression, callScope),
+            NonLogicalBinaryExpression binaryExpression => InferStableBinaryArgumentClrType(binaryExpression, callScope),
             _ => null
         };
 
         return IsSupportedStableParameterType(inferredType) ? inferredType : null;
     }
 
+    private Type? InferStableBinaryArgumentClrType(
+        NonLogicalBinaryExpression binaryExpression,
+        Scope callScope)
+    {
+        if (binaryExpression.Operator is Operator.Equality
+            or Operator.Inequality
+            or Operator.StrictEquality
+            or Operator.StrictInequality
+            or Operator.LessThan
+            or Operator.LessThanOrEqual
+            or Operator.GreaterThan
+            or Operator.GreaterThanOrEqual
+            or Operator.In
+            or Operator.InstanceOf)
+        {
+            return typeof(bool);
+        }
+
+        if (binaryExpression.Operator is not (
+                Operator.Addition
+                or Operator.Subtraction
+                or Operator.Multiplication
+                or Operator.Division
+                or Operator.Remainder
+                or Operator.Exponentiation
+                or Operator.BitwiseAnd
+                or Operator.BitwiseOr
+                or Operator.BitwiseXor
+                or Operator.LeftShift
+                or Operator.RightShift
+                or Operator.UnsignedRightShift))
+        {
+            return null;
+        }
+
+        if (callScope.MayUseBoundWithObject || ContainsWithStatement(callScope.AstNode))
+        {
+            return null;
+        }
+
+        var leftType = InferStableParameterArgumentClrType(binaryExpression.Left, callScope);
+        var rightType = InferStableParameterArgumentClrType(binaryExpression.Right, callScope);
+
+        // Requiring two proven Number operands keeps '+' away from string concatenation
+        // and all numeric operators away from BigInt.
+        return leftType == typeof(double) && rightType == typeof(double)
+            ? typeof(double)
+            : null;
+    }
+
+    private static bool ContainsWithStatement(Node node)
+    {
+        var containsWith = false;
+        var walker = new Jroc.Utilities.AstWalker();
+        walker.Visit(node, candidate =>
+        {
+            if (candidate is WithStatement)
+            {
+                containsWith = true;
+            }
+        });
+        return containsWith;
+    }
+
     private Type? InferStableIdentifierArgumentClrType(Scope callScope, string name)
     {
+        if (callScope.MayUseBoundWithObject || ContainsWithStatement(callScope.AstNode))
+        {
+            return null;
+        }
+
         var binding = TryResolveBinding(callScope, name);
+        if (binding?.IsCompileTimeConstant == true)
+        {
+            return binding.CompileTimeConstantType switch
+            {
+                Jroc.Services.JavascriptType.Number => typeof(double),
+                Jroc.Services.JavascriptType.String => typeof(string),
+                Jroc.Services.JavascriptType.Boolean => typeof(bool),
+                _ => null
+            };
+        }
+
         return binding?.IsStableType == true && IsSupportedStableParameterType(binding.ClrType)
             ? binding.ClrType
             : null;
@@ -353,6 +443,11 @@ public partial class SymbolTableBuilder
 
     private static Type? InferStableNewArgumentClrType(NewExpression newExpression, Scope callScope)
     {
+        if (callScope.MayUseBoundWithObject || ContainsWithStatement(callScope.AstNode))
+        {
+            return null;
+        }
+
         if (newExpression.Callee is Identifier ctorId && string.Equals(ctorId.Name, "Array", StringComparison.Ordinal))
         {
             return IsIdentifierShadowed(callScope, "Array") ? null : typeof(JavaScriptRuntime.Array);
@@ -363,6 +458,11 @@ public partial class SymbolTableBuilder
 
     private Type? InferStableCallArgumentClrType(CallExpression callExpression, Scope callScope)
     {
+        if (callScope.MayUseBoundWithObject || ContainsWithStatement(callScope.AstNode))
+        {
+            return null;
+        }
+
         if (callExpression.Callee is Identifier calleeId)
         {
             var binding = TryResolveBinding(callScope, calleeId.Name);
@@ -440,7 +540,10 @@ public partial class SymbolTableBuilder
         }
     }
 
-    private bool TryCreateParameterInferenceCandidate(Scope scope, out ParameterInferenceCandidate candidate)
+    private bool TryCreateParameterInferenceCandidate(
+        Scope scope,
+        IReadOnlyDictionary<Node, Scope> nodeScopes,
+        out ParameterInferenceCandidate candidate)
     {
         candidate = null!;
 
@@ -472,18 +575,110 @@ public partial class SymbolTableBuilder
             return false;
         }
 
-        foreach (var parameterName in parameterNames)
+        var requiresNumericType = new bool[parameterNames.Count];
+        for (var parameterIndex = 0; parameterIndex < parameterNames.Count; parameterIndex++)
         {
+            var parameterName = parameterNames[parameterIndex];
             if (!scope.Bindings.TryGetValue(parameterName, out var binding)
-                || binding.HasWrite
                 || binding.IsCaptured)
             {
                 return false;
             }
+
+            var (hasNumericUpdate, hasOtherWrite) = AnalyzeParameterWrites(scope, binding, nodeScopes);
+            if (hasOtherWrite || (binding.HasWrite && !hasNumericUpdate))
+            {
+                return false;
+            }
+
+            requiresNumericType[parameterIndex] = hasNumericUpdate;
         }
 
-        candidate = new ParameterInferenceCandidate(scope, parameterNames, hasDefaultValue);
+        candidate = new ParameterInferenceCandidate(
+            scope,
+            parameterNames,
+            hasDefaultValue,
+            requiresNumericType);
         return true;
+    }
+
+    private (bool HasNumericUpdate, bool HasOtherWrite) AnalyzeParameterWrites(
+        Scope scope,
+        BindingInfo binding,
+        IReadOnlyDictionary<Node, Scope> nodeScopes)
+    {
+        var sawNumericUpdate = false;
+        var sawOtherWrite = false;
+        var walker = new Jroc.Utilities.AstWalker();
+
+        walker.Visit(scope.AstNode, node =>
+        {
+            nodeScopes.TryGetValue(node, out var currentScope);
+            currentScope ??= scope;
+
+            switch (node)
+            {
+                case UpdateExpression { Argument: Identifier id }
+                    when ReferenceEquals(TryResolveBinding(currentScope, id.Name), binding):
+                    sawNumericUpdate = true;
+                    break;
+                case AssignmentExpression assignment
+                    when IsBindingWriteTarget(assignment.Left, currentScope, binding):
+                    sawOtherWrite = true;
+                    break;
+                case VariableDeclarator { Init: not null } declarator
+                    when IsBindingWriteTarget(declarator.Id, currentScope, binding):
+                    sawOtherWrite = true;
+                    break;
+                case FunctionDeclaration { Id: Identifier id }
+                    when ReferenceEquals(TryResolveBinding(currentScope, id.Name), binding):
+                    sawOtherWrite = true;
+                    break;
+                case ForOfStatement forOf
+                    when IsLoopBindingWriteTarget(forOf.Left, currentScope, binding):
+                    sawOtherWrite = true;
+                    break;
+                case ForInStatement forIn
+                    when IsLoopBindingWriteTarget(forIn.Left, currentScope, binding):
+                    sawOtherWrite = true;
+                    break;
+            }
+        });
+
+        return (sawNumericUpdate, sawOtherWrite);
+    }
+
+    private bool IsLoopBindingWriteTarget(Node target, Scope scope, BindingInfo binding)
+    {
+        if (target is not VariableDeclaration declaration)
+        {
+            return IsBindingWriteTarget(target, scope, binding);
+        }
+
+        return declaration.Kind == VariableDeclarationKind.Var
+            && declaration.Declarations.Any(declarator =>
+                IsBindingWriteTarget(declarator.Id, scope, binding));
+    }
+
+    private bool IsBindingWriteTarget(Node target, Scope scope, BindingInfo binding)
+    {
+        return target switch
+        {
+            Identifier id => ReferenceEquals(TryResolveBinding(scope, id.Name), binding),
+            AssignmentPattern assignment => IsBindingWriteTarget(assignment.Left, scope, binding),
+            RestElement rest => IsBindingWriteTarget(rest.Argument, scope, binding),
+            ArrayPattern array => array.Elements
+                .Where(element => element != null)
+                .Any(element => IsBindingWriteTarget(element!, scope, binding)),
+            ObjectPattern obj => obj.Properties.Any(property =>
+                property switch
+                {
+                    Property item => IsBindingWriteTarget(item.Value, scope, binding),
+                    RestElement rest => IsBindingWriteTarget(rest.Argument, scope, binding),
+                    _ => false
+                }),
+            _ => false
+        };
     }
 
     private static bool TryGetSimpleParameterNames(Node callableNode, out IReadOnlyList<string> parameterNames)

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.cs
@@ -105,6 +105,7 @@ namespace Jroc.SymbolTables
             }
 
             binding.HasWrite = true;
+            binding.HasNonInitializationWrite = true;
         }
 
         private static bool IsIdentifierNamed(Node? node, string name)
@@ -254,6 +255,7 @@ namespace Jroc.SymbolTables
             AnalyzeFreeVariables(globalScope);
             MarkCapturedVariables(globalScope);
             AnalyzeRuntimeTemporalDeadZoneChecks(globalScope);
+            AnalyzeCompileTimeConstants(globalScope);
 
             InferTypesToFixedPoint(globalScope);
 

--- a/src/Compiler/Utilities/AstWalker.cs
+++ b/src/Compiler/Utilities/AstWalker.cs
@@ -129,6 +129,11 @@ public class AstWalker
                 Visit(tryStmt.Finalizer, visitor);
                 break;
 
+            case WithStatement withStmt:
+                Visit(withStmt.Object, visitor);
+                Visit(withStmt.Body, visitor);
+                break;
+
             case CatchClause catchClause:
                 Visit(catchClause.Param, visitor);
                 Visit(catchClause.Body, visitor);
@@ -364,6 +369,11 @@ public class AstWalker
                 VisitWithContext(tryStmt.Block, enterNode, exitNode);
                 VisitWithContext(tryStmt.Handler, enterNode, exitNode);
                 VisitWithContext(tryStmt.Finalizer, enterNode, exitNode);
+                break;
+
+            case WithStatement withStmt:
+                VisitWithContext(withStmt.Object, enterNode, exitNode);
+                VisitWithContext(withStmt.Body, enterNode, exitNode);
                 break;
 
             case CatchClause catchClause:

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211d
+				// Method begins at RVA 0x2104
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,22 +51,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20f8
-			// Header size: 12
-			// Code size: 16 (0x10)
+			// Method begins at RVA 0x20e9
+			// Header size: 1
+			// Code size: 17 (0x11)
 			.maxstack 8
-			.locals init (
-				[0] float64
-			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld float64 Modules.ArrowFunction_CapturesOuterVariable/Scope::n
-			IL_0006: stloc.0
-			IL_0007: ldarg.2
-			IL_0008: ldloc.0
-			IL_0009: mul
-			IL_000a: box [System.Runtime]System.Double
-			IL_000f: ret
+			IL_0000: ldarg.2
+			IL_0001: ldc.r8 5
+			IL_000a: mul
+			IL_000b: box [System.Runtime]System.Double
+			IL_0010: ret
 		} // end of method ArrowFunction_L4C13::__js_call__
 
 	} // end of class ArrowFunction_L4C13
@@ -74,17 +68,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 0b 53 63 6f 70 65 20 6e 3d 7b 6e 7d 00 00
-		)
-		// Fields
-		.field public float64 n
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2114
+			// Method begins at RVA 0x20fb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -110,7 +98,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 155 (0x9b)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_CapturesOuterVariable/Scope,
@@ -123,51 +111,49 @@
 		IL_0000: newobj instance void Modules.ArrowFunction_CapturesOuterVariable/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldc.r8 5
-		IL_0011: stfld float64 Modules.ArrowFunction_CapturesOuterVariable/Scope::n
-		IL_0016: ldloc.0
-		IL_0017: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
-		IL_001c: ldftn object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
-		IL_0022: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
-		IL_0027: ldc.i4.1
-		IL_0028: newarr [System.Runtime]System.Object
-		IL_002d: dup
-		IL_002e: ldc.i4.0
-		IL_002f: ldloc.0
-		IL_0030: stelem.ref
-		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_003b: castclass class [System.Runtime]System.Func`3<object, float64, object>
-		IL_0040: ldc.i4.1
-		IL_0041: conv.r8
-		IL_0042: ldstr ""
-		IL_0047: ldc.i4.0
-		IL_0048: ldc.i4.0
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`3<object, float64, object>>(!!0)
-		IL_0053: stloc.2
-		IL_0054: ldloc.2
-		IL_0055: ldstr "mul"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_005f: stloc.1
-		IL_0060: ldstr "console"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.3
-		IL_0070: ldloc.0
-		IL_0071: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
-		IL_0076: ldnull
-		IL_0077: ldc.r8 3
-		IL_0080: call object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
-		IL_0085: stloc.s 4
-		IL_0087: ldloc.3
-		IL_0088: ldstr "log"
-		IL_008d: ldstr "product is "
-		IL_0092: ldloc.s 4
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0099: pop
-		IL_009a: ret
+		IL_0007: nop
+		IL_0008: ldloc.0
+		IL_0009: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
+		IL_000e: ldftn object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
+		IL_0014: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002d: castclass class [System.Runtime]System.Func`3<object, float64, object>
+		IL_0032: ldc.i4.1
+		IL_0033: conv.r8
+		IL_0034: ldstr ""
+		IL_0039: ldc.i4.0
+		IL_003a: ldc.i4.0
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`3<object, float64, object>>(!!0)
+		IL_0045: stloc.2
+		IL_0046: ldloc.2
+		IL_0047: ldstr "mul"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0051: stloc.1
+		IL_0052: ldstr "console"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0061: stloc.3
+		IL_0062: ldloc.0
+		IL_0063: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
+		IL_0068: ldnull
+		IL_0069: ldc.r8 3
+		IL_0072: call object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
+		IL_0077: stloc.s 4
+		IL_0079: ldloc.3
+		IL_007a: ldstr "log"
+		IL_007f: ldstr "product is "
+		IL_0084: ldloc.s 4
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method ArrowFunction_CapturesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_CapturesOuterVariable
@@ -179,7 +165,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2126
+		// Method begins at RVA 0x210d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2104
+				// Method begins at RVA 0x2103
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20e9
+			// Method begins at RVA 0x20e8
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -72,7 +72,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fb
+			// Method begins at RVA 0x20fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -98,7 +98,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 141 (0x8d)
+		// Code size: 140 (0x8c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_CapturesOuterVariable/Scope,
@@ -111,49 +111,48 @@
 		IL_0000: newobj instance void Modules.ArrowFunction_CapturesOuterVariable/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: ldloc.0
-		IL_0009: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
-		IL_000e: ldftn object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
-		IL_0014: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
-		IL_0019: ldc.i4.1
-		IL_001a: newarr [System.Runtime]System.Object
-		IL_001f: dup
-		IL_0020: ldc.i4.0
-		IL_0021: ldloc.0
-		IL_0022: stelem.ref
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_002d: castclass class [System.Runtime]System.Func`3<object, float64, object>
-		IL_0032: ldc.i4.1
-		IL_0033: conv.r8
-		IL_0034: ldstr ""
+		IL_0007: ldloc.0
+		IL_0008: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
+		IL_000d: ldftn object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
+		IL_0013: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0018: ldc.i4.1
+		IL_0019: newarr [System.Runtime]System.Object
+		IL_001e: dup
+		IL_001f: ldc.i4.0
+		IL_0020: ldloc.0
+		IL_0021: stelem.ref
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002c: castclass class [System.Runtime]System.Func`3<object, float64, object>
+		IL_0031: ldc.i4.1
+		IL_0032: conv.r8
+		IL_0033: ldstr ""
+		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.0
-		IL_003a: ldc.i4.0
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`3<object, float64, object>>(!!0)
-		IL_0045: stloc.2
-		IL_0046: ldloc.2
-		IL_0047: ldstr "mul"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0051: stloc.1
-		IL_0052: ldstr "console"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0061: stloc.3
-		IL_0062: ldloc.0
-		IL_0063: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
-		IL_0068: ldnull
-		IL_0069: ldc.r8 3
-		IL_0072: call object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
-		IL_0077: stloc.s 4
-		IL_0079: ldloc.3
-		IL_007a: ldstr "log"
-		IL_007f: ldstr "product is "
-		IL_0084: ldloc.s 4
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_008b: pop
-		IL_008c: ret
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`3<object, float64, object>>(!!0)
+		IL_0044: stloc.2
+		IL_0045: ldloc.2
+		IL_0046: ldstr "mul"
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0050: stloc.1
+		IL_0051: ldstr "console"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0060: stloc.3
+		IL_0061: ldloc.0
+		IL_0062: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
+		IL_0067: ldnull
+		IL_0068: ldc.r8 3
+		IL_0071: call object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, float64)
+		IL_0076: stloc.s 4
+		IL_0078: ldloc.3
+		IL_0079: ldstr "log"
+		IL_007e: ldstr "product is "
+		IL_0083: ldloc.s 4
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_008a: pop
+		IL_008b: ret
 	} // end of method ArrowFunction_CapturesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_CapturesOuterVariable
@@ -165,7 +164,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210d
+		// Method begins at RVA 0x210c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c2
+					// Method begins at RVA 0x21be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2134
+				// Method begins at RVA 0x2130
 				// Header size: 12
 				// Code size: 112 (0x70)
 				.maxstack 8
@@ -93,7 +93,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b9
+				// Method begins at RVA 0x21b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope,
@@ -132,52 +132,51 @@
 
 			IL_0000: newobj instance void Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: nop
-			IL_0007: ldnull
-			IL_0008: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
-			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0013: ldc.i4.2
-			IL_0014: newarr [System.Runtime]System.Object
-			IL_0019: dup
-			IL_001a: ldc.i4.0
-			IL_001b: ldarg.0
-			IL_001c: stelem.ref
-			IL_001d: dup
-			IL_001e: ldc.i4.1
-			IL_001f: ldloc.0
-			IL_0020: stelem.ref
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_002b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_0030: ldc.i4.0
-			IL_0031: conv.r8
-			IL_0032: ldstr ""
+			IL_0006: ldnull
+			IL_0007: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
+			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0012: ldc.i4.2
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldarg.0
+			IL_001b: stelem.ref
+			IL_001c: dup
+			IL_001d: ldc.i4.1
+			IL_001e: ldloc.0
+			IL_001f: stelem.ref
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_002f: ldc.i4.0
+			IL_0030: conv.r8
+			IL_0031: ldstr ""
+			IL_0036: ldc.i4.0
 			IL_0037: ldc.i4.0
-			IL_0038: ldc.i4.0
-			IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0043: stloc.2
-			IL_0044: ldloc.2
-			IL_0045: ldstr "nestedFunction"
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-			IL_004f: stloc.1
-			IL_0050: ldc.i4.2
-			IL_0051: newarr [System.Runtime]System.Object
-			IL_0056: dup
-			IL_0057: ldc.i4.0
-			IL_0058: ldarg.0
-			IL_0059: stelem.ref
-			IL_005a: dup
-			IL_005b: ldc.i4.1
-			IL_005c: ldloc.0
-			IL_005d: stelem.ref
-			IL_005e: stloc.3
-			IL_005f: ldloc.3
-			IL_0060: ldnull
-			IL_0061: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
-			IL_0066: pop
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_003d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0042: stloc.2
+			IL_0043: ldloc.2
+			IL_0044: ldstr "nestedFunction"
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+			IL_004e: stloc.1
+			IL_004f: ldc.i4.2
+			IL_0050: newarr [System.Runtime]System.Object
+			IL_0055: dup
+			IL_0056: ldc.i4.0
+			IL_0057: ldarg.0
+			IL_0058: stelem.ref
+			IL_0059: dup
+			IL_005a: ldc.i4.1
+			IL_005b: ldloc.0
+			IL_005c: stelem.ref
+			IL_005d: stloc.3
+			IL_005e: ldloc.3
+			IL_005f: ldnull
+			IL_0060: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
+			IL_0065: pop
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method ArrowFunction_L5C22::__js_call__
 
 	} // end of class ArrowFunction_L5C22
@@ -189,7 +188,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b0
+			// Method begins at RVA 0x21ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -215,7 +214,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope,
@@ -226,38 +225,37 @@
 		IL_0000: newobj instance void Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: ldloc.0
-		IL_0009: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-		IL_000e: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0019: ldc.i4.1
-		IL_001a: newarr [System.Runtime]System.Object
-		IL_001f: dup
-		IL_0020: ldc.i4.0
-		IL_0021: ldloc.0
-		IL_0022: stelem.ref
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_002d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0032: ldc.i4.0
-		IL_0033: conv.r8
-		IL_0034: ldstr ""
+		IL_0007: ldloc.0
+		IL_0008: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+		IL_000d: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_0013: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0018: ldc.i4.1
+		IL_0019: newarr [System.Runtime]System.Object
+		IL_001e: dup
+		IL_001f: ldc.i4.0
+		IL_0020: ldloc.0
+		IL_0021: stelem.ref
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0031: ldc.i4.0
+		IL_0032: conv.r8
+		IL_0033: ldstr ""
+		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.0
-		IL_003a: ldc.i4.0
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0045: stloc.2
-		IL_0046: ldloc.2
-		IL_0047: ldstr "testFunction"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0051: stloc.1
-		IL_0052: ldloc.0
-		IL_0053: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-		IL_0058: ldnull
-		IL_0059: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0044: stloc.2
+		IL_0045: ldloc.2
+		IL_0046: ldstr "testFunction"
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0050: stloc.1
+		IL_0051: ldloc.0
+		IL_0052: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+		IL_0057: ldnull
+		IL_0058: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method ArrowFunction_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes
@@ -269,7 +267,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21cb
+		// Method begins at RVA 0x21c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ee
+					// Method begins at RVA 0x21c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,14 +46,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2148
+				// Method begins at RVA 0x2134
 				// Header size: 12
-				// Code size: 136 (0x88)
+				// Code size: 112 (0x70)
 				.maxstack 8
 				.locals init (
-					[0] string,
-					[1] object,
-					[2] object
+					[0] string
 				)
 
 				IL_0000: ldstr "inner"
@@ -61,45 +59,29 @@
 				IL_0006: ldstr "console"
 				IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0015: stloc.1
-				IL_0016: ldarg.0
-				IL_0017: ldc.i4.0
-				IL_0018: ldelem.ref
-				IL_0019: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-				IL_001e: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-				IL_0023: stloc.2
-				IL_0024: ldloc.1
-				IL_0025: ldstr "log"
-				IL_002a: ldstr "Global:"
-				IL_002f: ldloc.2
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0035: pop
-				IL_0036: ldstr "console"
-				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0045: stloc.2
-				IL_0046: ldarg.0
-				IL_0047: ldc.i4.1
-				IL_0048: ldelem.ref
-				IL_0049: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope
-				IL_004e: ldfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
-				IL_0053: stloc.1
-				IL_0054: ldloc.2
-				IL_0055: ldstr "log"
-				IL_005a: ldstr "Outer:"
-				IL_005f: ldloc.1
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0065: pop
-				IL_0066: ldstr "console"
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0075: ldstr "log"
-				IL_007a: ldstr "Inner:"
-				IL_007f: ldloc.0
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0085: pop
-				IL_0086: ldnull
-				IL_0087: ret
+				IL_0015: ldstr "log"
+				IL_001a: ldstr "Global:"
+				IL_001f: ldstr "global"
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0029: pop
+				IL_002a: ldstr "console"
+				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0039: ldstr "log"
+				IL_003e: ldstr "Outer:"
+				IL_0043: ldstr "outer"
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_004d: pop
+				IL_004e: ldstr "console"
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_005d: ldstr "log"
+				IL_0062: ldstr "Inner:"
+				IL_0067: ldloc.0
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_006d: pop
+				IL_006e: ldnull
+				IL_006f: ret
 			} // end of method ArrowFunction_L8C28::__js_call__
 
 		} // end of class ArrowFunction_L8C28
@@ -107,18 +89,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 19 53 63 6f 70 65 20 6f 75 74 65 72 56 61
-				72 3d 7b 6f 75 74 65 72 56 61 72 7d 00 00
-			)
-			// Fields
-			.field public string outerVar
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e5
+				// Method begins at RVA 0x21b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,9 +119,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c8
+			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 115 (0x73)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope,
@@ -157,54 +132,52 @@
 
 			IL_0000: newobj instance void Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "outer"
-			IL_000c: stfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope::outerVar
-			IL_0011: ldnull
-			IL_0012: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
-			IL_0018: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_001d: ldc.i4.2
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: dup
-			IL_0028: ldc.i4.1
-			IL_0029: ldloc.0
-			IL_002a: stelem.ref
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0035: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_003a: ldc.i4.0
-			IL_003b: conv.r8
-			IL_003c: ldstr ""
-			IL_0041: ldc.i4.0
-			IL_0042: ldc.i4.0
-			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_004d: stloc.2
-			IL_004e: ldloc.2
-			IL_004f: ldstr "nestedFunction"
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-			IL_0059: stloc.1
-			IL_005a: ldc.i4.2
-			IL_005b: newarr [System.Runtime]System.Object
-			IL_0060: dup
-			IL_0061: ldc.i4.0
-			IL_0062: ldarg.0
-			IL_0063: stelem.ref
-			IL_0064: dup
-			IL_0065: ldc.i4.1
-			IL_0066: ldloc.0
-			IL_0067: stelem.ref
-			IL_0068: stloc.3
-			IL_0069: ldloc.3
-			IL_006a: ldnull
-			IL_006b: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
-			IL_0070: pop
-			IL_0071: ldnull
-			IL_0072: ret
+			IL_0006: nop
+			IL_0007: ldnull
+			IL_0008: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0013: ldc.i4.2
+			IL_0014: newarr [System.Runtime]System.Object
+			IL_0019: dup
+			IL_001a: ldc.i4.0
+			IL_001b: ldarg.0
+			IL_001c: stelem.ref
+			IL_001d: dup
+			IL_001e: ldc.i4.1
+			IL_001f: ldloc.0
+			IL_0020: stelem.ref
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_002b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0030: ldc.i4.0
+			IL_0031: conv.r8
+			IL_0032: ldstr ""
+			IL_0037: ldc.i4.0
+			IL_0038: ldc.i4.0
+			IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0043: stloc.2
+			IL_0044: ldloc.2
+			IL_0045: ldstr "nestedFunction"
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+			IL_004f: stloc.1
+			IL_0050: ldc.i4.2
+			IL_0051: newarr [System.Runtime]System.Object
+			IL_0056: dup
+			IL_0057: ldc.i4.0
+			IL_0058: ldarg.0
+			IL_0059: stelem.ref
+			IL_005a: dup
+			IL_005b: ldc.i4.1
+			IL_005c: ldloc.0
+			IL_005d: stelem.ref
+			IL_005e: stloc.3
+			IL_005f: ldloc.3
+			IL_0060: ldnull
+			IL_0061: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
+			IL_0066: pop
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method ArrowFunction_L5C22::__js_call__
 
 	} // end of class ArrowFunction_L5C22
@@ -212,18 +185,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 1b 53 63 6f 70 65 20 67 6c 6f 62 61 6c 56
-			61 72 3d 7b 67 6c 6f 62 61 6c 56 61 72 7d 00 00
-		)
-		// Fields
-		.field public string globalVar
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21dc
+			// Method begins at RVA 0x21b0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -249,7 +215,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 106 (0x6a)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope,
@@ -260,40 +226,38 @@
 		IL_0000: newobj instance void Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldstr "global"
-		IL_000d: stfld string Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-		IL_0012: ldloc.0
-		IL_0013: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-		IL_0018: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0023: ldc.i4.1
-		IL_0024: newarr [System.Runtime]System.Object
-		IL_0029: dup
-		IL_002a: ldc.i4.0
-		IL_002b: ldloc.0
-		IL_002c: stelem.ref
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_003c: ldc.i4.0
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.0
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_004f: stloc.2
-		IL_0050: ldloc.2
-		IL_0051: ldstr "testFunction"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_005b: stloc.1
-		IL_005c: ldloc.0
-		IL_005d: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
-		IL_0062: ldnull
-		IL_0063: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_0068: pop
-		IL_0069: ret
+		IL_0007: nop
+		IL_0008: ldloc.0
+		IL_0009: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+		IL_000e: ldftn object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0032: ldc.i4.0
+		IL_0033: conv.r8
+		IL_0034: ldstr ""
+		IL_0039: ldc.i4.0
+		IL_003a: ldc.i4.0
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0045: stloc.2
+		IL_0046: ldloc.2
+		IL_0047: ldstr "testFunction"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0051: stloc.1
+		IL_0052: ldloc.0
+		IL_0053: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+		IL_0058: ldnull
+		IL_0059: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method ArrowFunction_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes
@@ -305,7 +269,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f7
+		// Method begins at RVA 0x21cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2708
+				// Method begins at RVA 0x26eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2711
+				// Method begins at RVA 0x26f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,7 +126,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x271a
+				// Method begins at RVA 0x26fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2723
+				// Method begins at RVA 0x2706
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x272c
+				// Method begins at RVA 0x270f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -288,7 +288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2735
+				// Method begins at RVA 0x2718
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -341,7 +341,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273e
+				// Method begins at RVA 0x2721
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -404,7 +404,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2747
+				// Method begins at RVA 0x272a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -467,7 +467,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2750
+				// Method begins at RVA 0x2733
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -544,7 +544,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2759
+				// Method begins at RVA 0x273c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -562,7 +562,7 @@
 		.method public hidebysig static 
 			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
 				object newTarget,
-				object x
+				float64 x
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -570,48 +570,34 @@
 			)
 			// Method begins at RVA 0x26ac
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.0
-			IL_0007: ldloc.0
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stloc.1
-			IL_000e: ldloc.1
-			IL_000f: stloc.2
-			IL_0010: ldloc.0
-			IL_0011: ldc.r8 1
-			IL_001a: add
-			IL_001b: stloc.0
-			IL_001c: ldloc.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: stloc.1
-			IL_0023: ldloc.1
-			IL_0024: starg.s x
-			IL_0026: ldloc.2
-			IL_0027: ldarg.1
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_002d: stloc.3
-			IL_002e: ldc.i4.2
-			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0034: dup
-			IL_0035: ldloc.3
-			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_003b: dup
-			IL_003c: ldarg.1
-			IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0042: stloc.s 4
-			IL_0044: ldloc.s 4
-			IL_0046: ret
+			IL_0001: stloc.0
+			IL_0002: ldarg.1
+			IL_0003: ldc.r8 1
+			IL_000c: add
+			IL_000d: starg.s x
+			IL_000f: ldloc.0
+			IL_0010: ldarg.1
+			IL_0011: add
+			IL_0012: stloc.0
+			IL_0013: ldc.i4.2
+			IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0019: dup
+			IL_001a: ldloc.0
+			IL_001b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0020: dup
+			IL_0021: ldarg.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0027: stloc.1
+			IL_0028: ldloc.1
+			IL_0029: ret
 		} // end of method postfix::__js_call__
 
 	} // end of class postfix
@@ -648,7 +634,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26ff
+			// Method begins at RVA 0x26e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -685,7 +671,7 @@
 			[5] class [System.Runtime]System.Func`5<object, float64, float64, float64, object>,
 			[6] class [System.Runtime]System.Func`5<object, float64, float64, float64, object>,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[8] class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[10] object,
 			[11] object[],
@@ -807,15 +793,15 @@
 		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
 		IL_0149: stloc.s 7
 		IL_014b: ldnull
-		IL_014c: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, object)
-		IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0157: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_014c: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
+		IL_0152: newobj instance void class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
+		IL_0157: castclass class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>
 		IL_015c: ldc.i4.1
 		IL_015d: conv.r8
 		IL_015e: ldstr "postfix"
 		IL_0163: ldc.i4.0
 		IL_0164: ldc.i4.1
-		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>>(!!0, float64, string, bool, bool)
 		IL_016a: stloc.s 8
 		IL_016c: nop
 		IL_016d: nop
@@ -1070,7 +1056,7 @@
 		IL_04f4: ldloc.s 11
 		IL_04f6: ldc.r8 3
 		IL_04ff: box [System.Runtime]System.Double
-		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_0509: stloc.s 12
 		IL_050b: ldloc.s 12
 		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
@@ -1095,7 +1081,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2762
+		// Method begins at RVA 0x2745
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -22,7 +22,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2214
+			// Method begins at RVA 0x2210
 			// Header size: 12
 			// Code size: 34 (0x22)
 			.maxstack 8
@@ -56,7 +56,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2283
+				// Method begins at RVA 0x227f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228c
+				// Method begins at RVA 0x2288
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x2240
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -135,7 +135,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227a
+			// Method begins at RVA 0x2276
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -161,7 +161,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 437 (0x1b5)
+		// Code size: 435 (0x1b3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope,
@@ -180,141 +180,139 @@
 		IL_0000: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: nop
-		IL_0009: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_000e: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0013: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0018: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_001d: stloc.3
-		IL_001e: ldloc.3
-		IL_001f: ldstr "prototype"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0029: stloc.s 4
-		IL_002b: ldloc.0
-		IL_002c: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-		IL_0031: ldftn object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
-		IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_003c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0041: ldc.i4.0
-		IL_0042: conv.r8
-		IL_0043: ldstr ""
-		IL_0048: ldc.i4.0
-		IL_0049: ldc.i4.1
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_004f: stloc.s 5
-		IL_0051: ldloc.s 4
-		IL_0053: ldstr "bump"
-		IL_0058: ldloc.s 5
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_005f: pop
-		IL_0060: ldc.i4.1
-		IL_0061: newarr [System.Runtime]System.Object
-		IL_0066: dup
-		IL_0067: ldc.i4.0
-		IL_0068: ldloc.0
-		IL_0069: stelem.ref
-		IL_006a: stloc.s 6
-		IL_006c: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0071: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0076: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_007b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0080: stloc.3
-		IL_0081: ldloc.3
-		IL_0082: ldloc.s 6
-		IL_0084: ldc.r8 0.0
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0097: stloc.s 4
-		IL_0099: ldloc.s 4
-		IL_009b: stloc.1
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.s 6
-		IL_00a8: ldloc.s 6
-		IL_00aa: ldc.i4.0
-		IL_00ab: newarr [System.Runtime]System.Object
-		IL_00b0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00b5: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
-		IL_00ba: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00bf: stloc.2
-		IL_00c0: ldloc.2
-		IL_00c1: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_00c6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00cb: ldstr "prototype"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00d5: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00da: ldstr "console"
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: stloc.s 4
-		IL_00eb: ldloc.2
-		IL_00ec: ldstr "value"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 4
-		IL_00fa: ldstr "log"
-		IL_00ff: ldloc.s 7
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0106: pop
-		IL_0107: ldstr "console"
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0116: stloc.s 7
-		IL_0118: ldloc.2
-		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
-		IL_011e: stloc.s 8
-		IL_0120: ldc.i4.0
-		IL_0121: newarr [System.Runtime]System.Object
-		IL_0126: stloc.s 6
-		IL_0128: ldloc.s 8
-		IL_012a: ldstr "bump"
-		IL_012f: ldloc.s 6
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0136: stloc.s 4
-		IL_0138: ldloc.s 7
-		IL_013a: ldstr "log"
-		IL_013f: ldloc.s 4
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0146: pop
-		IL_0147: ldstr "console"
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0156: stloc.s 4
-		IL_0158: ldloc.2
-		IL_0159: ldstr "value"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0163: stloc.s 7
-		IL_0165: ldloc.s 4
-		IL_0167: ldstr "log"
-		IL_016c: ldloc.s 7
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0173: pop
-		IL_0174: ldstr "console"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0183: stloc.s 7
-		IL_0185: ldloc.2
-		IL_0186: ldstr "fieldKey"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0190: stloc.s 4
-		IL_0192: ldloc.s 4
-		IL_0194: ldnull
-		IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_019a: stloc.s 9
-		IL_019c: ldloc.s 9
-		IL_019e: box [System.Runtime]System.Boolean
-		IL_01a3: stloc.s 10
-		IL_01a5: ldloc.s 7
-		IL_01a7: ldstr "log"
-		IL_01ac: ldloc.s 10
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: pop
-		IL_01b4: ret
+		IL_0007: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_000c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0011: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001b: stloc.3
+		IL_001c: ldloc.3
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: stloc.s 4
+		IL_0029: ldloc.0
+		IL_002a: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
+		IL_002f: ldftn object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
+		IL_0035: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_003a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_003f: ldc.i4.0
+		IL_0040: conv.r8
+		IL_0041: ldstr ""
+		IL_0046: ldc.i4.0
+		IL_0047: ldc.i4.1
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_004d: stloc.s 5
+		IL_004f: ldloc.s 4
+		IL_0051: ldstr "bump"
+		IL_0056: ldloc.s 5
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005d: pop
+		IL_005e: ldc.i4.1
+		IL_005f: newarr [System.Runtime]System.Object
+		IL_0064: dup
+		IL_0065: ldc.i4.0
+		IL_0066: ldloc.0
+		IL_0067: stelem.ref
+		IL_0068: stloc.s 6
+		IL_006a: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_006f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0074: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0079: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_007e: stloc.3
+		IL_007f: ldloc.3
+		IL_0080: ldloc.s 6
+		IL_0082: ldc.r8 0.0
+		IL_008b: box [System.Runtime]System.Double
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0095: stloc.s 4
+		IL_0097: ldloc.s 4
+		IL_0099: stloc.1
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: stloc.s 6
+		IL_00a6: ldloc.s 6
+		IL_00a8: ldc.i4.0
+		IL_00a9: newarr [System.Runtime]System.Object
+		IL_00ae: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00b3: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
+		IL_00b8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00bd: stloc.2
+		IL_00be: ldloc.2
+		IL_00bf: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_00c4: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00c9: ldstr "prototype"
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00d8: ldstr "console"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e7: stloc.s 4
+		IL_00e9: ldloc.2
+		IL_00ea: ldstr "value"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f4: stloc.s 7
+		IL_00f6: ldloc.s 4
+		IL_00f8: ldstr "log"
+		IL_00fd: ldloc.s 7
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0104: pop
+		IL_0105: ldstr "console"
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0114: stloc.s 7
+		IL_0116: ldloc.2
+		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
+		IL_011c: stloc.s 8
+		IL_011e: ldc.i4.0
+		IL_011f: newarr [System.Runtime]System.Object
+		IL_0124: stloc.s 6
+		IL_0126: ldloc.s 8
+		IL_0128: ldstr "bump"
+		IL_012d: ldloc.s 6
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0134: stloc.s 4
+		IL_0136: ldloc.s 7
+		IL_0138: ldstr "log"
+		IL_013d: ldloc.s 4
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0144: pop
+		IL_0145: ldstr "console"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0154: stloc.s 4
+		IL_0156: ldloc.2
+		IL_0157: ldstr "value"
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0161: stloc.s 7
+		IL_0163: ldloc.s 4
+		IL_0165: ldstr "log"
+		IL_016a: ldloc.s 7
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0171: pop
+		IL_0172: ldstr "console"
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0181: stloc.s 7
+		IL_0183: ldloc.2
+		IL_0184: ldstr "fieldKey"
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018e: stloc.s 4
+		IL_0190: ldloc.s 4
+		IL_0192: ldnull
+		IL_0193: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0198: stloc.s 9
+		IL_019a: ldloc.s 9
+		IL_019c: box [System.Runtime]System.Boolean
+		IL_01a1: stloc.s 10
+		IL_01a3: ldloc.s 7
+		IL_01a5: ldstr "log"
+		IL_01aa: ldloc.s 10
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b1: pop
+		IL_01b2: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DynamicKey_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log
@@ -326,7 +324,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2295
+		// Method begins at RVA 0x2291
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -22,28 +22,25 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x222c
+			// Method begins at RVA 0x2214
 			// Header size: 12
-			// Code size: 37 (0x25)
+			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-			IL_0006: stloc.0
-			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0012: stloc.0
-			IL_0013: ldloc.0
-			IL_0014: ldc.r8 1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0022: stloc.1
-			IL_0023: ldloc.1
-			IL_0024: ret
+			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0005: ldstr "value"
+			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_000f: stloc.0
+			IL_0010: ldloc.0
+			IL_0011: ldc.r8 1
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_001f: stloc.1
+			IL_0020: ldloc.1
+			IL_0021: ret
 		} // end of method methodKey::__js_call__
 
 	} // end of class methodKey
@@ -59,7 +56,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a9
+				// Method begins at RVA 0x2283
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b2
+				// Method begins at RVA 0x228c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,13 +102,12 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2260
+			// Method begins at RVA 0x2244
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -121,19 +117,13 @@
 			IL_0008: ldarg.0
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::_scopes
-			IL_000f: ldarg.1
-			IL_0010: ldc.i4.0
-			IL_0011: ldelem.ref
-			IL_0012: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-			IL_0017: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-			IL_001c: stloc.1
-			IL_001d: ldarg.0
-			IL_001e: ldloc.1
-			IL_001f: ldc.r8 41
-			IL_0028: box [System.Runtime]System.Double
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassFieldDataProperty(object, object, object)
-			IL_0032: pop
-			IL_0033: ret
+			IL_000f: ldarg.0
+			IL_0010: ldstr "value"
+			IL_0015: ldc.r8 41
+			IL_001e: box [System.Runtime]System.Double
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassFieldDataProperty(object, object, object)
+			IL_0028: pop
+			IL_0029: ret
 		} // end of method Example::.ctor
 
 	} // end of class Example
@@ -141,21 +131,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 30 53 63 6f 70 65 20 66 69 65 6c 64 4b 65
-			79 3d 7b 66 69 65 6c 64 4b 65 79 7d 2c 20 6d 65
-			74 68 6f 64 4b 65 79 3d 7b 6d 65 74 68 6f 64 4b
-			65 79 7d 00 00
-		)
-		// Fields
-		.field public string fieldKey
-		.field public string methodKey
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a0
+			// Method begins at RVA 0x227a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -181,17 +161,17 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 462 (0x1ce)
+		// Code size: 437 (0x1b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope,
 			[1] object,
 			[2] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example,
-			[3] object,
-			[4] class [System.Runtime]System.Type,
-			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[7] object[],
+			[3] class [System.Runtime]System.Type,
+			[4] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[6] object[],
+			[7] object,
 			[8] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example,
 			[9] bool,
 			[10] object
@@ -200,154 +180,141 @@
 		IL_0000: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldstr "value"
-		IL_000d: stfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-		IL_0012: ldloc.0
-		IL_0013: ldstr "bump"
-		IL_0018: stfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
-		IL_001d: ldloc.0
-		IL_001e: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
-		IL_0023: stloc.3
-		IL_0024: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0029: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002e: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0038: stloc.s 4
-		IL_003a: ldloc.s 4
-		IL_003c: ldstr "prototype"
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0046: stloc.s 5
-		IL_0048: ldloc.0
-		IL_0049: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-		IL_004e: ldftn object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
-		IL_0054: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0059: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_005e: ldc.i4.0
-		IL_005f: conv.r8
-		IL_0060: ldstr ""
-		IL_0065: ldc.i4.0
-		IL_0066: ldc.i4.1
-		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_006c: stloc.s 6
-		IL_006e: ldloc.s 5
-		IL_0070: ldloc.3
-		IL_0071: ldloc.s 6
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0078: pop
-		IL_0079: ldc.i4.1
-		IL_007a: newarr [System.Runtime]System.Object
-		IL_007f: dup
-		IL_0080: ldc.i4.0
-		IL_0081: ldloc.0
-		IL_0082: stelem.ref
-		IL_0083: stloc.s 7
-		IL_0085: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_008a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_008f: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_0094: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0099: stloc.s 4
-		IL_009b: ldloc.s 4
-		IL_009d: ldloc.s 7
-		IL_009f: ldc.r8 0.0
-		IL_00a8: box [System.Runtime]System.Double
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_00b2: stloc.3
-		IL_00b3: ldloc.3
-		IL_00b4: stloc.1
-		IL_00b5: ldc.i4.1
-		IL_00b6: newarr [System.Runtime]System.Object
-		IL_00bb: dup
-		IL_00bc: ldc.i4.0
-		IL_00bd: ldloc.0
-		IL_00be: stelem.ref
-		IL_00bf: stloc.s 7
-		IL_00c1: ldloc.s 7
-		IL_00c3: ldc.i4.0
-		IL_00c4: newarr [System.Runtime]System.Object
-		IL_00c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00ce: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
-		IL_00d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00d8: stloc.2
-		IL_00d9: ldloc.2
-		IL_00da: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
-		IL_00df: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00e4: ldstr "prototype"
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00ee: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00f3: ldstr "console"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0102: stloc.3
-		IL_0103: ldloc.0
-		IL_0104: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::fieldKey
-		IL_0109: stloc.s 5
-		IL_010b: ldloc.2
-		IL_010c: ldloc.s 5
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0113: stloc.s 5
-		IL_0115: ldloc.3
-		IL_0116: ldstr "log"
-		IL_011b: ldloc.s 5
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0122: pop
-		IL_0123: ldstr "console"
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: stloc.s 5
-		IL_0134: ldloc.2
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
-		IL_013a: stloc.s 8
-		IL_013c: ldloc.0
-		IL_013d: ldfld string Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope::methodKey
-		IL_0142: stloc.3
-		IL_0143: ldc.i4.0
-		IL_0144: newarr [System.Runtime]System.Object
-		IL_0149: stloc.s 7
-		IL_014b: ldloc.s 8
-		IL_014d: ldloc.3
-		IL_014e: ldloc.s 7
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
-		IL_0155: stloc.3
-		IL_0156: ldloc.s 5
-		IL_0158: ldstr "log"
-		IL_015d: ldloc.3
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0163: pop
-		IL_0164: ldstr "console"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0173: stloc.3
-		IL_0174: ldloc.2
-		IL_0175: ldstr "value"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017f: stloc.s 5
-		IL_0181: ldloc.3
-		IL_0182: ldstr "log"
-		IL_0187: ldloc.s 5
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018e: pop
-		IL_018f: ldstr "console"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019e: stloc.s 5
-		IL_01a0: ldloc.2
-		IL_01a1: ldstr "fieldKey"
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ab: stloc.3
-		IL_01ac: ldloc.3
-		IL_01ad: ldnull
-		IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01b3: stloc.s 9
-		IL_01b5: ldloc.s 9
-		IL_01b7: box [System.Runtime]System.Boolean
-		IL_01bc: stloc.s 10
-		IL_01be: ldloc.s 5
-		IL_01c0: ldstr "log"
-		IL_01c5: ldloc.s 10
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cc: pop
-		IL_01cd: ret
+		IL_0007: nop
+		IL_0008: nop
+		IL_0009: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_000e: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0013: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0018: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001d: stloc.3
+		IL_001e: ldloc.3
+		IL_001f: ldstr "prototype"
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0029: stloc.s 4
+		IL_002b: ldloc.0
+		IL_002c: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
+		IL_0031: ldftn object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
+		IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_003c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0041: ldc.i4.0
+		IL_0042: conv.r8
+		IL_0043: ldstr ""
+		IL_0048: ldc.i4.0
+		IL_0049: ldc.i4.1
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_004f: stloc.s 5
+		IL_0051: ldloc.s 4
+		IL_0053: ldstr "bump"
+		IL_0058: ldloc.s 5
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_005f: pop
+		IL_0060: ldc.i4.1
+		IL_0061: newarr [System.Runtime]System.Object
+		IL_0066: dup
+		IL_0067: ldc.i4.0
+		IL_0068: ldloc.0
+		IL_0069: stelem.ref
+		IL_006a: stloc.s 6
+		IL_006c: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_0071: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0076: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_007b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0080: stloc.3
+		IL_0081: ldloc.3
+		IL_0082: ldloc.s 6
+		IL_0084: ldc.r8 0.0
+		IL_008d: box [System.Runtime]System.Double
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0097: stloc.s 4
+		IL_0099: ldloc.s 4
+		IL_009b: stloc.1
+		IL_009c: ldc.i4.1
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: dup
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldloc.0
+		IL_00a5: stelem.ref
+		IL_00a6: stloc.s 6
+		IL_00a8: ldloc.s 6
+		IL_00aa: ldc.i4.0
+		IL_00ab: newarr [System.Runtime]System.Object
+		IL_00b0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_00b5: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example::.ctor(object[])
+		IL_00ba: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00bf: stloc.2
+		IL_00c0: ldloc.2
+		IL_00c1: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example
+		IL_00c6: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00cb: ldstr "prototype"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00d5: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00da: ldstr "console"
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e9: stloc.s 4
+		IL_00eb: ldloc.2
+		IL_00ec: ldstr "value"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f6: stloc.s 7
+		IL_00f8: ldloc.s 4
+		IL_00fa: ldstr "log"
+		IL_00ff: ldloc.s 7
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0106: pop
+		IL_0107: ldstr "console"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.s 7
+		IL_0118: ldloc.2
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example>(!!0)
+		IL_011e: stloc.s 8
+		IL_0120: ldc.i4.0
+		IL_0121: newarr [System.Runtime]System.Object
+		IL_0126: stloc.s 6
+		IL_0128: ldloc.s 8
+		IL_012a: ldstr "bump"
+		IL_012f: ldloc.s 6
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember(object, object, object[])
+		IL_0136: stloc.s 4
+		IL_0138: ldloc.s 7
+		IL_013a: ldstr "log"
+		IL_013f: ldloc.s 4
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0146: pop
+		IL_0147: ldstr "console"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0156: stloc.s 4
+		IL_0158: ldloc.2
+		IL_0159: ldstr "value"
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0163: stloc.s 7
+		IL_0165: ldloc.s 4
+		IL_0167: ldstr "log"
+		IL_016c: ldloc.s 7
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0173: pop
+		IL_0174: ldstr "console"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: stloc.s 7
+		IL_0185: ldloc.2
+		IL_0186: ldstr "fieldKey"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0190: stloc.s 4
+		IL_0192: ldloc.s 4
+		IL_0194: ldnull
+		IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_019a: stloc.s 9
+		IL_019c: ldloc.s 9
+		IL_019e: box [System.Runtime]System.Boolean
+		IL_01a3: stloc.s 10
+		IL_01a5: ldloc.s 7
+		IL_01a7: ldstr "log"
+		IL_01ac: ldloc.s 10
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b3: pop
+		IL_01b4: ret
 	} // end of method Classes_ClassComputedFieldAndMethod_DynamicKey_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log
@@ -359,7 +326,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22bb
+		// Method begins at RVA 0x2295
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b3
+					// Method begins at RVA 0x219b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21bc
+					// Method begins at RVA 0x21a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,9 +69,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2114
+				// Method begins at RVA 0x2108
 				// Header size: 12
-				// Code size: 129 (0x81)
+				// Code size: 117 (0x75)
 				.maxstack 8
 				.locals init (
 					[0] object[],
@@ -104,26 +104,18 @@
 				IL_003a: ldstr "console"
 				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0049: stloc.2
-				IL_004a: ldarg.1
-				IL_004b: ldc.i4.1
-				IL_004c: ldelem.ref
-				IL_004d: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope
-				IL_0052: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0057: stloc.1
-				IL_0058: ldloc.2
-				IL_0059: ldstr "log"
-				IL_005e: ldloc.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0064: pop
-				IL_0065: ldstr "console"
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0074: ldstr "log"
-				IL_0079: ldarg.2
-				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_007f: pop
-				IL_0080: ret
+				IL_0049: ldstr "log"
+				IL_004e: ldstr "Hello from function"
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0058: pop
+				IL_0059: ldstr "console"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0068: ldstr "log"
+				IL_006d: ldarg.2
+				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0073: pop
+				IL_0074: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -131,19 +123,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21aa
+				// Method begins at RVA 0x2192
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +155,7 @@
 			)
 			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 97 (0x61)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope,
@@ -181,41 +165,39 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldstr "Hello from parameter"
-			IL_002f: stelem.ref
-			IL_0030: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0035: ldstr "Hello from parameter"
-			IL_003a: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
-			IL_003f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0044: stloc.1
-			IL_0045: ldloc.1
-			IL_0046: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass
-			IL_004b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0050: ldstr "prototype"
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_005a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_005f: ldnull
-			IL_0060: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldstr "Hello from parameter"
+			IL_0025: stelem.ref
+			IL_0026: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_002b: ldstr "Hello from parameter"
+			IL_0030: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
+			IL_0035: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_003a: stloc.1
+			IL_003b: ldloc.1
+			IL_003c: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass
+			IL_0041: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0046: ldstr "prototype"
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0050: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -238,7 +220,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a1
+			// Method begins at RVA 0x2189
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -306,7 +288,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c5
+		// Method begins at RVA 0x21ad
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -155,7 +155,7 @@
 			)
 			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 87 (0x57)
+			// Code size: 86 (0x56)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope,
@@ -166,38 +166,37 @@
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.1
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: dup
-			IL_001f: ldc.i4.0
-			IL_0020: ldstr "Hello from parameter"
-			IL_0025: stelem.ref
-			IL_0026: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002b: ldstr "Hello from parameter"
-			IL_0030: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
-			IL_0035: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_003a: stloc.1
-			IL_003b: ldloc.1
-			IL_003c: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass
-			IL_0041: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0046: ldstr "prototype"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0050: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0055: ldnull
-			IL_0056: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr "Hello from parameter"
+			IL_0024: stelem.ref
+			IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_002a: ldstr "Hello from parameter"
+			IL_002f: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
+			IL_0034: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_0039: stloc.1
+			IL_003a: ldloc.1
+			IL_003b: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass
+			IL_0040: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0045: ldstr "prototype"
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_004f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0054: ldnull
+			IL_0055: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -147,7 +147,7 @@
 			)
 			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 73 (0x49)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope,
@@ -158,33 +158,32 @@
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.0
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0023: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0039: ldstr "prototype"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0048: ldnull
-			IL_0049: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.0
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0022: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002c: stloc.1
+			IL_002d: ldloc.1
+			IL_002e: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+			IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0038: ldstr "prototype"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0042: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0047: ldnull
+			IL_0048: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2188
+					// Method begins at RVA 0x2174
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2191
+					// Method begins at RVA 0x217d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,9 +68,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2104
+				// Method begins at RVA 0x20fc
 				// Header size: 12
-				// Code size: 102 (0x66)
+				// Code size: 90 (0x5a)
 				.maxstack 8
 				.locals init (
 					[0] object[],
@@ -103,19 +103,11 @@
 				IL_003a: ldstr "console"
 				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0049: stloc.2
-				IL_004a: ldarg.1
-				IL_004b: ldc.i4.1
-				IL_004c: ldelem.ref
-				IL_004d: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
-				IL_0052: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0057: stloc.1
-				IL_0058: ldloc.2
-				IL_0059: ldstr "log"
-				IL_005e: ldloc.1
-				IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0064: pop
-				IL_0065: ret
+				IL_0049: ldstr "log"
+				IL_004e: ldstr "Hello from function"
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0058: pop
+				IL_0059: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -123,19 +115,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217f
+				// Method begins at RVA 0x216b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -163,7 +147,7 @@
 			)
 			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope,
@@ -173,36 +157,34 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.0
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002d: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-			IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0043: ldstr "prototype"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.0
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0023: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0039: ldstr "prototype"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0048: ldnull
+			IL_0049: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -225,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2176
+			// Method begins at RVA 0x2162
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -293,7 +275,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219a
+		// Method begins at RVA 0x2186
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -138,7 +138,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 87 (0x57)
+			// Code size: 86 (0x56)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope,
@@ -149,38 +149,37 @@
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.1
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: dup
-			IL_001f: ldc.i4.0
-			IL_0020: ldstr "Hello from parameter"
-			IL_0025: stelem.ref
-			IL_0026: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002b: ldstr "Hello from parameter"
-			IL_0030: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
-			IL_0035: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_003a: stloc.1
-			IL_003b: ldloc.1
-			IL_003c: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass
-			IL_0041: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0046: ldstr "prototype"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0050: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0055: ldnull
-			IL_0056: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.1
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: dup
+			IL_001e: ldc.i4.0
+			IL_001f: ldstr "Hello from parameter"
+			IL_0024: stelem.ref
+			IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_002a: ldstr "Hello from parameter"
+			IL_002f: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
+			IL_0034: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_0039: stloc.1
+			IL_003a: ldloc.1
+			IL_003b: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass
+			IL_0040: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0045: ldstr "prototype"
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_004f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0054: ldnull
+			IL_0055: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217c
+					// Method begins at RVA 0x2164
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2185
+					// Method begins at RVA 0x216d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,14 +69,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2108
+				// Method begins at RVA 0x20fc
 				// Header size: 12
-				// Code size: 86 (0x56)
+				// Code size: 74 (0x4a)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object,
-					[2] object
+					[0] object[]
 				)
 
 				IL_0000: ldarg.0
@@ -89,26 +87,18 @@
 				IL_000f: ldstr "console"
 				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001e: stloc.1
-				IL_001f: ldarg.1
-				IL_0020: ldc.i4.1
-				IL_0021: ldelem.ref
-				IL_0022: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope
-				IL_0027: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_002c: stloc.2
-				IL_002d: ldloc.1
-				IL_002e: ldstr "log"
-				IL_0033: ldloc.2
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0039: pop
-				IL_003a: ldstr "console"
-				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0049: ldstr "log"
-				IL_004e: ldarg.2
-				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0054: pop
-				IL_0055: ret
+				IL_001e: ldstr "log"
+				IL_0023: ldstr "Hello from function"
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_002d: pop
+				IL_002e: ldstr "console"
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_003d: ldstr "log"
+				IL_0042: ldarg.2
+				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0048: pop
+				IL_0049: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -116,19 +106,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2173
+				// Method begins at RVA 0x215b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +138,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 97 (0x61)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope,
@@ -166,41 +148,39 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldstr "Hello from parameter"
-			IL_002f: stelem.ref
-			IL_0030: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0035: ldstr "Hello from parameter"
-			IL_003a: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
-			IL_003f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0044: stloc.1
-			IL_0045: ldloc.1
-			IL_0046: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass
-			IL_004b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0050: ldstr "prototype"
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_005a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_005f: ldnull
-			IL_0060: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.1
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: dup
+			IL_001f: ldc.i4.0
+			IL_0020: ldstr "Hello from parameter"
+			IL_0025: stelem.ref
+			IL_0026: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_002b: ldstr "Hello from parameter"
+			IL_0030: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass::.ctor(object[], string)
+			IL_0035: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_003a: stloc.1
+			IL_003b: ldloc.1
+			IL_003c: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass
+			IL_0041: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0046: ldstr "prototype"
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0050: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -220,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216a
+			// Method begins at RVA 0x2152
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -285,7 +265,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218e
+		// Method begins at RVA 0x2176
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2151
+					// Method begins at RVA 0x213d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215a
+					// Method begins at RVA 0x2146
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,14 +68,12 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x20f8
+				// Method begins at RVA 0x20f0
 				// Header size: 12
-				// Code size: 59 (0x3b)
+				// Code size: 47 (0x2f)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object,
-					[2] object
+					[0] object[]
 				)
 
 				IL_0000: ldarg.0
@@ -88,19 +86,11 @@
 				IL_000f: ldstr "console"
 				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001e: stloc.1
-				IL_001f: ldarg.1
-				IL_0020: ldc.i4.1
-				IL_0021: ldelem.ref
-				IL_0022: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope
-				IL_0027: ldfld string Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_002c: stloc.2
-				IL_002d: ldloc.1
-				IL_002e: ldstr "log"
-				IL_0033: ldloc.2
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0039: pop
-				IL_003a: ret
+				IL_001e: ldstr "log"
+				IL_0023: ldstr "Hello from function"
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_002d: pop
+				IL_002e: ret
 			} // end of method MyClass::.ctor
 
 		} // end of class MyClass
@@ -108,19 +98,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2148
+				// Method begins at RVA 0x2134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -148,7 +130,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope,
@@ -158,36 +140,34 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.0
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002d: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass
-			IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0043: ldstr "prototype"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.0
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0023: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass
+			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0039: ldstr "prototype"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0048: ldnull
+			IL_0049: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -207,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213f
+			// Method begins at RVA 0x212b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -272,7 +252,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2163
+		// Method begins at RVA 0x214f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -130,7 +130,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 74 (0x4a)
+			// Code size: 73 (0x49)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope,
@@ -141,33 +141,32 @@
 			IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.0
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0023: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass
-			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0039: ldstr "prototype"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0048: ldnull
-			IL_0049: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.0
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0022: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002c: stloc.1
+			IL_002d: ldloc.1
+			IL_002e: ldtoken Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass
+			IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0038: ldstr "prototype"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0042: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0047: ldnull
+			IL_0048: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
@@ -132,7 +132,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 83 (0x53)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope,
@@ -144,33 +144,32 @@
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: nop
-		IL_0008: nop
-		IL_0009: ldc.i4.1
-		IL_000a: newarr [System.Runtime]System.Object
-		IL_000f: dup
-		IL_0010: ldc.i4.0
-		IL_0011: ldloc.0
-		IL_0012: stelem.ref
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldc.i4.1
-		IL_0016: newarr [System.Runtime]System.Object
-		IL_001b: dup
-		IL_001c: ldc.i4.0
-		IL_001d: ldstr "Hello from parameter"
-		IL_0022: stelem.ref
-		IL_0023: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0028: ldstr "Hello from parameter"
-		IL_002d: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass::.ctor(object[], string)
-		IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0037: stloc.1
-		IL_0038: ldloc.1
-		IL_0039: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass
-		IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0043: ldstr "prototype"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0052: ret
+		IL_0008: ldc.i4.1
+		IL_0009: newarr [System.Runtime]System.Object
+		IL_000e: dup
+		IL_000f: ldc.i4.0
+		IL_0010: ldloc.0
+		IL_0011: stelem.ref
+		IL_0012: stloc.2
+		IL_0013: ldloc.2
+		IL_0014: ldc.i4.1
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: dup
+		IL_001b: ldc.i4.0
+		IL_001c: ldstr "Hello from parameter"
+		IL_0021: stelem.ref
+		IL_0022: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0027: ldstr "Hello from parameter"
+		IL_002c: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass::.ctor(object[], string)
+		IL_0031: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0036: stloc.1
+		IL_0037: ldloc.1
+		IL_0038: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass
+		IL_003d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0042: ldstr "prototype"
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_004c: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0051: ret
 	} // end of method Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2127
+				// Method begins at RVA 0x210f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2130
+				// Method begins at RVA 0x2118
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,14 +65,12 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20bc
+			// Method begins at RVA 0x20b0
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object,
-				[2] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -85,26 +83,18 @@
 			IL_000f: ldstr "console"
 			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.1
-			IL_0020: ldc.i4.0
-			IL_0021: ldelem.ref
-			IL_0022: castclass Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope
-			IL_0027: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-			IL_002c: stloc.2
-			IL_002d: ldloc.1
-			IL_002e: ldstr "log"
-			IL_0033: ldloc.2
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0039: pop
-			IL_003a: ldstr "console"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0049: ldstr "log"
-			IL_004e: ldarg.2
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0054: pop
-			IL_0055: ret
+			IL_001e: ldstr "log"
+			IL_0023: ldstr "Hello from global"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002d: pop
+			IL_002e: ldstr "console"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003d: ldstr "log"
+			IL_0042: ldarg.2
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0048: pop
+			IL_0049: ret
 		} // end of method MyClass::.ctor
 
 	} // end of class MyClass
@@ -112,19 +102,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 21 53 63 6f 70 65 20 47 4c 4f 42 41 4c 5f
-			56 41 4c 55 45 3d 7b 47 4c 4f 42 41 4c 5f 56 41
-			4c 55 45 7d 00 00
-		)
-		// Fields
-		.field public string GLOBAL_VALUE
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211e
+			// Method begins at RVA 0x2106
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -150,7 +132,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 93 (0x5d)
+		// Code size: 83 (0x53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope,
@@ -161,36 +143,34 @@
 		IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldstr "Hello from global"
-		IL_000d: stfld string Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-		IL_0012: nop
-		IL_0013: ldc.i4.1
-		IL_0014: newarr [System.Runtime]System.Object
-		IL_0019: dup
-		IL_001a: ldc.i4.0
-		IL_001b: ldloc.0
-		IL_001c: stelem.ref
-		IL_001d: stloc.2
-		IL_001e: ldloc.2
-		IL_001f: ldc.i4.1
-		IL_0020: newarr [System.Runtime]System.Object
-		IL_0025: dup
-		IL_0026: ldc.i4.0
-		IL_0027: ldstr "Hello from parameter"
-		IL_002c: stelem.ref
-		IL_002d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0032: ldstr "Hello from parameter"
-		IL_0037: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass::.ctor(object[], string)
-		IL_003c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0041: stloc.1
-		IL_0042: ldloc.1
-		IL_0043: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass
-		IL_0048: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_004d: ldstr "prototype"
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0057: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_005c: ret
+		IL_0007: nop
+		IL_0008: nop
+		IL_0009: ldc.i4.1
+		IL_000a: newarr [System.Runtime]System.Object
+		IL_000f: dup
+		IL_0010: ldc.i4.0
+		IL_0011: ldloc.0
+		IL_0012: stelem.ref
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldc.i4.1
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: dup
+		IL_001c: ldc.i4.0
+		IL_001d: ldstr "Hello from parameter"
+		IL_0022: stelem.ref
+		IL_0023: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0028: ldstr "Hello from parameter"
+		IL_002d: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass::.ctor(object[], string)
+		IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0037: stloc.1
+		IL_0038: ldloc.1
+		IL_0039: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass
+		IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0043: ldstr "prototype"
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0052: ret
 	} // end of method Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log
@@ -202,7 +182,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2139
+		// Method begins at RVA 0x2121
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
@@ -124,7 +124,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 70 (0x46)
+		// Code size: 69 (0x45)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope,
@@ -136,28 +136,27 @@
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: nop
-		IL_0008: nop
-		IL_0009: ldc.i4.1
-		IL_000a: newarr [System.Runtime]System.Object
-		IL_000f: dup
-		IL_0010: ldc.i4.0
-		IL_0011: ldloc.0
-		IL_0012: stelem.ref
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldc.i4.0
-		IL_0016: newarr [System.Runtime]System.Object
-		IL_001b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0020: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass::.ctor(object[])
-		IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_002a: stloc.1
-		IL_002b: ldloc.1
-		IL_002c: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass
-		IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0036: ldstr "prototype"
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0040: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0045: ret
+		IL_0008: ldc.i4.1
+		IL_0009: newarr [System.Runtime]System.Object
+		IL_000e: dup
+		IL_000f: ldc.i4.0
+		IL_0010: ldloc.0
+		IL_0011: stelem.ref
+		IL_0012: stloc.2
+		IL_0013: ldloc.2
+		IL_0014: ldc.i4.0
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_001f: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass::.ctor(object[])
+		IL_0024: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0029: stloc.1
+		IL_002a: ldloc.1
+		IL_002b: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass
+		IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0035: ldstr "prototype"
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_003f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0044: ret
 	} // end of method Classes_ClassConstructor_AccessGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fc
+				// Method begins at RVA 0x20e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2105
+				// Method begins at RVA 0x20f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,14 +64,12 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ac
+			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Code size: 47 (0x2f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object,
-				[2] object
+				[0] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -84,19 +82,11 @@
 			IL_000f: ldstr "console"
 			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001e: stloc.1
-			IL_001f: ldarg.1
-			IL_0020: ldc.i4.0
-			IL_0021: ldelem.ref
-			IL_0022: castclass Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope
-			IL_0027: ldfld string Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_002c: stloc.2
-			IL_002d: ldloc.1
-			IL_002e: ldstr "log"
-			IL_0033: ldloc.2
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0039: pop
-			IL_003a: ret
+			IL_001e: ldstr "log"
+			IL_0023: ldstr "Hello from global"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002d: pop
+			IL_002e: ret
 		} // end of method MyClass::.ctor
 
 	} // end of class MyClass
@@ -104,19 +94,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 21 53 63 6f 70 65 20 47 4c 4f 42 41 4c 5f
-			56 41 4c 55 45 3d 7b 47 4c 4f 42 41 4c 5f 56 41
-			4c 55 45 7d 00 00
-		)
-		// Fields
-		.field public string GLOBAL_VALUE
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f3
+			// Method begins at RVA 0x20df
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -142,7 +124,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 80 (0x50)
+		// Code size: 70 (0x46)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope,
@@ -153,31 +135,29 @@
 		IL_0000: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldstr "Hello from global"
-		IL_000d: stfld string Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_0012: nop
-		IL_0013: ldc.i4.1
-		IL_0014: newarr [System.Runtime]System.Object
-		IL_0019: dup
-		IL_001a: ldc.i4.0
-		IL_001b: ldloc.0
-		IL_001c: stelem.ref
-		IL_001d: stloc.2
-		IL_001e: ldloc.2
-		IL_001f: ldc.i4.0
-		IL_0020: newarr [System.Runtime]System.Object
-		IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_002a: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass::.ctor(object[])
-		IL_002f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0034: stloc.1
-		IL_0035: ldloc.1
-		IL_0036: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass
-		IL_003b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0040: ldstr "prototype"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_004a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_004f: ret
+		IL_0007: nop
+		IL_0008: nop
+		IL_0009: ldc.i4.1
+		IL_000a: newarr [System.Runtime]System.Object
+		IL_000f: dup
+		IL_0010: ldc.i4.0
+		IL_0011: ldloc.0
+		IL_0012: stelem.ref
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldc.i4.0
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0020: newobj instance void Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass::.ctor(object[])
+		IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_002a: stloc.1
+		IL_002b: ldloc.1
+		IL_002c: ldtoken Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass
+		IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0036: ldstr "prototype"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0040: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0045: ret
 	} // end of method Classes_ClassConstructor_AccessGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessGlobalVariable_Log
@@ -189,7 +169,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210e
+		// Method begins at RVA 0x20fa
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -18,6 +18,87 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
+				// Method begins at RVA 0x21bc
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_ctor
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21c5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ctor::.ctor
+
+		} // end of class Scope_ctor
+
+
+		// Fields
+		.field private object[] _scopes
+		.field public float64 'value'
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2188
+			// Header size: 12
+			// Code size: 31 (0x1f)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::_scopes
+			IL_000f: ldarg.0
+			IL_0010: ldc.r8 42
+			IL_0019: stfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
+			IL_001e: ret
+		} // end of method Inner::.ctor
+
+	} // end of class Inner
+
+	.class nested public auto ansi beforefieldinit Outer
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
 				// Method begins at RVA 0x21ce
 				// Header size: 1
 				// Code size: 8 (0x8)
@@ -54,94 +135,6 @@
 
 		// Fields
 		.field private object[] _scopes
-		.field public float64 'value'
-
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor (
-				object[] scopes
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 02 00 00 00 00 00
-			)
-			// Method begins at RVA 0x2194
-			// Header size: 12
-			// Code size: 37 (0x25)
-			.maxstack 8
-			.locals init (
-				[0] object[],
-				[1] float64
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-			IL_0006: ldarg.1
-			IL_0007: stloc.0
-			IL_0008: ldarg.0
-			IL_0009: ldloc.0
-			IL_000a: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::_scopes
-			IL_000f: ldarg.1
-			IL_0010: ldc.i4.0
-			IL_0011: ldelem.ref
-			IL_0012: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
-			IL_0017: ldfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-			IL_001c: stloc.1
-			IL_001d: ldarg.0
-			IL_001e: ldloc.1
-			IL_001f: stfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner::'value'
-			IL_0024: ret
-		} // end of method Inner::.ctor
-
-	} // end of class Inner
-
-	.class nested public auto ansi beforefieldinit Outer
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x21e0
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-		.class nested public auto ansi beforefieldinit Scope_ctor
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x21e9
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope_ctor::.ctor
-
-		} // end of class Scope_ctor
-
-
-		// Fields
-		.field private object[] _scopes
 		.field public class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner inner
 
 		// Methods
@@ -153,7 +146,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x215c
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -184,20 +177,17 @@
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 30 53 63 6f 70 65 20 47 4c 4f 42 41 4c 5f
-			56 41 4c 55 45 3d 7b 47 4c 4f 42 41 4c 5f 56 41
-			4c 55 45 7d 2c 20 49 6e 6e 65 72 3d 7b 49 6e 6e
-			65 72 7d 00 00
+			01 00 13 53 63 6f 70 65 20 49 6e 6e 65 72 3d 7b
+			49 6e 6e 65 72 7d 00 00
 		)
 		// Fields
-		.field public float64 GLOBAL_VALUE
 		.field public object Inner
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c5
+			// Method begins at RVA 0x21b3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -223,7 +213,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 267 (0x10b)
+		// Code size: 253 (0xfd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope,
@@ -238,88 +228,86 @@
 		IL_0000: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldc.r8 42
-		IL_0011: stfld float64 Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::GLOBAL_VALUE
-		IL_0016: ldc.i4.1
-		IL_0017: newarr [System.Runtime]System.Object
-		IL_001c: dup
-		IL_001d: ldc.i4.0
-		IL_001e: ldloc.0
-		IL_001f: stelem.ref
-		IL_0020: stloc.3
-		IL_0021: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
-		IL_0026: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002b: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
-		IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0035: stloc.s 4
-		IL_0037: ldloc.s 4
-		IL_0039: ldloc.3
-		IL_003a: ldc.r8 0.0
-		IL_0043: box [System.Runtime]System.Double
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_004d: stloc.s 5
-		IL_004f: ldloc.0
-		IL_0050: ldloc.s 5
-		IL_0052: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::Inner
-		IL_0057: ldc.i4.1
-		IL_0058: newarr [System.Runtime]System.Object
-		IL_005d: dup
-		IL_005e: ldc.i4.0
-		IL_005f: ldloc.0
-		IL_0060: stelem.ref
-		IL_0061: stloc.3
-		IL_0062: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_0067: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_006c: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_0071: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0076: stloc.s 4
-		IL_0078: ldloc.s 4
-		IL_007a: ldloc.3
-		IL_007b: ldc.r8 0.0
-		IL_0084: box [System.Runtime]System.Double
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.s 5
-		IL_0092: stloc.1
-		IL_0093: ldc.i4.1
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldloc.0
-		IL_009c: stelem.ref
-		IL_009d: stloc.3
-		IL_009e: ldloc.3
-		IL_009f: ldc.i4.0
-		IL_00a0: newarr [System.Runtime]System.Object
-		IL_00a5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_00aa: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer::.ctor(object[])
-		IL_00af: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00b4: stloc.2
-		IL_00b5: ldloc.2
-		IL_00b6: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_00bb: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00c0: ldstr "prototype"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00ca: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00cf: ldstr "console"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: stloc.s 5
-		IL_00e0: ldloc.2
-		IL_00e1: ldstr "inner"
+		IL_0007: nop
+		IL_0008: ldc.i4.1
+		IL_0009: newarr [System.Runtime]System.Object
+		IL_000e: dup
+		IL_000f: ldc.i4.0
+		IL_0010: ldloc.0
+		IL_0011: stelem.ref
+		IL_0012: stloc.3
+		IL_0013: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
+		IL_0018: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001d: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
+		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0027: stloc.s 4
+		IL_0029: ldloc.s 4
+		IL_002b: ldloc.3
+		IL_002c: ldc.r8 0.0
+		IL_0035: box [System.Runtime]System.Double
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_003f: stloc.s 5
+		IL_0041: ldloc.0
+		IL_0042: ldloc.s 5
+		IL_0044: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::Inner
+		IL_0049: ldc.i4.1
+		IL_004a: newarr [System.Runtime]System.Object
+		IL_004f: dup
+		IL_0050: ldc.i4.0
+		IL_0051: ldloc.0
+		IL_0052: stelem.ref
+		IL_0053: stloc.3
+		IL_0054: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_0059: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_005e: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_0063: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0068: stloc.s 4
+		IL_006a: ldloc.s 4
+		IL_006c: ldloc.3
+		IL_006d: ldc.r8 0.0
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0080: stloc.s 5
+		IL_0082: ldloc.s 5
+		IL_0084: stloc.1
+		IL_0085: ldc.i4.1
+		IL_0086: newarr [System.Runtime]System.Object
+		IL_008b: dup
+		IL_008c: ldc.i4.0
+		IL_008d: ldloc.0
+		IL_008e: stelem.ref
+		IL_008f: stloc.3
+		IL_0090: ldloc.3
+		IL_0091: ldc.i4.0
+		IL_0092: newarr [System.Runtime]System.Object
+		IL_0097: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_009c: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer::.ctor(object[])
+		IL_00a1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00a6: stloc.2
+		IL_00a7: ldloc.2
+		IL_00a8: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_00ad: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00b2: ldstr "prototype"
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00bc: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00c1: ldstr "console"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.s 5
+		IL_00d2: ldloc.2
+		IL_00d3: ldstr "inner"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00dd: stloc.s 6
+		IL_00df: ldloc.s 6
+		IL_00e1: ldstr "value"
 		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00eb: stloc.s 6
-		IL_00ed: ldloc.s 6
-		IL_00ef: ldstr "value"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f9: stloc.s 6
-		IL_00fb: ldloc.s 5
-		IL_00fd: ldstr "log"
-		IL_0102: ldloc.s 6
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0109: pop
-		IL_010a: ret
+		IL_00ed: ldloc.s 5
+		IL_00ef: ldstr "log"
+		IL_00f4: ldloc.s 6
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fb: pop
+		IL_00fc: ret
 	} // end of method Classes_ClassConstructor_NewClassReferencingGlobal::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_NewClassReferencingGlobal
@@ -331,7 +319,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f2
+		// Method begins at RVA 0x21e0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bc
+				// Method begins at RVA 0x21b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c5
+				// Method begins at RVA 0x21c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x2184
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ce
+				// Method begins at RVA 0x21ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d7
+				// Method begins at RVA 0x21d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -146,7 +146,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2158
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -187,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b3
+			// Method begins at RVA 0x21af
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -213,7 +213,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 253 (0xfd)
+		// Code size: 252 (0xfc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope,
@@ -228,86 +228,85 @@
 		IL_0000: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: ldc.i4.1
-		IL_0009: newarr [System.Runtime]System.Object
-		IL_000e: dup
-		IL_000f: ldc.i4.0
-		IL_0010: ldloc.0
-		IL_0011: stelem.ref
-		IL_0012: stloc.3
-		IL_0013: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
-		IL_0018: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_001d: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
-		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0027: stloc.s 4
-		IL_0029: ldloc.s 4
-		IL_002b: ldloc.3
-		IL_002c: ldc.r8 0.0
-		IL_0035: box [System.Runtime]System.Double
-		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_003f: stloc.s 5
-		IL_0041: ldloc.0
-		IL_0042: ldloc.s 5
-		IL_0044: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::Inner
-		IL_0049: ldc.i4.1
-		IL_004a: newarr [System.Runtime]System.Object
-		IL_004f: dup
-		IL_0050: ldc.i4.0
-		IL_0051: ldloc.0
-		IL_0052: stelem.ref
-		IL_0053: stloc.3
-		IL_0054: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_0059: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_005e: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_0063: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0068: stloc.s 4
-		IL_006a: ldloc.s 4
-		IL_006c: ldloc.3
-		IL_006d: ldc.r8 0.0
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.s 5
-		IL_0084: stloc.1
-		IL_0085: ldc.i4.1
-		IL_0086: newarr [System.Runtime]System.Object
-		IL_008b: dup
-		IL_008c: ldc.i4.0
-		IL_008d: ldloc.0
-		IL_008e: stelem.ref
-		IL_008f: stloc.3
-		IL_0090: ldloc.3
-		IL_0091: ldc.i4.0
-		IL_0092: newarr [System.Runtime]System.Object
-		IL_0097: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_009c: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer::.ctor(object[])
-		IL_00a1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_00a6: stloc.2
-		IL_00a7: ldloc.2
-		IL_00a8: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
-		IL_00ad: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_00b2: ldstr "prototype"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_00bc: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_00c1: ldstr "console"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d0: stloc.s 5
-		IL_00d2: ldloc.2
-		IL_00d3: ldstr "inner"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00dd: stloc.s 6
-		IL_00df: ldloc.s 6
-		IL_00e1: ldstr "value"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00eb: stloc.s 6
-		IL_00ed: ldloc.s 5
-		IL_00ef: ldstr "log"
-		IL_00f4: ldloc.s 6
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fb: pop
-		IL_00fc: ret
+		IL_0007: ldc.i4.1
+		IL_0008: newarr [System.Runtime]System.Object
+		IL_000d: dup
+		IL_000e: ldc.i4.0
+		IL_000f: ldloc.0
+		IL_0010: stelem.ref
+		IL_0011: stloc.3
+		IL_0012: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
+		IL_0017: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001c: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner
+		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0026: stloc.s 4
+		IL_0028: ldloc.s 4
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 0.0
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_003e: stloc.s 5
+		IL_0040: ldloc.0
+		IL_0041: ldloc.s 5
+		IL_0043: stfld object Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope::Inner
+		IL_0048: ldc.i4.1
+		IL_0049: newarr [System.Runtime]System.Object
+		IL_004e: dup
+		IL_004f: ldc.i4.0
+		IL_0050: ldloc.0
+		IL_0051: stelem.ref
+		IL_0052: stloc.3
+		IL_0053: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_0058: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_005d: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_0062: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0067: stloc.s 4
+		IL_0069: ldloc.s 4
+		IL_006b: ldloc.3
+		IL_006c: ldc.r8 0.0
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_007f: stloc.s 5
+		IL_0081: ldloc.s 5
+		IL_0083: stloc.1
+		IL_0084: ldc.i4.1
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: dup
+		IL_008b: ldc.i4.0
+		IL_008c: ldloc.0
+		IL_008d: stelem.ref
+		IL_008e: stloc.3
+		IL_008f: ldloc.3
+		IL_0090: ldc.i4.0
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_009b: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer::.ctor(object[])
+		IL_00a0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_00a5: stloc.2
+		IL_00a6: ldloc.2
+		IL_00a7: ldtoken Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer
+		IL_00ac: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_00b1: ldstr "prototype"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_00bb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_00c0: ldstr "console"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cf: stloc.s 5
+		IL_00d1: ldloc.2
+		IL_00d2: ldstr "inner"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00dc: stloc.s 6
+		IL_00de: ldloc.s 6
+		IL_00e0: ldstr "value"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ea: stloc.s 6
+		IL_00ec: ldloc.s 5
+		IL_00ee: ldstr "log"
+		IL_00f3: ldloc.s 6
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fa: pop
+		IL_00fb: ret
 	} // end of method Classes_ClassConstructor_NewClassReferencingGlobal::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_NewClassReferencingGlobal
@@ -319,7 +318,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e0
+		// Method begins at RVA 0x21dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -152,7 +152,7 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope,
@@ -164,39 +164,38 @@
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.0
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::.ctor(object[])
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
-			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0039: ldstr "prototype"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0048: ldloc.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass>(!!0)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.0
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0022: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::.ctor(object[])
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002c: stloc.1
+			IL_002d: ldloc.1
+			IL_002e: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
+			IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0038: ldstr "prototype"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0042: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0047: ldloc.1
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass>(!!0)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
+			IL_0054: pop
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method ArrowFunction_L5C27::__js_call__
 
 	} // end of class ArrowFunction_L5C27
@@ -234,7 +233,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope,
@@ -245,38 +244,37 @@
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: ldloc.0
-		IL_0009: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-		IL_000e: ldftn object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0019: ldc.i4.1
-		IL_001a: newarr [System.Runtime]System.Object
-		IL_001f: dup
-		IL_0020: ldc.i4.0
-		IL_0021: ldloc.0
-		IL_0022: stelem.ref
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_002d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0032: ldc.i4.0
-		IL_0033: conv.r8
-		IL_0034: ldstr ""
+		IL_0007: ldloc.0
+		IL_0008: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+		IL_000d: ldftn object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_0013: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0018: ldc.i4.1
+		IL_0019: newarr [System.Runtime]System.Object
+		IL_001e: dup
+		IL_001f: ldc.i4.0
+		IL_0020: ldloc.0
+		IL_0021: stelem.ref
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0031: ldc.i4.0
+		IL_0032: conv.r8
+		IL_0033: ldstr ""
+		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.0
-		IL_003a: ldc.i4.0
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0045: stloc.2
-		IL_0046: ldloc.2
-		IL_0047: ldstr "testArrowFunction"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0051: stloc.1
-		IL_0052: ldloc.0
-		IL_0053: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0058: ldnull
-		IL_0059: call object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0044: stloc.2
+		IL_0045: ldloc.2
+		IL_0046: ldstr "testArrowFunction"
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0050: stloc.1
+		IL_0051: ldloc.0
+		IL_0052: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0057: ldnull
+		IL_0058: call object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d4
+					// Method begins at RVA 0x219a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21dd
+					// Method begins at RVA 0x21a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2120
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,49 +92,27 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2154
+				// Method begins at RVA 0x213c
 				// Header size: 12
-				// Code size: 98 (0x62)
+				// Code size: 64 (0x40)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object
-				)
 
 				IL_0000: ldstr "console"
 				IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000f: stloc.0
-				IL_0010: ldarg.0
-				IL_0011: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
-				IL_0016: ldc.i4.0
-				IL_0017: ldelem.ref
-				IL_0018: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-				IL_001d: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-				IL_0022: stloc.1
-				IL_0023: ldloc.0
-				IL_0024: ldstr "log"
-				IL_0029: ldloc.1
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002f: pop
-				IL_0030: ldstr "console"
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003f: stloc.1
-				IL_0040: ldarg.0
-				IL_0041: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::_scopes
-				IL_0046: ldc.i4.1
-				IL_0047: ldelem.ref
-				IL_0048: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope
-				IL_004d: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
-				IL_0052: stloc.0
-				IL_0053: ldloc.1
-				IL_0054: ldstr "log"
-				IL_0059: ldloc.0
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_005f: pop
-				IL_0060: ldnull
-				IL_0061: ret
+				IL_000f: ldstr "log"
+				IL_0014: ldstr "Hello from global"
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_001e: pop
+				IL_001f: ldstr "console"
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002e: ldstr "log"
+				IL_0033: ldstr "Hello from function"
+				IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_003d: pop
+				IL_003e: ldnull
+				IL_003f: ret
 			} // end of method MyClass::logValues
 
 		} // end of class MyClass
@@ -142,19 +120,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x2191
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -180,9 +150,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c8
+			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope,
@@ -193,42 +163,40 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.0
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002d: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::.ctor(object[])
-			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
-			IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0043: ldstr "prototype"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0052: ldloc.1
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass>(!!0)
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
-			IL_005f: pop
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.0
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::.ctor(object[])
+			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
+			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0039: ldstr "prototype"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0048: ldloc.1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass>(!!0)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method ArrowFunction_L5C27::__js_call__
 
 	} // end of class ArrowFunction_L5C27
@@ -236,19 +204,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 21 53 63 6f 70 65 20 47 4c 4f 42 41 4c 5f
-			56 41 4c 55 45 3d 7b 47 4c 4f 42 41 4c 5f 56 41
-			4c 55 45 7d 00 00
-		)
-		// Fields
-		.field public string GLOBAL_VALUE
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x2188
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -274,7 +234,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 106 (0x6a)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope,
@@ -285,40 +245,38 @@
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldstr "Hello from global"
-		IL_000d: stfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_0012: ldloc.0
-		IL_0013: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0018: ldftn object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0023: ldc.i4.1
-		IL_0024: newarr [System.Runtime]System.Object
-		IL_0029: dup
-		IL_002a: ldc.i4.0
-		IL_002b: ldloc.0
-		IL_002c: stelem.ref
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_003c: ldc.i4.0
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.0
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_004f: stloc.2
-		IL_0050: ldloc.2
-		IL_0051: ldstr "testArrowFunction"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_005b: stloc.1
-		IL_005c: ldloc.0
-		IL_005d: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0062: ldnull
-		IL_0063: call object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_0068: pop
-		IL_0069: ret
+		IL_0007: nop
+		IL_0008: ldloc.0
+		IL_0009: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+		IL_000e: ldftn object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_0014: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0019: ldc.i4.1
+		IL_001a: newarr [System.Runtime]System.Object
+		IL_001f: dup
+		IL_0020: ldc.i4.0
+		IL_0021: ldloc.0
+		IL_0022: stelem.ref
+		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0032: ldc.i4.0
+		IL_0033: conv.r8
+		IL_0034: ldstr ""
+		IL_0039: ldc.i4.0
+		IL_003a: ldc.i4.0
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0045: stloc.2
+		IL_0046: ldloc.2
+		IL_0047: ldstr "testArrowFunction"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0051: stloc.1
+		IL_0052: ldloc.0
+		IL_0053: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0058: ldnull
+		IL_0059: call object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log
@@ -330,7 +288,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e6
+		// Method begins at RVA 0x21ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2198
+					// Method begins at RVA 0x2170
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a1
+					// Method begins at RVA 0x2179
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x212c
+				// Method begins at RVA 0x2120
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,33 +92,20 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2148
-				// Header size: 12
-				// Code size: 50 (0x32)
+				// Method begins at RVA 0x213c
+				// Header size: 1
+				// Code size: 33 (0x21)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object
-				)
 
 				IL_0000: ldstr "console"
 				IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000f: stloc.0
-				IL_0010: ldarg.0
-				IL_0011: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::_scopes
-				IL_0016: ldc.i4.1
-				IL_0017: ldelem.ref
-				IL_0018: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope
-				IL_001d: ldfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
-				IL_0022: stloc.1
-				IL_0023: ldloc.0
-				IL_0024: ldstr "log"
-				IL_0029: ldloc.1
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002f: pop
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000f: ldstr "log"
+				IL_0014: ldstr "Hello from function"
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_001e: pop
+				IL_001f: ldnull
+				IL_0020: ret
 			} // end of method MyClass::logValue
 
 		} // end of class MyClass
@@ -126,19 +113,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218f
+				// Method begins at RVA 0x2167
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,7 +145,7 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope,
@@ -177,42 +156,40 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.0
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002d: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::.ctor(object[])
-			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
-			IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0043: ldstr "prototype"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0052: ldloc.1
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass>(!!0)
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
-			IL_005f: pop
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.0
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::.ctor(object[])
+			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
+			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0039: ldstr "prototype"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0048: ldloc.1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass>(!!0)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method ArrowFunction_L3C27::__js_call__
 
 	} // end of class ArrowFunction_L3C27
@@ -224,7 +201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2186
+			// Method begins at RVA 0x215e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -303,7 +280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21aa
+		// Method begins at RVA 0x2182
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -145,7 +145,7 @@
 			)
 			// Method begins at RVA 0x20bc
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope,
@@ -157,39 +157,38 @@
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.0
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::.ctor(object[])
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
-			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0039: ldstr "prototype"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0048: ldloc.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass>(!!0)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.0
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0022: newobj instance void Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::.ctor(object[])
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002c: stloc.1
+			IL_002d: ldloc.1
+			IL_002e: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
+			IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0038: ldstr "prototype"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0042: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0047: ldloc.1
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass>(!!0)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: callvirt instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
+			IL_0054: pop
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method ArrowFunction_L3C27::__js_call__
 
 	} // end of class ArrowFunction_L3C27

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -165,7 +165,7 @@
 			)
 			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope,
@@ -177,39 +177,38 @@
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.0
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0039: ldstr "prototype"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0048: ldloc.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass>(!!0)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.0
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0022: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002c: stloc.1
+			IL_002d: ldloc.1
+			IL_002e: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+			IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0038: ldstr "prototype"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0042: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0047: ldloc.1
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass>(!!0)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
+			IL_0054: pop
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b0
+					// Method begins at RVA 0x2193
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b9
+					// Method begins at RVA 0x219c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2114
+				// Method begins at RVA 0x2108
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,9 +92,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2130
+				// Method begins at RVA 0x2124
 				// Header size: 12
-				// Code size: 98 (0x62)
+				// Code size: 81 (0x51)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -120,21 +120,12 @@
 				IL_0030: ldstr "console"
 				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_003f: stloc.1
-				IL_0040: ldarg.0
-				IL_0041: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::_scopes
-				IL_0046: ldc.i4.1
-				IL_0047: ldelem.ref
-				IL_0048: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope
-				IL_004d: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0052: stloc.0
-				IL_0053: ldloc.1
-				IL_0054: ldstr "log"
-				IL_0059: ldloc.0
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_005f: pop
-				IL_0060: ldnull
-				IL_0061: ret
+				IL_003f: ldstr "log"
+				IL_0044: ldstr "Hello from function"
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004e: pop
+				IL_004f: ldnull
+				IL_0050: ret
 			} // end of method MyClass::logValues
 
 		} // end of class MyClass
@@ -142,19 +133,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a7
+				// Method begins at RVA 0x218a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +165,7 @@
 			)
 			// Method begins at RVA 0x20a4
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope,
@@ -193,42 +176,40 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.0
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002d: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-			IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0043: ldstr "prototype"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0052: ldloc.1
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass>(!!0)
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
-			IL_005f: pop
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.0
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0039: ldstr "prototype"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0048: ldloc.1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass>(!!0)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -251,7 +232,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219e
+			// Method begins at RVA 0x2181
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -319,7 +300,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c2
+		// Method begins at RVA 0x21a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -145,7 +145,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 87 (0x57)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope,
@@ -157,39 +157,38 @@
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: nop
-			IL_0007: nop
-			IL_0008: ldc.i4.2
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: dup
-			IL_0013: ldc.i4.1
-			IL_0014: ldloc.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldc.i4.0
-			IL_0019: newarr [System.Runtime]System.Object
-			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
-			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0039: ldstr "prototype"
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0048: ldloc.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass>(!!0)
-			IL_004e: stloc.3
-			IL_004f: ldloc.3
-			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0007: ldc.i4.2
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: dup
+			IL_0012: ldc.i4.1
+			IL_0013: ldloc.0
+			IL_0014: stelem.ref
+			IL_0015: stloc.2
+			IL_0016: ldloc.2
+			IL_0017: ldc.i4.0
+			IL_0018: newarr [System.Runtime]System.Object
+			IL_001d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0022: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0027: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002c: stloc.1
+			IL_002d: ldloc.1
+			IL_002e: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
+			IL_0033: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0038: ldstr "prototype"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0042: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0047: ldloc.1
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass>(!!0)
+			IL_004d: stloc.3
+			IL_004e: ldloc.3
+			IL_004f: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
+			IL_0054: pop
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2174
+					// Method begins at RVA 0x214c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217d
+					// Method begins at RVA 0x2155
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2108
+				// Method begins at RVA 0x20fc
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,33 +92,20 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2124
-				// Header size: 12
-				// Code size: 50 (0x32)
+				// Method begins at RVA 0x2118
+				// Header size: 1
+				// Code size: 33 (0x21)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object
-				)
 
 				IL_0000: ldstr "console"
 				IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000f: stloc.0
-				IL_0010: ldarg.0
-				IL_0011: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::_scopes
-				IL_0016: ldc.i4.1
-				IL_0017: ldelem.ref
-				IL_0018: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope
-				IL_001d: ldfld string Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-				IL_0022: stloc.1
-				IL_0023: ldloc.0
-				IL_0024: ldstr "log"
-				IL_0029: ldloc.1
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002f: pop
-				IL_0030: ldnull
-				IL_0031: ret
+				IL_000f: ldstr "log"
+				IL_0014: ldstr "Hello from function"
+				IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_001e: pop
+				IL_001f: ldnull
+				IL_0020: ret
 			} // end of method MyClass::logValue
 
 		} // end of class MyClass
@@ -126,19 +113,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 25 53 63 6f 70 65 20 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 3d 7b 46 55 4e 43 54 49 4f
-				4e 5f 56 41 4c 55 45 7d 00 00
-			)
-			// Fields
-			.field public string FUNCTION_VALUE
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216b
+				// Method begins at RVA 0x2143
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,7 +145,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope,
@@ -177,42 +156,40 @@
 
 			IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldstr "Hello from function"
-			IL_000c: stfld string Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/Scope::FUNCTION_VALUE
-			IL_0011: nop
-			IL_0012: ldc.i4.2
-			IL_0013: newarr [System.Runtime]System.Object
-			IL_0018: dup
-			IL_0019: ldc.i4.0
-			IL_001a: ldarg.0
-			IL_001b: stelem.ref
-			IL_001c: dup
-			IL_001d: ldc.i4.1
-			IL_001e: ldloc.0
-			IL_001f: stelem.ref
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.i4.0
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_002d: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
-			IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_0037: stloc.1
-			IL_0038: ldloc.1
-			IL_0039: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
-			IL_003e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0043: ldstr "prototype"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_004d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_0052: ldloc.1
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass>(!!0)
-			IL_0058: stloc.3
-			IL_0059: ldloc.3
-			IL_005a: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
-			IL_005f: pop
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_0006: nop
+			IL_0007: nop
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldloc.0
+			IL_0015: stelem.ref
+			IL_0016: stloc.2
+			IL_0017: ldloc.2
+			IL_0018: ldc.i4.0
+			IL_0019: newarr [System.Runtime]System.Object
+			IL_001e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_0023: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::.ctor(object[])
+			IL_0028: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_002d: stloc.1
+			IL_002e: ldloc.1
+			IL_002f: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
+			IL_0034: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0039: ldstr "prototype"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_0043: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_0048: ldloc.1
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass>(!!0)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: callvirt instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -232,7 +209,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2162
+			// Method begins at RVA 0x213a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -297,7 +274,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2186
+		// Method begins at RVA 0x215e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211f
+				// Method begins at RVA 0x20f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2128
+				// Method begins at RVA 0x2100
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20bc
+			// Method begins at RVA 0x20b0
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -88,33 +88,20 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20d8
-			// Header size: 12
-			// Code size: 50 (0x32)
+			// Method begins at RVA 0x20cc
+			// Header size: 1
+			// Code size: 33 (0x21)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object
-			)
 
 			IL_0000: ldstr "console"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000f: stloc.0
-			IL_0010: ldarg.0
-			IL_0011: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::_scopes
-			IL_0016: ldc.i4.0
-			IL_0017: ldelem.ref
-			IL_0018: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope
-			IL_001d: ldfld string Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-			IL_0022: stloc.1
-			IL_0023: ldloc.0
-			IL_0024: ldstr "log"
-			IL_0029: ldloc.1
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002f: pop
-			IL_0030: ldnull
-			IL_0031: ret
+			IL_000f: ldstr "log"
+			IL_0014: ldstr "Hello from global"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_001e: pop
+			IL_001f: ldnull
+			IL_0020: ret
 		} // end of method MyClass::logGlobal
 
 	} // end of class MyClass
@@ -122,19 +109,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 21 53 63 6f 70 65 20 47 4c 4f 42 41 4c 5f
-			56 41 4c 55 45 3d 7b 47 4c 4f 42 41 4c 5f 56 41
-			4c 55 45 7d 00 00
-		)
-		// Fields
-		.field public string GLOBAL_VALUE
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2116
+			// Method begins at RVA 0x20ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -160,7 +139,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 94 (0x5e)
+		// Code size: 84 (0x54)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope,
@@ -172,37 +151,35 @@
 		IL_0000: newobj instance void Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldstr "Hello from global"
-		IL_000d: stfld string Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_0012: nop
-		IL_0013: ldc.i4.1
-		IL_0014: newarr [System.Runtime]System.Object
-		IL_0019: dup
-		IL_001a: ldc.i4.0
-		IL_001b: ldloc.0
-		IL_001c: stelem.ref
-		IL_001d: stloc.2
-		IL_001e: ldloc.2
-		IL_001f: ldc.i4.0
-		IL_0020: newarr [System.Runtime]System.Object
-		IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_002a: newobj instance void Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::.ctor(object[])
-		IL_002f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0034: stloc.1
-		IL_0035: ldloc.1
-		IL_0036: ldtoken Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
-		IL_003b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0040: ldstr "prototype"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_004a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_004f: ldloc.1
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass>(!!0)
-		IL_0055: stloc.3
-		IL_0056: ldloc.3
-		IL_0057: callvirt instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
-		IL_005c: pop
-		IL_005d: ret
+		IL_0007: nop
+		IL_0008: nop
+		IL_0009: ldc.i4.1
+		IL_000a: newarr [System.Runtime]System.Object
+		IL_000f: dup
+		IL_0010: ldc.i4.0
+		IL_0011: ldloc.0
+		IL_0012: stelem.ref
+		IL_0013: stloc.2
+		IL_0014: ldloc.2
+		IL_0015: ldc.i4.0
+		IL_0016: newarr [System.Runtime]System.Object
+		IL_001b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0020: newobj instance void Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::.ctor(object[])
+		IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_002a: stloc.1
+		IL_002b: ldloc.1
+		IL_002c: ldtoken Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
+		IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0036: ldstr "prototype"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0040: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0045: ldloc.1
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass>(!!0)
+		IL_004b: stloc.3
+		IL_004c: ldloc.3
+		IL_004d: callvirt instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
+		IL_0052: pop
+		IL_0053: ret
 	} // end of method Classes_ClassMethod_AccessGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessGlobalVariable_Log
@@ -214,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2131
+		// Method begins at RVA 0x2109
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -139,7 +139,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 84 (0x54)
+		// Code size: 83 (0x53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessGlobalVariable_Log/Scope,
@@ -152,34 +152,33 @@
 		IL_0005: stloc.0
 		IL_0006: nop
 		IL_0007: nop
-		IL_0008: nop
-		IL_0009: ldc.i4.1
-		IL_000a: newarr [System.Runtime]System.Object
-		IL_000f: dup
-		IL_0010: ldc.i4.0
-		IL_0011: ldloc.0
-		IL_0012: stelem.ref
-		IL_0013: stloc.2
-		IL_0014: ldloc.2
-		IL_0015: ldc.i4.0
-		IL_0016: newarr [System.Runtime]System.Object
-		IL_001b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0020: newobj instance void Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::.ctor(object[])
-		IL_0025: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_002a: stloc.1
-		IL_002b: ldloc.1
-		IL_002c: ldtoken Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
-		IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0036: ldstr "prototype"
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0040: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0045: ldloc.1
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass>(!!0)
-		IL_004b: stloc.3
-		IL_004c: ldloc.3
-		IL_004d: callvirt instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
-		IL_0052: pop
-		IL_0053: ret
+		IL_0008: ldc.i4.1
+		IL_0009: newarr [System.Runtime]System.Object
+		IL_000e: dup
+		IL_000f: ldc.i4.0
+		IL_0010: ldloc.0
+		IL_0011: stelem.ref
+		IL_0012: stloc.2
+		IL_0013: ldloc.2
+		IL_0014: ldc.i4.0
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_001f: newobj instance void Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::.ctor(object[])
+		IL_0024: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0029: stloc.1
+		IL_002a: ldloc.1
+		IL_002b: ldtoken Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
+		IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0035: ldstr "prototype"
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_003f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0044: ldloc.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass>(!!0)
+		IL_004a: stloc.3
+		IL_004b: ldloc.3
+		IL_004c: callvirt instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
+		IL_0051: pop
+		IL_0052: ret
 	} // end of method Classes_ClassMethod_AccessGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -240,7 +240,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 550 (0x226)
+			// Code size: 549 (0x225)
 			.maxstack 13
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
@@ -254,237 +254,236 @@
 
 			IL_0000: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: nop
-			IL_0007: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_000c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0011: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_001b: stloc.3
-			IL_001c: ldc.i4.2
-			IL_001d: newarr [System.Runtime]System.Object
-			IL_0022: dup
-			IL_0023: ldc.i4.0
-			IL_0024: ldarg.0
-			IL_0025: stelem.ref
-			IL_0026: dup
-			IL_0027: ldc.i4.1
-			IL_0028: ldloc.0
-			IL_0029: stelem.ref
-			IL_002a: stloc.s 4
-			IL_002c: ldc.i4.s 10
-			IL_002e: newarr [System.Runtime]System.Object
-			IL_0033: dup
-			IL_0034: ldc.i4.0
-			IL_0035: ldloc.3
-			IL_0036: stelem.ref
-			IL_0037: dup
-			IL_0038: ldc.i4.1
-			IL_0039: ldstr "m"
-			IL_003e: stelem.ref
-			IL_003f: dup
-			IL_0040: ldc.i4.2
-			IL_0041: ldstr "m"
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.3
-			IL_0049: ldc.r8 0.0
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.4
-			IL_005a: ldstr "m"
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.5
-			IL_0062: ldc.i4.0
-			IL_0063: box [System.Runtime]System.Boolean
-			IL_0068: stelem.ref
-			IL_0069: dup
-			IL_006a: ldc.i4.6
-			IL_006b: ldc.i4.0
-			IL_006c: box [System.Runtime]System.Boolean
-			IL_0071: stelem.ref
-			IL_0072: dup
-			IL_0073: ldc.i4.7
-			IL_0074: ldc.i4.0
-			IL_0075: box [System.Runtime]System.Boolean
-			IL_007a: stelem.ref
-			IL_007b: dup
-			IL_007c: ldc.i4.8
-			IL_007d: ldc.i4.0
-			IL_007e: box [System.Runtime]System.Boolean
-			IL_0083: stelem.ref
-			IL_0084: dup
-			IL_0085: ldc.i4.s 9
-			IL_0087: ldloc.s 4
-			IL_0089: stelem.ref
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-			IL_008f: pop
-			IL_0090: ldc.i4.2
-			IL_0091: newarr [System.Runtime]System.Object
-			IL_0096: dup
-			IL_0097: ldc.i4.0
-			IL_0098: ldarg.0
-			IL_0099: stelem.ref
-			IL_009a: dup
-			IL_009b: ldc.i4.1
-			IL_009c: ldloc.0
-			IL_009d: stelem.ref
-			IL_009e: stloc.s 4
-			IL_00a0: ldloc.3
-			IL_00a1: ldloc.s 4
-			IL_00a3: ldc.r8 0.0
-			IL_00ac: box [System.Runtime]System.Double
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00b6: stloc.s 5
-			IL_00b8: ldloc.s 5
-			IL_00ba: stloc.1
-			IL_00bb: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00c0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00c5: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00ca: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00cf: stloc.3
-			IL_00d0: ldc.i4.2
-			IL_00d1: newarr [System.Runtime]System.Object
-			IL_00d6: dup
-			IL_00d7: ldc.i4.0
-			IL_00d8: ldarg.0
-			IL_00d9: stelem.ref
-			IL_00da: dup
-			IL_00db: ldc.i4.1
-			IL_00dc: ldloc.0
-			IL_00dd: stelem.ref
-			IL_00de: stloc.s 4
-			IL_00e0: ldc.i4.s 10
-			IL_00e2: newarr [System.Runtime]System.Object
-			IL_00e7: dup
-			IL_00e8: ldc.i4.0
-			IL_00e9: ldloc.3
-			IL_00ea: stelem.ref
-			IL_00eb: dup
-			IL_00ec: ldc.i4.1
-			IL_00ed: ldstr "n"
-			IL_00f2: stelem.ref
-			IL_00f3: dup
-			IL_00f4: ldc.i4.2
-			IL_00f5: ldstr "n"
-			IL_00fa: stelem.ref
-			IL_00fb: dup
-			IL_00fc: ldc.i4.3
-			IL_00fd: ldc.r8 0.0
-			IL_0106: box [System.Runtime]System.Double
-			IL_010b: stelem.ref
-			IL_010c: dup
-			IL_010d: ldc.i4.4
-			IL_010e: ldstr "n"
-			IL_0113: stelem.ref
-			IL_0114: dup
-			IL_0115: ldc.i4.5
-			IL_0116: ldc.i4.0
-			IL_0117: box [System.Runtime]System.Boolean
-			IL_011c: stelem.ref
-			IL_011d: dup
-			IL_011e: ldc.i4.6
-			IL_011f: ldc.i4.0
-			IL_0120: box [System.Runtime]System.Boolean
-			IL_0125: stelem.ref
-			IL_0126: dup
-			IL_0127: ldc.i4.7
-			IL_0128: ldc.i4.0
-			IL_0129: box [System.Runtime]System.Boolean
-			IL_012e: stelem.ref
-			IL_012f: dup
-			IL_0130: ldc.i4.8
-			IL_0131: ldc.i4.0
-			IL_0132: box [System.Runtime]System.Boolean
-			IL_0137: stelem.ref
-			IL_0138: dup
-			IL_0139: ldc.i4.s 9
-			IL_013b: ldloc.s 4
-			IL_013d: stelem.ref
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-			IL_0143: pop
-			IL_0144: ldc.i4.2
-			IL_0145: newarr [System.Runtime]System.Object
-			IL_014a: dup
-			IL_014b: ldc.i4.0
-			IL_014c: ldarg.0
-			IL_014d: stelem.ref
-			IL_014e: dup
-			IL_014f: ldc.i4.1
-			IL_0150: ldloc.0
-			IL_0151: stelem.ref
-			IL_0152: stloc.s 4
-			IL_0154: ldloc.3
-			IL_0155: ldloc.s 4
-			IL_0157: ldc.r8 0.0
-			IL_0160: box [System.Runtime]System.Double
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_016a: stloc.s 5
-			IL_016c: ldloc.s 5
-			IL_016e: ldloc.1
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_0174: stloc.s 5
-			IL_0176: ldloc.s 5
-			IL_0178: stloc.2
-			IL_0179: ldstr "console"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0188: stloc.s 5
-			IL_018a: ldc.i4.2
-			IL_018b: newarr [System.Runtime]System.Object
-			IL_0190: dup
-			IL_0191: ldc.i4.0
-			IL_0192: ldarg.0
-			IL_0193: stelem.ref
-			IL_0194: dup
-			IL_0195: ldc.i4.1
-			IL_0196: ldloc.0
-			IL_0197: stelem.ref
-			IL_0198: stloc.s 4
-			IL_019a: ldloc.s 4
-			IL_019c: ldc.i4.0
-			IL_019d: newarr [System.Runtime]System.Object
-			IL_01a2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_01a7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_01ac: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
-			IL_01b1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_01b6: stloc.s 6
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_01c2: stloc.s 6
-			IL_01c4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_01c9: ldloc.s 6
-			IL_01cb: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01d0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_01d5: ldstr "prototype"
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_01df: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_01e4: ldloc.s 6
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01eb: stloc.s 6
-			IL_01ed: ldloc.s 6
-			IL_01ef: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01f4: dup
-			IL_01f5: brfalse IL_0206
+			IL_0006: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+			IL_000b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0010: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_001a: stloc.3
+			IL_001b: ldc.i4.2
+			IL_001c: newarr [System.Runtime]System.Object
+			IL_0021: dup
+			IL_0022: ldc.i4.0
+			IL_0023: ldarg.0
+			IL_0024: stelem.ref
+			IL_0025: dup
+			IL_0026: ldc.i4.1
+			IL_0027: ldloc.0
+			IL_0028: stelem.ref
+			IL_0029: stloc.s 4
+			IL_002b: ldc.i4.s 10
+			IL_002d: newarr [System.Runtime]System.Object
+			IL_0032: dup
+			IL_0033: ldc.i4.0
+			IL_0034: ldloc.3
+			IL_0035: stelem.ref
+			IL_0036: dup
+			IL_0037: ldc.i4.1
+			IL_0038: ldstr "m"
+			IL_003d: stelem.ref
+			IL_003e: dup
+			IL_003f: ldc.i4.2
+			IL_0040: ldstr "m"
+			IL_0045: stelem.ref
+			IL_0046: dup
+			IL_0047: ldc.i4.3
+			IL_0048: ldc.r8 0.0
+			IL_0051: box [System.Runtime]System.Double
+			IL_0056: stelem.ref
+			IL_0057: dup
+			IL_0058: ldc.i4.4
+			IL_0059: ldstr "m"
+			IL_005e: stelem.ref
+			IL_005f: dup
+			IL_0060: ldc.i4.5
+			IL_0061: ldc.i4.0
+			IL_0062: box [System.Runtime]System.Boolean
+			IL_0067: stelem.ref
+			IL_0068: dup
+			IL_0069: ldc.i4.6
+			IL_006a: ldc.i4.0
+			IL_006b: box [System.Runtime]System.Boolean
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.7
+			IL_0073: ldc.i4.0
+			IL_0074: box [System.Runtime]System.Boolean
+			IL_0079: stelem.ref
+			IL_007a: dup
+			IL_007b: ldc.i4.8
+			IL_007c: ldc.i4.0
+			IL_007d: box [System.Runtime]System.Boolean
+			IL_0082: stelem.ref
+			IL_0083: dup
+			IL_0084: ldc.i4.s 9
+			IL_0086: ldloc.s 4
+			IL_0088: stelem.ref
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+			IL_008e: pop
+			IL_008f: ldc.i4.2
+			IL_0090: newarr [System.Runtime]System.Object
+			IL_0095: dup
+			IL_0096: ldc.i4.0
+			IL_0097: ldarg.0
+			IL_0098: stelem.ref
+			IL_0099: dup
+			IL_009a: ldc.i4.1
+			IL_009b: ldloc.0
+			IL_009c: stelem.ref
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.3
+			IL_00a0: ldloc.s 4
+			IL_00a2: ldc.r8 0.0
+			IL_00ab: box [System.Runtime]System.Double
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_00b5: stloc.s 5
+			IL_00b7: ldloc.s 5
+			IL_00b9: stloc.1
+			IL_00ba: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00bf: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00c4: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00c9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00ce: stloc.3
+			IL_00cf: ldc.i4.2
+			IL_00d0: newarr [System.Runtime]System.Object
+			IL_00d5: dup
+			IL_00d6: ldc.i4.0
+			IL_00d7: ldarg.0
+			IL_00d8: stelem.ref
+			IL_00d9: dup
+			IL_00da: ldc.i4.1
+			IL_00db: ldloc.0
+			IL_00dc: stelem.ref
+			IL_00dd: stloc.s 4
+			IL_00df: ldc.i4.s 10
+			IL_00e1: newarr [System.Runtime]System.Object
+			IL_00e6: dup
+			IL_00e7: ldc.i4.0
+			IL_00e8: ldloc.3
+			IL_00e9: stelem.ref
+			IL_00ea: dup
+			IL_00eb: ldc.i4.1
+			IL_00ec: ldstr "n"
+			IL_00f1: stelem.ref
+			IL_00f2: dup
+			IL_00f3: ldc.i4.2
+			IL_00f4: ldstr "n"
+			IL_00f9: stelem.ref
+			IL_00fa: dup
+			IL_00fb: ldc.i4.3
+			IL_00fc: ldc.r8 0.0
+			IL_0105: box [System.Runtime]System.Double
+			IL_010a: stelem.ref
+			IL_010b: dup
+			IL_010c: ldc.i4.4
+			IL_010d: ldstr "n"
+			IL_0112: stelem.ref
+			IL_0113: dup
+			IL_0114: ldc.i4.5
+			IL_0115: ldc.i4.0
+			IL_0116: box [System.Runtime]System.Boolean
+			IL_011b: stelem.ref
+			IL_011c: dup
+			IL_011d: ldc.i4.6
+			IL_011e: ldc.i4.0
+			IL_011f: box [System.Runtime]System.Boolean
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.7
+			IL_0127: ldc.i4.0
+			IL_0128: box [System.Runtime]System.Boolean
+			IL_012d: stelem.ref
+			IL_012e: dup
+			IL_012f: ldc.i4.8
+			IL_0130: ldc.i4.0
+			IL_0131: box [System.Runtime]System.Boolean
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.s 9
+			IL_013a: ldloc.s 4
+			IL_013c: stelem.ref
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+			IL_0142: pop
+			IL_0143: ldc.i4.2
+			IL_0144: newarr [System.Runtime]System.Object
+			IL_0149: dup
+			IL_014a: ldc.i4.0
+			IL_014b: ldarg.0
+			IL_014c: stelem.ref
+			IL_014d: dup
+			IL_014e: ldc.i4.1
+			IL_014f: ldloc.0
+			IL_0150: stelem.ref
+			IL_0151: stloc.s 4
+			IL_0153: ldloc.3
+			IL_0154: ldloc.s 4
+			IL_0156: ldc.r8 0.0
+			IL_015f: box [System.Runtime]System.Double
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_0169: stloc.s 5
+			IL_016b: ldloc.s 5
+			IL_016d: ldloc.1
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_0173: stloc.s 5
+			IL_0175: ldloc.s 5
+			IL_0177: stloc.2
+			IL_0178: ldstr "console"
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0187: stloc.s 5
+			IL_0189: ldc.i4.2
+			IL_018a: newarr [System.Runtime]System.Object
+			IL_018f: dup
+			IL_0190: ldc.i4.0
+			IL_0191: ldarg.0
+			IL_0192: stelem.ref
+			IL_0193: dup
+			IL_0194: ldc.i4.1
+			IL_0195: ldloc.0
+			IL_0196: stelem.ref
+			IL_0197: stloc.s 4
+			IL_0199: ldloc.s 4
+			IL_019b: ldc.i4.0
+			IL_019c: newarr [System.Runtime]System.Object
+			IL_01a1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_01a6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_01ab: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
+			IL_01b0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_01b5: stloc.s 6
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_01c1: stloc.s 6
+			IL_01c3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_01c8: ldloc.s 6
+			IL_01ca: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01cf: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_01d4: ldstr "prototype"
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_01de: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_01e3: ldloc.s 6
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ea: stloc.s 6
+			IL_01ec: ldloc.s 6
+			IL_01ee: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01f3: dup
+			IL_01f4: brfalse IL_0205
 
-			IL_01fa: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-			IL_01ff: stloc.s 6
-			IL_0201: br IL_0215
+			IL_01f9: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_01fe: stloc.s 6
+			IL_0200: br IL_0214
 
-			IL_0206: pop
-			IL_0207: ldloc.s 6
-			IL_0209: ldstr "n"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0213: stloc.s 6
+			IL_0205: pop
+			IL_0206: ldloc.s 6
+			IL_0208: ldstr "n"
+			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0212: stloc.s 6
 
-			IL_0215: ldloc.s 5
-			IL_0217: ldstr "log"
-			IL_021c: ldloc.s 6
-			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0223: pop
-			IL_0224: ldnull
-			IL_0225: ret
+			IL_0214: ldloc.s 5
+			IL_0216: ldstr "log"
+			IL_021b: ldloc.s 6
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0222: pop
+			IL_0223: ldnull
+			IL_0224: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2362
+					// Method begins at RVA 0x2343
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x236b
+					// Method begins at RVA 0x234c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22d8
+				// Method begins at RVA 0x22cc
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,20 +92,13 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2332
+				// Method begins at RVA 0x2326
 				// Header size: 1
-				// Code size: 29 (0x1d)
+				// Code size: 10 (0xa)
 				.maxstack 8
 
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::_scopes
-				IL_0006: ldc.i4.1
-				IL_0007: ldelem.ref
-				IL_0008: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope
-				IL_000d: ldfld float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
-				IL_0012: ldc.r8 2
-				IL_001b: add
-				IL_001c: ret
+				IL_0000: ldc.r8 42
+				IL_0009: ret
 			} // end of method Base::m
 
 		} // end of class Base
@@ -121,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2374
+					// Method begins at RVA 0x2355
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -141,7 +134,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x237d
+					// Method begins at RVA 0x235e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -167,7 +160,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22f4
+				// Method begins at RVA 0x22e8
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -194,7 +187,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2318
+				// Method begins at RVA 0x230c
 				// Header size: 12
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -215,18 +208,11 @@
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
 		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 19 53 63 6f 70 65 20 63 61 70 74 75 72 65
-				64 3d 7b 63 61 70 74 75 72 65 64 7d 00 00
-			)
-			// Fields
-			.field public float64 captured
-
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2359
+				// Method begins at RVA 0x233a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -254,7 +240,7 @@
 			)
 			// Method begins at RVA 0x2098
 			// Header size: 12
-			// Code size: 564 (0x234)
+			// Code size: 550 (0x226)
 			.maxstack 13
 			.locals init (
 				[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope,
@@ -268,239 +254,237 @@
 
 			IL_0000: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldloc.0
-			IL_0007: ldc.r8 40
-			IL_0010: stfld float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Scope::captured
-			IL_0015: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_001a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_001f: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-			IL_0024: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_0029: stloc.3
-			IL_002a: ldc.i4.2
-			IL_002b: newarr [System.Runtime]System.Object
-			IL_0030: dup
-			IL_0031: ldc.i4.0
-			IL_0032: ldarg.0
-			IL_0033: stelem.ref
-			IL_0034: dup
-			IL_0035: ldc.i4.1
-			IL_0036: ldloc.0
-			IL_0037: stelem.ref
-			IL_0038: stloc.s 4
-			IL_003a: ldc.i4.s 10
-			IL_003c: newarr [System.Runtime]System.Object
-			IL_0041: dup
-			IL_0042: ldc.i4.0
-			IL_0043: ldloc.3
-			IL_0044: stelem.ref
-			IL_0045: dup
-			IL_0046: ldc.i4.1
-			IL_0047: ldstr "m"
-			IL_004c: stelem.ref
-			IL_004d: dup
-			IL_004e: ldc.i4.2
-			IL_004f: ldstr "m"
-			IL_0054: stelem.ref
-			IL_0055: dup
-			IL_0056: ldc.i4.3
-			IL_0057: ldc.r8 0.0
-			IL_0060: box [System.Runtime]System.Double
-			IL_0065: stelem.ref
-			IL_0066: dup
-			IL_0067: ldc.i4.4
-			IL_0068: ldstr "m"
-			IL_006d: stelem.ref
-			IL_006e: dup
-			IL_006f: ldc.i4.5
-			IL_0070: ldc.i4.0
-			IL_0071: box [System.Runtime]System.Boolean
-			IL_0076: stelem.ref
-			IL_0077: dup
-			IL_0078: ldc.i4.6
-			IL_0079: ldc.i4.0
-			IL_007a: box [System.Runtime]System.Boolean
-			IL_007f: stelem.ref
-			IL_0080: dup
-			IL_0081: ldc.i4.7
-			IL_0082: ldc.i4.0
-			IL_0083: box [System.Runtime]System.Boolean
-			IL_0088: stelem.ref
-			IL_0089: dup
-			IL_008a: ldc.i4.8
-			IL_008b: ldc.i4.0
-			IL_008c: box [System.Runtime]System.Boolean
-			IL_0091: stelem.ref
-			IL_0092: dup
-			IL_0093: ldc.i4.s 9
-			IL_0095: ldloc.s 4
-			IL_0097: stelem.ref
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-			IL_009d: pop
-			IL_009e: ldc.i4.2
-			IL_009f: newarr [System.Runtime]System.Object
-			IL_00a4: dup
-			IL_00a5: ldc.i4.0
-			IL_00a6: ldarg.0
-			IL_00a7: stelem.ref
-			IL_00a8: dup
-			IL_00a9: ldc.i4.1
-			IL_00aa: ldloc.0
-			IL_00ab: stelem.ref
-			IL_00ac: stloc.s 4
-			IL_00ae: ldloc.3
-			IL_00af: ldloc.s 4
-			IL_00b1: ldc.r8 0.0
-			IL_00ba: box [System.Runtime]System.Double
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_00c4: stloc.s 5
-			IL_00c6: ldloc.s 5
-			IL_00c8: stloc.1
-			IL_00c9: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00ce: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00d3: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_00d8: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_00dd: stloc.3
-			IL_00de: ldc.i4.2
-			IL_00df: newarr [System.Runtime]System.Object
-			IL_00e4: dup
-			IL_00e5: ldc.i4.0
-			IL_00e6: ldarg.0
-			IL_00e7: stelem.ref
-			IL_00e8: dup
-			IL_00e9: ldc.i4.1
-			IL_00ea: ldloc.0
-			IL_00eb: stelem.ref
-			IL_00ec: stloc.s 4
-			IL_00ee: ldc.i4.s 10
-			IL_00f0: newarr [System.Runtime]System.Object
-			IL_00f5: dup
-			IL_00f6: ldc.i4.0
-			IL_00f7: ldloc.3
-			IL_00f8: stelem.ref
-			IL_00f9: dup
-			IL_00fa: ldc.i4.1
-			IL_00fb: ldstr "n"
-			IL_0100: stelem.ref
-			IL_0101: dup
-			IL_0102: ldc.i4.2
-			IL_0103: ldstr "n"
-			IL_0108: stelem.ref
-			IL_0109: dup
-			IL_010a: ldc.i4.3
-			IL_010b: ldc.r8 0.0
-			IL_0114: box [System.Runtime]System.Double
-			IL_0119: stelem.ref
-			IL_011a: dup
-			IL_011b: ldc.i4.4
-			IL_011c: ldstr "n"
-			IL_0121: stelem.ref
-			IL_0122: dup
-			IL_0123: ldc.i4.5
-			IL_0124: ldc.i4.0
-			IL_0125: box [System.Runtime]System.Boolean
-			IL_012a: stelem.ref
-			IL_012b: dup
-			IL_012c: ldc.i4.6
-			IL_012d: ldc.i4.0
-			IL_012e: box [System.Runtime]System.Boolean
-			IL_0133: stelem.ref
-			IL_0134: dup
-			IL_0135: ldc.i4.7
-			IL_0136: ldc.i4.0
-			IL_0137: box [System.Runtime]System.Boolean
-			IL_013c: stelem.ref
-			IL_013d: dup
-			IL_013e: ldc.i4.8
-			IL_013f: ldc.i4.0
-			IL_0140: box [System.Runtime]System.Boolean
-			IL_0145: stelem.ref
-			IL_0146: dup
-			IL_0147: ldc.i4.s 9
-			IL_0149: ldloc.s 4
-			IL_014b: stelem.ref
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-			IL_0151: pop
-			IL_0152: ldc.i4.2
-			IL_0153: newarr [System.Runtime]System.Object
-			IL_0158: dup
-			IL_0159: ldc.i4.0
-			IL_015a: ldarg.0
-			IL_015b: stelem.ref
-			IL_015c: dup
-			IL_015d: ldc.i4.1
-			IL_015e: ldloc.0
-			IL_015f: stelem.ref
-			IL_0160: stloc.s 4
-			IL_0162: ldloc.3
-			IL_0163: ldloc.s 4
-			IL_0165: ldc.r8 0.0
-			IL_016e: box [System.Runtime]System.Double
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-			IL_0178: stloc.s 5
-			IL_017a: ldloc.s 5
-			IL_017c: ldloc.1
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-			IL_0182: stloc.s 5
-			IL_0184: ldloc.s 5
-			IL_0186: stloc.2
-			IL_0187: ldstr "console"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0196: stloc.s 5
-			IL_0198: ldc.i4.2
-			IL_0199: newarr [System.Runtime]System.Object
-			IL_019e: dup
-			IL_019f: ldc.i4.0
-			IL_01a0: ldarg.0
-			IL_01a1: stelem.ref
-			IL_01a2: dup
-			IL_01a3: ldc.i4.1
-			IL_01a4: ldloc.0
-			IL_01a5: stelem.ref
-			IL_01a6: stloc.s 4
-			IL_01a8: ldloc.s 4
-			IL_01aa: ldc.i4.0
-			IL_01ab: newarr [System.Runtime]System.Object
-			IL_01b0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_01b5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_01ba: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
-			IL_01bf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_01c4: stloc.s 6
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_01d0: stloc.s 6
-			IL_01d2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_01d7: ldloc.s 6
-			IL_01d9: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_01de: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_01e3: ldstr "prototype"
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_01ed: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_01f2: ldloc.s 6
-			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f9: stloc.s 6
-			IL_01fb: ldloc.s 6
-			IL_01fd: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-			IL_0202: dup
-			IL_0203: brfalse IL_0214
+			IL_0006: nop
+			IL_0007: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+			IL_000c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0011: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+			IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_001b: stloc.3
+			IL_001c: ldc.i4.2
+			IL_001d: newarr [System.Runtime]System.Object
+			IL_0022: dup
+			IL_0023: ldc.i4.0
+			IL_0024: ldarg.0
+			IL_0025: stelem.ref
+			IL_0026: dup
+			IL_0027: ldc.i4.1
+			IL_0028: ldloc.0
+			IL_0029: stelem.ref
+			IL_002a: stloc.s 4
+			IL_002c: ldc.i4.s 10
+			IL_002e: newarr [System.Runtime]System.Object
+			IL_0033: dup
+			IL_0034: ldc.i4.0
+			IL_0035: ldloc.3
+			IL_0036: stelem.ref
+			IL_0037: dup
+			IL_0038: ldc.i4.1
+			IL_0039: ldstr "m"
+			IL_003e: stelem.ref
+			IL_003f: dup
+			IL_0040: ldc.i4.2
+			IL_0041: ldstr "m"
+			IL_0046: stelem.ref
+			IL_0047: dup
+			IL_0048: ldc.i4.3
+			IL_0049: ldc.r8 0.0
+			IL_0052: box [System.Runtime]System.Double
+			IL_0057: stelem.ref
+			IL_0058: dup
+			IL_0059: ldc.i4.4
+			IL_005a: ldstr "m"
+			IL_005f: stelem.ref
+			IL_0060: dup
+			IL_0061: ldc.i4.5
+			IL_0062: ldc.i4.0
+			IL_0063: box [System.Runtime]System.Boolean
+			IL_0068: stelem.ref
+			IL_0069: dup
+			IL_006a: ldc.i4.6
+			IL_006b: ldc.i4.0
+			IL_006c: box [System.Runtime]System.Boolean
+			IL_0071: stelem.ref
+			IL_0072: dup
+			IL_0073: ldc.i4.7
+			IL_0074: ldc.i4.0
+			IL_0075: box [System.Runtime]System.Boolean
+			IL_007a: stelem.ref
+			IL_007b: dup
+			IL_007c: ldc.i4.8
+			IL_007d: ldc.i4.0
+			IL_007e: box [System.Runtime]System.Boolean
+			IL_0083: stelem.ref
+			IL_0084: dup
+			IL_0085: ldc.i4.s 9
+			IL_0087: ldloc.s 4
+			IL_0089: stelem.ref
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+			IL_008f: pop
+			IL_0090: ldc.i4.2
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: stelem.ref
+			IL_009a: dup
+			IL_009b: ldc.i4.1
+			IL_009c: ldloc.0
+			IL_009d: stelem.ref
+			IL_009e: stloc.s 4
+			IL_00a0: ldloc.3
+			IL_00a1: ldloc.s 4
+			IL_00a3: ldc.r8 0.0
+			IL_00ac: box [System.Runtime]System.Double
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_00b6: stloc.s 5
+			IL_00b8: ldloc.s 5
+			IL_00ba: stloc.1
+			IL_00bb: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00c0: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00c5: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_00ca: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_00cf: stloc.3
+			IL_00d0: ldc.i4.2
+			IL_00d1: newarr [System.Runtime]System.Object
+			IL_00d6: dup
+			IL_00d7: ldc.i4.0
+			IL_00d8: ldarg.0
+			IL_00d9: stelem.ref
+			IL_00da: dup
+			IL_00db: ldc.i4.1
+			IL_00dc: ldloc.0
+			IL_00dd: stelem.ref
+			IL_00de: stloc.s 4
+			IL_00e0: ldc.i4.s 10
+			IL_00e2: newarr [System.Runtime]System.Object
+			IL_00e7: dup
+			IL_00e8: ldc.i4.0
+			IL_00e9: ldloc.3
+			IL_00ea: stelem.ref
+			IL_00eb: dup
+			IL_00ec: ldc.i4.1
+			IL_00ed: ldstr "n"
+			IL_00f2: stelem.ref
+			IL_00f3: dup
+			IL_00f4: ldc.i4.2
+			IL_00f5: ldstr "n"
+			IL_00fa: stelem.ref
+			IL_00fb: dup
+			IL_00fc: ldc.i4.3
+			IL_00fd: ldc.r8 0.0
+			IL_0106: box [System.Runtime]System.Double
+			IL_010b: stelem.ref
+			IL_010c: dup
+			IL_010d: ldc.i4.4
+			IL_010e: ldstr "n"
+			IL_0113: stelem.ref
+			IL_0114: dup
+			IL_0115: ldc.i4.5
+			IL_0116: ldc.i4.0
+			IL_0117: box [System.Runtime]System.Boolean
+			IL_011c: stelem.ref
+			IL_011d: dup
+			IL_011e: ldc.i4.6
+			IL_011f: ldc.i4.0
+			IL_0120: box [System.Runtime]System.Boolean
+			IL_0125: stelem.ref
+			IL_0126: dup
+			IL_0127: ldc.i4.7
+			IL_0128: ldc.i4.0
+			IL_0129: box [System.Runtime]System.Boolean
+			IL_012e: stelem.ref
+			IL_012f: dup
+			IL_0130: ldc.i4.8
+			IL_0131: ldc.i4.0
+			IL_0132: box [System.Runtime]System.Boolean
+			IL_0137: stelem.ref
+			IL_0138: dup
+			IL_0139: ldc.i4.s 9
+			IL_013b: ldloc.s 4
+			IL_013d: stelem.ref
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+			IL_0143: pop
+			IL_0144: ldc.i4.2
+			IL_0145: newarr [System.Runtime]System.Object
+			IL_014a: dup
+			IL_014b: ldc.i4.0
+			IL_014c: ldarg.0
+			IL_014d: stelem.ref
+			IL_014e: dup
+			IL_014f: ldc.i4.1
+			IL_0150: ldloc.0
+			IL_0151: stelem.ref
+			IL_0152: stloc.s 4
+			IL_0154: ldloc.3
+			IL_0155: ldloc.s 4
+			IL_0157: ldc.r8 0.0
+			IL_0160: box [System.Runtime]System.Double
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+			IL_016a: stloc.s 5
+			IL_016c: ldloc.s 5
+			IL_016e: ldloc.1
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+			IL_0174: stloc.s 5
+			IL_0176: ldloc.s 5
+			IL_0178: stloc.2
+			IL_0179: ldstr "console"
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0188: stloc.s 5
+			IL_018a: ldc.i4.2
+			IL_018b: newarr [System.Runtime]System.Object
+			IL_0190: dup
+			IL_0191: ldc.i4.0
+			IL_0192: ldarg.0
+			IL_0193: stelem.ref
+			IL_0194: dup
+			IL_0195: ldc.i4.1
+			IL_0196: ldloc.0
+			IL_0197: stelem.ref
+			IL_0198: stloc.s 4
+			IL_019a: ldloc.s 4
+			IL_019c: ldc.i4.0
+			IL_019d: newarr [System.Runtime]System.Object
+			IL_01a2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_01a7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_01ac: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::.ctor(object[])
+			IL_01b1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_01b6: stloc.s 6
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_01c2: stloc.s 6
+			IL_01c4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_01c9: ldloc.s 6
+			IL_01cb: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01d0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_01d5: ldstr "prototype"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_01df: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_01e4: ldloc.s 6
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 6
+			IL_01ed: ldloc.s 6
+			IL_01ef: isinst Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+			IL_01f4: dup
+			IL_01f5: brfalse IL_0206
 
-			IL_0208: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-			IL_020d: stloc.s 6
-			IL_020f: br IL_0223
+			IL_01fa: callvirt instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+			IL_01ff: stloc.s 6
+			IL_0201: br IL_0215
 
-			IL_0214: pop
-			IL_0215: ldloc.s 6
-			IL_0217: ldstr "n"
-			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0221: stloc.s 6
+			IL_0206: pop
+			IL_0207: ldloc.s 6
+			IL_0209: ldstr "n"
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0213: stloc.s 6
 
-			IL_0223: ldloc.s 5
-			IL_0225: ldstr "log"
-			IL_022a: ldloc.s 6
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0231: pop
-			IL_0232: ldnull
-			IL_0233: ret
+			IL_0215: ldloc.s 5
+			IL_0217: ldstr "log"
+			IL_021c: ldloc.s 6
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0223: pop
+			IL_0224: ldnull
+			IL_0225: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -519,7 +503,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2350
+			// Method begins at RVA 0x2331
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -584,7 +568,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2386
+		// Method begins at RVA 0x2367
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrimeCtor_BitArrayAdd.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrimeCtor_BitArrayAdd.verified.txt
@@ -53,12 +53,12 @@
 
 
 		// Fields
-		.field public object n
+		.field public float64 n
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor (
-				object n
+				float64 n
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -73,7 +73,7 @@
 			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 			IL_0006: ldarg.0
 			IL_0007: ldarg.1
-			IL_0008: stfld object Modules.Classes_PrimeCtor_BitArrayAdd/BitArray::n
+			IL_0008: stfld float64 Modules.Classes_PrimeCtor_BitArrayAdd/BitArray::n
 			IL_000d: ret
 		} // end of method BitArray::.ctor
 
@@ -177,8 +177,8 @@
 			IL_0038: box [System.Runtime]System.Double
 			IL_003d: stloc.2
 			IL_003e: ldarg.0
-			IL_003f: ldloc.2
-			IL_0040: newobj instance void Modules.Classes_PrimeCtor_BitArrayAdd/BitArray::.ctor(object)
+			IL_003f: ldloc.1
+			IL_0040: newobj instance void Modules.Classes_PrimeCtor_BitArrayAdd/BitArray::.ctor(float64)
 			IL_0045: stfld class Modules.Classes_PrimeCtor_BitArrayAdd/BitArray Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve::bitArray
 			IL_004a: ret
 		} // end of method PrimeSieve::.ctor

--- a/tests/Jroc.Tests/Function/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Function/ExecutionTests.cs
@@ -282,6 +282,9 @@ namespace Jroc.Tests.Function
         [Fact]
         public Task Function_ParameterTypeInference_DirectRotateArrayArgument() { var testName = nameof(Function_ParameterTypeInference_DirectRotateArrayArgument); return ExecutionTest(testName); }
 
+        [Fact]
+        public Task Function_ParameterTypeInference_BinaryArguments() { var testName = nameof(Function_ParameterTypeInference_BinaryArguments); return ExecutionTest(testName); }
+
         // ABI optimization tests: non-capturing functions should NOT have scopes parameter
         [Fact]
         public Task Function_NoCapture_NoScopesParameter() { var testName = nameof(Function_NoCapture_NoScopesParameter); return ExecutionTest(testName); }

--- a/tests/Jroc.Tests/Function/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Function/GeneratorTests.cs
@@ -300,6 +300,35 @@ namespace Jroc.Tests.Function
             });
         }
 
+        [Fact]
+        public Task Function_ParameterTypeInference_BinaryArguments()
+        {
+            var testName = nameof(Function_ParameterTypeInference_BinaryArguments);
+            return GenerateTest(testName, verifyAssembly: assembly =>
+            {
+                var moduleType = assembly.GetType($"Modules.{testName}", throwOnError: true)!;
+                var receiverType = moduleType.GetNestedType("BinaryReceiver", BindingFlags.Public | BindingFlags.NonPublic)!;
+
+                foreach (var methodName in new[] { "add", "multiply", "shift", "increment" })
+                {
+                    var method = receiverType.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+                    Assert.Equal(typeof(double), Assert.Single(method.GetParameters()).ParameterType);
+                }
+
+                var dynamicMethod = receiverType.GetMethod("dynamicAdd", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+                Assert.Equal(typeof(object), Assert.Single(dynamicMethod.GetParameters()).ParameterType);
+
+                var bigintMethod = receiverType.GetMethod("bigint", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+                Assert.Equal(typeof(object), Assert.Single(bigintMethod.GetParameters()).ParameterType);
+
+                foreach (var methodName in new[] { "incrementBoolean", "destructure", "iterate", "iterateVar", "iterateVarIn", "redeclare", "functionRedeclare" })
+                {
+                    var method = receiverType.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+                    Assert.Equal(typeof(object), Assert.Single(method.GetParameters()).ParameterType);
+                }
+            });
+        }
+
         // ABI optimization tests: non-capturing functions should NOT have scopes parameter
         [Fact]
         public Task Function_NoCapture_NoScopesParameter() { var testName = nameof(Function_NoCapture_NoScopesParameter); return GenerateTest(testName); }

--- a/tests/Jroc.Tests/Function/JavaScript/Function_ParameterTypeInference_BinaryArguments.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_ParameterTypeInference_BinaryArguments.js
@@ -1,0 +1,98 @@
+"use strict";
+
+class BinaryReceiver {
+  add(value) {
+    return value;
+  }
+
+  multiply(value) {
+    return value;
+  }
+
+  shift(value) {
+    return value;
+  }
+
+  increment(value) {
+    value++;
+    return value;
+  }
+
+  incrementBoolean(value) {
+    value++;
+    return value;
+  }
+
+  dynamicAdd(value) {
+    return value;
+  }
+
+  bigint(value) {
+    return typeof value;
+  }
+
+  destructure(value) {
+    value++;
+    [value] = ["text"];
+    return typeof value;
+  }
+
+  iterate(value) {
+    value++;
+    for (value of ["text"]) {
+    }
+    return typeof value;
+  }
+
+  iterateVar(value) {
+    value++;
+    for (var value of ["text"]) {
+    }
+    return typeof value;
+  }
+
+  iterateVarIn(value) {
+    value++;
+    for (var value in { text: true }) {
+    }
+    return typeof value;
+  }
+
+  redeclare(value) {
+    var value = "text";
+    value++;
+    return typeof value;
+  }
+
+  functionRedeclare(value) {
+    function value() {
+    }
+    value++;
+    return typeof value;
+  }
+
+  run() {
+    const number = 7;
+    const text = "value";
+    const bigA = BigInt(1);
+    const bigB = BigInt(1);
+
+    console.log(this.add(number + 1));
+    console.log(this.multiply(number * 2));
+    console.log(this.shift(number >>> 1));
+    console.log(this.increment(number + 1));
+    console.log(this.incrementBoolean(true));
+    console.log(this.dynamicAdd(text + 1));
+    console.log(this.destructure(number));
+    console.log(this.iterate(number));
+    console.log(this.iterateVar(number));
+    console.log(this.iterateVarIn(number));
+    console.log(this.redeclare(number));
+    if (false) {
+      this.bigint((bigA & bigB) | (bigA & bigB));
+      this.functionRedeclare(number);
+    }
+  }
+}
+
+new BinaryReceiver().run();

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
@@ -1,0 +1,11 @@
+﻿8
+14
+3
+9
+2
+value1
+string
+string
+string
+string
+number

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
@@ -1,0 +1,1442 @@
+﻿// IL code: Function_ParameterTypeInference_BinaryArguments
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Function_ParameterTypeInference_BinaryArguments
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit 'value'
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x280b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x20cc
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method 'value'::__js_call__
+
+	} // end of class value
+
+	.class nested public auto ansi beforefieldinit BinaryReceiver
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2772
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_add
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x277b
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_add::.ctor
+
+		} // end of class Scope_add
+
+		.class nested public auto ansi beforefieldinit Scope_multiply
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2784
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_multiply::.ctor
+
+		} // end of class Scope_multiply
+
+		.class nested public auto ansi beforefieldinit Scope_shift
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x278d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_shift::.ctor
+
+		} // end of class Scope_shift
+
+		.class nested public auto ansi beforefieldinit Scope_increment
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2796
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_increment::.ctor
+
+		} // end of class Scope_increment
+
+		.class nested public auto ansi beforefieldinit Scope_incrementBoolean
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x279f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_incrementBoolean::.ctor
+
+		} // end of class Scope_incrementBoolean
+
+		.class nested public auto ansi beforefieldinit Scope_dynamicAdd
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27a8
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_dynamicAdd::.ctor
+
+		} // end of class Scope_dynamicAdd
+
+		.class nested public auto ansi beforefieldinit Scope_bigint
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27b1
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_bigint::.ctor
+
+		} // end of class Scope_bigint
+
+		.class nested public auto ansi beforefieldinit Scope_destructure
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27ba
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_destructure::.ctor
+
+		} // end of class Scope_destructure
+
+		.class nested public auto ansi beforefieldinit Scope_iterate
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L42C28
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x27cc
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L42C28::.ctor
+
+			} // end of class Block_L42C28
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27c3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_iterate::.ctor
+
+		} // end of class Scope_iterate
+
+		.class nested public auto ansi beforefieldinit Scope_iterateVar
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L49C32
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x27de
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L49C32::.ctor
+
+			} // end of class Block_L49C32
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27d5
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_iterateVar::.ctor
+
+		} // end of class Scope_iterateVar
+
+		.class nested public auto ansi beforefieldinit Scope_iterateVarIn
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L56C38
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x27f0
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L56C38::.ctor
+
+			} // end of class Block_L56C38
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27e7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_iterateVarIn::.ctor
+
+		} // end of class Scope_iterateVarIn
+
+		.class nested public auto ansi beforefieldinit Scope_redeclare
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27f9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_redeclare::.ctor
+
+		} // end of class Scope_redeclare
+
+		.class nested public auto ansi beforefieldinit Scope_functionRedeclare
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2802
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_functionRedeclare::.ctor
+
+		} // end of class Scope_functionRedeclare
+
+		.class nested public auto ansi beforefieldinit Scope_run
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L91C15
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x281d
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L91C15::.ctor
+
+			} // end of class Block_L91C15
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2814
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_run::.ctor
+
+		} // end of class Scope_run
+
+
+		// Fields
+		.field private object[] _scopes
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x20d0
+			// Header size: 12
+			// Code size: 16 (0x10)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::_scopes
+			IL_000f: ret
+		} // end of method BinaryReceiver::.ctor
+
+		.method public hidebysig 
+			instance float64 'add' (
+				float64 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x23c1
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method BinaryReceiver::'add'
+
+		.method public hidebysig 
+			instance float64 multiply (
+				float64 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x272a
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method BinaryReceiver::multiply
+
+		.method public hidebysig 
+			instance float64 shift (
+				float64 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2766
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method BinaryReceiver::shift
+
+		.method public hidebysig 
+			instance float64 increment (
+				float64 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2519
+			// Header size: 1
+			// Code size: 15 (0xf)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ldc.r8 1
+			IL_000a: add
+			IL_000b: starg.s 'value'
+			IL_000d: ldarg.1
+			IL_000e: ret
+		} // end of method BinaryReceiver::increment
+
+		.method public hidebysig 
+			instance float64 incrementBoolean (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x252c
+			// Header size: 12
+			// Code size: 34 (0x22)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 1
+			IL_000f: add
+			IL_0010: stloc.0
+			IL_0011: ldloc.0
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: starg.s 'value'
+			IL_001b: ldarg.1
+			IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0021: ret
+		} // end of method BinaryReceiver::incrementBoolean
+
+		.method public hidebysig 
+			instance object dynamicAdd (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x24bc
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method BinaryReceiver::dynamicAdd
+
+		.method public hidebysig 
+			instance object bigint (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x23c4
+			// Header size: 12
+			// Code size: 9 (0x9)
+			.maxstack 8
+			.locals init (
+				[0] string
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ret
+		} // end of method BinaryReceiver::bigint
+
+		.method public hidebysig 
+			instance object destructure (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x23dc
+			// Header size: 12
+			// Code size: 195 (0xc3)
+			.maxstack 12
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[1] bool,
+				[2] bool,
+				[3] float64,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[6] object,
+				[7] object,
+				[8] string
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 1
+			IL_000f: add
+			IL_0010: stloc.3
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.s 4
+			IL_0019: ldloc.s 4
+			IL_001b: starg.s 'value'
+			IL_001d: ldc.i4.1
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0023: dup
+			IL_0024: ldstr "text"
+			IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_002e: stloc.s 5
+			IL_0030: ldloc.s 5
+			IL_0032: brfalse IL_0043
+
+			IL_0037: ldloc.s 5
+			IL_0039: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_003e: brfalse IL_0054
+
+			IL_0043: ldloc.s 5
+			IL_0045: ldstr ""
+			IL_004a: ldstr "0"
+			IL_004f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+
+			IL_0054: ldloc.s 5
+			IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_005b: stloc.0
+			IL_005c: ldc.i4.0
+			IL_005d: stloc.1
+			IL_005e: ldc.i4.0
+			IL_005f: stloc.2
+			.try
+			{
+				IL_0060: ldloc.2
+				IL_0061: brtrue IL_0089
+
+				IL_0066: ldloc.0
+				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_006c: stloc.s 6
+				IL_006e: ldloc.s 6
+				IL_0070: brfalse IL_0087
+
+				IL_0075: ldloc.s 6
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_007c: stloc.s 6
+				IL_007e: ldloc.s 6
+				IL_0080: stloc.s 7
+				IL_0082: br IL_008c
+
+				IL_0087: ldc.i4.1
+				IL_0088: stloc.2
+
+				IL_0089: ldnull
+				IL_008a: stloc.s 7
+
+				IL_008c: ldloc.s 7
+				IL_008e: starg.s 'value'
+				IL_0090: ldloc.2
+				IL_0091: brtrue IL_009e
+
+				IL_0096: ldc.i4.1
+				IL_0097: stloc.1
+				IL_0098: ldloc.0
+				IL_0099: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+
+				IL_009e: ldc.i4.1
+				IL_009f: stloc.1
+				IL_00a0: leave IL_00b8
+			} // end .try
+			finally
+			{
+				IL_00a5: ldloc.1
+				IL_00a6: brtrue IL_00b7
+
+				IL_00ab: ldloc.2
+				IL_00ac: brtrue IL_00b7
+
+				IL_00b1: ldloc.0
+				IL_00b2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+
+				IL_00b7: endfinally
+			} // end handler
+
+			IL_00b8: ldarg.1
+			IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_00be: stloc.s 8
+			IL_00c0: ldloc.s 8
+			IL_00c2: ret
+		} // end of method BinaryReceiver::destructure
+
+		.method public hidebysig 
+			instance object iterate (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x255c
+			// Header size: 12
+			// Code size: 148 (0x94)
+			.maxstack 12
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[1] bool,
+				[2] bool,
+				[3] float64,
+				[4] object,
+				[5] object,
+				[6] bool,
+				[7] string
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 1
+			IL_000f: add
+			IL_0010: stloc.3
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.s 4
+			IL_0019: ldloc.s 4
+			IL_001b: starg.s 'value'
+			IL_001d: ldc.i4.1
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0023: dup
+			IL_0024: ldstr "text"
+			IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0033: stloc.0
+			IL_0034: ldc.i4.0
+			IL_0035: stloc.1
+			IL_0036: ldc.i4.0
+			IL_0037: stloc.2
+			.try
+			{
+				// loop start (head: IL_0038)
+					IL_0038: ldloc.0
+					IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_003e: stloc.s 5
+					IL_0040: ldloc.s 5
+					IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0047: stloc.s 6
+					IL_0049: ldloc.s 6
+					IL_004b: brtrue IL_006f
+
+					IL_0050: ldloc.s 5
+					IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0057: stloc.s 5
+					IL_0059: ldloc.s 5
+					IL_005b: starg.s 'value'
+					IL_005d: br IL_0038
+				// end loop
+				IL_0062: ldloc.0
+				IL_0063: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0068: ldc.i4.1
+				IL_0069: stloc.2
+				IL_006a: leave IL_0089
+
+				IL_006f: ldc.i4.1
+				IL_0070: stloc.1
+				IL_0071: leave IL_0089
+			} // end .try
+			finally
+			{
+				IL_0076: ldloc.1
+				IL_0077: brtrue IL_0088
+
+				IL_007c: ldloc.2
+				IL_007d: brtrue IL_0088
+
+				IL_0082: ldloc.0
+				IL_0083: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+
+				IL_0088: endfinally
+			} // end handler
+
+			IL_0089: ldarg.1
+			IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_008f: stloc.s 7
+			IL_0091: ldloc.s 7
+			IL_0093: ret
+		} // end of method BinaryReceiver::iterate
+
+		.method public hidebysig 
+			instance object iterateVar (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x260c
+			// Header size: 12
+			// Code size: 148 (0x94)
+			.maxstack 12
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+				[1] bool,
+				[2] bool,
+				[3] float64,
+				[4] object,
+				[5] object,
+				[6] bool,
+				[7] string
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 1
+			IL_000f: add
+			IL_0010: stloc.3
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.s 4
+			IL_0019: ldloc.s 4
+			IL_001b: starg.s 'value'
+			IL_001d: ldc.i4.1
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0023: dup
+			IL_0024: ldstr "text"
+			IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0033: stloc.0
+			IL_0034: ldc.i4.0
+			IL_0035: stloc.1
+			IL_0036: ldc.i4.0
+			IL_0037: stloc.2
+			.try
+			{
+				// loop start (head: IL_0038)
+					IL_0038: ldloc.0
+					IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_003e: stloc.s 5
+					IL_0040: ldloc.s 5
+					IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0047: stloc.s 6
+					IL_0049: ldloc.s 6
+					IL_004b: brtrue IL_006f
+
+					IL_0050: ldloc.s 5
+					IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0057: stloc.s 5
+					IL_0059: ldloc.s 5
+					IL_005b: starg.s 'value'
+					IL_005d: br IL_0038
+				// end loop
+				IL_0062: ldloc.0
+				IL_0063: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0068: ldc.i4.1
+				IL_0069: stloc.2
+				IL_006a: leave IL_0089
+
+				IL_006f: ldc.i4.1
+				IL_0070: stloc.1
+				IL_0071: leave IL_0089
+			} // end .try
+			finally
+			{
+				IL_0076: ldloc.1
+				IL_0077: brtrue IL_0088
+
+				IL_007c: ldloc.2
+				IL_007d: brtrue IL_0088
+
+				IL_0082: ldloc.0
+				IL_0083: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+
+				IL_0088: endfinally
+			} // end handler
+
+			IL_0089: ldarg.1
+			IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_008f: stloc.s 7
+			IL_0091: ldloc.s 7
+			IL_0093: ret
+		} // end of method BinaryReceiver::iterateVar
+
+		.method public hidebysig 
+			instance object iterateVarIn (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x26bc
+			// Header size: 12
+			// Code size: 98 (0x62)
+			.maxstack 13
+			.locals init (
+				[0] object,
+				[1] float64,
+				[2] object,
+				[3] object,
+				[4] bool,
+				[5] string
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 1
+			IL_000f: add
+			IL_0010: stloc.1
+			IL_0011: ldloc.1
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.2
+			IL_0018: ldloc.2
+			IL_0019: starg.s 'value'
+			IL_001b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0020: dup
+			IL_0021: ldstr "text"
+			IL_0026: ldc.i4.1
+			IL_0027: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::EnumerateObjectProperties(object)
+			IL_0031: stloc.0
+			// loop start (head: IL_0032)
+				IL_0032: ldloc.0
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_0038: stloc.3
+				IL_0039: ldloc.3
+				IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_003f: stloc.s 4
+				IL_0041: ldloc.s 4
+				IL_0043: brtrue IL_0057
+
+				IL_0048: ldloc.3
+				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_004e: stloc.3
+				IL_004f: ldloc.3
+				IL_0050: starg.s 'value'
+				IL_0052: br IL_0032
+			// end loop
+
+			IL_0057: ldarg.1
+			IL_0058: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_005d: stloc.s 5
+			IL_005f: ldloc.s 5
+			IL_0061: ret
+		} // end of method BinaryReceiver::iterateVarIn
+
+		.method public hidebysig 
+			instance object redeclare (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2730
+			// Header size: 12
+			// Code size: 42 (0x2a)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] float64,
+				[2] object,
+				[3] string
+			)
+
+			IL_0000: ldstr "text"
+			IL_0005: stloc.0
+			IL_0006: ldarg.1
+			IL_0007: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000c: ldc.r8 1
+			IL_0015: add
+			IL_0016: stloc.1
+			IL_0017: ldloc.1
+			IL_0018: box [System.Runtime]System.Double
+			IL_001d: stloc.2
+			IL_001e: ldloc.2
+			IL_001f: starg.s 'value'
+			IL_0021: ldarg.1
+			IL_0022: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0027: stloc.3
+			IL_0028: ldloc.3
+			IL_0029: ret
+		} // end of method BinaryReceiver::redeclare
+
+		.method public hidebysig 
+			instance object functionRedeclare (
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x24c0
+			// Header size: 12
+			// Code size: 77 (0x4d)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_functionRedeclare,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+				[2] float64,
+				[3] object,
+				[4] string
+			)
+
+			IL_0000: newobj instance void Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_functionRedeclare::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldnull
+			IL_0007: ldftn object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
+			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0017: ldc.i4.0
+			IL_0018: conv.r8
+			IL_0019: ldstr "value"
+			IL_001e: ldc.i4.0
+			IL_001f: ldc.i4.1
+			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0025: stloc.1
+			IL_0026: nop
+			IL_0027: ldarg.1
+			IL_0028: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_002d: ldc.r8 1
+			IL_0036: add
+			IL_0037: stloc.2
+			IL_0038: ldloc.2
+			IL_0039: box [System.Runtime]System.Double
+			IL_003e: stloc.3
+			IL_003f: ldloc.3
+			IL_0040: starg.s 'value'
+			IL_0042: ldarg.1
+			IL_0043: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0048: stloc.s 4
+			IL_004a: ldloc.s 4
+			IL_004c: ret
+		} // end of method BinaryReceiver::functionRedeclare
+
+		.method public hidebysig 
+			instance object run () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x20ec
+			// Header size: 12
+			// Code size: 713 (0x2c9)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] string,
+				[2] object,
+				[3] object,
+				[4] float64,
+				[5] object,
+				[6] object,
+				[7] object,
+				[8] object,
+				[9] object,
+				[10] float64
+			)
+
+			IL_0000: ldc.r8 7
+			IL_0009: stloc.0
+			IL_000a: ldstr "value"
+			IL_000f: stloc.1
+			IL_0010: ldc.r8 1
+			IL_0019: box [System.Runtime]System.Double
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_0023: stloc.2
+			IL_0024: ldc.r8 1
+			IL_002d: box [System.Runtime]System.Double
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_0037: stloc.3
+			IL_0038: ldstr "console"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0047: ldloc.0
+			IL_0048: ldc.r8 1
+			IL_0051: add
+			IL_0052: stloc.s 4
+			IL_0054: ldarg.0
+			IL_0055: ldloc.s 4
+			IL_0057: callvirt instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::'add'(float64)
+			IL_005c: box [System.Runtime]System.Double
+			IL_0061: stloc.s 5
+			IL_0063: ldstr "log"
+			IL_0068: ldloc.s 5
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006f: pop
+			IL_0070: ldstr "console"
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007f: ldloc.0
+			IL_0080: ldc.r8 2
+			IL_0089: mul
+			IL_008a: stloc.s 4
+			IL_008c: ldarg.0
+			IL_008d: ldloc.s 4
+			IL_008f: callvirt instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::multiply(float64)
+			IL_0094: box [System.Runtime]System.Double
+			IL_0099: stloc.s 5
+			IL_009b: ldstr "log"
+			IL_00a0: ldloc.s 5
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a7: pop
+			IL_00a8: ldstr "console"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b7: stloc.s 6
+			IL_00b9: ldloc.0
+			IL_00ba: conv.i4
+			IL_00bb: conv.u4
+			IL_00bc: ldc.r8 1
+			IL_00c5: conv.i4
+			IL_00c6: shr.un
+			IL_00c7: conv.r.un
+			IL_00c8: stloc.s 4
+			IL_00ca: ldarg.0
+			IL_00cb: ldloc.s 4
+			IL_00cd: callvirt instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::shift(float64)
+			IL_00d2: box [System.Runtime]System.Double
+			IL_00d7: stloc.s 5
+			IL_00d9: ldloc.s 6
+			IL_00db: ldstr "log"
+			IL_00e0: ldloc.s 5
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e7: pop
+			IL_00e8: ldstr "console"
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f7: ldloc.0
+			IL_00f8: ldc.r8 1
+			IL_0101: add
+			IL_0102: stloc.s 4
+			IL_0104: ldarg.0
+			IL_0105: ldloc.s 4
+			IL_0107: callvirt instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::increment(float64)
+			IL_010c: box [System.Runtime]System.Double
+			IL_0111: stloc.s 5
+			IL_0113: ldstr "log"
+			IL_0118: ldloc.s 5
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011f: pop
+			IL_0120: ldstr "console"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012f: ldarg.0
+			IL_0130: ldc.i4.1
+			IL_0131: box [System.Runtime]System.Boolean
+			IL_0136: callvirt instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::incrementBoolean(object)
+			IL_013b: box [System.Runtime]System.Double
+			IL_0140: stloc.s 5
+			IL_0142: ldstr "log"
+			IL_0147: ldloc.s 5
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_014e: pop
+			IL_014f: ldstr "console"
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015e: stloc.s 6
+			IL_0160: ldloc.1
+			IL_0161: ldc.r8 1
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_016f: stloc.s 7
+			IL_0171: ldarg.0
+			IL_0172: ldloc.s 7
+			IL_0174: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::dynamicAdd(object)
+			IL_0179: stloc.s 8
+			IL_017b: ldloc.s 6
+			IL_017d: ldstr "log"
+			IL_0182: ldloc.s 8
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0189: pop
+			IL_018a: ldstr "console"
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0199: ldloc.0
+			IL_019a: box [System.Runtime]System.Double
+			IL_019f: stloc.s 5
+			IL_01a1: ldarg.0
+			IL_01a2: ldloc.s 5
+			IL_01a4: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::destructure(object)
+			IL_01a9: stloc.s 8
+			IL_01ab: ldstr "log"
+			IL_01b0: ldloc.s 8
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b7: pop
+			IL_01b8: ldstr "console"
+			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c7: ldloc.0
+			IL_01c8: box [System.Runtime]System.Double
+			IL_01cd: stloc.s 5
+			IL_01cf: ldarg.0
+			IL_01d0: ldloc.s 5
+			IL_01d2: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterate(object)
+			IL_01d7: stloc.s 8
+			IL_01d9: ldstr "log"
+			IL_01de: ldloc.s 8
+			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01e5: pop
+			IL_01e6: ldstr "console"
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f5: ldloc.0
+			IL_01f6: box [System.Runtime]System.Double
+			IL_01fb: stloc.s 5
+			IL_01fd: ldarg.0
+			IL_01fe: ldloc.s 5
+			IL_0200: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVar(object)
+			IL_0205: stloc.s 8
+			IL_0207: ldstr "log"
+			IL_020c: ldloc.s 8
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0213: pop
+			IL_0214: ldstr "console"
+			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0223: ldloc.0
+			IL_0224: box [System.Runtime]System.Double
+			IL_0229: stloc.s 5
+			IL_022b: ldarg.0
+			IL_022c: ldloc.s 5
+			IL_022e: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVarIn(object)
+			IL_0233: stloc.s 8
+			IL_0235: ldstr "log"
+			IL_023a: ldloc.s 8
+			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0241: pop
+			IL_0242: ldstr "console"
+			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0251: ldloc.0
+			IL_0252: box [System.Runtime]System.Double
+			IL_0257: stloc.s 5
+			IL_0259: ldarg.0
+			IL_025a: ldloc.s 5
+			IL_025c: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::redeclare(object)
+			IL_0261: stloc.s 8
+			IL_0263: ldstr "log"
+			IL_0268: ldloc.s 8
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_026f: pop
+			IL_0270: ldc.i4.0
+			IL_0271: brfalse IL_02c7
+
+			IL_0276: ldloc.2
+			IL_0277: ldloc.3
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseAnd(object, object)
+			IL_027d: stloc.s 7
+			IL_027f: ldloc.2
+			IL_0280: ldloc.3
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseAnd(object, object)
+			IL_0286: stloc.s 9
+			IL_0288: ldloc.s 7
+			IL_028a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_028f: stloc.s 4
+			IL_0291: ldloc.s 9
+			IL_0293: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0298: stloc.s 10
+			IL_029a: ldloc.s 4
+			IL_029c: conv.i4
+			IL_029d: ldloc.s 10
+			IL_029f: conv.i4
+			IL_02a0: or
+			IL_02a1: conv.r8
+			IL_02a2: stloc.s 10
+			IL_02a4: ldloc.s 10
+			IL_02a6: box [System.Runtime]System.Double
+			IL_02ab: stloc.s 5
+			IL_02ad: ldarg.0
+			IL_02ae: ldloc.s 5
+			IL_02b0: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::bigint(object)
+			IL_02b5: pop
+			IL_02b6: ldloc.0
+			IL_02b7: box [System.Runtime]System.Double
+			IL_02bc: stloc.s 5
+			IL_02be: ldarg.0
+			IL_02bf: ldloc.s 5
+			IL_02c1: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::functionRedeclare(object)
+			IL_02c6: pop
+
+			IL_02c7: ldnull
+			IL_02c8: ret
+		} // end of method BinaryReceiver::run
+
+	} // end of class BinaryReceiver
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2769
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 112 (0x70)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_ParameterTypeInference_BinaryArguments/Scope,
+			[1] object[],
+			[2] class Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver,
+			[3] object
+		)
+
+		IL_0000: newobj instance void Modules.Function_ParameterTypeInference_BinaryArguments/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: nop
+		IL_0007: nop
+		IL_0008: ldc.i4.1
+		IL_0009: newarr [System.Runtime]System.Object
+		IL_000e: dup
+		IL_000f: ldc.i4.0
+		IL_0010: ldloc.0
+		IL_0011: stelem.ref
+		IL_0012: stloc.1
+		IL_0013: ldloc.1
+		IL_0014: ldc.i4.0
+		IL_0015: newarr [System.Runtime]System.Object
+		IL_001a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_001f: newobj instance void Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::.ctor(object[])
+		IL_0024: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0029: stloc.2
+		IL_002a: ldloc.2
+		IL_002b: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+		IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0035: ldstr "prototype"
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_003f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0044: ldloc.2
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004a: stloc.3
+		IL_004b: ldloc.3
+		IL_004c: isinst Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+		IL_0051: dup
+		IL_0052: brfalse IL_0062
+
+		IL_0057: callvirt instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::run()
+		IL_005c: pop
+		IL_005d: br IL_006f
+
+		IL_0062: pop
+		IL_0063: ldloc.3
+		IL_0064: ldstr "run"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006e: pop
+
+		IL_006f: ret
+	} // end of method Function_ParameterTypeInference_BinaryArguments::__js_module_init__
+
+} // end of class Modules.Function_ParameterTypeInference_BinaryArguments
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2826
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Function_ParameterTypeInference_BinaryArguments::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x261c
+				// Method begins at RVA 0x2604
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2625
+				// Method begins at RVA 0x260d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -128,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262e
+				// Method begins at RVA 0x2616
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2637
+				// Method begins at RVA 0x261f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -236,7 +236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2640
+				// Method begins at RVA 0x2628
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -299,7 +299,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2649
+				// Method begins at RVA 0x2631
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -317,7 +317,7 @@
 		.method public hidebysig static 
 			class [JavaScriptRuntime]JavaScriptRuntime.Array __js_call__ (
 				object newTarget,
-				object 'value'
+				float64 'value'
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -325,51 +325,39 @@
 			)
 			// Method begins at RVA 0x2578
 			// Header size: 12
-			// Code size: 78 (0x4e)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] object,
-				[2] object,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] float64,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.0
-			IL_0007: ldloc.0
-			IL_0008: box [System.Runtime]System.Double
-			IL_000d: stloc.1
-			IL_000e: ldloc.1
-			IL_000f: stloc.2
-			IL_0010: ldloc.0
-			IL_0011: ldc.r8 1
-			IL_001a: add
-			IL_001b: stloc.0
-			IL_001c: ldloc.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: stloc.1
-			IL_0023: ldloc.1
-			IL_0024: starg.s 'value'
-			IL_0026: ldarg.1
-			IL_0027: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_002c: stloc.0
-			IL_002d: ldloc.2
-			IL_002e: ldloc.0
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0034: stloc.3
-			IL_0035: ldc.i4.2
-			IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_003b: dup
-			IL_003c: ldloc.3
-			IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0042: dup
-			IL_0043: ldarg.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0049: stloc.s 4
-			IL_004b: ldloc.s 4
-			IL_004d: ret
+			IL_0001: stloc.0
+			IL_0002: ldarg.1
+			IL_0003: ldc.r8 1
+			IL_000c: add
+			IL_000d: starg.s 'value'
+			IL_000f: ldarg.1
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_001a: stloc.1
+			IL_001b: ldloc.0
+			IL_001c: ldloc.1
+			IL_001d: add
+			IL_001e: stloc.1
+			IL_001f: ldc.i4.2
+			IL_0020: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0025: dup
+			IL_0026: ldloc.1
+			IL_0027: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_002c: dup
+			IL_002d: ldarg.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0033: stloc.2
+			IL_0034: ldloc.2
+			IL_0035: ret
 		} // end of method postfix::__js_call__
 
 	} // end of class postfix
@@ -385,7 +373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2652
+				// Method begins at RVA 0x263a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -411,7 +399,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x25bc
 			// Header size: 12
 			// Code size: 51 (0x33)
 			.maxstack 8
@@ -464,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x265b
+				// Method begins at RVA 0x2643
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -484,7 +472,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2664
+				// Method begins at RVA 0x264c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -511,7 +499,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2613
+			// Method begins at RVA 0x25fb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -546,7 +534,7 @@
 			[3] class [System.Runtime]System.Func`3<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object>,
 			[4] class [System.Runtime]System.Func`3<object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object>,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[6] class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] class [System.Runtime]System.Exception,
 			[9] object,
@@ -624,15 +612,15 @@
 		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldnull
-		IL_00a9: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, object)
-		IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00b4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00a9: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
+		IL_00af: newobj instance void class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>::.ctor(object, native int)
+		IL_00b4: castclass class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>
 		IL_00b9: ldc.i4.1
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "postfix"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, class [JavaScriptRuntime]JavaScriptRuntime.Array>>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop
@@ -791,7 +779,7 @@
 		IL_02d3: ldloc.s 16
 		IL_02d5: ldc.r8 3
 		IL_02de: box [System.Runtime]System.Double
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_02e8: stloc.s 15
 		IL_02ea: ldloc.s 15
 		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
@@ -928,7 +916,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x266d
+		// Method begins at RVA 0x2655
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2796
+				// Method begins at RVA 0x2757
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f8
+			// Method begins at RVA 0x23ea
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x279f
+				// Method begins at RVA 0x2760
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23fb
+			// Method begins at RVA 0x23ed
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27b1
+					// Method begins at RVA 0x2772
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a8
+				// Method begins at RVA 0x2769
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23fe
+			// Method begins at RVA 0x23f0
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -191,7 +191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27c3
+					// Method begins at RVA 0x2784
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ba
+				// Method begins at RVA 0x277b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -234,7 +234,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2418
+			// Method begins at RVA 0x240a
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27cc
+				// Method begins at RVA 0x278d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -289,7 +289,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27de
+					// Method begins at RVA 0x279f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d5
+				// Method begins at RVA 0x2796
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -333,15 +333,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2434
+			// Method begins at RVA 0x2424
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] float64,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -349,41 +348,33 @@
 			// loop start (head: IL_000a)
 				IL_000a: ldloc.0
 				IL_000b: stloc.1
-				IL_000c: ldarg.0
-				IL_000d: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0012: ldc.r8 15
-				IL_001b: mul
-				IL_001c: stloc.2
-				IL_001d: ldloc.1
-				IL_001e: ldloc.2
-				IL_001f: clt
-				IL_0021: brfalse IL_005b
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 15360
+				IL_0016: clt
+				IL_0018: brfalse IL_0053
 
-				IL_0026: ldc.i4.0
-				IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_002c: stloc.3
-				IL_002d: ldarg.0
-				IL_002e: ldloc.3
-				IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0034: ldarg.0
-				IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_003a: stloc.3
-				IL_003b: ldarg.0
-				IL_003c: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0041: stloc.2
-				IL_0042: ldloc.3
-				IL_0043: ldloc.2
-				IL_0044: ldc.i4.1
-				IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-				IL_004a: ldloc.0
-				IL_004b: ldc.r8 1
-				IL_0054: add
-				IL_0055: stloc.0
-				IL_0056: br IL_000a
+				IL_001d: ldc.i4.0
+				IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+				IL_0023: stloc.2
+				IL_0024: ldarg.0
+				IL_0025: ldloc.2
+				IL_0026: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_002b: ldarg.0
+				IL_002c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0031: stloc.2
+				IL_0032: ldloc.2
+				IL_0033: ldc.r8 1024
+				IL_003c: ldc.i4.1
+				IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+				IL_0042: ldloc.0
+				IL_0043: ldc.r8 1
+				IL_004c: add
+				IL_004d: stloc.0
+				IL_004e: br IL_000a
 			// end loop
 
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0053: ldnull
+			IL_0054: ret
 		} // end of method ArrowFunction_L15C32::__js_call__
 
 	} // end of class ArrowFunction_L15C32
@@ -399,7 +390,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e7
+				// Method begins at RVA 0x27a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -419,7 +410,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f0
+				// Method begins at RVA 0x27b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,16 +436,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x24a0
+			// Method begins at RVA 0x2488
 			// Header size: 12
-			// Code size: 99 (0x63)
+			// Code size: 89 (0x59)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
-				[2] float64,
-				[3] object,
-				[4] object
+				[2] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -462,41 +451,33 @@
 			// loop start (head: IL_000a)
 				IL_000a: ldloc.0
 				IL_000b: stloc.1
-				IL_000c: ldarg.0
-				IL_000d: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0012: ldc.r8 10
-				IL_001b: mul
-				IL_001c: stloc.2
-				IL_001d: ldloc.1
-				IL_001e: ldloc.2
-				IL_001f: clt
-				IL_0021: brfalse IL_0061
+				IL_000c: ldloc.1
+				IL_000d: ldc.r8 10240
+				IL_0016: clt
+				IL_0018: brfalse IL_0057
 
-				IL_0026: ldarg.0
-				IL_0027: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_002c: box [System.Runtime]System.Double
-				IL_0031: stloc.3
-				IL_0032: ldc.i4.1
-				IL_0033: newarr [System.Runtime]System.Object
-				IL_0038: dup
-				IL_0039: ldc.i4.0
-				IL_003a: ldloc.3
-				IL_003b: stelem.ref
-				IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
-				IL_0041: stloc.s 4
-				IL_0043: ldarg.0
-				IL_0044: ldloc.s 4
-				IL_0046: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_004b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0050: ldloc.0
-				IL_0051: ldc.r8 1
-				IL_005a: add
-				IL_005b: stloc.0
-				IL_005c: br IL_000a
+				IL_001d: ldc.i4.1
+				IL_001e: newarr [System.Runtime]System.Object
+				IL_0023: dup
+				IL_0024: ldc.i4.0
+				IL_0025: ldc.r8 1024
+				IL_002e: box [System.Runtime]System.Double
+				IL_0033: stelem.ref
+				IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
+				IL_0039: stloc.2
+				IL_003a: ldarg.0
+				IL_003b: ldloc.2
+				IL_003c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0041: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0046: ldloc.0
+				IL_0047: ldc.r8 1
+				IL_0050: add
+				IL_0051: stloc.0
+				IL_0052: br IL_000a
 			// end loop
 
-			IL_0061: ldnull
-			IL_0062: ret
+			IL_0057: ldnull
+			IL_0058: ret
 		} // end of method ArrowFunction_L22C41::__js_call__
 
 	} // end of class ArrowFunction_L22C41
@@ -512,7 +493,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f9
+				// Method begins at RVA 0x27ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -532,7 +513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2802
+				// Method begins at RVA 0x27c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -558,16 +539,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x24f0
 			// Header size: 12
-			// Code size: 85 (0x55)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] float64,
-				[3] float64,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -581,33 +561,30 @@
 			// loop start (head: IL_0018)
 				IL_0018: ldloc.0
 				IL_0019: stloc.2
-				IL_001a: ldarg.0
-				IL_001b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0020: stloc.3
-				IL_0021: ldloc.2
-				IL_0022: ldloc.3
-				IL_0023: clt
-				IL_0025: brfalse IL_0053
+				IL_001a: ldloc.2
+				IL_001b: ldc.r8 1024
+				IL_0024: clt
+				IL_0026: brfalse IL_0052
 
-				IL_002a: ldarg.0
-				IL_002b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0030: stloc.1
-				IL_0031: ldloc.0
-				IL_0032: box [System.Runtime]System.Double
-				IL_0037: stloc.s 4
+				IL_002b: ldarg.0
+				IL_002c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0031: stloc.1
+				IL_0032: ldloc.0
+				IL_0033: box [System.Runtime]System.Double
+				IL_0038: stloc.3
 				IL_0039: ldloc.1
-				IL_003a: ldloc.s 4
-				IL_003c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
-				IL_0041: pop
-				IL_0042: ldloc.0
-				IL_0043: ldc.r8 1
-				IL_004c: add
-				IL_004d: stloc.0
-				IL_004e: br IL_0018
+				IL_003a: ldloc.3
+				IL_003b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
+				IL_0040: pop
+				IL_0041: ldloc.0
+				IL_0042: ldc.r8 1
+				IL_004b: add
+				IL_004c: stloc.0
+				IL_004d: br IL_0018
 			// end loop
 
-			IL_0053: ldnull
-			IL_0054: ret
+			IL_0052: ldnull
+			IL_0053: ret
 		} // end of method ArrowFunction_L27C37::__js_call__
 
 	} // end of class ArrowFunction_L27C37
@@ -623,7 +600,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280b
+				// Method begins at RVA 0x27cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -643,7 +620,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2814
+				// Method begins at RVA 0x27d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -669,16 +646,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2550
 			// Header size: 12
-			// Code size: 113 (0x71)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] float64,
-				[3] float64,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -692,37 +668,34 @@
 			// loop start (head: IL_0018)
 				IL_0018: ldloc.0
 				IL_0019: stloc.2
-				IL_001a: ldarg.0
-				IL_001b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0020: stloc.3
-				IL_0021: ldloc.2
-				IL_0022: ldloc.3
-				IL_0023: clt
-				IL_0025: brfalse IL_006f
+				IL_001a: ldloc.2
+				IL_001b: ldc.r8 1024
+				IL_0024: clt
+				IL_0026: brfalse IL_006e
 
-				IL_002a: ldarg.0
-				IL_002b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_0030: stloc.1
-				IL_0031: ldloc.0
-				IL_0032: box [System.Runtime]System.Double
-				IL_0037: stloc.s 4
+				IL_002b: ldarg.0
+				IL_002c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0031: stloc.1
+				IL_0032: ldloc.0
+				IL_0033: box [System.Runtime]System.Double
+				IL_0038: stloc.3
 				IL_0039: ldloc.1
 				IL_003a: ldc.r8 0.0
 				IL_0043: box [System.Runtime]System.Double
 				IL_0048: ldc.r8 0.0
 				IL_0051: box [System.Runtime]System.Double
-				IL_0056: ldloc.s 4
-				IL_0058: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
-				IL_005d: pop
-				IL_005e: ldloc.0
-				IL_005f: ldc.r8 1
-				IL_0068: add
-				IL_0069: stloc.0
-				IL_006a: br IL_0018
+				IL_0056: ldloc.3
+				IL_0057: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
+				IL_005c: pop
+				IL_005d: ldloc.0
+				IL_005e: ldc.r8 1
+				IL_0067: add
+				IL_0068: stloc.0
+				IL_0069: br IL_0018
 			// end loop
 
-			IL_006f: ldnull
-			IL_0070: ret
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method ArrowFunction_L33C36::__js_call__
 
 	} // end of class ArrowFunction_L33C36
@@ -738,7 +711,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x281d
+				// Method begins at RVA 0x27de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -758,7 +731,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2826
+				// Method begins at RVA 0x27e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -784,16 +757,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x25f4
+			// Method begins at RVA 0x25cc
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] float64,
-				[3] float64,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -805,29 +777,26 @@
 			// loop start (head: IL_0016)
 				IL_0016: ldloc.1
 				IL_0017: stloc.2
-				IL_0018: ldarg.0
-				IL_0019: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001e: stloc.3
-				IL_001f: ldloc.2
-				IL_0020: ldloc.3
-				IL_0021: clt
-				IL_0023: brfalse IL_0049
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 1024
+				IL_0022: clt
+				IL_0024: brfalse IL_0048
 
-				IL_0028: ldloc.0
-				IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::shift()
-				IL_002e: stloc.s 4
+				IL_0029: ldloc.0
+				IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::shift()
+				IL_002f: stloc.3
 				IL_0030: ldarg.0
-				IL_0031: ldloc.s 4
-				IL_0033: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0038: ldloc.1
-				IL_0039: ldc.r8 1
-				IL_0042: add
-				IL_0043: stloc.1
-				IL_0044: br IL_0016
+				IL_0031: ldloc.3
+				IL_0032: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0037: ldloc.1
+				IL_0038: ldc.r8 1
+				IL_0041: add
+				IL_0042: stloc.1
+				IL_0043: br IL_0016
 			// end loop
 
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0048: ldnull
+			IL_0049: ret
 		} // end of method ArrowFunction_L39C37::__js_call__
 
 	} // end of class ArrowFunction_L39C37
@@ -843,7 +812,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282f
+				// Method begins at RVA 0x27f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -863,7 +832,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2838
+				// Method begins at RVA 0x27f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -889,16 +858,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x264c
+			// Method begins at RVA 0x2624
 			// Header size: 12
-			// Code size: 103 (0x67)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] float64,
-				[3] float64,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -910,33 +878,30 @@
 			// loop start (head: IL_0016)
 				IL_0016: ldloc.1
 				IL_0017: stloc.2
-				IL_0018: ldarg.0
-				IL_0019: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001e: stloc.3
-				IL_001f: ldloc.2
-				IL_0020: ldloc.3
-				IL_0021: clt
-				IL_0023: brfalse IL_0065
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 1024
+				IL_0022: clt
+				IL_0024: brfalse IL_0064
 
-				IL_0028: ldloc.0
-				IL_0029: ldc.r8 0.0
-				IL_0032: box [System.Runtime]System.Double
-				IL_0037: ldc.r8 1
-				IL_0040: box [System.Runtime]System.Double
-				IL_0045: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
-				IL_004a: stloc.s 4
+				IL_0029: ldloc.0
+				IL_002a: ldc.r8 0.0
+				IL_0033: box [System.Runtime]System.Double
+				IL_0038: ldc.r8 1
+				IL_0041: box [System.Runtime]System.Double
+				IL_0046: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object)
+				IL_004b: stloc.3
 				IL_004c: ldarg.0
-				IL_004d: ldloc.s 4
-				IL_004f: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0054: ldloc.1
-				IL_0055: ldc.r8 1
-				IL_005e: add
-				IL_005f: stloc.1
-				IL_0060: br IL_0016
+				IL_004d: ldloc.3
+				IL_004e: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0053: ldloc.1
+				IL_0054: ldc.r8 1
+				IL_005d: add
+				IL_005e: stloc.1
+				IL_005f: br IL_0016
 			// end loop
 
-			IL_0065: ldnull
-			IL_0066: ret
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method ArrowFunction_L45C38::__js_call__
 
 	} // end of class ArrowFunction_L45C38
@@ -952,7 +917,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2841
+				// Method begins at RVA 0x2802
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -972,7 +937,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x284a
+				// Method begins at RVA 0x280b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -998,16 +963,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x26c0
+			// Method begins at RVA 0x2698
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] float64,
-				[3] float64,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -1021,35 +985,30 @@
 			// loop start (head: IL_0018)
 				IL_0018: ldloc.0
 				IL_0019: stloc.2
-				IL_001a: ldarg.0
-				IL_001b: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_0020: ldc.r8 25
-				IL_0029: mul
-				IL_002a: stloc.3
-				IL_002b: ldloc.2
-				IL_002c: ldloc.3
-				IL_002d: clt
-				IL_002f: brfalse IL_005d
+				IL_001a: ldloc.2
+				IL_001b: ldc.r8 25600
+				IL_0024: clt
+				IL_0026: brfalse IL_0052
 
-				IL_0034: ldarg.0
-				IL_0035: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-				IL_003a: stloc.1
-				IL_003b: ldloc.0
-				IL_003c: box [System.Runtime]System.Double
-				IL_0041: stloc.s 4
-				IL_0043: ldloc.1
-				IL_0044: ldloc.s 4
-				IL_0046: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_004b: pop
-				IL_004c: ldloc.0
-				IL_004d: ldc.r8 1
-				IL_0056: add
-				IL_0057: stloc.0
-				IL_0058: br IL_0018
+				IL_002b: ldarg.0
+				IL_002c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+				IL_0031: stloc.1
+				IL_0032: ldloc.0
+				IL_0033: box [System.Runtime]System.Double
+				IL_0038: stloc.3
+				IL_0039: ldloc.1
+				IL_003a: ldloc.3
+				IL_003b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0040: pop
+				IL_0041: ldloc.0
+				IL_0042: ldc.r8 1
+				IL_004b: add
+				IL_004c: stloc.0
+				IL_004d: br IL_0018
 			// end loop
 
-			IL_005d: ldnull
-			IL_005e: ret
+			IL_0052: ldnull
+			IL_0053: ret
 		} // end of method ArrowFunction_L51C34::__js_call__
 
 	} // end of class ArrowFunction_L51C34
@@ -1065,7 +1024,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2853
+				// Method begins at RVA 0x2814
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1085,7 +1044,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285c
+				// Method begins at RVA 0x281d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1111,16 +1070,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x272c
+			// Method begins at RVA 0x26f8
 			// Header size: 12
-			// Code size: 85 (0x55)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] float64,
 				[2] float64,
-				[3] float64,
-				[4] object
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -1132,31 +1090,26 @@
 			// loop start (head: IL_0016)
 				IL_0016: ldloc.1
 				IL_0017: stloc.2
-				IL_0018: ldarg.0
-				IL_0019: ldfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-				IL_001e: ldc.r8 25
-				IL_0027: mul
-				IL_0028: stloc.3
-				IL_0029: ldloc.2
-				IL_002a: ldloc.3
-				IL_002b: clt
-				IL_002d: brfalse IL_0053
+				IL_0018: ldloc.2
+				IL_0019: ldc.r8 25600
+				IL_0022: clt
+				IL_0024: brfalse IL_0048
 
-				IL_0032: ldloc.0
-				IL_0033: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
-				IL_0038: stloc.s 4
-				IL_003a: ldarg.0
-				IL_003b: ldloc.s 4
-				IL_003d: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-				IL_0042: ldloc.1
-				IL_0043: ldc.r8 1
-				IL_004c: add
-				IL_004d: stloc.1
-				IL_004e: br IL_0016
+				IL_0029: ldloc.0
+				IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+				IL_002f: stloc.3
+				IL_0030: ldarg.0
+				IL_0031: ldloc.3
+				IL_0032: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+				IL_0037: ldloc.1
+				IL_0038: ldc.r8 1
+				IL_0041: add
+				IL_0042: stloc.1
+				IL_0043: br IL_0016
 			// end loop
 
-			IL_0053: ldnull
-			IL_0054: ret
+			IL_0048: ldnull
+			IL_0049: ret
 		} // end of method ArrowFunction_L57C35::__js_call__
 
 	} // end of class ArrowFunction_L57C35
@@ -1165,13 +1118,13 @@
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 65 53 63 6f 70 65 20 73 74 61 72 74 54 65
+			01 00 5e 53 63 6f 70 65 20 73 74 61 72 74 54 65
 			73 74 3d 7b 73 74 61 72 74 54 65 73 74 7d 2c 20
 			65 6e 64 54 65 73 74 3d 7b 65 6e 64 54 65 73 74
 			7d 2c 20 70 72 65 70 3d 7b 70 72 65 70 7d 2c 20
 			74 65 73 74 3d 7b 74 65 73 74 7d 2c 20 72 65 74
 			3d 7b 72 65 74 7d 2c 20 74 6d 70 3d 7b 74 6d 70
-			7d 2c 20 69 3d 7b 69 7d 00 00
+			7d 00 00
 		)
 		// Fields
 		.field public object startTest
@@ -1180,13 +1133,12 @@
 		.field public object test
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array 'ret'
 		.field public object tmp
-		.field public float64 i
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x278d
+			// Method begins at RVA 0x274e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1212,7 +1164,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 924 (0x39c)
+		// Code size: 910 (0x38e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
@@ -1296,246 +1248,244 @@
 		IL_00b8: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
 		IL_00bd: ldc.r8 500
 		IL_00c6: stloc.s 5
-		IL_00c8: ldloc.0
-		IL_00c9: ldc.r8 1024
-		IL_00d2: stfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-		IL_00d7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00dc: stloc.s 6
-		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_00e4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ef: ldc.i4.1
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: dup
-		IL_00f6: ldc.i4.0
-		IL_00f7: ldloc.0
-		IL_00f8: stelem.ref
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0103: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0108: ldc.i4.0
-		IL_0109: conv.r8
-		IL_010a: ldstr ""
-		IL_010f: ldc.i4.0
-		IL_0110: ldc.i4.0
-		IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_011b: stloc.s 8
-		IL_011d: ldloc.s 4
-		IL_011f: ldloc.s 6
-		IL_0121: ldstr "Array Construction, []"
-		IL_0126: ldloc.s 8
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_012d: pop
-		IL_012e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0133: stloc.s 6
-		IL_0135: ldloc.0
-		IL_0136: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_013b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0141: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0146: ldc.i4.1
-		IL_0147: newarr [System.Runtime]System.Object
-		IL_014c: dup
-		IL_014d: ldc.i4.0
-		IL_014e: ldloc.0
-		IL_014f: stelem.ref
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_015a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_015f: ldc.i4.0
-		IL_0160: conv.r8
-		IL_0161: ldstr ""
-		IL_0166: ldc.i4.0
-		IL_0167: ldc.i4.0
-		IL_0168: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0172: stloc.s 8
-		IL_0174: ldloc.s 4
-		IL_0176: ldloc.s 6
-		IL_0178: ldstr "Array Construction, new Array()"
-		IL_017d: ldloc.s 8
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0184: pop
-		IL_0185: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_018a: stloc.s 6
-		IL_018c: ldloc.0
-		IL_018d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0192: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0198: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_019d: ldc.i4.1
-		IL_019e: newarr [System.Runtime]System.Object
-		IL_01a3: dup
-		IL_01a4: ldc.i4.0
-		IL_01a5: ldloc.0
-		IL_01a6: stelem.ref
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01b1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_01b6: ldc.i4.0
-		IL_01b7: conv.r8
-		IL_01b8: ldstr ""
-		IL_01bd: ldc.i4.0
-		IL_01be: ldc.i4.0
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_01c9: stloc.s 8
-		IL_01cb: ldloc.s 4
-		IL_01cd: ldloc.s 6
-		IL_01cf: ldstr "Array Construction, unshift"
-		IL_01d4: ldloc.s 8
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01db: pop
-		IL_01dc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01e1: stloc.s 6
-		IL_01e3: ldloc.0
-		IL_01e4: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_01e9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_01ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01f4: ldc.i4.1
-		IL_01f5: newarr [System.Runtime]System.Object
-		IL_01fa: dup
-		IL_01fb: ldc.i4.0
-		IL_01fc: ldloc.0
-		IL_01fd: stelem.ref
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0208: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_020d: ldc.i4.0
-		IL_020e: conv.r8
-		IL_020f: ldstr ""
-		IL_0214: ldc.i4.0
-		IL_0215: ldc.i4.0
-		IL_0216: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_021b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0220: stloc.s 8
-		IL_0222: ldloc.s 4
-		IL_0224: ldloc.s 6
-		IL_0226: ldstr "Array Construction, splice"
-		IL_022b: ldloc.s 8
-		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0232: pop
-		IL_0233: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0238: stloc.s 6
-		IL_023a: ldloc.0
-		IL_023b: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0240: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0246: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_024b: ldc.i4.1
-		IL_024c: newarr [System.Runtime]System.Object
-		IL_0251: dup
-		IL_0252: ldc.i4.0
-		IL_0253: ldloc.0
-		IL_0254: stelem.ref
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_025f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0264: ldc.i4.0
-		IL_0265: conv.r8
-		IL_0266: ldstr ""
-		IL_026b: ldc.i4.0
-		IL_026c: ldc.i4.0
-		IL_026d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0272: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0277: stloc.s 8
-		IL_0279: ldloc.s 4
-		IL_027b: ldloc.s 6
-		IL_027d: ldstr "Array Deconstruction, shift"
-		IL_0282: ldloc.s 8
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0289: pop
-		IL_028a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_028f: stloc.s 6
-		IL_0291: ldloc.0
-		IL_0292: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0297: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02a2: ldc.i4.1
-		IL_02a3: newarr [System.Runtime]System.Object
-		IL_02a8: dup
-		IL_02a9: ldc.i4.0
-		IL_02aa: ldloc.0
-		IL_02ab: stelem.ref
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02b6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_02bb: ldc.i4.0
-		IL_02bc: conv.r8
-		IL_02bd: ldstr ""
-		IL_02c2: ldc.i4.0
-		IL_02c3: ldc.i4.0
-		IL_02c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02ce: stloc.s 8
-		IL_02d0: ldloc.s 4
-		IL_02d2: ldloc.s 6
-		IL_02d4: ldstr "Array Deconstruction, splice"
-		IL_02d9: ldloc.s 8
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02e0: pop
-		IL_02e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02e6: stloc.s 6
-		IL_02e8: ldloc.0
-		IL_02e9: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_02ee: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_02f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02f9: ldc.i4.1
-		IL_02fa: newarr [System.Runtime]System.Object
-		IL_02ff: dup
-		IL_0300: ldc.i4.0
-		IL_0301: ldloc.0
-		IL_0302: stelem.ref
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_030d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0312: ldc.i4.0
-		IL_0313: conv.r8
-		IL_0314: ldstr ""
-		IL_0319: ldc.i4.0
-		IL_031a: ldc.i4.0
-		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0325: stloc.s 8
-		IL_0327: ldloc.s 4
-		IL_0329: ldloc.s 6
-		IL_032b: ldstr "Array Construction, push"
-		IL_0330: ldloc.s 8
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0337: pop
-		IL_0338: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_033d: stloc.s 6
-		IL_033f: ldloc.0
-		IL_0340: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0345: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_034b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0350: ldc.i4.1
-		IL_0351: newarr [System.Runtime]System.Object
-		IL_0356: dup
-		IL_0357: ldc.i4.0
-		IL_0358: ldloc.0
-		IL_0359: stelem.ref
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0364: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0369: ldc.i4.0
-		IL_036a: conv.r8
-		IL_036b: ldstr ""
-		IL_0370: ldc.i4.0
-		IL_0371: ldc.i4.0
-		IL_0372: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0377: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_037c: stloc.s 8
-		IL_037e: ldloc.s 4
-		IL_0380: ldloc.s 6
-		IL_0382: ldstr "Array Deconstruction, pop"
-		IL_0387: ldloc.s 8
-		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_038e: pop
-		IL_038f: ldloc.2
-		IL_0390: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_039a: pop
-		IL_039b: ret
+		IL_00c8: nop
+		IL_00c9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ce: stloc.s 6
+		IL_00d0: ldloc.0
+		IL_00d1: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_00d6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00e1: ldc.i4.1
+		IL_00e2: newarr [System.Runtime]System.Object
+		IL_00e7: dup
+		IL_00e8: ldc.i4.0
+		IL_00e9: ldloc.0
+		IL_00ea: stelem.ref
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00f5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00fa: ldc.i4.0
+		IL_00fb: conv.r8
+		IL_00fc: ldstr ""
+		IL_0101: ldc.i4.0
+		IL_0102: ldc.i4.0
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_010d: stloc.s 8
+		IL_010f: ldloc.s 4
+		IL_0111: ldloc.s 6
+		IL_0113: ldstr "Array Construction, []"
+		IL_0118: ldloc.s 8
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_011f: pop
+		IL_0120: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0125: stloc.s 6
+		IL_0127: ldloc.0
+		IL_0128: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_012d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0133: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0138: ldc.i4.1
+		IL_0139: newarr [System.Runtime]System.Object
+		IL_013e: dup
+		IL_013f: ldc.i4.0
+		IL_0140: ldloc.0
+		IL_0141: stelem.ref
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_014c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0151: ldc.i4.0
+		IL_0152: conv.r8
+		IL_0153: ldstr ""
+		IL_0158: ldc.i4.0
+		IL_0159: ldc.i4.0
+		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0164: stloc.s 8
+		IL_0166: ldloc.s 4
+		IL_0168: ldloc.s 6
+		IL_016a: ldstr "Array Construction, new Array()"
+		IL_016f: ldloc.s 8
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0176: pop
+		IL_0177: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017c: stloc.s 6
+		IL_017e: ldloc.0
+		IL_017f: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0184: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_018a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_018f: ldc.i4.1
+		IL_0190: newarr [System.Runtime]System.Object
+		IL_0195: dup
+		IL_0196: ldc.i4.0
+		IL_0197: ldloc.0
+		IL_0198: stelem.ref
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01a3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01a8: ldc.i4.0
+		IL_01a9: conv.r8
+		IL_01aa: ldstr ""
+		IL_01af: ldc.i4.0
+		IL_01b0: ldc.i4.0
+		IL_01b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_01bb: stloc.s 8
+		IL_01bd: ldloc.s 4
+		IL_01bf: ldloc.s 6
+		IL_01c1: ldstr "Array Construction, unshift"
+		IL_01c6: ldloc.s 8
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01cd: pop
+		IL_01ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01d3: stloc.s 6
+		IL_01d5: ldloc.0
+		IL_01d6: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_01db: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_01e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01e6: ldc.i4.1
+		IL_01e7: newarr [System.Runtime]System.Object
+		IL_01ec: dup
+		IL_01ed: ldc.i4.0
+		IL_01ee: ldloc.0
+		IL_01ef: stelem.ref
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01fa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01ff: ldc.i4.0
+		IL_0200: conv.r8
+		IL_0201: ldstr ""
+		IL_0206: ldc.i4.0
+		IL_0207: ldc.i4.0
+		IL_0208: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0212: stloc.s 8
+		IL_0214: ldloc.s 4
+		IL_0216: ldloc.s 6
+		IL_0218: ldstr "Array Construction, splice"
+		IL_021d: ldloc.s 8
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0224: pop
+		IL_0225: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_022a: stloc.s 6
+		IL_022c: ldloc.0
+		IL_022d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0232: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_023d: ldc.i4.1
+		IL_023e: newarr [System.Runtime]System.Object
+		IL_0243: dup
+		IL_0244: ldc.i4.0
+		IL_0245: ldloc.0
+		IL_0246: stelem.ref
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0251: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0256: ldc.i4.0
+		IL_0257: conv.r8
+		IL_0258: ldstr ""
+		IL_025d: ldc.i4.0
+		IL_025e: ldc.i4.0
+		IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0269: stloc.s 8
+		IL_026b: ldloc.s 4
+		IL_026d: ldloc.s 6
+		IL_026f: ldstr "Array Deconstruction, shift"
+		IL_0274: ldloc.s 8
+		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_027b: pop
+		IL_027c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0281: stloc.s 6
+		IL_0283: ldloc.0
+		IL_0284: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0289: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_028f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0294: ldc.i4.1
+		IL_0295: newarr [System.Runtime]System.Object
+		IL_029a: dup
+		IL_029b: ldc.i4.0
+		IL_029c: ldloc.0
+		IL_029d: stelem.ref
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02a8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_02ad: ldc.i4.0
+		IL_02ae: conv.r8
+		IL_02af: ldstr ""
+		IL_02b4: ldc.i4.0
+		IL_02b5: ldc.i4.0
+		IL_02b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_02bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_02c0: stloc.s 8
+		IL_02c2: ldloc.s 4
+		IL_02c4: ldloc.s 6
+		IL_02c6: ldstr "Array Deconstruction, splice"
+		IL_02cb: ldloc.s 8
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02d2: pop
+		IL_02d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02d8: stloc.s 6
+		IL_02da: ldloc.0
+		IL_02db: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_02e0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_02e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02eb: ldc.i4.1
+		IL_02ec: newarr [System.Runtime]System.Object
+		IL_02f1: dup
+		IL_02f2: ldc.i4.0
+		IL_02f3: ldloc.0
+		IL_02f4: stelem.ref
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02ff: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0304: ldc.i4.0
+		IL_0305: conv.r8
+		IL_0306: ldstr ""
+		IL_030b: ldc.i4.0
+		IL_030c: ldc.i4.0
+		IL_030d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0317: stloc.s 8
+		IL_0319: ldloc.s 4
+		IL_031b: ldloc.s 6
+		IL_031d: ldstr "Array Construction, push"
+		IL_0322: ldloc.s 8
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0329: pop
+		IL_032a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_032f: stloc.s 6
+		IL_0331: ldloc.0
+		IL_0332: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0337: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0342: ldc.i4.1
+		IL_0343: newarr [System.Runtime]System.Object
+		IL_0348: dup
+		IL_0349: ldc.i4.0
+		IL_034a: ldloc.0
+		IL_034b: stelem.ref
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0356: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_035b: ldc.i4.0
+		IL_035c: conv.r8
+		IL_035d: ldstr ""
+		IL_0362: ldc.i4.0
+		IL_0363: ldc.i4.0
+		IL_0364: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0369: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_036e: stloc.s 8
+		IL_0370: ldloc.s 4
+		IL_0372: ldloc.s 6
+		IL_0374: ldstr "Array Deconstruction, pop"
+		IL_0379: ldloc.s 8
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0380: pop
+		IL_0381: ldloc.2
+		IL_0382: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_038c: pop
+		IL_038d: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Array_Modern::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Array_Modern
@@ -1547,7 +1497,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2865
+		// Method begins at RVA 0x2826
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ea
+			// Method begins at RVA 0x23e9
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ed
+			// Method begins at RVA 0x23ec
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -156,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f0
+			// Method begins at RVA 0x23ef
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -234,7 +234,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x240a
+			// Method begins at RVA 0x2409
 			// Header size: 1
 			// Code size: 25 (0x19)
 			.maxstack 8
@@ -1164,7 +1164,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 910 (0x38e)
+		// Code size: 909 (0x38d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
@@ -1248,244 +1248,243 @@
 		IL_00b8: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
 		IL_00bd: ldc.r8 500
 		IL_00c6: stloc.s 5
-		IL_00c8: nop
-		IL_00c9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ce: stloc.s 6
-		IL_00d0: ldloc.0
-		IL_00d1: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_00d6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.0
-		IL_00ea: stelem.ref
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00f5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_00fa: ldc.i4.0
-		IL_00fb: conv.r8
-		IL_00fc: ldstr ""
+		IL_00c8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00cd: stloc.s 6
+		IL_00cf: ldloc.0
+		IL_00d0: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_00d5: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00e0: ldc.i4.1
+		IL_00e1: newarr [System.Runtime]System.Object
+		IL_00e6: dup
+		IL_00e7: ldc.i4.0
+		IL_00e8: ldloc.0
+		IL_00e9: stelem.ref
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00f4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00f9: ldc.i4.0
+		IL_00fa: conv.r8
+		IL_00fb: ldstr ""
+		IL_0100: ldc.i4.0
 		IL_0101: ldc.i4.0
-		IL_0102: ldc.i4.0
-		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_010d: stloc.s 8
-		IL_010f: ldloc.s 4
-		IL_0111: ldloc.s 6
-		IL_0113: ldstr "Array Construction, []"
-		IL_0118: ldloc.s 8
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_011f: pop
-		IL_0120: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0125: stloc.s 6
-		IL_0127: ldloc.0
-		IL_0128: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_012d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0133: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0138: ldc.i4.1
-		IL_0139: newarr [System.Runtime]System.Object
-		IL_013e: dup
-		IL_013f: ldc.i4.0
-		IL_0140: ldloc.0
-		IL_0141: stelem.ref
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_014c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0151: ldc.i4.0
-		IL_0152: conv.r8
-		IL_0153: ldstr ""
+		IL_0102: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_010c: stloc.s 8
+		IL_010e: ldloc.s 4
+		IL_0110: ldloc.s 6
+		IL_0112: ldstr "Array Construction, []"
+		IL_0117: ldloc.s 8
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_011e: pop
+		IL_011f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0124: stloc.s 6
+		IL_0126: ldloc.0
+		IL_0127: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_012c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0137: ldc.i4.1
+		IL_0138: newarr [System.Runtime]System.Object
+		IL_013d: dup
+		IL_013e: ldc.i4.0
+		IL_013f: ldloc.0
+		IL_0140: stelem.ref
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_014b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0150: ldc.i4.0
+		IL_0151: conv.r8
+		IL_0152: ldstr ""
+		IL_0157: ldc.i4.0
 		IL_0158: ldc.i4.0
-		IL_0159: ldc.i4.0
-		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0164: stloc.s 8
-		IL_0166: ldloc.s 4
-		IL_0168: ldloc.s 6
-		IL_016a: ldstr "Array Construction, new Array()"
-		IL_016f: ldloc.s 8
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0176: pop
-		IL_0177: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_017c: stloc.s 6
-		IL_017e: ldloc.0
-		IL_017f: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0184: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_018a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_018f: ldc.i4.1
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: dup
-		IL_0196: ldc.i4.0
-		IL_0197: ldloc.0
-		IL_0198: stelem.ref
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01a3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_01a8: ldc.i4.0
-		IL_01a9: conv.r8
-		IL_01aa: ldstr ""
+		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_015e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0163: stloc.s 8
+		IL_0165: ldloc.s 4
+		IL_0167: ldloc.s 6
+		IL_0169: ldstr "Array Construction, new Array()"
+		IL_016e: ldloc.s 8
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0175: pop
+		IL_0176: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017b: stloc.s 6
+		IL_017d: ldloc.0
+		IL_017e: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0183: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0189: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_018e: ldc.i4.1
+		IL_018f: newarr [System.Runtime]System.Object
+		IL_0194: dup
+		IL_0195: ldc.i4.0
+		IL_0196: ldloc.0
+		IL_0197: stelem.ref
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01a2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01a7: ldc.i4.0
+		IL_01a8: conv.r8
+		IL_01a9: ldstr ""
+		IL_01ae: ldc.i4.0
 		IL_01af: ldc.i4.0
-		IL_01b0: ldc.i4.0
-		IL_01b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_01bb: stloc.s 8
-		IL_01bd: ldloc.s 4
-		IL_01bf: ldloc.s 6
-		IL_01c1: ldstr "Array Construction, unshift"
-		IL_01c6: ldloc.s 8
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01cd: pop
-		IL_01ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01d3: stloc.s 6
-		IL_01d5: ldloc.0
-		IL_01d6: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_01db: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_01e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01e6: ldc.i4.1
-		IL_01e7: newarr [System.Runtime]System.Object
-		IL_01ec: dup
-		IL_01ed: ldc.i4.0
-		IL_01ee: ldloc.0
-		IL_01ef: stelem.ref
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01fa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_01ff: ldc.i4.0
-		IL_0200: conv.r8
-		IL_0201: ldstr ""
+		IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_01ba: stloc.s 8
+		IL_01bc: ldloc.s 4
+		IL_01be: ldloc.s 6
+		IL_01c0: ldstr "Array Construction, unshift"
+		IL_01c5: ldloc.s 8
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01cc: pop
+		IL_01cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01d2: stloc.s 6
+		IL_01d4: ldloc.0
+		IL_01d5: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_01da: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_01e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01e5: ldc.i4.1
+		IL_01e6: newarr [System.Runtime]System.Object
+		IL_01eb: dup
+		IL_01ec: ldc.i4.0
+		IL_01ed: ldloc.0
+		IL_01ee: stelem.ref
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01f9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01fe: ldc.i4.0
+		IL_01ff: conv.r8
+		IL_0200: ldstr ""
+		IL_0205: ldc.i4.0
 		IL_0206: ldc.i4.0
-		IL_0207: ldc.i4.0
-		IL_0208: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0212: stloc.s 8
-		IL_0214: ldloc.s 4
-		IL_0216: ldloc.s 6
-		IL_0218: ldstr "Array Construction, splice"
-		IL_021d: ldloc.s 8
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0224: pop
-		IL_0225: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_022a: stloc.s 6
-		IL_022c: ldloc.0
-		IL_022d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0232: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_023d: ldc.i4.1
-		IL_023e: newarr [System.Runtime]System.Object
-		IL_0243: dup
-		IL_0244: ldc.i4.0
-		IL_0245: ldloc.0
-		IL_0246: stelem.ref
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0251: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0256: ldc.i4.0
-		IL_0257: conv.r8
-		IL_0258: ldstr ""
+		IL_0207: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_020c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0211: stloc.s 8
+		IL_0213: ldloc.s 4
+		IL_0215: ldloc.s 6
+		IL_0217: ldstr "Array Construction, splice"
+		IL_021c: ldloc.s 8
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0223: pop
+		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0229: stloc.s 6
+		IL_022b: ldloc.0
+		IL_022c: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0231: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0237: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_023c: ldc.i4.1
+		IL_023d: newarr [System.Runtime]System.Object
+		IL_0242: dup
+		IL_0243: ldc.i4.0
+		IL_0244: ldloc.0
+		IL_0245: stelem.ref
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0250: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0255: ldc.i4.0
+		IL_0256: conv.r8
+		IL_0257: ldstr ""
+		IL_025c: ldc.i4.0
 		IL_025d: ldc.i4.0
-		IL_025e: ldc.i4.0
-		IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0269: stloc.s 8
-		IL_026b: ldloc.s 4
-		IL_026d: ldloc.s 6
-		IL_026f: ldstr "Array Deconstruction, shift"
-		IL_0274: ldloc.s 8
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_027b: pop
-		IL_027c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0281: stloc.s 6
-		IL_0283: ldloc.0
-		IL_0284: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0289: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_028f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0294: ldc.i4.1
-		IL_0295: newarr [System.Runtime]System.Object
-		IL_029a: dup
-		IL_029b: ldc.i4.0
-		IL_029c: ldloc.0
-		IL_029d: stelem.ref
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02a8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_02ad: ldc.i4.0
-		IL_02ae: conv.r8
-		IL_02af: ldstr ""
+		IL_025e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0263: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0268: stloc.s 8
+		IL_026a: ldloc.s 4
+		IL_026c: ldloc.s 6
+		IL_026e: ldstr "Array Deconstruction, shift"
+		IL_0273: ldloc.s 8
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_027a: pop
+		IL_027b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0280: stloc.s 6
+		IL_0282: ldloc.0
+		IL_0283: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0288: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_028e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0293: ldc.i4.1
+		IL_0294: newarr [System.Runtime]System.Object
+		IL_0299: dup
+		IL_029a: ldc.i4.0
+		IL_029b: ldloc.0
+		IL_029c: stelem.ref
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02a7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_02ac: ldc.i4.0
+		IL_02ad: conv.r8
+		IL_02ae: ldstr ""
+		IL_02b3: ldc.i4.0
 		IL_02b4: ldc.i4.0
-		IL_02b5: ldc.i4.0
-		IL_02b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_02bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02c0: stloc.s 8
-		IL_02c2: ldloc.s 4
-		IL_02c4: ldloc.s 6
-		IL_02c6: ldstr "Array Deconstruction, splice"
-		IL_02cb: ldloc.s 8
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02d2: pop
-		IL_02d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02d8: stloc.s 6
-		IL_02da: ldloc.0
-		IL_02db: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_02e0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_02e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02eb: ldc.i4.1
-		IL_02ec: newarr [System.Runtime]System.Object
-		IL_02f1: dup
-		IL_02f2: ldc.i4.0
-		IL_02f3: ldloc.0
-		IL_02f4: stelem.ref
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02ff: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0304: ldc.i4.0
-		IL_0305: conv.r8
-		IL_0306: ldstr ""
+		IL_02b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_02ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_02bf: stloc.s 8
+		IL_02c1: ldloc.s 4
+		IL_02c3: ldloc.s 6
+		IL_02c5: ldstr "Array Deconstruction, splice"
+		IL_02ca: ldloc.s 8
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02d1: pop
+		IL_02d2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02d7: stloc.s 6
+		IL_02d9: ldloc.0
+		IL_02da: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_02df: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_02e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02ea: ldc.i4.1
+		IL_02eb: newarr [System.Runtime]System.Object
+		IL_02f0: dup
+		IL_02f1: ldc.i4.0
+		IL_02f2: ldloc.0
+		IL_02f3: stelem.ref
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02fe: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0303: ldc.i4.0
+		IL_0304: conv.r8
+		IL_0305: ldstr ""
+		IL_030a: ldc.i4.0
 		IL_030b: ldc.i4.0
-		IL_030c: ldc.i4.0
-		IL_030d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0317: stloc.s 8
-		IL_0319: ldloc.s 4
-		IL_031b: ldloc.s 6
-		IL_031d: ldstr "Array Construction, push"
-		IL_0322: ldloc.s 8
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0329: pop
-		IL_032a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_032f: stloc.s 6
-		IL_0331: ldloc.0
-		IL_0332: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0337: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0342: ldc.i4.1
-		IL_0343: newarr [System.Runtime]System.Object
-		IL_0348: dup
-		IL_0349: ldc.i4.0
-		IL_034a: ldloc.0
-		IL_034b: stelem.ref
-		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0356: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_035b: ldc.i4.0
-		IL_035c: conv.r8
-		IL_035d: ldstr ""
+		IL_030c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0311: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0316: stloc.s 8
+		IL_0318: ldloc.s 4
+		IL_031a: ldloc.s 6
+		IL_031c: ldstr "Array Construction, push"
+		IL_0321: ldloc.s 8
+		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0328: pop
+		IL_0329: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_032e: stloc.s 6
+		IL_0330: ldloc.0
+		IL_0331: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0336: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_033c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0341: ldc.i4.1
+		IL_0342: newarr [System.Runtime]System.Object
+		IL_0347: dup
+		IL_0348: ldc.i4.0
+		IL_0349: ldloc.0
+		IL_034a: stelem.ref
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0355: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_035a: ldc.i4.0
+		IL_035b: conv.r8
+		IL_035c: ldstr ""
+		IL_0361: ldc.i4.0
 		IL_0362: ldc.i4.0
-		IL_0363: ldc.i4.0
-		IL_0364: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0369: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_036e: stloc.s 8
-		IL_0370: ldloc.s 4
-		IL_0372: ldloc.s 6
-		IL_0374: ldstr "Array Deconstruction, pop"
-		IL_0379: ldloc.s 8
-		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0380: pop
-		IL_0381: ldloc.2
-		IL_0382: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_038c: pop
-		IL_038d: ret
+		IL_0363: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0368: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_036d: stloc.s 8
+		IL_036f: ldloc.s 4
+		IL_0371: ldloc.s 6
+		IL_0373: ldstr "Array Deconstruction, pop"
+		IL_0378: ldloc.s 8
+		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_037f: pop
+		IL_0380: ldloc.2
+		IL_0381: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_038b: pop
+		IL_038c: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Array_Modern::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Array_Modern

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3138
+						// Method begins at RVA 0x30bb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x312f
+					// Method begins at RVA 0x30b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3126
+				// Method begins at RVA 0x30a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,9 +101,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2440
 			// Header size: 12
-			// Code size: 242 (0xf2)
+			// Code size: 237 (0xed)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -111,10 +111,9 @@
 				[2] object,
 				[3] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
 				[4] float64,
-				[5] float64,
-				[6] object[],
-				[7] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
-				[8] object
+				[5] object[],
+				[6] class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve,
+				[7] object
 			)
 
 			IL_0000: ldarg.3
@@ -132,77 +131,72 @@
 			IL_002b: ldstr "now"
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_0035: stloc.1
-			IL_0036: ldarg.0
-			IL_0037: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_003c: stloc.s 4
-			IL_003e: ldarg.3
-			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0044: stloc.s 5
-			IL_0046: ldloc.s 5
-			IL_0048: ldloc.s 4
-			IL_004a: mul
-			IL_004b: stloc.s 4
-			IL_004d: ldloc.1
-			IL_004e: ldloc.s 4
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0055: stloc.2
-			// loop start (head: IL_0056)
-				IL_0056: nop
-				IL_0057: ldc.i4.1
-				IL_0058: newarr [System.Runtime]System.Object
-				IL_005d: dup
-				IL_005e: ldc.i4.0
-				IL_005f: ldarg.0
-				IL_0060: stelem.ref
-				IL_0061: stloc.s 6
-				IL_0063: ldloc.s 6
-				IL_0065: ldc.i4.1
-				IL_0066: newarr [System.Runtime]System.Object
-				IL_006b: dup
-				IL_006c: ldc.i4.0
-				IL_006d: ldarg.2
-				IL_006e: box [System.Runtime]System.Double
-				IL_0073: stelem.ref
-				IL_0074: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_0079: ldarg.2
-				IL_007a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], float64)
-				IL_007f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_0084: stloc.3
-				IL_0085: ldloc.3
-				IL_0086: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_008b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_0090: ldstr "prototype"
-				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-				IL_009a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_009f: ldloc.3
-				IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve>(!!0)
-				IL_00a5: stloc.s 7
-				IL_00a7: ldloc.s 7
-				IL_00a9: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
-				IL_00ae: pop
-				IL_00af: ldloc.0
-				IL_00b0: ldc.r8 1
-				IL_00b9: add
-				IL_00ba: stloc.0
-				IL_00bb: ldarg.0
-				IL_00bc: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-				IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c6: ldstr "now"
-				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_00d0: stloc.s 8
-				IL_00d2: ldloc.s 8
-				IL_00d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d9: ldloc.2
-				IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00df: clt
-				IL_00e1: brfalse IL_00eb
+			IL_0036: ldarg.3
+			IL_0037: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003c: ldc.r8 1000
+			IL_0045: mul
+			IL_0046: stloc.s 4
+			IL_0048: ldloc.1
+			IL_0049: ldloc.s 4
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0050: stloc.2
+			// loop start (head: IL_0051)
+				IL_0051: nop
+				IL_0052: ldc.i4.1
+				IL_0053: newarr [System.Runtime]System.Object
+				IL_0058: dup
+				IL_0059: ldc.i4.0
+				IL_005a: ldarg.0
+				IL_005b: stelem.ref
+				IL_005c: stloc.s 5
+				IL_005e: ldloc.s 5
+				IL_0060: ldc.i4.1
+				IL_0061: newarr [System.Runtime]System.Object
+				IL_0066: dup
+				IL_0067: ldc.i4.0
+				IL_0068: ldarg.2
+				IL_0069: box [System.Runtime]System.Double
+				IL_006e: stelem.ref
+				IL_006f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_0074: ldarg.2
+				IL_0075: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::.ctor(object[], float64)
+				IL_007a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_007f: stloc.3
+				IL_0080: ldloc.3
+				IL_0081: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0086: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_008b: ldstr "prototype"
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+				IL_0095: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_009a: ldloc.3
+				IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve>(!!0)
+				IL_00a0: stloc.s 6
+				IL_00a2: ldloc.s 6
+				IL_00a4: callvirt instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+				IL_00a9: pop
+				IL_00aa: ldloc.0
+				IL_00ab: ldc.r8 1
+				IL_00b4: add
+				IL_00b5: stloc.0
+				IL_00b6: ldarg.0
+				IL_00b7: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c1: ldstr "now"
+				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00cb: stloc.s 7
+				IL_00cd: ldloc.s 7
+				IL_00cf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d4: ldloc.2
+				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00da: clt
+				IL_00dc: brfalse IL_00e6
 
-				IL_00e6: br IL_0056
+				IL_00e1: br IL_0051
 			// end loop
 
-			IL_00eb: ldloc.0
-			IL_00ec: box [System.Runtime]System.Double
-			IL_00f1: ret
+			IL_00e6: ldloc.0
+			IL_00e7: box [System.Runtime]System.Double
+			IL_00ec: ret
 		} // end of method ArrowFunction_L210C23::__js_call__
 
 	} // end of class ArrowFunction_L210C23
@@ -233,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3141
+				// Method begins at RVA 0x30c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -260,9 +254,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x255c
+			// Method begins at RVA 0x253c
 			// Header size: 12
-			// Code size: 538 (0x21a)
+			// Code size: 533 (0x215)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -280,9 +274,7 @@
 				[12] object,
 				[13] bool,
 				[14] object,
-				[15] float64,
-				[16] float64,
-				[17] string
+				[15] string
 			)
 
 			IL_0000: ldarg.2
@@ -425,50 +417,45 @@
 			IL_0181: ldloc.s 5
 			IL_0183: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0188: sub
-			IL_0189: stloc.s 15
-			IL_018b: ldarg.0
-			IL_018c: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0191: stloc.s 16
-			IL_0193: ldloc.s 15
-			IL_0195: ldloc.s 16
-			IL_0197: div
-			IL_0198: stloc.s 8
-			IL_019a: ldstr "console"
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a9: stloc.s 12
-			IL_01ab: ldloc.3
-			IL_01ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b1: stloc.s 17
-			IL_01b3: ldstr "\nrogiervandam-"
-			IL_01b8: ldloc.s 17
-			IL_01ba: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01bf: ldstr ";"
-			IL_01c4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c9: ldloc.s 6
-			IL_01cb: box [System.Runtime]System.Double
-			IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d5: stloc.s 17
-			IL_01d7: ldloc.s 17
-			IL_01d9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01de: ldstr ";"
-			IL_01e3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e8: ldloc.s 8
-			IL_01ea: box [System.Runtime]System.Double
-			IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f4: stloc.s 17
-			IL_01f6: ldloc.s 17
-			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fd: ldstr ";1;algorithm=base,faithful=yes,bits=1"
-			IL_0202: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0207: stloc.s 17
-			IL_0209: ldloc.s 12
-			IL_020b: ldstr "log"
-			IL_0210: ldloc.s 17
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0217: pop
-			IL_0218: ldnull
-			IL_0219: ret
+			IL_0189: ldc.r8 1000
+			IL_0192: div
+			IL_0193: stloc.s 8
+			IL_0195: ldstr "console"
+			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a4: stloc.s 12
+			IL_01a6: ldloc.3
+			IL_01a7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ac: stloc.s 15
+			IL_01ae: ldstr "\nrogiervandam-"
+			IL_01b3: ldloc.s 15
+			IL_01b5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ba: ldstr ";"
+			IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c4: ldloc.s 6
+			IL_01c6: box [System.Runtime]System.Double
+			IL_01cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d0: stloc.s 15
+			IL_01d2: ldloc.s 15
+			IL_01d4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d9: ldstr ";"
+			IL_01de: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e3: ldloc.s 8
+			IL_01e5: box [System.Runtime]System.Double
+			IL_01ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ef: stloc.s 15
+			IL_01f1: ldloc.s 15
+			IL_01f3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f8: ldstr ";1;algorithm=base,faithful=yes,bits=1"
+			IL_01fd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0202: stloc.s 15
+			IL_0204: ldloc.s 12
+			IL_0206: ldstr "log"
+			IL_020b: ldloc.s 15
+			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0212: pop
+			IL_0213: ldnull
+			IL_0214: ret
 		} // end of method ArrowFunction_L229C14::__js_call__
 
 	} // end of class ArrowFunction_L229C14
@@ -484,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3018
+				// Method begins at RVA 0x2f9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -504,7 +491,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3021
+				// Method begins at RVA 0x2fa4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -524,7 +511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302a
+				// Method begins at RVA 0x2fad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -552,7 +539,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3045
+						// Method begins at RVA 0x2fc8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -576,7 +563,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3057
+							// Method begins at RVA 0x2fda
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -594,7 +581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x304e
+						// Method begins at RVA 0x2fd1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -612,7 +599,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x303c
+					// Method begins at RVA 0x2fbf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -640,7 +627,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3072
+							// Method begins at RVA 0x2ff5
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -658,7 +645,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3069
+						// Method begins at RVA 0x2fec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -676,7 +663,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3060
+					// Method begins at RVA 0x2fe3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -700,7 +687,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3084
+						// Method begins at RVA 0x3007
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -718,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x307b
+					// Method begins at RVA 0x2ffe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +723,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3033
+				// Method begins at RVA 0x2fb6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -756,7 +743,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x308d
+				// Method begins at RVA 0x3010
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -780,7 +767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x309f
+					// Method begins at RVA 0x3022
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -798,7 +785,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3096
+				// Method begins at RVA 0x3019
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -820,15 +807,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor (
 				object[] scopes,
-				object size
+				float64 size
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27e8
+			// Method begins at RVA 0x27c4
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 63 (0x3f)
 			.maxstack 8
 			.locals init (
 				[0] object[],
@@ -845,28 +832,25 @@
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray::_scopes
 			IL_000f: ldarg.2
-			IL_0010: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0015: stloc.1
-			IL_0016: ldloc.1
-			IL_0017: conv.i4
-			IL_0018: conv.u4
-			IL_0019: ldc.r8 5
-			IL_0022: conv.i4
-			IL_0023: shr.un
-			IL_0024: conv.r.un
-			IL_0025: stloc.1
-			IL_0026: ldc.r8 1
-			IL_002f: ldloc.1
-			IL_0030: add
-			IL_0031: stloc.1
-			IL_0032: ldloc.1
-			IL_0033: box [System.Runtime]System.Double
-			IL_0038: stloc.2
-			IL_0039: ldarg.0
-			IL_003a: ldloc.2
-			IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-			IL_0040: stfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0045: ret
+			IL_0010: conv.i4
+			IL_0011: conv.u4
+			IL_0012: ldc.r8 5
+			IL_001b: conv.i4
+			IL_001c: shr.un
+			IL_001d: conv.r.un
+			IL_001e: stloc.1
+			IL_001f: ldc.r8 1
+			IL_0028: ldloc.1
+			IL_0029: add
+			IL_002a: stloc.1
+			IL_002b: ldloc.1
+			IL_002c: box [System.Runtime]System.Double
+			IL_0031: stloc.2
+			IL_0032: ldarg.0
+			IL_0033: ldloc.2
+			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_003e: ret
 		} // end of method BitArray::.ctor
 
 		.method public hidebysig 
@@ -877,7 +861,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a88
+			// Method begins at RVA 0x2a30
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -941,9 +925,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2888
+			// Method begins at RVA 0x2848
 			// Header size: 12
-			// Code size: 498 (0x1f2)
+			// Code size: 475 (0x1db)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -961,265 +945,256 @@
 				[12] float64
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray::_scopes
-			IL_0006: ldc.i4.0
-			IL_0007: ldelem.ref
-			IL_0008: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-			IL_000d: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
-			IL_0012: ldc.r8 2
-			IL_001b: div
+			IL_0000: ldarg.2
+			IL_0001: ldc.r8 16
+			IL_000a: cgt
+			IL_000c: brfalse IL_0107
+
+			IL_0011: ldc.r8 32
+			IL_001a: ldarg.2
+			IL_001b: mul
 			IL_001c: stloc.s 12
-			IL_001e: ldarg.2
+			IL_001e: ldarg.1
 			IL_001f: ldloc.s 12
-			IL_0021: cgt
-			IL_0023: brfalse IL_011e
+			IL_0021: add
+			IL_0022: stloc.0
+			IL_0023: ldloc.0
+			IL_0024: stloc.s 12
+			IL_0026: ldloc.s 12
+			IL_0028: ldarg.3
+			IL_0029: cgt
+			IL_002b: brfalse IL_0056
 
-			IL_0028: ldc.r8 32
-			IL_0031: ldarg.2
-			IL_0032: mul
-			IL_0033: stloc.s 12
-			IL_0035: ldarg.1
-			IL_0036: ldloc.s 12
-			IL_0038: add
-			IL_0039: stloc.0
-			IL_003a: ldloc.0
-			IL_003b: stloc.s 12
-			IL_003d: ldloc.s 12
-			IL_003f: ldarg.3
-			IL_0040: cgt
-			IL_0042: brfalse IL_006d
+			IL_0030: ldarg.1
+			IL_0031: stloc.1
+			// loop start (head: IL_0032)
+				IL_0032: ldloc.1
+				IL_0033: stloc.s 12
+				IL_0035: ldloc.s 12
+				IL_0037: ldarg.3
+				IL_0038: clt
+				IL_003a: brfalse IL_0054
 
-			IL_0047: ldarg.1
-			IL_0048: stloc.1
-			// loop start (head: IL_0049)
-				IL_0049: ldloc.1
+				IL_003f: ldarg.0
+				IL_0040: ldloc.1
+				IL_0041: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+				IL_0046: pop
+				IL_0047: ldloc.1
+				IL_0048: ldarg.2
+				IL_0049: add
 				IL_004a: stloc.s 12
 				IL_004c: ldloc.s 12
-				IL_004e: ldarg.3
-				IL_004f: clt
-				IL_0051: brfalse IL_006b
-
-				IL_0056: ldarg.0
-				IL_0057: ldloc.1
-				IL_0058: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-				IL_005d: pop
-				IL_005e: ldloc.1
-				IL_005f: ldarg.2
-				IL_0060: add
-				IL_0061: stloc.s 12
-				IL_0063: ldloc.s 12
-				IL_0065: stloc.1
-				IL_0066: br IL_0049
+				IL_004e: stloc.1
+				IL_004f: br IL_0032
 			// end loop
 
-			IL_006b: ldnull
-			IL_006c: ret
+			IL_0054: ldnull
+			IL_0055: ret
 
-			IL_006d: ldarg.3
-			IL_006e: conv.i4
-			IL_006f: conv.u4
-			IL_0070: ldc.r8 5
-			IL_0079: conv.i4
-			IL_007a: shr.un
-			IL_007b: conv.r.un
-			IL_007c: stloc.2
-			IL_007d: ldarg.1
-			IL_007e: stloc.3
-			// loop start (head: IL_007f)
-				IL_007f: ldloc.3
-				IL_0080: stloc.s 12
-				IL_0082: ldloc.s 12
-				IL_0084: ldloc.0
-				IL_0085: clt
-				IL_0087: brfalse IL_011c
+			IL_0056: ldarg.3
+			IL_0057: conv.i4
+			IL_0058: conv.u4
+			IL_0059: ldc.r8 5
+			IL_0062: conv.i4
+			IL_0063: shr.un
+			IL_0064: conv.r.un
+			IL_0065: stloc.2
+			IL_0066: ldarg.1
+			IL_0067: stloc.3
+			// loop start (head: IL_0068)
+				IL_0068: ldloc.3
+				IL_0069: stloc.s 12
+				IL_006b: ldloc.s 12
+				IL_006d: ldloc.0
+				IL_006e: clt
+				IL_0070: brfalse IL_0105
 
-				IL_008c: ldloc.3
-				IL_008d: stloc.s 12
-				IL_008f: ldloc.s 12
-				IL_0091: conv.i4
-				IL_0092: conv.u4
-				IL_0093: ldc.r8 5
-				IL_009c: conv.i4
-				IL_009d: shr.un
-				IL_009e: conv.r.un
-				IL_009f: stloc.s 4
-				IL_00a1: ldloc.3
-				IL_00a2: stloc.s 12
-				IL_00a4: ldloc.s 12
-				IL_00a6: conv.i4
-				IL_00a7: ldc.r8 31
-				IL_00b0: conv.i4
-				IL_00b1: and
-				IL_00b2: conv.r8
-				IL_00b3: stloc.s 5
-				IL_00b5: ldc.r8 1
-				IL_00be: conv.i4
-				IL_00bf: ldloc.s 5
-				IL_00c1: conv.i4
-				IL_00c2: shl
-				IL_00c3: conv.r8
-				IL_00c4: stloc.s 6
-				// loop start (head: IL_00c6)
-					IL_00c6: nop
-					IL_00c7: ldarg.0
-					IL_00c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_00cd: ldloc.s 4
-					IL_00cf: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_00d4: stloc.s 12
-					IL_00d6: ldloc.s 12
-					IL_00d8: conv.i4
-					IL_00d9: ldloc.s 6
-					IL_00db: conv.i4
-					IL_00dc: or
-					IL_00dd: conv.r8
-					IL_00de: stloc.s 12
-					IL_00e0: ldarg.0
-					IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_00e6: ldloc.s 4
-					IL_00e8: ldloc.s 12
-					IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_00ef: ldloc.s 4
-					IL_00f1: ldarg.2
-					IL_00f2: add
-					IL_00f3: stloc.s 12
-					IL_00f5: ldloc.s 12
-					IL_00f7: stloc.s 4
-					IL_00f9: ldloc.s 4
-					IL_00fb: stloc.s 12
-					IL_00fd: ldloc.s 12
-					IL_00ff: ldloc.2
-					IL_0100: cgt
-					IL_0102: ldc.i4.0
-					IL_0103: ceq
-					IL_0105: brfalse IL_010f
+				IL_0075: ldloc.3
+				IL_0076: stloc.s 12
+				IL_0078: ldloc.s 12
+				IL_007a: conv.i4
+				IL_007b: conv.u4
+				IL_007c: ldc.r8 5
+				IL_0085: conv.i4
+				IL_0086: shr.un
+				IL_0087: conv.r.un
+				IL_0088: stloc.s 4
+				IL_008a: ldloc.3
+				IL_008b: stloc.s 12
+				IL_008d: ldloc.s 12
+				IL_008f: conv.i4
+				IL_0090: ldc.r8 31
+				IL_0099: conv.i4
+				IL_009a: and
+				IL_009b: conv.r8
+				IL_009c: stloc.s 5
+				IL_009e: ldc.r8 1
+				IL_00a7: conv.i4
+				IL_00a8: ldloc.s 5
+				IL_00aa: conv.i4
+				IL_00ab: shl
+				IL_00ac: conv.r8
+				IL_00ad: stloc.s 6
+				// loop start (head: IL_00af)
+					IL_00af: nop
+					IL_00b0: ldarg.0
+					IL_00b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00b6: ldloc.s 4
+					IL_00b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00bd: stloc.s 12
+					IL_00bf: ldloc.s 12
+					IL_00c1: conv.i4
+					IL_00c2: ldloc.s 6
+					IL_00c4: conv.i4
+					IL_00c5: or
+					IL_00c6: conv.r8
+					IL_00c7: stloc.s 12
+					IL_00c9: ldarg.0
+					IL_00ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00cf: ldloc.s 4
+					IL_00d1: ldloc.s 12
+					IL_00d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_00d8: ldloc.s 4
+					IL_00da: ldarg.2
+					IL_00db: add
+					IL_00dc: stloc.s 12
+					IL_00de: ldloc.s 12
+					IL_00e0: stloc.s 4
+					IL_00e2: ldloc.s 4
+					IL_00e4: stloc.s 12
+					IL_00e6: ldloc.s 12
+					IL_00e8: ldloc.2
+					IL_00e9: cgt
+					IL_00eb: ldc.i4.0
+					IL_00ec: ceq
+					IL_00ee: brfalse IL_00f8
 
-					IL_010a: br IL_00c6
+					IL_00f3: br IL_00af
 				// end loop
 
-				IL_010f: ldloc.3
-				IL_0110: ldarg.2
-				IL_0111: add
-				IL_0112: stloc.s 12
-				IL_0114: ldloc.s 12
-				IL_0116: stloc.3
-				IL_0117: br IL_007f
+				IL_00f8: ldloc.3
+				IL_00f9: ldarg.2
+				IL_00fa: add
+				IL_00fb: stloc.s 12
+				IL_00fd: ldloc.s 12
+				IL_00ff: stloc.3
+				IL_0100: br IL_0068
 			// end loop
 
-			IL_011c: ldnull
-			IL_011d: ret
+			IL_0105: ldnull
+			IL_0106: ret
 
-			IL_011e: ldarg.1
-			IL_011f: stloc.s 7
-			IL_0121: ldloc.s 7
-			IL_0123: stloc.s 12
-			IL_0125: ldloc.s 12
-			IL_0127: conv.i4
-			IL_0128: conv.u4
-			IL_0129: ldc.r8 5
-			IL_0132: conv.i4
-			IL_0133: shr.un
-			IL_0134: conv.r.un
-			IL_0135: stloc.s 8
-			IL_0137: ldarg.0
-			IL_0138: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_013d: ldloc.s 8
-			IL_013f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0144: stloc.s 9
-			// loop start (head: IL_0146)
-				IL_0146: ldloc.s 7
-				IL_0148: stloc.s 12
-				IL_014a: ldloc.s 12
-				IL_014c: ldarg.3
-				IL_014d: clt
-				IL_014f: brfalse IL_01e1
+			IL_0107: ldarg.1
+			IL_0108: stloc.s 7
+			IL_010a: ldloc.s 7
+			IL_010c: stloc.s 12
+			IL_010e: ldloc.s 12
+			IL_0110: conv.i4
+			IL_0111: conv.u4
+			IL_0112: ldc.r8 5
+			IL_011b: conv.i4
+			IL_011c: shr.un
+			IL_011d: conv.r.un
+			IL_011e: stloc.s 8
+			IL_0120: ldarg.0
+			IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0126: ldloc.s 8
+			IL_0128: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_012d: stloc.s 9
+			// loop start (head: IL_012f)
+				IL_012f: ldloc.s 7
+				IL_0131: stloc.s 12
+				IL_0133: ldloc.s 12
+				IL_0135: ldarg.3
+				IL_0136: clt
+				IL_0138: brfalse IL_01ca
 
-				IL_0154: ldloc.s 7
-				IL_0156: stloc.s 12
-				IL_0158: ldloc.s 12
-				IL_015a: conv.i4
-				IL_015b: ldc.r8 31
-				IL_0164: conv.i4
-				IL_0165: and
-				IL_0166: conv.r8
-				IL_0167: stloc.s 10
-				IL_0169: ldc.r8 1
-				IL_0172: conv.i4
-				IL_0173: ldloc.s 10
-				IL_0175: conv.i4
-				IL_0176: shl
-				IL_0177: conv.r8
-				IL_0178: stloc.s 12
-				IL_017a: ldloc.s 9
-				IL_017c: conv.i4
-				IL_017d: ldloc.s 12
-				IL_017f: conv.i4
-				IL_0180: or
-				IL_0181: conv.r8
-				IL_0182: stloc.s 12
-				IL_0184: ldloc.s 12
-				IL_0186: stloc.s 9
-				IL_0188: ldloc.s 7
-				IL_018a: ldarg.2
-				IL_018b: add
-				IL_018c: stloc.s 12
-				IL_018e: ldloc.s 12
-				IL_0190: stloc.s 7
-				IL_0192: ldloc.s 7
-				IL_0194: stloc.s 12
-				IL_0196: ldloc.s 12
-				IL_0198: conv.i4
-				IL_0199: conv.u4
-				IL_019a: ldc.r8 5
-				IL_01a3: conv.i4
-				IL_01a4: shr.un
-				IL_01a5: conv.r.un
-				IL_01a6: stloc.s 11
-				IL_01a8: ldloc.s 11
-				IL_01aa: ldloc.s 8
-				IL_01ac: ceq
-				IL_01ae: ldc.i4.0
-				IL_01af: ceq
-				IL_01b1: brfalse IL_01dc
+				IL_013d: ldloc.s 7
+				IL_013f: stloc.s 12
+				IL_0141: ldloc.s 12
+				IL_0143: conv.i4
+				IL_0144: ldc.r8 31
+				IL_014d: conv.i4
+				IL_014e: and
+				IL_014f: conv.r8
+				IL_0150: stloc.s 10
+				IL_0152: ldc.r8 1
+				IL_015b: conv.i4
+				IL_015c: ldloc.s 10
+				IL_015e: conv.i4
+				IL_015f: shl
+				IL_0160: conv.r8
+				IL_0161: stloc.s 12
+				IL_0163: ldloc.s 9
+				IL_0165: conv.i4
+				IL_0166: ldloc.s 12
+				IL_0168: conv.i4
+				IL_0169: or
+				IL_016a: conv.r8
+				IL_016b: stloc.s 12
+				IL_016d: ldloc.s 12
+				IL_016f: stloc.s 9
+				IL_0171: ldloc.s 7
+				IL_0173: ldarg.2
+				IL_0174: add
+				IL_0175: stloc.s 12
+				IL_0177: ldloc.s 12
+				IL_0179: stloc.s 7
+				IL_017b: ldloc.s 7
+				IL_017d: stloc.s 12
+				IL_017f: ldloc.s 12
+				IL_0181: conv.i4
+				IL_0182: conv.u4
+				IL_0183: ldc.r8 5
+				IL_018c: conv.i4
+				IL_018d: shr.un
+				IL_018e: conv.r.un
+				IL_018f: stloc.s 11
+				IL_0191: ldloc.s 11
+				IL_0193: ldloc.s 8
+				IL_0195: ceq
+				IL_0197: ldc.i4.0
+				IL_0198: ceq
+				IL_019a: brfalse IL_01c5
 
-				IL_01b6: ldarg.0
-				IL_01b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_01bc: ldloc.s 8
-				IL_01be: ldloc.s 9
-				IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_01c5: ldloc.s 11
-				IL_01c7: stloc.s 8
-				IL_01c9: ldarg.0
-				IL_01ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_01cf: ldloc.s 8
-				IL_01d1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_01d6: stloc.s 12
-				IL_01d8: ldloc.s 12
-				IL_01da: stloc.s 9
+				IL_019f: ldarg.0
+				IL_01a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01a5: ldloc.s 8
+				IL_01a7: ldloc.s 9
+				IL_01a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01ae: ldloc.s 11
+				IL_01b0: stloc.s 8
+				IL_01b2: ldarg.0
+				IL_01b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01b8: ldloc.s 8
+				IL_01ba: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_01bf: stloc.s 12
+				IL_01c1: ldloc.s 12
+				IL_01c3: stloc.s 9
 
-				IL_01dc: br IL_0146
+				IL_01c5: br IL_012f
 			// end loop
 
-			IL_01e1: ldarg.0
-			IL_01e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_01e7: ldloc.s 8
-			IL_01e9: ldloc.s 9
-			IL_01eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_01f0: ldnull
-			IL_01f1: ret
+			IL_01ca: ldarg.0
+			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_01d0: ldloc.s 8
+			IL_01d2: ldloc.s 9
+			IL_01d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_01d9: ldnull
+			IL_01da: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
 			instance float64 testBitTrue (
-				object index
+				float64 index
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ae8
+			// Method begins at RVA 0x2a90
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 68 (0x44)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1229,92 +1204,81 @@
 			)
 
 			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.2
-			IL_0007: ldloc.2
-			IL_0008: conv.i4
-			IL_0009: conv.u4
-			IL_000a: ldc.r8 5
-			IL_0013: conv.i4
-			IL_0014: shr.un
-			IL_0015: conv.r.un
-			IL_0016: stloc.0
-			IL_0017: ldloc.2
-			IL_0018: conv.i4
-			IL_0019: ldc.r8 31
-			IL_0022: conv.i4
-			IL_0023: and
-			IL_0024: conv.r8
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_002c: ldloc.0
-			IL_002d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0032: stloc.2
-			IL_0033: ldc.r8 1
+			IL_0001: conv.i4
+			IL_0002: conv.u4
+			IL_0003: ldc.r8 5
+			IL_000c: conv.i4
+			IL_000d: shr.un
+			IL_000e: conv.r.un
+			IL_000f: stloc.0
+			IL_0010: ldarg.1
+			IL_0011: conv.i4
+			IL_0012: ldc.r8 31
+			IL_001b: conv.i4
+			IL_001c: and
+			IL_001d: conv.r8
+			IL_001e: stloc.1
+			IL_001f: ldarg.0
+			IL_0020: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0025: ldloc.0
+			IL_0026: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_002b: stloc.2
+			IL_002c: ldc.r8 1
+			IL_0035: conv.i4
+			IL_0036: ldloc.1
+			IL_0037: conv.i4
+			IL_0038: shl
+			IL_0039: conv.r8
+			IL_003a: stloc.3
+			IL_003b: ldloc.2
 			IL_003c: conv.i4
-			IL_003d: ldloc.1
+			IL_003d: ldloc.3
 			IL_003e: conv.i4
-			IL_003f: shl
+			IL_003f: and
 			IL_0040: conv.r8
 			IL_0041: stloc.3
-			IL_0042: ldloc.2
-			IL_0043: conv.i4
-			IL_0044: ldloc.3
-			IL_0045: conv.i4
-			IL_0046: and
-			IL_0047: conv.r8
-			IL_0048: stloc.3
-			IL_0049: ldloc.3
-			IL_004a: ret
+			IL_0042: ldloc.3
+			IL_0043: ret
 		} // end of method BitArray::testBitTrue
 
 		.method public hidebysig 
 			instance float64 searchBitFalse (
-				object index
+				float64 index
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x283c
+			// Method begins at RVA 0x2810
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] bool,
-				[2] object
+				[1] bool
 			)
 
 			// loop start
 				IL_0000: ldarg.0
 				IL_0001: ldarg.1
-				IL_0002: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
+				IL_0002: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
 				IL_0007: stloc.0
 				IL_0008: ldloc.0
 				IL_0009: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
 				IL_000e: stloc.1
 				IL_000f: ldloc.1
-				IL_0010: brfalse IL_0035
+				IL_0010: brfalse IL_0027
 
 				IL_0015: ldarg.1
-				IL_0016: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_001b: ldc.r8 1
-				IL_0024: add
-				IL_0025: stloc.0
-				IL_0026: ldloc.0
-				IL_0027: box [System.Runtime]System.Double
-				IL_002c: stloc.2
-				IL_002d: ldloc.2
-				IL_002e: starg.s index
-				IL_0030: br IL_0000
+				IL_0016: ldc.r8 1
+				IL_001f: add
+				IL_0020: starg.s index
+				IL_0022: br IL_0000
 			// end loop
 
-			IL_0035: nop
-			IL_0036: ldarg.1
-			IL_0037: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_003c: ret
+			IL_0027: nop
+			IL_0028: ldarg.1
+			IL_0029: ret
 		} // end of method BitArray::searchBitFalse
 
 	} // end of class BitArray
@@ -1330,7 +1294,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a8
+				// Method begins at RVA 0x302b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1350,7 +1314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30b1
+				// Method begins at RVA 0x3034
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1374,7 +1338,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30c3
+					// Method begins at RVA 0x3046
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1392,7 +1356,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ba
+				// Method begins at RVA 0x303d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1412,7 +1376,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30cc
+				// Method begins at RVA 0x304f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1440,7 +1404,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30e7
+						// Method begins at RVA 0x306a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1458,7 +1422,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30de
+					// Method begins at RVA 0x3061
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1476,7 +1440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30d5
+				// Method begins at RVA 0x3058
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1500,7 +1464,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f9
+					// Method begins at RVA 0x307c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1524,7 +1488,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x310b
+						// Method begins at RVA 0x308e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1542,7 +1506,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3102
+					// Method begins at RVA 0x3085
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1560,7 +1524,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f0
+				// Method begins at RVA 0x3073
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1584,7 +1548,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x311d
+					// Method begins at RVA 0x30a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1602,7 +1566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3114
+				// Method begins at RVA 0x3097
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1632,7 +1596,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2784
+			// Method begins at RVA 0x2760
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -1676,8 +1640,8 @@
 			IL_0046: stloc.2
 			IL_0047: ldarg.0
 			IL_0048: ldloc.0
-			IL_0049: ldloc.2
-			IL_004a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray::.ctor(object[], object)
+			IL_0049: ldloc.1
+			IL_004a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray::.ctor(object[], float64)
 			IL_004f: stfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
 			IL_0054: ret
 		} // end of method PrimeSieve::.ctor
@@ -1688,9 +1652,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b40
+			// Method begins at RVA 0x2ae0
 			// Header size: 12
-			// Code size: 177 (0xb1)
+			// Code size: 168 (0xa8)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1698,8 +1662,7 @@
 				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
-				[6] object
+				[5] class Modules.Compile_Performance_PrimeJavaScript/BitArray
 			)
 
 			IL_0000: ldarg.0
@@ -1715,7 +1678,7 @@
 				IL_001e: ldloc.s 4
 				IL_0020: ldloc.0
 				IL_0021: clt
-				IL_0023: brfalse IL_00af
+				IL_0023: brfalse IL_00a6
 
 				IL_0028: ldloc.1
 				IL_0029: stloc.s 4
@@ -1758,20 +1721,17 @@
 				IL_0087: ldc.r8 1
 				IL_0090: add
 				IL_0091: stloc.s 4
-				IL_0093: ldloc.s 4
-				IL_0095: box [System.Runtime]System.Double
-				IL_009a: stloc.s 6
-				IL_009c: ldloc.s 5
-				IL_009e: ldloc.s 6
-				IL_00a0: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(object)
-				IL_00a5: stloc.s 4
-				IL_00a7: ldloc.s 4
-				IL_00a9: stloc.1
-				IL_00aa: br IL_001b
+				IL_0093: ldloc.s 5
+				IL_0095: ldloc.s 4
+				IL_0097: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(float64)
+				IL_009c: stloc.s 4
+				IL_009e: ldloc.s 4
+				IL_00a0: stloc.1
+				IL_00a1: br IL_001b
 			// end loop
 
-			IL_00af: ldarg.0
-			IL_00b0: ret
+			IL_00a6: ldarg.0
+			IL_00a7: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
@@ -1780,17 +1740,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ea0
+			// Method begins at RVA 0x2e34
 			// Header size: 12
-			// Code size: 114 (0x72)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] float64,
 				[3] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
-				[4] object,
-				[5] bool
+				[4] bool
 			)
 
 			IL_0000: ldc.r8 1
@@ -1804,41 +1763,38 @@
 				IL_0017: ldarg.0
 				IL_0018: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
 				IL_001d: clt
-				IL_001f: brfalse IL_0070
+				IL_001f: brfalse IL_0067
 
 				IL_0024: ldarg.0
 				IL_0025: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
 				IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
 				IL_002f: stloc.3
-				IL_0030: ldloc.1
-				IL_0031: box [System.Runtime]System.Double
-				IL_0036: stloc.s 4
-				IL_0038: ldloc.3
-				IL_0039: ldloc.s 4
-				IL_003b: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
-				IL_0040: stloc.2
-				IL_0041: ldloc.2
-				IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
-				IL_0047: ldc.i4.0
-				IL_0048: ceq
-				IL_004a: stloc.s 5
-				IL_004c: ldloc.s 5
-				IL_004e: brfalse IL_005f
+				IL_0030: ldloc.3
+				IL_0031: ldloc.1
+				IL_0032: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
+				IL_0037: stloc.2
+				IL_0038: ldloc.2
+				IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
+				IL_003e: ldc.i4.0
+				IL_003f: ceq
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.s 4
+				IL_0045: brfalse IL_0056
 
-				IL_0053: ldloc.0
-				IL_0054: ldc.r8 1
-				IL_005d: add
-				IL_005e: stloc.0
+				IL_004a: ldloc.0
+				IL_004b: ldc.r8 1
+				IL_0054: add
+				IL_0055: stloc.0
 
-				IL_005f: ldloc.1
-				IL_0060: ldc.r8 1
-				IL_0069: add
-				IL_006a: stloc.1
-				IL_006b: br IL_0014
+				IL_0056: ldloc.1
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.1
+				IL_0062: br IL_0014
 			// end loop
 
-			IL_0070: ldloc.0
-			IL_0071: ret
+			IL_0067: ldloc.0
+			IL_0068: ret
 		} // end of method PrimeSieve::countPrimes
 
 		.method public hidebysig 
@@ -1849,9 +1805,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f20
+			// Method begins at RVA 0x2eac
 			// Header size: 12
-			// Code size: 227 (0xe3)
+			// Code size: 218 (0xda)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1860,8 +1816,8 @@
 				[3] float64,
 				[4] float64,
 				[5] class Modules.Compile_Performance_PrimeJavaScript/BitArray,
-				[6] object,
-				[7] bool
+				[6] bool,
+				[7] object
 			)
 
 			IL_0000: ldarg.1
@@ -1888,7 +1844,7 @@
 				IL_0043: ldarg.0
 				IL_0044: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
 				IL_0049: clt
-				IL_004b: brfalse IL_00e1
+				IL_004b: brfalse IL_00d8
 
 				IL_0050: ldloc.2
 				IL_0051: stloc.3
@@ -1902,54 +1858,51 @@
 				IL_0060: ceq
 				IL_0062: brfalse IL_006c
 
-				IL_0067: br IL_00e1
+				IL_0067: br IL_00d8
 
 				IL_006c: ldarg.0
 				IL_006d: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
 				IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Compile_Performance_PrimeJavaScript/BitArray>(!!0)
 				IL_0077: stloc.s 5
-				IL_0079: ldloc.1
-				IL_007a: box [System.Runtime]System.Double
-				IL_007f: stloc.s 6
-				IL_0081: ldloc.s 5
-				IL_0083: ldloc.s 6
-				IL_0085: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(object)
-				IL_008a: stloc.s 4
-				IL_008c: ldloc.s 4
-				IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
-				IL_0093: ldc.i4.0
-				IL_0094: ceq
-				IL_0096: stloc.s 7
-				IL_0098: ldloc.s 7
-				IL_009a: brfalse IL_00d0
+				IL_0079: ldloc.s 5
+				IL_007b: ldloc.1
+				IL_007c: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
+				IL_0081: stloc.s 4
+				IL_0083: ldloc.s 4
+				IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
+				IL_008a: ldc.i4.0
+				IL_008b: ceq
+				IL_008d: stloc.s 6
+				IL_008f: ldloc.s 6
+				IL_0091: brfalse IL_00c7
 
-				IL_009f: ldloc.1
-				IL_00a0: stloc.s 4
-				IL_00a2: ldloc.s 4
-				IL_00a4: ldc.r8 2
-				IL_00ad: mul
-				IL_00ae: ldc.r8 1
-				IL_00b7: add
-				IL_00b8: stloc.s 4
-				IL_00ba: ldloc.s 4
-				IL_00bc: box [System.Runtime]System.Double
-				IL_00c1: stloc.s 6
-				IL_00c3: ldloc.0
-				IL_00c4: ldloc.s 6
-				IL_00c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00cb: stloc.s 4
-				IL_00cd: ldloc.s 4
-				IL_00cf: stloc.2
+				IL_0096: ldloc.1
+				IL_0097: stloc.s 4
+				IL_0099: ldloc.s 4
+				IL_009b: ldc.r8 2
+				IL_00a4: mul
+				IL_00a5: ldc.r8 1
+				IL_00ae: add
+				IL_00af: stloc.s 4
+				IL_00b1: ldloc.s 4
+				IL_00b3: box [System.Runtime]System.Double
+				IL_00b8: stloc.s 7
+				IL_00ba: ldloc.0
+				IL_00bb: ldloc.s 7
+				IL_00bd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00c2: stloc.s 4
+				IL_00c4: ldloc.s 4
+				IL_00c6: stloc.2
 
-				IL_00d0: ldloc.1
-				IL_00d1: ldc.r8 1
-				IL_00da: add
-				IL_00db: stloc.1
-				IL_00dc: br IL_0040
+				IL_00c7: ldloc.1
+				IL_00c8: ldc.r8 1
+				IL_00d1: add
+				IL_00d2: stloc.1
+				IL_00d3: br IL_0040
 			// end loop
 
-			IL_00e1: ldloc.0
-			IL_00e2: ret
+			IL_00d8: ldloc.0
+			IL_00d9: ret
 		} // end of method PrimeSieve::getPrimes
 
 		.method public hidebysig 
@@ -1960,7 +1913,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c00
+			// Method begins at RVA 0x2b94
 			// Header size: 12
 			// Code size: 658 (0x292)
 			.maxstack 8
@@ -2176,22 +2129,15 @@
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 80 b0 53 63 6f 70 65 20 4e 4f 57 5f 55 4e
-			49 54 53 5f 50 45 52 5f 53 45 43 4f 4e 44 3d 7b
-			4e 4f 57 5f 55 4e 49 54 53 5f 50 45 52 5f 53 45
-			43 4f 4e 44 7d 2c 20 57 4f 52 44 5f 53 49 5a 45
-			3d 7b 57 4f 52 44 5f 53 49 5a 45 7d 2c 20 70 65
-			72 66 6f 72 6d 61 6e 63 65 3d 7b 70 65 72 66 6f
-			72 6d 61 6e 63 65 7d 2c 20 42 69 74 41 72 72 61
-			79 3d 7b 42 69 74 41 72 72 61 79 7d 2c 20 50 72
-			69 6d 65 53 69 65 76 65 3d 7b 50 72 69 6d 65 53
-			69 65 76 65 7d 2c 20 72 75 6e 53 69 65 76 65 42
-			61 74 63 68 3d 7b 72 75 6e 53 69 65 76 65 42 61
-			74 63 68 7d 00 00
+			01 00 6c 53 63 6f 70 65 20 70 65 72 66 6f 72 6d
+			61 6e 63 65 3d 7b 70 65 72 66 6f 72 6d 61 6e 63
+			65 7d 2c 20 42 69 74 41 72 72 61 79 3d 7b 42 69
+			74 41 72 72 61 79 7d 2c 20 50 72 69 6d 65 53 69
+			65 76 65 3d 7b 50 72 69 6d 65 53 69 65 76 65 7d
+			2c 20 72 75 6e 53 69 65 76 65 42 61 74 63 68 3d
+			7b 72 75 6e 53 69 65 76 65 42 61 74 63 68 7d 00 00
 		)
 		// Fields
-		.field public float64 NOW_UNITS_PER_SECOND
-		.field public float64 WORD_SIZE
 		.field public object performance
 		.field public object BitArray
 		.field public object PrimeSieve
@@ -2201,7 +2147,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x300f
+			// Method begins at RVA 0x2f92
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2231,7 +2177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314a
+				// Method begins at RVA 0x30cd
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2244,7 +2190,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x3152
+				// Method begins at RVA 0x30d5
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2259,7 +2205,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x315a
+				// Method begins at RVA 0x30dd
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2277,7 +2223,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x316f
+				// Method begins at RVA 0x30f2
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2292,7 +2238,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3177
+				// Method begins at RVA 0x30fa
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2310,7 +2256,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x318c
+				// Method begins at RVA 0x310f
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2325,7 +2271,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3194
+				// Method begins at RVA 0x3117
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2343,7 +2289,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x31a9
+				// Method begins at RVA 0x312c
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2358,7 +2304,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x31b1
+				// Method begins at RVA 0x3134
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2391,7 +2337,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1022 (0x3fe)
+		// Code size: 994 (0x3e2)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -2410,388 +2356,384 @@
 		IL_0000: newobj instance void Modules.Compile_Performance_PrimeJavaScript/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldc.r8 1000
-		IL_0011: stfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-		IL_0016: ldloc.0
-		IL_0017: ldc.r8 32
-		IL_0020: stfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::WORD_SIZE
-		IL_0025: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::.ctor()
-		IL_002a: stloc.1
-		IL_002b: ldloc.1
-		IL_002c: ldc.r8 1000000
-		IL_0035: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_sieveSize(float64)
-		IL_003a: ldloc.1
-		IL_003b: ldc.r8 5
-		IL_0044: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_timeLimitSeconds(float64)
-		IL_0049: ldloc.1
-		IL_004a: ldc.i4.0
-		IL_004b: box [System.Runtime]System.Boolean
-		IL_0050: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_0055: ldloc.1
-		IL_0056: ldstr ""
-		IL_005b: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
-		IL_0060: ldarg.1
-		IL_0061: ldstr "perf_hooks"
-		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.s 4
-		IL_006f: brfalse IL_0080
+		IL_0007: nop
+		IL_0008: nop
+		IL_0009: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::.ctor()
+		IL_000e: stloc.1
+		IL_000f: ldloc.1
+		IL_0010: ldc.r8 1000000
+		IL_0019: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_sieveSize(float64)
+		IL_001e: ldloc.1
+		IL_001f: ldc.r8 5
+		IL_0028: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_timeLimitSeconds(float64)
+		IL_002d: ldloc.1
+		IL_002e: ldc.i4.0
+		IL_002f: box [System.Runtime]System.Boolean
+		IL_0034: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_0039: ldloc.1
+		IL_003a: ldstr ""
+		IL_003f: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
+		IL_0044: ldarg.1
+		IL_0045: ldstr "perf_hooks"
+		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_004f: stloc.s 4
+		IL_0051: ldloc.s 4
+		IL_0053: brfalse IL_0064
 
-		IL_0074: ldloc.s 4
-		IL_0076: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_007b: brfalse IL_0091
+		IL_0058: ldloc.s 4
+		IL_005a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_005f: brfalse IL_0075
 
-		IL_0080: ldloc.s 4
-		IL_0082: ldstr ""
-		IL_0087: ldstr "performance"
-		IL_008c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0064: ldloc.s 4
+		IL_0066: ldstr ""
+		IL_006b: ldstr "performance"
+		IL_0070: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0091: ldloc.s 4
-		IL_0093: ldstr "performance"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009d: stloc.s 4
-		IL_009f: ldloc.0
-		IL_00a0: ldloc.s 4
-		IL_00a2: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-		IL_00a7: ldstr "process"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b1: ldstr "argv"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bb: stloc.s 4
-		IL_00bd: ldloc.s 4
-		IL_00bf: ldc.r8 0.0
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00cd: stloc.s 4
-		IL_00cf: ldloc.s 4
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d6: stloc.s 4
-		IL_00d8: ldstr "[\\\\/]"
-		IL_00dd: ldstr ""
-		IL_00e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e7: stloc.s 5
+		IL_0075: ldloc.s 4
+		IL_0077: ldstr "performance"
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0081: stloc.s 4
+		IL_0083: ldloc.0
+		IL_0084: ldloc.s 4
+		IL_0086: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+		IL_008b: ldstr "process"
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0095: ldstr "argv"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009f: stloc.s 4
+		IL_00a1: ldloc.s 4
+		IL_00a3: ldc.r8 0.0
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00b1: stloc.s 4
+		IL_00b3: ldloc.s 4
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ba: stloc.s 4
+		IL_00bc: ldstr "[\\\\/]"
+		IL_00c1: ldstr ""
+		IL_00c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00cb: stloc.s 5
+		IL_00cd: ldloc.s 4
+		IL_00cf: ldstr "split"
+		IL_00d4: ldloc.s 5
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00db: stloc.2
+		IL_00dc: ldloc.2
+		IL_00dd: ldstr "length"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e7: stloc.s 4
 		IL_00e9: ldloc.s 4
-		IL_00eb: ldstr "split"
-		IL_00f0: ldloc.s 5
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f7: stloc.2
-		IL_00f8: ldloc.2
-		IL_00f9: ldstr "length"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0103: stloc.s 4
-		IL_0105: ldloc.s 4
-		IL_0107: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_010c: ldc.r8 1
-		IL_0115: sub
-		IL_0116: stloc.s 6
-		IL_0118: ldloc.2
-		IL_0119: ldloc.s 6
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0120: stloc.s 4
-		IL_0122: ldloc.1
-		IL_0123: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_0128: ldloc.s 4
-		IL_012a: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
-		IL_012f: ldstr "process"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0139: ldstr "argv"
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0143: stloc.s 4
-		IL_0145: ldloc.s 4
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: ldstr "includes"
-		IL_0151: ldstr "verbose"
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: stloc.s 4
-		IL_015d: ldloc.1
-		IL_015e: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_0163: ldloc.s 4
-		IL_0165: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_016a: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_016f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0174: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0179: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017e: stloc.s 7
-		IL_0180: ldc.i4.1
-		IL_0181: newarr [System.Runtime]System.Object
-		IL_0186: dup
-		IL_0187: ldc.i4.0
-		IL_0188: ldloc.0
-		IL_0189: stelem.ref
-		IL_018a: stloc.s 8
-		IL_018c: ldc.i4.s 10
-		IL_018e: newarr [System.Runtime]System.Object
-		IL_0193: dup
-		IL_0194: ldc.i4.0
-		IL_0195: ldloc.s 7
-		IL_0197: stelem.ref
-		IL_0198: dup
-		IL_0199: ldc.i4.1
-		IL_019a: ldstr "setBitTrue"
-		IL_019f: stelem.ref
-		IL_01a0: dup
-		IL_01a1: ldc.i4.2
-		IL_01a2: ldstr "setBitTrue"
-		IL_01a7: stelem.ref
-		IL_01a8: dup
-		IL_01a9: ldc.i4.3
-		IL_01aa: ldc.r8 1
-		IL_01b3: box [System.Runtime]System.Double
-		IL_01b8: stelem.ref
-		IL_01b9: dup
-		IL_01ba: ldc.i4.4
-		IL_01bb: ldstr "setBitTrue"
-		IL_01c0: stelem.ref
-		IL_01c1: dup
-		IL_01c2: ldc.i4.5
-		IL_01c3: ldc.i4.0
-		IL_01c4: box [System.Runtime]System.Boolean
-		IL_01c9: stelem.ref
-		IL_01ca: dup
-		IL_01cb: ldc.i4.6
-		IL_01cc: ldc.i4.0
-		IL_01cd: box [System.Runtime]System.Boolean
-		IL_01d2: stelem.ref
-		IL_01d3: dup
-		IL_01d4: ldc.i4.7
-		IL_01d5: ldc.i4.0
-		IL_01d6: box [System.Runtime]System.Boolean
-		IL_01db: stelem.ref
+		IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00f0: ldc.r8 1
+		IL_00f9: sub
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.2
+		IL_00fd: ldloc.s 6
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0104: stloc.s 4
+		IL_0106: ldloc.1
+		IL_0107: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_010c: ldloc.s 4
+		IL_010e: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
+		IL_0113: ldstr "process"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011d: ldstr "argv"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0127: stloc.s 4
+		IL_0129: ldloc.s 4
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: ldstr "includes"
+		IL_0135: ldstr "verbose"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013f: stloc.s 4
+		IL_0141: ldloc.1
+		IL_0142: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_0147: ldloc.s 4
+		IL_0149: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_014e: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0153: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0158: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_015d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0162: stloc.s 7
+		IL_0164: ldc.i4.1
+		IL_0165: newarr [System.Runtime]System.Object
+		IL_016a: dup
+		IL_016b: ldc.i4.0
+		IL_016c: ldloc.0
+		IL_016d: stelem.ref
+		IL_016e: stloc.s 8
+		IL_0170: ldc.i4.s 10
+		IL_0172: newarr [System.Runtime]System.Object
+		IL_0177: dup
+		IL_0178: ldc.i4.0
+		IL_0179: ldloc.s 7
+		IL_017b: stelem.ref
+		IL_017c: dup
+		IL_017d: ldc.i4.1
+		IL_017e: ldstr "setBitTrue"
+		IL_0183: stelem.ref
+		IL_0184: dup
+		IL_0185: ldc.i4.2
+		IL_0186: ldstr "setBitTrue"
+		IL_018b: stelem.ref
+		IL_018c: dup
+		IL_018d: ldc.i4.3
+		IL_018e: ldc.r8 1
+		IL_0197: box [System.Runtime]System.Double
+		IL_019c: stelem.ref
+		IL_019d: dup
+		IL_019e: ldc.i4.4
+		IL_019f: ldstr "setBitTrue"
+		IL_01a4: stelem.ref
+		IL_01a5: dup
+		IL_01a6: ldc.i4.5
+		IL_01a7: ldc.i4.0
+		IL_01a8: box [System.Runtime]System.Boolean
+		IL_01ad: stelem.ref
+		IL_01ae: dup
+		IL_01af: ldc.i4.6
+		IL_01b0: ldc.i4.0
+		IL_01b1: box [System.Runtime]System.Boolean
+		IL_01b6: stelem.ref
+		IL_01b7: dup
+		IL_01b8: ldc.i4.7
+		IL_01b9: ldc.i4.0
+		IL_01ba: box [System.Runtime]System.Boolean
+		IL_01bf: stelem.ref
+		IL_01c0: dup
+		IL_01c1: ldc.i4.8
+		IL_01c2: ldc.i4.0
+		IL_01c3: box [System.Runtime]System.Boolean
+		IL_01c8: stelem.ref
+		IL_01c9: dup
+		IL_01ca: ldc.i4.s 9
+		IL_01cc: ldloc.s 8
+		IL_01ce: stelem.ref
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01d4: pop
+		IL_01d5: ldc.i4.s 10
+		IL_01d7: newarr [System.Runtime]System.Object
 		IL_01dc: dup
-		IL_01dd: ldc.i4.8
-		IL_01de: ldc.i4.0
-		IL_01df: box [System.Runtime]System.Boolean
-		IL_01e4: stelem.ref
-		IL_01e5: dup
-		IL_01e6: ldc.i4.s 9
-		IL_01e8: ldloc.s 8
-		IL_01ea: stelem.ref
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01f0: pop
-		IL_01f1: ldc.i4.s 10
-		IL_01f3: newarr [System.Runtime]System.Object
-		IL_01f8: dup
-		IL_01f9: ldc.i4.0
-		IL_01fa: ldloc.s 7
-		IL_01fc: stelem.ref
-		IL_01fd: dup
-		IL_01fe: ldc.i4.1
-		IL_01ff: ldstr "setBitsTrue"
-		IL_0204: stelem.ref
-		IL_0205: dup
-		IL_0206: ldc.i4.2
-		IL_0207: ldstr "setBitsTrue"
-		IL_020c: stelem.ref
-		IL_020d: dup
-		IL_020e: ldc.i4.3
-		IL_020f: ldc.r8 3
-		IL_0218: box [System.Runtime]System.Double
-		IL_021d: stelem.ref
-		IL_021e: dup
-		IL_021f: ldc.i4.4
-		IL_0220: ldstr "setBitsTrue"
-		IL_0225: stelem.ref
-		IL_0226: dup
-		IL_0227: ldc.i4.5
-		IL_0228: ldc.i4.0
-		IL_0229: box [System.Runtime]System.Boolean
-		IL_022e: stelem.ref
-		IL_022f: dup
-		IL_0230: ldc.i4.6
-		IL_0231: ldc.i4.0
-		IL_0232: box [System.Runtime]System.Boolean
-		IL_0237: stelem.ref
-		IL_0238: dup
-		IL_0239: ldc.i4.7
-		IL_023a: ldc.i4.0
-		IL_023b: box [System.Runtime]System.Boolean
-		IL_0240: stelem.ref
+		IL_01dd: ldc.i4.0
+		IL_01de: ldloc.s 7
+		IL_01e0: stelem.ref
+		IL_01e1: dup
+		IL_01e2: ldc.i4.1
+		IL_01e3: ldstr "setBitsTrue"
+		IL_01e8: stelem.ref
+		IL_01e9: dup
+		IL_01ea: ldc.i4.2
+		IL_01eb: ldstr "setBitsTrue"
+		IL_01f0: stelem.ref
+		IL_01f1: dup
+		IL_01f2: ldc.i4.3
+		IL_01f3: ldc.r8 3
+		IL_01fc: box [System.Runtime]System.Double
+		IL_0201: stelem.ref
+		IL_0202: dup
+		IL_0203: ldc.i4.4
+		IL_0204: ldstr "setBitsTrue"
+		IL_0209: stelem.ref
+		IL_020a: dup
+		IL_020b: ldc.i4.5
+		IL_020c: ldc.i4.0
+		IL_020d: box [System.Runtime]System.Boolean
+		IL_0212: stelem.ref
+		IL_0213: dup
+		IL_0214: ldc.i4.6
+		IL_0215: ldc.i4.0
+		IL_0216: box [System.Runtime]System.Boolean
+		IL_021b: stelem.ref
+		IL_021c: dup
+		IL_021d: ldc.i4.7
+		IL_021e: ldc.i4.0
+		IL_021f: box [System.Runtime]System.Boolean
+		IL_0224: stelem.ref
+		IL_0225: dup
+		IL_0226: ldc.i4.8
+		IL_0227: ldc.i4.0
+		IL_0228: box [System.Runtime]System.Boolean
+		IL_022d: stelem.ref
+		IL_022e: dup
+		IL_022f: ldc.i4.s 9
+		IL_0231: ldloc.s 8
+		IL_0233: stelem.ref
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0239: pop
+		IL_023a: ldc.i4.s 10
+		IL_023c: newarr [System.Runtime]System.Object
 		IL_0241: dup
-		IL_0242: ldc.i4.8
-		IL_0243: ldc.i4.0
-		IL_0244: box [System.Runtime]System.Boolean
-		IL_0249: stelem.ref
-		IL_024a: dup
-		IL_024b: ldc.i4.s 9
-		IL_024d: ldloc.s 8
-		IL_024f: stelem.ref
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0255: pop
-		IL_0256: ldc.i4.s 10
-		IL_0258: newarr [System.Runtime]System.Object
-		IL_025d: dup
-		IL_025e: ldc.i4.0
-		IL_025f: ldloc.s 7
-		IL_0261: stelem.ref
-		IL_0262: dup
-		IL_0263: ldc.i4.1
-		IL_0264: ldstr "testBitTrue"
-		IL_0269: stelem.ref
-		IL_026a: dup
-		IL_026b: ldc.i4.2
-		IL_026c: ldstr "testBitTrue"
-		IL_0271: stelem.ref
-		IL_0272: dup
-		IL_0273: ldc.i4.3
-		IL_0274: ldc.r8 1
-		IL_027d: box [System.Runtime]System.Double
-		IL_0282: stelem.ref
-		IL_0283: dup
-		IL_0284: ldc.i4.4
-		IL_0285: ldstr "testBitTrue"
-		IL_028a: stelem.ref
-		IL_028b: dup
-		IL_028c: ldc.i4.5
-		IL_028d: ldc.i4.0
-		IL_028e: box [System.Runtime]System.Boolean
-		IL_0293: stelem.ref
-		IL_0294: dup
-		IL_0295: ldc.i4.6
-		IL_0296: ldc.i4.0
-		IL_0297: box [System.Runtime]System.Boolean
-		IL_029c: stelem.ref
-		IL_029d: dup
-		IL_029e: ldc.i4.7
-		IL_029f: ldc.i4.0
-		IL_02a0: box [System.Runtime]System.Boolean
-		IL_02a5: stelem.ref
+		IL_0242: ldc.i4.0
+		IL_0243: ldloc.s 7
+		IL_0245: stelem.ref
+		IL_0246: dup
+		IL_0247: ldc.i4.1
+		IL_0248: ldstr "testBitTrue"
+		IL_024d: stelem.ref
+		IL_024e: dup
+		IL_024f: ldc.i4.2
+		IL_0250: ldstr "testBitTrue"
+		IL_0255: stelem.ref
+		IL_0256: dup
+		IL_0257: ldc.i4.3
+		IL_0258: ldc.r8 1
+		IL_0261: box [System.Runtime]System.Double
+		IL_0266: stelem.ref
+		IL_0267: dup
+		IL_0268: ldc.i4.4
+		IL_0269: ldstr "testBitTrue"
+		IL_026e: stelem.ref
+		IL_026f: dup
+		IL_0270: ldc.i4.5
+		IL_0271: ldc.i4.0
+		IL_0272: box [System.Runtime]System.Boolean
+		IL_0277: stelem.ref
+		IL_0278: dup
+		IL_0279: ldc.i4.6
+		IL_027a: ldc.i4.0
+		IL_027b: box [System.Runtime]System.Boolean
+		IL_0280: stelem.ref
+		IL_0281: dup
+		IL_0282: ldc.i4.7
+		IL_0283: ldc.i4.0
+		IL_0284: box [System.Runtime]System.Boolean
+		IL_0289: stelem.ref
+		IL_028a: dup
+		IL_028b: ldc.i4.8
+		IL_028c: ldc.i4.0
+		IL_028d: box [System.Runtime]System.Boolean
+		IL_0292: stelem.ref
+		IL_0293: dup
+		IL_0294: ldc.i4.s 9
+		IL_0296: ldloc.s 8
+		IL_0298: stelem.ref
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_029e: pop
+		IL_029f: ldc.i4.s 10
+		IL_02a1: newarr [System.Runtime]System.Object
 		IL_02a6: dup
-		IL_02a7: ldc.i4.8
-		IL_02a8: ldc.i4.0
-		IL_02a9: box [System.Runtime]System.Boolean
-		IL_02ae: stelem.ref
-		IL_02af: dup
-		IL_02b0: ldc.i4.s 9
-		IL_02b2: ldloc.s 8
-		IL_02b4: stelem.ref
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_02ba: pop
-		IL_02bb: ldc.i4.s 10
-		IL_02bd: newarr [System.Runtime]System.Object
-		IL_02c2: dup
-		IL_02c3: ldc.i4.0
-		IL_02c4: ldloc.s 7
-		IL_02c6: stelem.ref
-		IL_02c7: dup
-		IL_02c8: ldc.i4.1
-		IL_02c9: ldstr "searchBitFalse"
-		IL_02ce: stelem.ref
-		IL_02cf: dup
-		IL_02d0: ldc.i4.2
-		IL_02d1: ldstr "searchBitFalse"
-		IL_02d6: stelem.ref
-		IL_02d7: dup
-		IL_02d8: ldc.i4.3
-		IL_02d9: ldc.r8 1
-		IL_02e2: box [System.Runtime]System.Double
-		IL_02e7: stelem.ref
-		IL_02e8: dup
-		IL_02e9: ldc.i4.4
-		IL_02ea: ldstr "searchBitFalse"
-		IL_02ef: stelem.ref
-		IL_02f0: dup
-		IL_02f1: ldc.i4.5
-		IL_02f2: ldc.i4.0
-		IL_02f3: box [System.Runtime]System.Boolean
-		IL_02f8: stelem.ref
-		IL_02f9: dup
-		IL_02fa: ldc.i4.6
-		IL_02fb: ldc.i4.0
-		IL_02fc: box [System.Runtime]System.Boolean
-		IL_0301: stelem.ref
-		IL_0302: dup
-		IL_0303: ldc.i4.7
-		IL_0304: ldc.i4.0
-		IL_0305: box [System.Runtime]System.Boolean
-		IL_030a: stelem.ref
-		IL_030b: dup
-		IL_030c: ldc.i4.8
-		IL_030d: ldc.i4.0
-		IL_030e: box [System.Runtime]System.Boolean
-		IL_0313: stelem.ref
-		IL_0314: dup
-		IL_0315: ldc.i4.s 9
-		IL_0317: ldloc.s 8
-		IL_0319: stelem.ref
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_031f: pop
-		IL_0320: ldc.i4.1
-		IL_0321: newarr [System.Runtime]System.Object
-		IL_0326: dup
-		IL_0327: ldc.i4.0
-		IL_0328: ldloc.0
-		IL_0329: stelem.ref
-		IL_032a: stloc.s 8
-		IL_032c: ldloc.s 7
-		IL_032e: ldloc.s 8
-		IL_0330: ldc.r8 1
-		IL_0339: box [System.Runtime]System.Double
-		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0343: stloc.s 4
-		IL_0345: ldloc.0
-		IL_0346: ldloc.s 4
-		IL_0348: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_034d: nop
-		IL_034e: ldloc.0
-		IL_034f: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0354: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, float64, object)
-		IL_035a: newobj instance void class [System.Runtime]System.Func`4<object, float64, object, object>::.ctor(object, native int)
-		IL_035f: ldc.i4.1
-		IL_0360: newarr [System.Runtime]System.Object
-		IL_0365: dup
-		IL_0366: ldc.i4.0
-		IL_0367: ldloc.0
-		IL_0368: stelem.ref
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0373: castclass class [System.Runtime]System.Func`4<object, float64, object, object>
-		IL_0378: ldc.i4.1
-		IL_0379: conv.r8
-		IL_037a: ldstr ""
-		IL_037f: ldc.i4.0
-		IL_0380: ldc.i4.0
-		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0, float64, string, bool, bool)
-		IL_0386: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0)
-		IL_038b: stloc.s 9
-		IL_038d: ldloc.s 9
-		IL_038f: ldstr "runSieveBatch"
-		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0399: stloc.s 4
-		IL_039b: ldloc.0
-		IL_039c: ldloc.s 4
-		IL_039e: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_03a3: ldloc.0
-		IL_03a4: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_03a9: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_03af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_03b4: ldc.i4.1
-		IL_03b5: newarr [System.Runtime]System.Object
-		IL_03ba: dup
-		IL_03bb: ldc.i4.0
-		IL_03bc: ldloc.0
-		IL_03bd: stelem.ref
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_03c8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_03cd: ldc.i4.1
-		IL_03ce: conv.r8
-		IL_03cf: ldstr ""
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldc.i4.0
-		IL_03d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_03db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_03e0: stloc.s 10
-		IL_03e2: ldloc.s 10
-		IL_03e4: ldstr "main"
-		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_03ee: stloc.3
-		IL_03ef: ldloc.0
-		IL_03f0: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_03f5: ldnull
-		IL_03f6: ldloc.1
-		IL_03f7: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_03fc: pop
-		IL_03fd: ret
+		IL_02a7: ldc.i4.0
+		IL_02a8: ldloc.s 7
+		IL_02aa: stelem.ref
+		IL_02ab: dup
+		IL_02ac: ldc.i4.1
+		IL_02ad: ldstr "searchBitFalse"
+		IL_02b2: stelem.ref
+		IL_02b3: dup
+		IL_02b4: ldc.i4.2
+		IL_02b5: ldstr "searchBitFalse"
+		IL_02ba: stelem.ref
+		IL_02bb: dup
+		IL_02bc: ldc.i4.3
+		IL_02bd: ldc.r8 1
+		IL_02c6: box [System.Runtime]System.Double
+		IL_02cb: stelem.ref
+		IL_02cc: dup
+		IL_02cd: ldc.i4.4
+		IL_02ce: ldstr "searchBitFalse"
+		IL_02d3: stelem.ref
+		IL_02d4: dup
+		IL_02d5: ldc.i4.5
+		IL_02d6: ldc.i4.0
+		IL_02d7: box [System.Runtime]System.Boolean
+		IL_02dc: stelem.ref
+		IL_02dd: dup
+		IL_02de: ldc.i4.6
+		IL_02df: ldc.i4.0
+		IL_02e0: box [System.Runtime]System.Boolean
+		IL_02e5: stelem.ref
+		IL_02e6: dup
+		IL_02e7: ldc.i4.7
+		IL_02e8: ldc.i4.0
+		IL_02e9: box [System.Runtime]System.Boolean
+		IL_02ee: stelem.ref
+		IL_02ef: dup
+		IL_02f0: ldc.i4.8
+		IL_02f1: ldc.i4.0
+		IL_02f2: box [System.Runtime]System.Boolean
+		IL_02f7: stelem.ref
+		IL_02f8: dup
+		IL_02f9: ldc.i4.s 9
+		IL_02fb: ldloc.s 8
+		IL_02fd: stelem.ref
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0303: pop
+		IL_0304: ldc.i4.1
+		IL_0305: newarr [System.Runtime]System.Object
+		IL_030a: dup
+		IL_030b: ldc.i4.0
+		IL_030c: ldloc.0
+		IL_030d: stelem.ref
+		IL_030e: stloc.s 8
+		IL_0310: ldloc.s 7
+		IL_0312: ldloc.s 8
+		IL_0314: ldc.r8 1
+		IL_031d: box [System.Runtime]System.Double
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0327: stloc.s 4
+		IL_0329: ldloc.0
+		IL_032a: ldloc.s 4
+		IL_032c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_0331: nop
+		IL_0332: ldloc.0
+		IL_0333: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0338: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, float64, object)
+		IL_033e: newobj instance void class [System.Runtime]System.Func`4<object, float64, object, object>::.ctor(object, native int)
+		IL_0343: ldc.i4.1
+		IL_0344: newarr [System.Runtime]System.Object
+		IL_0349: dup
+		IL_034a: ldc.i4.0
+		IL_034b: ldloc.0
+		IL_034c: stelem.ref
+		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0357: castclass class [System.Runtime]System.Func`4<object, float64, object, object>
+		IL_035c: ldc.i4.1
+		IL_035d: conv.r8
+		IL_035e: ldstr ""
+		IL_0363: ldc.i4.0
+		IL_0364: ldc.i4.0
+		IL_0365: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0, float64, string, bool, bool)
+		IL_036a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0)
+		IL_036f: stloc.s 9
+		IL_0371: ldloc.s 9
+		IL_0373: ldstr "runSieveBatch"
+		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_037d: stloc.s 4
+		IL_037f: ldloc.0
+		IL_0380: ldloc.s 4
+		IL_0382: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0387: ldloc.0
+		IL_0388: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_038d: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_0393: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0398: ldc.i4.1
+		IL_0399: newarr [System.Runtime]System.Object
+		IL_039e: dup
+		IL_039f: ldc.i4.0
+		IL_03a0: ldloc.0
+		IL_03a1: stelem.ref
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_03ac: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_03b1: ldc.i4.1
+		IL_03b2: conv.r8
+		IL_03b3: ldstr ""
+		IL_03b8: ldc.i4.0
+		IL_03b9: ldc.i4.0
+		IL_03ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_03bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_03c4: stloc.s 10
+		IL_03c6: ldloc.s 10
+		IL_03c8: ldstr "main"
+		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03d2: stloc.3
+		IL_03d3: ldloc.0
+		IL_03d4: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_03d9: ldnull
+		IL_03da: ldloc.1
+		IL_03db: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_03e0: pop
+		IL_03e1: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -2803,7 +2745,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31c6
+		// Method begins at RVA 0x3149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30bb
+						// Method begins at RVA 0x30b7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30b2
+					// Method begins at RVA 0x30ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a9
+				// Method begins at RVA 0x30a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2440
+			// Method begins at RVA 0x243c
 			// Header size: 12
 			// Code size: 237 (0xed)
 			.maxstack 8
@@ -227,7 +227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c4
+				// Method begins at RVA 0x30c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -254,7 +254,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x253c
+			// Method begins at RVA 0x2538
 			// Header size: 12
 			// Code size: 533 (0x215)
 			.maxstack 8
@@ -471,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2f9b
+				// Method begins at RVA 0x2f97
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -491,7 +491,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fa4
+				// Method begins at RVA 0x2fa0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -511,7 +511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fad
+				// Method begins at RVA 0x2fa9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -539,7 +539,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fc8
+						// Method begins at RVA 0x2fc4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -563,7 +563,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2fda
+							// Method begins at RVA 0x2fd6
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -581,7 +581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fd1
+						// Method begins at RVA 0x2fcd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -599,7 +599,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fbf
+					// Method begins at RVA 0x2fbb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -627,7 +627,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ff5
+							// Method begins at RVA 0x2ff1
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -645,7 +645,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fec
+						// Method begins at RVA 0x2fe8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -663,7 +663,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fe3
+					// Method begins at RVA 0x2fdf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -687,7 +687,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3007
+						// Method begins at RVA 0x3003
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -705,7 +705,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ffe
+					// Method begins at RVA 0x2ffa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -723,7 +723,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fb6
+				// Method begins at RVA 0x2fb2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -743,7 +743,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3010
+				// Method begins at RVA 0x300c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -767,7 +767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3022
+					// Method begins at RVA 0x301e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -785,7 +785,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3019
+				// Method begins at RVA 0x3015
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -813,7 +813,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27c4
+			// Method begins at RVA 0x27c0
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -861,7 +861,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x2a2c
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -925,7 +925,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2848
+			// Method begins at RVA 0x2844
 			// Header size: 12
 			// Code size: 475 (0x1db)
 			.maxstack 8
@@ -1192,7 +1192,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a90
+			// Method begins at RVA 0x2a8c
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1249,7 +1249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2810
+			// Method begins at RVA 0x280c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1294,7 +1294,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x302b
+				// Method begins at RVA 0x3027
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1314,7 +1314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3034
+				// Method begins at RVA 0x3030
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1338,7 +1338,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3046
+					// Method begins at RVA 0x3042
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1356,7 +1356,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x303d
+				// Method begins at RVA 0x3039
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1376,7 +1376,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x304f
+				// Method begins at RVA 0x304b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1404,7 +1404,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x306a
+						// Method begins at RVA 0x3066
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1422,7 +1422,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3061
+					// Method begins at RVA 0x305d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1440,7 +1440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3058
+				// Method begins at RVA 0x3054
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1464,7 +1464,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x307c
+					// Method begins at RVA 0x3078
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1488,7 +1488,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x308e
+						// Method begins at RVA 0x308a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1506,7 +1506,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3085
+					// Method begins at RVA 0x3081
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1524,7 +1524,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3073
+				// Method begins at RVA 0x306f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1548,7 +1548,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30a0
+					// Method begins at RVA 0x309c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1566,7 +1566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3097
+				// Method begins at RVA 0x3093
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1596,7 +1596,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2760
+			// Method begins at RVA 0x275c
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -1652,7 +1652,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ae0
+			// Method begins at RVA 0x2adc
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -1740,7 +1740,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e34
+			// Method begins at RVA 0x2e30
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -1805,7 +1805,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2eac
+			// Method begins at RVA 0x2ea8
 			// Header size: 12
 			// Code size: 218 (0xda)
 			.maxstack 8
@@ -1913,7 +1913,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b94
+			// Method begins at RVA 0x2b90
 			// Header size: 12
 			// Code size: 658 (0x292)
 			.maxstack 8
@@ -2147,7 +2147,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f92
+			// Method begins at RVA 0x2f8e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2177,7 +2177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30cd
+				// Method begins at RVA 0x30c9
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2190,7 +2190,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x30d5
+				// Method begins at RVA 0x30d1
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2205,7 +2205,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30dd
+				// Method begins at RVA 0x30d9
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2223,7 +2223,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x30f2
+				// Method begins at RVA 0x30ee
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2238,7 +2238,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x30fa
+				// Method begins at RVA 0x30f6
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2256,7 +2256,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x310f
+				// Method begins at RVA 0x310b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2271,7 +2271,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3117
+				// Method begins at RVA 0x3113
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2289,7 +2289,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x312c
+				// Method begins at RVA 0x3128
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2304,7 +2304,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x3134
+				// Method begins at RVA 0x3130
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2337,7 +2337,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 994 (0x3e2)
+		// Code size: 992 (0x3e0)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -2356,384 +2356,382 @@
 		IL_0000: newobj instance void Modules.Compile_Performance_PrimeJavaScript/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: nop
-		IL_0009: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::.ctor()
-		IL_000e: stloc.1
-		IL_000f: ldloc.1
-		IL_0010: ldc.r8 1000000
-		IL_0019: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_sieveSize(float64)
-		IL_001e: ldloc.1
-		IL_001f: ldc.r8 5
-		IL_0028: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_timeLimitSeconds(float64)
-		IL_002d: ldloc.1
-		IL_002e: ldc.i4.0
-		IL_002f: box [System.Runtime]System.Boolean
-		IL_0034: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_0039: ldloc.1
-		IL_003a: ldstr ""
-		IL_003f: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
-		IL_0044: ldarg.1
-		IL_0045: ldstr "perf_hooks"
-		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.s 4
-		IL_0053: brfalse IL_0064
+		IL_0007: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::.ctor()
+		IL_000c: stloc.1
+		IL_000d: ldloc.1
+		IL_000e: ldc.r8 1000000
+		IL_0017: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_sieveSize(float64)
+		IL_001c: ldloc.1
+		IL_001d: ldc.r8 5
+		IL_0026: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_timeLimitSeconds(float64)
+		IL_002b: ldloc.1
+		IL_002c: ldc.i4.0
+		IL_002d: box [System.Runtime]System.Boolean
+		IL_0032: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_0037: ldloc.1
+		IL_0038: ldstr ""
+		IL_003d: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
+		IL_0042: ldarg.1
+		IL_0043: ldstr "perf_hooks"
+		IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_004d: stloc.s 4
+		IL_004f: ldloc.s 4
+		IL_0051: brfalse IL_0062
 
-		IL_0058: ldloc.s 4
-		IL_005a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_005f: brfalse IL_0075
+		IL_0056: ldloc.s 4
+		IL_0058: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_005d: brfalse IL_0073
 
-		IL_0064: ldloc.s 4
-		IL_0066: ldstr ""
-		IL_006b: ldstr "performance"
-		IL_0070: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0062: ldloc.s 4
+		IL_0064: ldstr ""
+		IL_0069: ldstr "performance"
+		IL_006e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0075: ldloc.s 4
-		IL_0077: ldstr "performance"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0081: stloc.s 4
-		IL_0083: ldloc.0
-		IL_0084: ldloc.s 4
-		IL_0086: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-		IL_008b: ldstr "process"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0095: ldstr "argv"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009f: stloc.s 4
-		IL_00a1: ldloc.s 4
-		IL_00a3: ldc.r8 0.0
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b1: stloc.s 4
-		IL_00b3: ldloc.s 4
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ba: stloc.s 4
-		IL_00bc: ldstr "[\\\\/]"
-		IL_00c1: ldstr ""
-		IL_00c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "split"
-		IL_00d4: ldloc.s 5
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00db: stloc.2
-		IL_00dc: ldloc.2
-		IL_00dd: ldstr "length"
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e7: stloc.s 4
-		IL_00e9: ldloc.s 4
-		IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00f0: ldc.r8 1
-		IL_00f9: sub
-		IL_00fa: stloc.s 6
-		IL_00fc: ldloc.2
-		IL_00fd: ldloc.s 6
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0104: stloc.s 4
-		IL_0106: ldloc.1
-		IL_0107: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_010c: ldloc.s 4
-		IL_010e: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
-		IL_0113: ldstr "process"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011d: ldstr "argv"
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0127: stloc.s 4
-		IL_0129: ldloc.s 4
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0130: ldstr "includes"
-		IL_0135: ldstr "verbose"
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013f: stloc.s 4
-		IL_0141: ldloc.1
-		IL_0142: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_0147: ldloc.s 4
-		IL_0149: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_014e: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0153: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0158: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_015d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0162: stloc.s 7
-		IL_0164: ldc.i4.1
-		IL_0165: newarr [System.Runtime]System.Object
-		IL_016a: dup
-		IL_016b: ldc.i4.0
-		IL_016c: ldloc.0
-		IL_016d: stelem.ref
-		IL_016e: stloc.s 8
-		IL_0170: ldc.i4.s 10
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: dup
-		IL_0178: ldc.i4.0
-		IL_0179: ldloc.s 7
-		IL_017b: stelem.ref
-		IL_017c: dup
-		IL_017d: ldc.i4.1
-		IL_017e: ldstr "setBitTrue"
-		IL_0183: stelem.ref
-		IL_0184: dup
-		IL_0185: ldc.i4.2
-		IL_0186: ldstr "setBitTrue"
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.3
-		IL_018e: ldc.r8 1
-		IL_0197: box [System.Runtime]System.Double
-		IL_019c: stelem.ref
-		IL_019d: dup
-		IL_019e: ldc.i4.4
-		IL_019f: ldstr "setBitTrue"
-		IL_01a4: stelem.ref
-		IL_01a5: dup
-		IL_01a6: ldc.i4.5
-		IL_01a7: ldc.i4.0
-		IL_01a8: box [System.Runtime]System.Boolean
-		IL_01ad: stelem.ref
-		IL_01ae: dup
-		IL_01af: ldc.i4.6
-		IL_01b0: ldc.i4.0
-		IL_01b1: box [System.Runtime]System.Boolean
-		IL_01b6: stelem.ref
-		IL_01b7: dup
-		IL_01b8: ldc.i4.7
-		IL_01b9: ldc.i4.0
-		IL_01ba: box [System.Runtime]System.Boolean
-		IL_01bf: stelem.ref
-		IL_01c0: dup
-		IL_01c1: ldc.i4.8
-		IL_01c2: ldc.i4.0
-		IL_01c3: box [System.Runtime]System.Boolean
-		IL_01c8: stelem.ref
-		IL_01c9: dup
-		IL_01ca: ldc.i4.s 9
-		IL_01cc: ldloc.s 8
-		IL_01ce: stelem.ref
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01d4: pop
-		IL_01d5: ldc.i4.s 10
-		IL_01d7: newarr [System.Runtime]System.Object
-		IL_01dc: dup
-		IL_01dd: ldc.i4.0
-		IL_01de: ldloc.s 7
-		IL_01e0: stelem.ref
-		IL_01e1: dup
-		IL_01e2: ldc.i4.1
-		IL_01e3: ldstr "setBitsTrue"
-		IL_01e8: stelem.ref
-		IL_01e9: dup
-		IL_01ea: ldc.i4.2
-		IL_01eb: ldstr "setBitsTrue"
-		IL_01f0: stelem.ref
-		IL_01f1: dup
-		IL_01f2: ldc.i4.3
-		IL_01f3: ldc.r8 3
-		IL_01fc: box [System.Runtime]System.Double
-		IL_0201: stelem.ref
-		IL_0202: dup
-		IL_0203: ldc.i4.4
-		IL_0204: ldstr "setBitsTrue"
-		IL_0209: stelem.ref
-		IL_020a: dup
-		IL_020b: ldc.i4.5
-		IL_020c: ldc.i4.0
-		IL_020d: box [System.Runtime]System.Boolean
-		IL_0212: stelem.ref
-		IL_0213: dup
-		IL_0214: ldc.i4.6
-		IL_0215: ldc.i4.0
-		IL_0216: box [System.Runtime]System.Boolean
-		IL_021b: stelem.ref
-		IL_021c: dup
-		IL_021d: ldc.i4.7
-		IL_021e: ldc.i4.0
-		IL_021f: box [System.Runtime]System.Boolean
-		IL_0224: stelem.ref
-		IL_0225: dup
-		IL_0226: ldc.i4.8
-		IL_0227: ldc.i4.0
-		IL_0228: box [System.Runtime]System.Boolean
-		IL_022d: stelem.ref
-		IL_022e: dup
-		IL_022f: ldc.i4.s 9
-		IL_0231: ldloc.s 8
-		IL_0233: stelem.ref
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0239: pop
-		IL_023a: ldc.i4.s 10
-		IL_023c: newarr [System.Runtime]System.Object
-		IL_0241: dup
-		IL_0242: ldc.i4.0
-		IL_0243: ldloc.s 7
-		IL_0245: stelem.ref
-		IL_0246: dup
-		IL_0247: ldc.i4.1
-		IL_0248: ldstr "testBitTrue"
-		IL_024d: stelem.ref
-		IL_024e: dup
-		IL_024f: ldc.i4.2
-		IL_0250: ldstr "testBitTrue"
-		IL_0255: stelem.ref
-		IL_0256: dup
-		IL_0257: ldc.i4.3
-		IL_0258: ldc.r8 1
-		IL_0261: box [System.Runtime]System.Double
-		IL_0266: stelem.ref
-		IL_0267: dup
-		IL_0268: ldc.i4.4
-		IL_0269: ldstr "testBitTrue"
-		IL_026e: stelem.ref
-		IL_026f: dup
-		IL_0270: ldc.i4.5
-		IL_0271: ldc.i4.0
-		IL_0272: box [System.Runtime]System.Boolean
-		IL_0277: stelem.ref
-		IL_0278: dup
-		IL_0279: ldc.i4.6
-		IL_027a: ldc.i4.0
-		IL_027b: box [System.Runtime]System.Boolean
-		IL_0280: stelem.ref
-		IL_0281: dup
-		IL_0282: ldc.i4.7
-		IL_0283: ldc.i4.0
-		IL_0284: box [System.Runtime]System.Boolean
-		IL_0289: stelem.ref
-		IL_028a: dup
-		IL_028b: ldc.i4.8
-		IL_028c: ldc.i4.0
-		IL_028d: box [System.Runtime]System.Boolean
-		IL_0292: stelem.ref
-		IL_0293: dup
-		IL_0294: ldc.i4.s 9
-		IL_0296: ldloc.s 8
-		IL_0298: stelem.ref
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_029e: pop
-		IL_029f: ldc.i4.s 10
-		IL_02a1: newarr [System.Runtime]System.Object
-		IL_02a6: dup
-		IL_02a7: ldc.i4.0
-		IL_02a8: ldloc.s 7
-		IL_02aa: stelem.ref
-		IL_02ab: dup
-		IL_02ac: ldc.i4.1
-		IL_02ad: ldstr "searchBitFalse"
-		IL_02b2: stelem.ref
-		IL_02b3: dup
-		IL_02b4: ldc.i4.2
-		IL_02b5: ldstr "searchBitFalse"
-		IL_02ba: stelem.ref
-		IL_02bb: dup
-		IL_02bc: ldc.i4.3
-		IL_02bd: ldc.r8 1
-		IL_02c6: box [System.Runtime]System.Double
-		IL_02cb: stelem.ref
-		IL_02cc: dup
-		IL_02cd: ldc.i4.4
-		IL_02ce: ldstr "searchBitFalse"
-		IL_02d3: stelem.ref
-		IL_02d4: dup
-		IL_02d5: ldc.i4.5
-		IL_02d6: ldc.i4.0
-		IL_02d7: box [System.Runtime]System.Boolean
-		IL_02dc: stelem.ref
-		IL_02dd: dup
-		IL_02de: ldc.i4.6
-		IL_02df: ldc.i4.0
-		IL_02e0: box [System.Runtime]System.Boolean
-		IL_02e5: stelem.ref
-		IL_02e6: dup
-		IL_02e7: ldc.i4.7
-		IL_02e8: ldc.i4.0
-		IL_02e9: box [System.Runtime]System.Boolean
-		IL_02ee: stelem.ref
-		IL_02ef: dup
-		IL_02f0: ldc.i4.8
-		IL_02f1: ldc.i4.0
-		IL_02f2: box [System.Runtime]System.Boolean
-		IL_02f7: stelem.ref
-		IL_02f8: dup
-		IL_02f9: ldc.i4.s 9
-		IL_02fb: ldloc.s 8
-		IL_02fd: stelem.ref
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0303: pop
-		IL_0304: ldc.i4.1
-		IL_0305: newarr [System.Runtime]System.Object
-		IL_030a: dup
-		IL_030b: ldc.i4.0
-		IL_030c: ldloc.0
-		IL_030d: stelem.ref
-		IL_030e: stloc.s 8
-		IL_0310: ldloc.s 7
-		IL_0312: ldloc.s 8
-		IL_0314: ldc.r8 1
-		IL_031d: box [System.Runtime]System.Double
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0327: stloc.s 4
-		IL_0329: ldloc.0
-		IL_032a: ldloc.s 4
-		IL_032c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_0331: nop
-		IL_0332: ldloc.0
-		IL_0333: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0338: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, float64, object)
-		IL_033e: newobj instance void class [System.Runtime]System.Func`4<object, float64, object, object>::.ctor(object, native int)
-		IL_0343: ldc.i4.1
-		IL_0344: newarr [System.Runtime]System.Object
-		IL_0349: dup
-		IL_034a: ldc.i4.0
-		IL_034b: ldloc.0
-		IL_034c: stelem.ref
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0357: castclass class [System.Runtime]System.Func`4<object, float64, object, object>
-		IL_035c: ldc.i4.1
-		IL_035d: conv.r8
-		IL_035e: ldstr ""
-		IL_0363: ldc.i4.0
-		IL_0364: ldc.i4.0
-		IL_0365: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0, float64, string, bool, bool)
-		IL_036a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0)
-		IL_036f: stloc.s 9
-		IL_0371: ldloc.s 9
-		IL_0373: ldstr "runSieveBatch"
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_037d: stloc.s 4
-		IL_037f: ldloc.0
-		IL_0380: ldloc.s 4
-		IL_0382: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_0387: ldloc.0
-		IL_0388: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_038d: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_0393: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0398: ldc.i4.1
-		IL_0399: newarr [System.Runtime]System.Object
-		IL_039e: dup
-		IL_039f: ldc.i4.0
-		IL_03a0: ldloc.0
-		IL_03a1: stelem.ref
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_03ac: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_03b1: ldc.i4.1
-		IL_03b2: conv.r8
-		IL_03b3: ldstr ""
-		IL_03b8: ldc.i4.0
-		IL_03b9: ldc.i4.0
-		IL_03ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_03bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_03c4: stloc.s 10
-		IL_03c6: ldloc.s 10
-		IL_03c8: ldstr "main"
-		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_03d2: stloc.3
-		IL_03d3: ldloc.0
-		IL_03d4: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_03d9: ldnull
-		IL_03da: ldloc.1
-		IL_03db: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_03e0: pop
-		IL_03e1: ret
+		IL_0073: ldloc.s 4
+		IL_0075: ldstr "performance"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.0
+		IL_0082: ldloc.s 4
+		IL_0084: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+		IL_0089: ldstr "process"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0093: ldstr "argv"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009d: stloc.s 4
+		IL_009f: ldloc.s 4
+		IL_00a1: ldc.r8 0.0
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00af: stloc.s 4
+		IL_00b1: ldloc.s 4
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b8: stloc.s 4
+		IL_00ba: ldstr "[\\\\/]"
+		IL_00bf: ldstr ""
+		IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c9: stloc.s 5
+		IL_00cb: ldloc.s 4
+		IL_00cd: ldstr "split"
+		IL_00d2: ldloc.s 5
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d9: stloc.2
+		IL_00da: ldloc.2
+		IL_00db: ldstr "length"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e5: stloc.s 4
+		IL_00e7: ldloc.s 4
+		IL_00e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00ee: ldc.r8 1
+		IL_00f7: sub
+		IL_00f8: stloc.s 6
+		IL_00fa: ldloc.2
+		IL_00fb: ldloc.s 6
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0102: stloc.s 4
+		IL_0104: ldloc.1
+		IL_0105: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_010a: ldloc.s 4
+		IL_010c: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
+		IL_0111: ldstr "process"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011b: ldstr "argv"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0125: stloc.s 4
+		IL_0127: ldloc.s 4
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012e: ldstr "includes"
+		IL_0133: ldstr "verbose"
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: stloc.s 4
+		IL_013f: ldloc.1
+		IL_0140: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_0145: ldloc.s 4
+		IL_0147: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_014c: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0151: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0156: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_015b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0160: stloc.s 7
+		IL_0162: ldc.i4.1
+		IL_0163: newarr [System.Runtime]System.Object
+		IL_0168: dup
+		IL_0169: ldc.i4.0
+		IL_016a: ldloc.0
+		IL_016b: stelem.ref
+		IL_016c: stloc.s 8
+		IL_016e: ldc.i4.s 10
+		IL_0170: newarr [System.Runtime]System.Object
+		IL_0175: dup
+		IL_0176: ldc.i4.0
+		IL_0177: ldloc.s 7
+		IL_0179: stelem.ref
+		IL_017a: dup
+		IL_017b: ldc.i4.1
+		IL_017c: ldstr "setBitTrue"
+		IL_0181: stelem.ref
+		IL_0182: dup
+		IL_0183: ldc.i4.2
+		IL_0184: ldstr "setBitTrue"
+		IL_0189: stelem.ref
+		IL_018a: dup
+		IL_018b: ldc.i4.3
+		IL_018c: ldc.r8 1
+		IL_0195: box [System.Runtime]System.Double
+		IL_019a: stelem.ref
+		IL_019b: dup
+		IL_019c: ldc.i4.4
+		IL_019d: ldstr "setBitTrue"
+		IL_01a2: stelem.ref
+		IL_01a3: dup
+		IL_01a4: ldc.i4.5
+		IL_01a5: ldc.i4.0
+		IL_01a6: box [System.Runtime]System.Boolean
+		IL_01ab: stelem.ref
+		IL_01ac: dup
+		IL_01ad: ldc.i4.6
+		IL_01ae: ldc.i4.0
+		IL_01af: box [System.Runtime]System.Boolean
+		IL_01b4: stelem.ref
+		IL_01b5: dup
+		IL_01b6: ldc.i4.7
+		IL_01b7: ldc.i4.0
+		IL_01b8: box [System.Runtime]System.Boolean
+		IL_01bd: stelem.ref
+		IL_01be: dup
+		IL_01bf: ldc.i4.8
+		IL_01c0: ldc.i4.0
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stelem.ref
+		IL_01c7: dup
+		IL_01c8: ldc.i4.s 9
+		IL_01ca: ldloc.s 8
+		IL_01cc: stelem.ref
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01d2: pop
+		IL_01d3: ldc.i4.s 10
+		IL_01d5: newarr [System.Runtime]System.Object
+		IL_01da: dup
+		IL_01db: ldc.i4.0
+		IL_01dc: ldloc.s 7
+		IL_01de: stelem.ref
+		IL_01df: dup
+		IL_01e0: ldc.i4.1
+		IL_01e1: ldstr "setBitsTrue"
+		IL_01e6: stelem.ref
+		IL_01e7: dup
+		IL_01e8: ldc.i4.2
+		IL_01e9: ldstr "setBitsTrue"
+		IL_01ee: stelem.ref
+		IL_01ef: dup
+		IL_01f0: ldc.i4.3
+		IL_01f1: ldc.r8 3
+		IL_01fa: box [System.Runtime]System.Double
+		IL_01ff: stelem.ref
+		IL_0200: dup
+		IL_0201: ldc.i4.4
+		IL_0202: ldstr "setBitsTrue"
+		IL_0207: stelem.ref
+		IL_0208: dup
+		IL_0209: ldc.i4.5
+		IL_020a: ldc.i4.0
+		IL_020b: box [System.Runtime]System.Boolean
+		IL_0210: stelem.ref
+		IL_0211: dup
+		IL_0212: ldc.i4.6
+		IL_0213: ldc.i4.0
+		IL_0214: box [System.Runtime]System.Boolean
+		IL_0219: stelem.ref
+		IL_021a: dup
+		IL_021b: ldc.i4.7
+		IL_021c: ldc.i4.0
+		IL_021d: box [System.Runtime]System.Boolean
+		IL_0222: stelem.ref
+		IL_0223: dup
+		IL_0224: ldc.i4.8
+		IL_0225: ldc.i4.0
+		IL_0226: box [System.Runtime]System.Boolean
+		IL_022b: stelem.ref
+		IL_022c: dup
+		IL_022d: ldc.i4.s 9
+		IL_022f: ldloc.s 8
+		IL_0231: stelem.ref
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0237: pop
+		IL_0238: ldc.i4.s 10
+		IL_023a: newarr [System.Runtime]System.Object
+		IL_023f: dup
+		IL_0240: ldc.i4.0
+		IL_0241: ldloc.s 7
+		IL_0243: stelem.ref
+		IL_0244: dup
+		IL_0245: ldc.i4.1
+		IL_0246: ldstr "testBitTrue"
+		IL_024b: stelem.ref
+		IL_024c: dup
+		IL_024d: ldc.i4.2
+		IL_024e: ldstr "testBitTrue"
+		IL_0253: stelem.ref
+		IL_0254: dup
+		IL_0255: ldc.i4.3
+		IL_0256: ldc.r8 1
+		IL_025f: box [System.Runtime]System.Double
+		IL_0264: stelem.ref
+		IL_0265: dup
+		IL_0266: ldc.i4.4
+		IL_0267: ldstr "testBitTrue"
+		IL_026c: stelem.ref
+		IL_026d: dup
+		IL_026e: ldc.i4.5
+		IL_026f: ldc.i4.0
+		IL_0270: box [System.Runtime]System.Boolean
+		IL_0275: stelem.ref
+		IL_0276: dup
+		IL_0277: ldc.i4.6
+		IL_0278: ldc.i4.0
+		IL_0279: box [System.Runtime]System.Boolean
+		IL_027e: stelem.ref
+		IL_027f: dup
+		IL_0280: ldc.i4.7
+		IL_0281: ldc.i4.0
+		IL_0282: box [System.Runtime]System.Boolean
+		IL_0287: stelem.ref
+		IL_0288: dup
+		IL_0289: ldc.i4.8
+		IL_028a: ldc.i4.0
+		IL_028b: box [System.Runtime]System.Boolean
+		IL_0290: stelem.ref
+		IL_0291: dup
+		IL_0292: ldc.i4.s 9
+		IL_0294: ldloc.s 8
+		IL_0296: stelem.ref
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_029c: pop
+		IL_029d: ldc.i4.s 10
+		IL_029f: newarr [System.Runtime]System.Object
+		IL_02a4: dup
+		IL_02a5: ldc.i4.0
+		IL_02a6: ldloc.s 7
+		IL_02a8: stelem.ref
+		IL_02a9: dup
+		IL_02aa: ldc.i4.1
+		IL_02ab: ldstr "searchBitFalse"
+		IL_02b0: stelem.ref
+		IL_02b1: dup
+		IL_02b2: ldc.i4.2
+		IL_02b3: ldstr "searchBitFalse"
+		IL_02b8: stelem.ref
+		IL_02b9: dup
+		IL_02ba: ldc.i4.3
+		IL_02bb: ldc.r8 1
+		IL_02c4: box [System.Runtime]System.Double
+		IL_02c9: stelem.ref
+		IL_02ca: dup
+		IL_02cb: ldc.i4.4
+		IL_02cc: ldstr "searchBitFalse"
+		IL_02d1: stelem.ref
+		IL_02d2: dup
+		IL_02d3: ldc.i4.5
+		IL_02d4: ldc.i4.0
+		IL_02d5: box [System.Runtime]System.Boolean
+		IL_02da: stelem.ref
+		IL_02db: dup
+		IL_02dc: ldc.i4.6
+		IL_02dd: ldc.i4.0
+		IL_02de: box [System.Runtime]System.Boolean
+		IL_02e3: stelem.ref
+		IL_02e4: dup
+		IL_02e5: ldc.i4.7
+		IL_02e6: ldc.i4.0
+		IL_02e7: box [System.Runtime]System.Boolean
+		IL_02ec: stelem.ref
+		IL_02ed: dup
+		IL_02ee: ldc.i4.8
+		IL_02ef: ldc.i4.0
+		IL_02f0: box [System.Runtime]System.Boolean
+		IL_02f5: stelem.ref
+		IL_02f6: dup
+		IL_02f7: ldc.i4.s 9
+		IL_02f9: ldloc.s 8
+		IL_02fb: stelem.ref
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0301: pop
+		IL_0302: ldc.i4.1
+		IL_0303: newarr [System.Runtime]System.Object
+		IL_0308: dup
+		IL_0309: ldc.i4.0
+		IL_030a: ldloc.0
+		IL_030b: stelem.ref
+		IL_030c: stloc.s 8
+		IL_030e: ldloc.s 7
+		IL_0310: ldloc.s 8
+		IL_0312: ldc.r8 1
+		IL_031b: box [System.Runtime]System.Double
+		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0325: stloc.s 4
+		IL_0327: ldloc.0
+		IL_0328: ldloc.s 4
+		IL_032a: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_032f: nop
+		IL_0330: ldloc.0
+		IL_0331: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0336: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, float64, object)
+		IL_033c: newobj instance void class [System.Runtime]System.Func`4<object, float64, object, object>::.ctor(object, native int)
+		IL_0341: ldc.i4.1
+		IL_0342: newarr [System.Runtime]System.Object
+		IL_0347: dup
+		IL_0348: ldc.i4.0
+		IL_0349: ldloc.0
+		IL_034a: stelem.ref
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0355: castclass class [System.Runtime]System.Func`4<object, float64, object, object>
+		IL_035a: ldc.i4.1
+		IL_035b: conv.r8
+		IL_035c: ldstr ""
+		IL_0361: ldc.i4.0
+		IL_0362: ldc.i4.0
+		IL_0363: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0, float64, string, bool, bool)
+		IL_0368: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [System.Runtime]System.Func`4<object, float64, object, object>>(!!0)
+		IL_036d: stloc.s 9
+		IL_036f: ldloc.s 9
+		IL_0371: ldstr "runSieveBatch"
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_037b: stloc.s 4
+		IL_037d: ldloc.0
+		IL_037e: ldloc.s 4
+		IL_0380: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0385: ldloc.0
+		IL_0386: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_038b: ldftn object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_0391: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0396: ldc.i4.1
+		IL_0397: newarr [System.Runtime]System.Object
+		IL_039c: dup
+		IL_039d: ldc.i4.0
+		IL_039e: ldloc.0
+		IL_039f: stelem.ref
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_03aa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_03af: ldc.i4.1
+		IL_03b0: conv.r8
+		IL_03b1: ldstr ""
+		IL_03b6: ldc.i4.0
+		IL_03b7: ldc.i4.0
+		IL_03b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_03c2: stloc.s 10
+		IL_03c4: ldloc.s 10
+		IL_03c6: ldstr "main"
+		IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_03d0: stloc.3
+		IL_03d1: ldloc.0
+		IL_03d2: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_03d7: ldnull
+		IL_03d8: ldloc.1
+		IL_03d9: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_03de: pop
+		IL_03df: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -2745,7 +2743,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3149
+		// Method begins at RVA 0x3145
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -33,7 +33,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3294
+						// Method begins at RVA 0x3217
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x328b
+					// Method begins at RVA 0x320e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3282
+				// Method begins at RVA 0x3205
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,9 +101,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2634
+			// Method begins at RVA 0x2618
 			// Header size: 12
-			// Code size: 237 (0xed)
+			// Code size: 232 (0xe8)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -111,10 +111,9 @@
 				[2] object,
 				[3] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
 				[4] float64,
-				[5] float64,
-				[6] object[],
-				[7] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
-				[8] object
+				[5] object[],
+				[6] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve,
+				[7] object
 			)
 
 			IL_0000: ldarg.3
@@ -132,76 +131,71 @@
 			IL_002b: ldstr "now"
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_0035: stloc.1
-			IL_0036: ldarg.0
-			IL_0037: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-			IL_003c: stloc.s 4
-			IL_003e: ldarg.3
-			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0044: stloc.s 5
-			IL_0046: ldloc.s 5
-			IL_0048: ldloc.s 4
-			IL_004a: mul
-			IL_004b: stloc.s 4
-			IL_004d: ldloc.1
-			IL_004e: ldloc.s 4
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0055: stloc.2
-			// loop start (head: IL_0056)
-				IL_0056: nop
-				IL_0057: ldc.i4.1
-				IL_0058: newarr [System.Runtime]System.Object
-				IL_005d: dup
-				IL_005e: ldc.i4.0
-				IL_005f: ldarg.0
-				IL_0060: stelem.ref
-				IL_0061: stloc.s 6
-				IL_0063: ldloc.s 6
-				IL_0065: ldc.i4.1
-				IL_0066: newarr [System.Runtime]System.Object
-				IL_006b: dup
-				IL_006c: ldc.i4.0
-				IL_006d: ldarg.2
-				IL_006e: stelem.ref
-				IL_006f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-				IL_0074: ldarg.2
-				IL_0075: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
-				IL_007a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-				IL_007f: stloc.3
-				IL_0080: ldloc.3
-				IL_0081: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_0086: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_008b: ldstr "prototype"
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-				IL_0095: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-				IL_009a: ldloc.3
-				IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve>(!!0)
-				IL_00a0: stloc.s 7
-				IL_00a2: ldloc.s 7
-				IL_00a4: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
-				IL_00a9: pop
-				IL_00aa: ldloc.0
-				IL_00ab: ldc.r8 1
-				IL_00b4: add
-				IL_00b5: stloc.0
-				IL_00b6: ldarg.0
-				IL_00b7: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00c1: ldstr "now"
-				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_00cb: stloc.s 8
-				IL_00cd: ldloc.s 8
-				IL_00cf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d4: ldloc.2
-				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00da: clt
-				IL_00dc: brfalse IL_00e6
+			IL_0036: ldarg.3
+			IL_0037: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003c: ldc.r8 1000
+			IL_0045: mul
+			IL_0046: stloc.s 4
+			IL_0048: ldloc.1
+			IL_0049: ldloc.s 4
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0050: stloc.2
+			// loop start (head: IL_0051)
+				IL_0051: nop
+				IL_0052: ldc.i4.1
+				IL_0053: newarr [System.Runtime]System.Object
+				IL_0058: dup
+				IL_0059: ldc.i4.0
+				IL_005a: ldarg.0
+				IL_005b: stelem.ref
+				IL_005c: stloc.s 5
+				IL_005e: ldloc.s 5
+				IL_0060: ldc.i4.1
+				IL_0061: newarr [System.Runtime]System.Object
+				IL_0066: dup
+				IL_0067: ldc.i4.0
+				IL_0068: ldarg.2
+				IL_0069: stelem.ref
+				IL_006a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+				IL_006f: ldarg.2
+				IL_0070: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::.ctor(object[], object)
+				IL_0075: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+				IL_007a: stloc.3
+				IL_007b: ldloc.3
+				IL_007c: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0081: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+				IL_0086: ldstr "prototype"
+				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+				IL_0090: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+				IL_0095: ldloc.3
+				IL_0096: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve>(!!0)
+				IL_009b: stloc.s 6
+				IL_009d: ldloc.s 6
+				IL_009f: callvirt instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
+				IL_00a4: pop
+				IL_00a5: ldloc.0
+				IL_00a6: ldc.r8 1
+				IL_00af: add
+				IL_00b0: stloc.0
+				IL_00b1: ldarg.0
+				IL_00b2: ldfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00bc: ldstr "now"
+				IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00c6: stloc.s 7
+				IL_00c8: ldloc.s 7
+				IL_00ca: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00cf: ldloc.2
+				IL_00d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d5: clt
+				IL_00d7: brfalse IL_00e1
 
-				IL_00e1: br IL_0056
+				IL_00dc: br IL_0051
 			// end loop
 
-			IL_00e6: ldloc.0
-			IL_00e7: box [System.Runtime]System.Double
-			IL_00ec: ret
+			IL_00e1: ldloc.0
+			IL_00e2: box [System.Runtime]System.Double
+			IL_00e7: ret
 		} // end of method ArrowFunction_L213C23::__js_call__
 
 	} // end of class ArrowFunction_L213C23
@@ -232,7 +226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x329d
+				// Method begins at RVA 0x3220
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +253,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2730
+			// Method begins at RVA 0x270c
 			// Header size: 12
 			// Code size: 431 (0x1af)
 			.maxstack 8
@@ -434,7 +428,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3174
+				// Method begins at RVA 0x30f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -454,7 +448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x317d
+				// Method begins at RVA 0x3100
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -474,7 +468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3186
+				// Method begins at RVA 0x3109
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -502,7 +496,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a1
+						// Method begins at RVA 0x3124
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -526,7 +520,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x31b3
+							// Method begins at RVA 0x3136
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -544,7 +538,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31aa
+						// Method begins at RVA 0x312d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -562,7 +556,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3198
+					// Method begins at RVA 0x311b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -590,7 +584,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x31ce
+							// Method begins at RVA 0x3151
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -608,7 +602,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31c5
+						// Method begins at RVA 0x3148
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -626,7 +620,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31bc
+					// Method begins at RVA 0x313f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -650,7 +644,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31e0
+						// Method begins at RVA 0x3163
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -668,7 +662,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d7
+					// Method begins at RVA 0x315a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -686,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318f
+				// Method begins at RVA 0x3112
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -706,7 +700,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e9
+				// Method begins at RVA 0x316c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -730,7 +724,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31fb
+					// Method begins at RVA 0x317e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -748,7 +742,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f2
+				// Method begins at RVA 0x3175
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -770,15 +764,15 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor (
 				object[] scopes,
-				object size
+				float64 size
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2954
+			// Method begins at RVA 0x2930
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 63 (0x3f)
 			.maxstack 8
 			.locals init (
 				[0] object[],
@@ -795,28 +789,25 @@
 			IL_0009: ldloc.0
 			IL_000a: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::_scopes
 			IL_000f: ldarg.2
-			IL_0010: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0015: stloc.1
-			IL_0016: ldloc.1
-			IL_0017: conv.i4
-			IL_0018: conv.u4
-			IL_0019: ldc.r8 5
-			IL_0022: conv.i4
-			IL_0023: shr.un
-			IL_0024: conv.r.un
-			IL_0025: stloc.1
-			IL_0026: ldc.r8 1
-			IL_002f: ldloc.1
-			IL_0030: add
-			IL_0031: stloc.1
-			IL_0032: ldloc.1
-			IL_0033: box [System.Runtime]System.Double
-			IL_0038: stloc.2
-			IL_0039: ldarg.0
-			IL_003a: ldloc.2
-			IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-			IL_0040: stfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0045: ret
+			IL_0010: conv.i4
+			IL_0011: conv.u4
+			IL_0012: ldc.r8 5
+			IL_001b: conv.i4
+			IL_001c: shr.un
+			IL_001d: conv.r.un
+			IL_001e: stloc.1
+			IL_001f: ldc.r8 1
+			IL_0028: ldloc.1
+			IL_0029: add
+			IL_002a: stloc.1
+			IL_002b: ldloc.1
+			IL_002c: box [System.Runtime]System.Double
+			IL_0031: stloc.2
+			IL_0032: ldarg.0
+			IL_0033: ldloc.2
+			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_003e: ret
 		} // end of method BitArray::.ctor
 
 		.method public hidebysig 
@@ -827,7 +818,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bf4
+			// Method begins at RVA 0x2b9c
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -891,9 +882,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29f4
+			// Method begins at RVA 0x29b4
 			// Header size: 12
-			// Code size: 498 (0x1f2)
+			// Code size: 475 (0x1db)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -911,265 +902,256 @@
 				[12] float64
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::_scopes
-			IL_0006: ldc.i4.0
-			IL_0007: ldelem.ref
-			IL_0008: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-			IL_000d: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
-			IL_0012: ldc.r8 2
-			IL_001b: div
+			IL_0000: ldarg.2
+			IL_0001: ldc.r8 16
+			IL_000a: cgt
+			IL_000c: brfalse IL_0107
+
+			IL_0011: ldc.r8 32
+			IL_001a: ldarg.2
+			IL_001b: mul
 			IL_001c: stloc.s 12
-			IL_001e: ldarg.2
+			IL_001e: ldarg.1
 			IL_001f: ldloc.s 12
-			IL_0021: cgt
-			IL_0023: brfalse IL_011e
+			IL_0021: add
+			IL_0022: stloc.0
+			IL_0023: ldloc.0
+			IL_0024: stloc.s 12
+			IL_0026: ldloc.s 12
+			IL_0028: ldarg.3
+			IL_0029: cgt
+			IL_002b: brfalse IL_0056
 
-			IL_0028: ldc.r8 32
-			IL_0031: ldarg.2
-			IL_0032: mul
-			IL_0033: stloc.s 12
-			IL_0035: ldarg.1
-			IL_0036: ldloc.s 12
-			IL_0038: add
-			IL_0039: stloc.0
-			IL_003a: ldloc.0
-			IL_003b: stloc.s 12
-			IL_003d: ldloc.s 12
-			IL_003f: ldarg.3
-			IL_0040: cgt
-			IL_0042: brfalse IL_006d
+			IL_0030: ldarg.1
+			IL_0031: stloc.1
+			// loop start (head: IL_0032)
+				IL_0032: ldloc.1
+				IL_0033: stloc.s 12
+				IL_0035: ldloc.s 12
+				IL_0037: ldarg.3
+				IL_0038: clt
+				IL_003a: brfalse IL_0054
 
-			IL_0047: ldarg.1
-			IL_0048: stloc.1
-			// loop start (head: IL_0049)
-				IL_0049: ldloc.1
+				IL_003f: ldarg.0
+				IL_0040: ldloc.1
+				IL_0041: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+				IL_0046: pop
+				IL_0047: ldloc.1
+				IL_0048: ldarg.2
+				IL_0049: add
 				IL_004a: stloc.s 12
 				IL_004c: ldloc.s 12
-				IL_004e: ldarg.3
-				IL_004f: clt
-				IL_0051: brfalse IL_006b
-
-				IL_0056: ldarg.0
-				IL_0057: ldloc.1
-				IL_0058: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-				IL_005d: pop
-				IL_005e: ldloc.1
-				IL_005f: ldarg.2
-				IL_0060: add
-				IL_0061: stloc.s 12
-				IL_0063: ldloc.s 12
-				IL_0065: stloc.1
-				IL_0066: br IL_0049
+				IL_004e: stloc.1
+				IL_004f: br IL_0032
 			// end loop
 
-			IL_006b: ldnull
-			IL_006c: ret
+			IL_0054: ldnull
+			IL_0055: ret
 
-			IL_006d: ldarg.3
-			IL_006e: conv.i4
-			IL_006f: conv.u4
-			IL_0070: ldc.r8 5
-			IL_0079: conv.i4
-			IL_007a: shr.un
-			IL_007b: conv.r.un
-			IL_007c: stloc.2
-			IL_007d: ldarg.1
-			IL_007e: stloc.3
-			// loop start (head: IL_007f)
-				IL_007f: ldloc.3
-				IL_0080: stloc.s 12
-				IL_0082: ldloc.s 12
-				IL_0084: ldloc.0
-				IL_0085: clt
-				IL_0087: brfalse IL_011c
+			IL_0056: ldarg.3
+			IL_0057: conv.i4
+			IL_0058: conv.u4
+			IL_0059: ldc.r8 5
+			IL_0062: conv.i4
+			IL_0063: shr.un
+			IL_0064: conv.r.un
+			IL_0065: stloc.2
+			IL_0066: ldarg.1
+			IL_0067: stloc.3
+			// loop start (head: IL_0068)
+				IL_0068: ldloc.3
+				IL_0069: stloc.s 12
+				IL_006b: ldloc.s 12
+				IL_006d: ldloc.0
+				IL_006e: clt
+				IL_0070: brfalse IL_0105
 
-				IL_008c: ldloc.3
-				IL_008d: stloc.s 12
-				IL_008f: ldloc.s 12
-				IL_0091: conv.i4
-				IL_0092: conv.u4
-				IL_0093: ldc.r8 5
-				IL_009c: conv.i4
-				IL_009d: shr.un
-				IL_009e: conv.r.un
-				IL_009f: stloc.s 4
-				IL_00a1: ldloc.3
-				IL_00a2: stloc.s 12
-				IL_00a4: ldloc.s 12
-				IL_00a6: conv.i4
-				IL_00a7: ldc.r8 31
-				IL_00b0: conv.i4
-				IL_00b1: and
-				IL_00b2: conv.r8
-				IL_00b3: stloc.s 5
-				IL_00b5: ldc.r8 1
-				IL_00be: conv.i4
-				IL_00bf: ldloc.s 5
-				IL_00c1: conv.i4
-				IL_00c2: shl
-				IL_00c3: conv.r8
-				IL_00c4: stloc.s 6
-				// loop start (head: IL_00c6)
-					IL_00c6: nop
-					IL_00c7: ldarg.0
-					IL_00c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_00cd: ldloc.s 4
-					IL_00cf: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_00d4: stloc.s 12
-					IL_00d6: ldloc.s 12
-					IL_00d8: conv.i4
-					IL_00d9: ldloc.s 6
-					IL_00db: conv.i4
-					IL_00dc: or
-					IL_00dd: conv.r8
-					IL_00de: stloc.s 12
-					IL_00e0: ldarg.0
-					IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_00e6: ldloc.s 4
-					IL_00e8: ldloc.s 12
-					IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_00ef: ldloc.s 4
-					IL_00f1: ldarg.2
-					IL_00f2: add
-					IL_00f3: stloc.s 12
-					IL_00f5: ldloc.s 12
-					IL_00f7: stloc.s 4
-					IL_00f9: ldloc.s 4
-					IL_00fb: stloc.s 12
-					IL_00fd: ldloc.s 12
-					IL_00ff: ldloc.2
-					IL_0100: cgt
-					IL_0102: ldc.i4.0
-					IL_0103: ceq
-					IL_0105: brfalse IL_010f
+				IL_0075: ldloc.3
+				IL_0076: stloc.s 12
+				IL_0078: ldloc.s 12
+				IL_007a: conv.i4
+				IL_007b: conv.u4
+				IL_007c: ldc.r8 5
+				IL_0085: conv.i4
+				IL_0086: shr.un
+				IL_0087: conv.r.un
+				IL_0088: stloc.s 4
+				IL_008a: ldloc.3
+				IL_008b: stloc.s 12
+				IL_008d: ldloc.s 12
+				IL_008f: conv.i4
+				IL_0090: ldc.r8 31
+				IL_0099: conv.i4
+				IL_009a: and
+				IL_009b: conv.r8
+				IL_009c: stloc.s 5
+				IL_009e: ldc.r8 1
+				IL_00a7: conv.i4
+				IL_00a8: ldloc.s 5
+				IL_00aa: conv.i4
+				IL_00ab: shl
+				IL_00ac: conv.r8
+				IL_00ad: stloc.s 6
+				// loop start (head: IL_00af)
+					IL_00af: nop
+					IL_00b0: ldarg.0
+					IL_00b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00b6: ldloc.s 4
+					IL_00b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00bd: stloc.s 12
+					IL_00bf: ldloc.s 12
+					IL_00c1: conv.i4
+					IL_00c2: ldloc.s 6
+					IL_00c4: conv.i4
+					IL_00c5: or
+					IL_00c6: conv.r8
+					IL_00c7: stloc.s 12
+					IL_00c9: ldarg.0
+					IL_00ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00cf: ldloc.s 4
+					IL_00d1: ldloc.s 12
+					IL_00d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_00d8: ldloc.s 4
+					IL_00da: ldarg.2
+					IL_00db: add
+					IL_00dc: stloc.s 12
+					IL_00de: ldloc.s 12
+					IL_00e0: stloc.s 4
+					IL_00e2: ldloc.s 4
+					IL_00e4: stloc.s 12
+					IL_00e6: ldloc.s 12
+					IL_00e8: ldloc.2
+					IL_00e9: cgt
+					IL_00eb: ldc.i4.0
+					IL_00ec: ceq
+					IL_00ee: brfalse IL_00f8
 
-					IL_010a: br IL_00c6
+					IL_00f3: br IL_00af
 				// end loop
 
-				IL_010f: ldloc.3
-				IL_0110: ldarg.2
-				IL_0111: add
-				IL_0112: stloc.s 12
-				IL_0114: ldloc.s 12
-				IL_0116: stloc.3
-				IL_0117: br IL_007f
+				IL_00f8: ldloc.3
+				IL_00f9: ldarg.2
+				IL_00fa: add
+				IL_00fb: stloc.s 12
+				IL_00fd: ldloc.s 12
+				IL_00ff: stloc.3
+				IL_0100: br IL_0068
 			// end loop
 
-			IL_011c: ldnull
-			IL_011d: ret
+			IL_0105: ldnull
+			IL_0106: ret
 
-			IL_011e: ldarg.1
-			IL_011f: stloc.s 7
-			IL_0121: ldloc.s 7
-			IL_0123: stloc.s 12
-			IL_0125: ldloc.s 12
-			IL_0127: conv.i4
-			IL_0128: conv.u4
-			IL_0129: ldc.r8 5
-			IL_0132: conv.i4
-			IL_0133: shr.un
-			IL_0134: conv.r.un
-			IL_0135: stloc.s 8
-			IL_0137: ldarg.0
-			IL_0138: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_013d: ldloc.s 8
-			IL_013f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0144: stloc.s 9
-			// loop start (head: IL_0146)
-				IL_0146: ldloc.s 7
-				IL_0148: stloc.s 12
-				IL_014a: ldloc.s 12
-				IL_014c: ldarg.3
-				IL_014d: clt
-				IL_014f: brfalse IL_01e1
+			IL_0107: ldarg.1
+			IL_0108: stloc.s 7
+			IL_010a: ldloc.s 7
+			IL_010c: stloc.s 12
+			IL_010e: ldloc.s 12
+			IL_0110: conv.i4
+			IL_0111: conv.u4
+			IL_0112: ldc.r8 5
+			IL_011b: conv.i4
+			IL_011c: shr.un
+			IL_011d: conv.r.un
+			IL_011e: stloc.s 8
+			IL_0120: ldarg.0
+			IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0126: ldloc.s 8
+			IL_0128: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_012d: stloc.s 9
+			// loop start (head: IL_012f)
+				IL_012f: ldloc.s 7
+				IL_0131: stloc.s 12
+				IL_0133: ldloc.s 12
+				IL_0135: ldarg.3
+				IL_0136: clt
+				IL_0138: brfalse IL_01ca
 
-				IL_0154: ldloc.s 7
-				IL_0156: stloc.s 12
-				IL_0158: ldloc.s 12
-				IL_015a: conv.i4
-				IL_015b: ldc.r8 31
-				IL_0164: conv.i4
-				IL_0165: and
-				IL_0166: conv.r8
-				IL_0167: stloc.s 10
-				IL_0169: ldc.r8 1
-				IL_0172: conv.i4
-				IL_0173: ldloc.s 10
-				IL_0175: conv.i4
-				IL_0176: shl
-				IL_0177: conv.r8
-				IL_0178: stloc.s 12
-				IL_017a: ldloc.s 9
-				IL_017c: conv.i4
-				IL_017d: ldloc.s 12
-				IL_017f: conv.i4
-				IL_0180: or
-				IL_0181: conv.r8
-				IL_0182: stloc.s 12
-				IL_0184: ldloc.s 12
-				IL_0186: stloc.s 9
-				IL_0188: ldloc.s 7
-				IL_018a: ldarg.2
-				IL_018b: add
-				IL_018c: stloc.s 12
-				IL_018e: ldloc.s 12
-				IL_0190: stloc.s 7
-				IL_0192: ldloc.s 7
-				IL_0194: stloc.s 12
-				IL_0196: ldloc.s 12
-				IL_0198: conv.i4
-				IL_0199: conv.u4
-				IL_019a: ldc.r8 5
-				IL_01a3: conv.i4
-				IL_01a4: shr.un
-				IL_01a5: conv.r.un
-				IL_01a6: stloc.s 11
-				IL_01a8: ldloc.s 11
-				IL_01aa: ldloc.s 8
-				IL_01ac: ceq
-				IL_01ae: ldc.i4.0
-				IL_01af: ceq
-				IL_01b1: brfalse IL_01dc
+				IL_013d: ldloc.s 7
+				IL_013f: stloc.s 12
+				IL_0141: ldloc.s 12
+				IL_0143: conv.i4
+				IL_0144: ldc.r8 31
+				IL_014d: conv.i4
+				IL_014e: and
+				IL_014f: conv.r8
+				IL_0150: stloc.s 10
+				IL_0152: ldc.r8 1
+				IL_015b: conv.i4
+				IL_015c: ldloc.s 10
+				IL_015e: conv.i4
+				IL_015f: shl
+				IL_0160: conv.r8
+				IL_0161: stloc.s 12
+				IL_0163: ldloc.s 9
+				IL_0165: conv.i4
+				IL_0166: ldloc.s 12
+				IL_0168: conv.i4
+				IL_0169: or
+				IL_016a: conv.r8
+				IL_016b: stloc.s 12
+				IL_016d: ldloc.s 12
+				IL_016f: stloc.s 9
+				IL_0171: ldloc.s 7
+				IL_0173: ldarg.2
+				IL_0174: add
+				IL_0175: stloc.s 12
+				IL_0177: ldloc.s 12
+				IL_0179: stloc.s 7
+				IL_017b: ldloc.s 7
+				IL_017d: stloc.s 12
+				IL_017f: ldloc.s 12
+				IL_0181: conv.i4
+				IL_0182: conv.u4
+				IL_0183: ldc.r8 5
+				IL_018c: conv.i4
+				IL_018d: shr.un
+				IL_018e: conv.r.un
+				IL_018f: stloc.s 11
+				IL_0191: ldloc.s 11
+				IL_0193: ldloc.s 8
+				IL_0195: ceq
+				IL_0197: ldc.i4.0
+				IL_0198: ceq
+				IL_019a: brfalse IL_01c5
 
-				IL_01b6: ldarg.0
-				IL_01b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_01bc: ldloc.s 8
-				IL_01be: ldloc.s 9
-				IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_01c5: ldloc.s 11
-				IL_01c7: stloc.s 8
-				IL_01c9: ldarg.0
-				IL_01ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_01cf: ldloc.s 8
-				IL_01d1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_01d6: stloc.s 12
-				IL_01d8: ldloc.s 12
-				IL_01da: stloc.s 9
+				IL_019f: ldarg.0
+				IL_01a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01a5: ldloc.s 8
+				IL_01a7: ldloc.s 9
+				IL_01a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01ae: ldloc.s 11
+				IL_01b0: stloc.s 8
+				IL_01b2: ldarg.0
+				IL_01b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01b8: ldloc.s 8
+				IL_01ba: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_01bf: stloc.s 12
+				IL_01c1: ldloc.s 12
+				IL_01c3: stloc.s 9
 
-				IL_01dc: br IL_0146
+				IL_01c5: br IL_012f
 			// end loop
 
-			IL_01e1: ldarg.0
-			IL_01e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_01e7: ldloc.s 8
-			IL_01e9: ldloc.s 9
-			IL_01eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_01f0: ldnull
-			IL_01f1: ret
+			IL_01ca: ldarg.0
+			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_01d0: ldloc.s 8
+			IL_01d2: ldloc.s 9
+			IL_01d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_01d9: ldnull
+			IL_01da: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
 			instance float64 testBitTrue (
-				object index
+				float64 index
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c54
+			// Method begins at RVA 0x2bfc
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 68 (0x44)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1179,92 +1161,81 @@
 			)
 
 			IL_0000: ldarg.1
-			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0006: stloc.2
-			IL_0007: ldloc.2
-			IL_0008: conv.i4
-			IL_0009: conv.u4
-			IL_000a: ldc.r8 5
-			IL_0013: conv.i4
-			IL_0014: shr.un
-			IL_0015: conv.r.un
-			IL_0016: stloc.0
-			IL_0017: ldloc.2
-			IL_0018: conv.i4
-			IL_0019: ldc.r8 31
-			IL_0022: conv.i4
-			IL_0023: and
-			IL_0024: conv.r8
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_002c: ldloc.0
-			IL_002d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0032: stloc.2
-			IL_0033: ldc.r8 1
+			IL_0001: conv.i4
+			IL_0002: conv.u4
+			IL_0003: ldc.r8 5
+			IL_000c: conv.i4
+			IL_000d: shr.un
+			IL_000e: conv.r.un
+			IL_000f: stloc.0
+			IL_0010: ldarg.1
+			IL_0011: conv.i4
+			IL_0012: ldc.r8 31
+			IL_001b: conv.i4
+			IL_001c: and
+			IL_001d: conv.r8
+			IL_001e: stloc.1
+			IL_001f: ldarg.0
+			IL_0020: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0025: ldloc.0
+			IL_0026: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_002b: stloc.2
+			IL_002c: ldc.r8 1
+			IL_0035: conv.i4
+			IL_0036: ldloc.1
+			IL_0037: conv.i4
+			IL_0038: shl
+			IL_0039: conv.r8
+			IL_003a: stloc.3
+			IL_003b: ldloc.2
 			IL_003c: conv.i4
-			IL_003d: ldloc.1
+			IL_003d: ldloc.3
 			IL_003e: conv.i4
-			IL_003f: shl
+			IL_003f: and
 			IL_0040: conv.r8
 			IL_0041: stloc.3
-			IL_0042: ldloc.2
-			IL_0043: conv.i4
-			IL_0044: ldloc.3
-			IL_0045: conv.i4
-			IL_0046: and
-			IL_0047: conv.r8
-			IL_0048: stloc.3
-			IL_0049: ldloc.3
-			IL_004a: ret
+			IL_0042: ldloc.3
+			IL_0043: ret
 		} // end of method BitArray::testBitTrue
 
 		.method public hidebysig 
 			instance float64 searchBitFalse (
-				object index
+				float64 index
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a8
+			// Method begins at RVA 0x297c
 			// Header size: 12
-			// Code size: 61 (0x3d)
+			// Code size: 42 (0x2a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] bool,
-				[2] object
+				[1] bool
 			)
 
 			// loop start
 				IL_0000: ldarg.0
 				IL_0001: ldarg.1
-				IL_0002: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(object)
+				IL_0002: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
 				IL_0007: stloc.0
 				IL_0008: ldloc.0
 				IL_0009: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
 				IL_000e: stloc.1
 				IL_000f: ldloc.1
-				IL_0010: brfalse IL_0035
+				IL_0010: brfalse IL_0027
 
 				IL_0015: ldarg.1
-				IL_0016: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_001b: ldc.r8 1
-				IL_0024: add
-				IL_0025: stloc.0
-				IL_0026: ldloc.0
-				IL_0027: box [System.Runtime]System.Double
-				IL_002c: stloc.2
-				IL_002d: ldloc.2
-				IL_002e: starg.s index
-				IL_0030: br IL_0000
+				IL_0016: ldc.r8 1
+				IL_001f: add
+				IL_0020: starg.s index
+				IL_0022: br IL_0000
 			// end loop
 
-			IL_0035: nop
-			IL_0036: ldarg.1
-			IL_0037: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_003c: ret
+			IL_0027: nop
+			IL_0028: ldarg.1
+			IL_0029: ret
 		} // end of method BitArray::searchBitFalse
 
 	} // end of class BitArray
@@ -1280,7 +1251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3204
+				// Method begins at RVA 0x3187
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1300,7 +1271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x320d
+				// Method begins at RVA 0x3190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1324,7 +1295,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321f
+					// Method begins at RVA 0x31a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1342,7 +1313,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3216
+				// Method begins at RVA 0x3199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1362,7 +1333,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3228
+				// Method begins at RVA 0x31ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1390,7 +1361,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3243
+						// Method begins at RVA 0x31c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1408,7 +1379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x323a
+					// Method begins at RVA 0x31bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1426,7 +1397,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3231
+				// Method begins at RVA 0x31b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1450,7 +1421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3255
+					// Method begins at RVA 0x31d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1474,7 +1445,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3267
+						// Method begins at RVA 0x31ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1492,7 +1463,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x325e
+					// Method begins at RVA 0x31e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1510,7 +1481,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x324c
+				// Method begins at RVA 0x31cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1534,7 +1505,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3279
+					// Method begins at RVA 0x31fc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1552,7 +1523,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3270
+				// Method begins at RVA 0x31f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1582,7 +1553,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28ec
+			// Method begins at RVA 0x28c8
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -1629,8 +1600,8 @@
 			IL_004d: stloc.2
 			IL_004e: ldarg.0
 			IL_004f: ldloc.0
-			IL_0050: ldloc.2
-			IL_0051: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::.ctor(object[], object)
+			IL_0050: ldloc.1
+			IL_0051: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::.ctor(object[], float64)
 			IL_0056: stfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
 			IL_005b: ret
 		} // end of method PrimeSieve::.ctor
@@ -1641,9 +1612,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cac
+			// Method begins at RVA 0x2c4c
 			// Header size: 12
-			// Code size: 177 (0xb1)
+			// Code size: 168 (0xa8)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1651,8 +1622,7 @@
 				[2] float64,
 				[3] float64,
 				[4] float64,
-				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
-				[6] object
+				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
 			)
 
 			IL_0000: ldarg.0
@@ -1668,7 +1638,7 @@
 				IL_001e: ldloc.s 4
 				IL_0020: ldloc.0
 				IL_0021: clt
-				IL_0023: brfalse IL_00af
+				IL_0023: brfalse IL_00a6
 
 				IL_0028: ldloc.1
 				IL_0029: stloc.s 4
@@ -1711,20 +1681,17 @@
 				IL_0087: ldc.r8 1
 				IL_0090: add
 				IL_0091: stloc.s 4
-				IL_0093: ldloc.s 4
-				IL_0095: box [System.Runtime]System.Double
-				IL_009a: stloc.s 6
-				IL_009c: ldloc.s 5
-				IL_009e: ldloc.s 6
-				IL_00a0: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(object)
-				IL_00a5: stloc.s 4
-				IL_00a7: ldloc.s 4
-				IL_00a9: stloc.1
-				IL_00aa: br IL_001b
+				IL_0093: ldloc.s 5
+				IL_0095: ldloc.s 4
+				IL_0097: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(float64)
+				IL_009c: stloc.s 4
+				IL_009e: ldloc.s 4
+				IL_00a0: stloc.1
+				IL_00a1: br IL_001b
 			// end loop
 
-			IL_00af: ldarg.0
-			IL_00b0: ret
+			IL_00a6: ldarg.0
+			IL_00a7: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
@@ -1733,17 +1700,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ffc
+			// Method begins at RVA 0x2f90
 			// Header size: 12
-			// Code size: 114 (0x72)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] float64,
 				[3] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
-				[4] object,
-				[5] bool
+				[4] bool
 			)
 
 			IL_0000: ldc.r8 1
@@ -1757,41 +1723,38 @@
 				IL_0017: ldarg.0
 				IL_0018: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
 				IL_001d: clt
-				IL_001f: brfalse IL_0070
+				IL_001f: brfalse IL_0067
 
 				IL_0024: ldarg.0
 				IL_0025: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
 				IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
 				IL_002f: stloc.3
-				IL_0030: ldloc.1
-				IL_0031: box [System.Runtime]System.Double
-				IL_0036: stloc.s 4
-				IL_0038: ldloc.3
-				IL_0039: ldloc.s 4
-				IL_003b: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(object)
-				IL_0040: stloc.2
-				IL_0041: ldloc.2
-				IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
-				IL_0047: ldc.i4.0
-				IL_0048: ceq
-				IL_004a: stloc.s 5
-				IL_004c: ldloc.s 5
-				IL_004e: brfalse IL_005f
+				IL_0030: ldloc.3
+				IL_0031: ldloc.1
+				IL_0032: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
+				IL_0037: stloc.2
+				IL_0038: ldloc.2
+				IL_0039: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
+				IL_003e: ldc.i4.0
+				IL_003f: ceq
+				IL_0041: stloc.s 4
+				IL_0043: ldloc.s 4
+				IL_0045: brfalse IL_0056
 
-				IL_0053: ldloc.0
-				IL_0054: ldc.r8 1
-				IL_005d: add
-				IL_005e: stloc.0
+				IL_004a: ldloc.0
+				IL_004b: ldc.r8 1
+				IL_0054: add
+				IL_0055: stloc.0
 
-				IL_005f: ldloc.1
-				IL_0060: ldc.r8 1
-				IL_0069: add
-				IL_006a: stloc.1
-				IL_006b: br IL_0014
+				IL_0056: ldloc.1
+				IL_0057: ldc.r8 1
+				IL_0060: add
+				IL_0061: stloc.1
+				IL_0062: br IL_0014
 			// end loop
 
-			IL_0070: ldloc.0
-			IL_0071: ret
+			IL_0067: ldloc.0
+			IL_0068: ret
 		} // end of method PrimeSieve::countPrimes
 
 		.method public hidebysig 
@@ -1802,9 +1765,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x307c
+			// Method begins at RVA 0x3008
 			// Header size: 12
-			// Code size: 227 (0xe3)
+			// Code size: 218 (0xda)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1813,8 +1776,8 @@
 				[3] float64,
 				[4] float64,
 				[5] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray,
-				[6] object,
-				[7] bool
+				[6] bool,
+				[7] object
 			)
 
 			IL_0000: ldarg.1
@@ -1841,7 +1804,7 @@
 				IL_0043: ldarg.0
 				IL_0044: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
 				IL_0049: clt
-				IL_004b: brfalse IL_00e1
+				IL_004b: brfalse IL_00d8
 
 				IL_0050: ldloc.2
 				IL_0051: stloc.3
@@ -1855,54 +1818,51 @@
 				IL_0060: ceq
 				IL_0062: brfalse IL_006c
 
-				IL_0067: br IL_00e1
+				IL_0067: br IL_00d8
 
 				IL_006c: ldarg.0
 				IL_006d: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
 				IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray>(!!0)
 				IL_0077: stloc.s 5
-				IL_0079: ldloc.1
-				IL_007a: box [System.Runtime]System.Double
-				IL_007f: stloc.s 6
-				IL_0081: ldloc.s 5
-				IL_0083: ldloc.s 6
-				IL_0085: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(object)
-				IL_008a: stloc.s 4
-				IL_008c: ldloc.s 4
-				IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
-				IL_0093: ldc.i4.0
-				IL_0094: ceq
-				IL_0096: stloc.s 7
-				IL_0098: ldloc.s 7
-				IL_009a: brfalse IL_00d0
+				IL_0079: ldloc.s 5
+				IL_007b: ldloc.1
+				IL_007c: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
+				IL_0081: stloc.s 4
+				IL_0083: ldloc.s 4
+				IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(float64)
+				IL_008a: ldc.i4.0
+				IL_008b: ceq
+				IL_008d: stloc.s 6
+				IL_008f: ldloc.s 6
+				IL_0091: brfalse IL_00c7
 
-				IL_009f: ldloc.1
-				IL_00a0: stloc.s 4
-				IL_00a2: ldloc.s 4
-				IL_00a4: ldc.r8 2
-				IL_00ad: mul
-				IL_00ae: ldc.r8 1
-				IL_00b7: add
-				IL_00b8: stloc.s 4
-				IL_00ba: ldloc.s 4
-				IL_00bc: box [System.Runtime]System.Double
-				IL_00c1: stloc.s 6
-				IL_00c3: ldloc.0
-				IL_00c4: ldloc.s 6
-				IL_00c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00cb: stloc.s 4
-				IL_00cd: ldloc.s 4
-				IL_00cf: stloc.2
+				IL_0096: ldloc.1
+				IL_0097: stloc.s 4
+				IL_0099: ldloc.s 4
+				IL_009b: ldc.r8 2
+				IL_00a4: mul
+				IL_00a5: ldc.r8 1
+				IL_00ae: add
+				IL_00af: stloc.s 4
+				IL_00b1: ldloc.s 4
+				IL_00b3: box [System.Runtime]System.Double
+				IL_00b8: stloc.s 7
+				IL_00ba: ldloc.0
+				IL_00bb: ldloc.s 7
+				IL_00bd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00c2: stloc.s 4
+				IL_00c4: ldloc.s 4
+				IL_00c6: stloc.2
 
-				IL_00d0: ldloc.1
-				IL_00d1: ldc.r8 1
-				IL_00da: add
-				IL_00db: stloc.1
-				IL_00dc: br IL_0040
+				IL_00c7: ldloc.1
+				IL_00c8: ldc.r8 1
+				IL_00d1: add
+				IL_00d2: stloc.1
+				IL_00d3: br IL_0040
 			// end loop
 
-			IL_00e1: ldloc.0
-			IL_00e2: ret
+			IL_00d8: ldloc.0
+			IL_00d9: ret
 		} // end of method PrimeSieve::getPrimes
 
 		.method public hidebysig 
@@ -1913,7 +1873,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d6c
+			// Method begins at RVA 0x2d00
 			// Header size: 12
 			// Code size: 643 (0x283)
 			.maxstack 8
@@ -2126,20 +2086,14 @@
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 80 91 53 63 6f 70 65 20 4e 4f 57 5f 55 4e
-			49 54 53 5f 50 45 52 5f 53 45 43 4f 4e 44 3d 7b
-			4e 4f 57 5f 55 4e 49 54 53 5f 50 45 52 5f 53 45
-			43 4f 4e 44 7d 2c 20 57 4f 52 44 5f 53 49 5a 45
-			3d 7b 57 4f 52 44 5f 53 49 5a 45 7d 2c 20 70 65
-			72 66 6f 72 6d 61 6e 63 65 3d 7b 70 65 72 66 6f
-			72 6d 61 6e 63 65 7d 2c 20 42 69 74 41 72 72 61
-			79 3d 7b 42 69 74 41 72 72 61 79 7d 2c 20 50 72
-			69 6d 65 53 69 65 76 65 3d 7b 50 72 69 6d 65 53
-			69 65 76 65 7d 00 00
+			01 00 4d 53 63 6f 70 65 20 70 65 72 66 6f 72 6d
+			61 6e 63 65 3d 7b 70 65 72 66 6f 72 6d 61 6e 63
+			65 7d 2c 20 42 69 74 41 72 72 61 79 3d 7b 42 69
+			74 41 72 72 61 79 7d 2c 20 50 72 69 6d 65 53 69
+			65 76 65 3d 7b 50 72 69 6d 65 53 69 65 76 65 7d
+			00 00
 		)
 		// Fields
-		.field public float64 NOW_UNITS_PER_SECOND
-		.field public float64 WORD_SIZE
 		.field public object performance
 		.field public object BitArray
 		.field public object PrimeSieve
@@ -2148,7 +2102,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x316b
+			// Method begins at RVA 0x30ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2178,7 +2132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32a6
+				// Method begins at RVA 0x3229
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2191,7 +2145,7 @@
 			.method public hidebysig 
 				instance float64 get_sieveSize () cil managed 
 			{
-				// Method begins at RVA 0x32ae
+				// Method begins at RVA 0x3231
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2206,7 +2160,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x32b6
+				// Method begins at RVA 0x3239
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2224,7 +2178,7 @@
 			.method public hidebysig 
 				instance float64 get_timeLimitSeconds () cil managed 
 			{
-				// Method begins at RVA 0x32cb
+				// Method begins at RVA 0x324e
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2239,7 +2193,7 @@
 					float64 ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x32d3
+				// Method begins at RVA 0x3256
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2257,7 +2211,7 @@
 			.method public hidebysig 
 				instance object get_verbose () cil managed 
 			{
-				// Method begins at RVA 0x32e8
+				// Method begins at RVA 0x326b
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2272,7 +2226,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x32f0
+				// Method begins at RVA 0x3273
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2290,7 +2244,7 @@
 			.method public hidebysig 
 				instance object get_runtime () cil managed 
 			{
-				// Method begins at RVA 0x3305
+				// Method begins at RVA 0x3288
 				// Header size: 1
 				// Code size: 7 (0x7)
 				.maxstack 8
@@ -2305,7 +2259,7 @@
 					object ''
 				) cil managed 
 			{
-				// Method begins at RVA 0x330d
+				// Method begins at RVA 0x3290
 				// Header size: 1
 				// Code size: 20 (0x14)
 				.maxstack 8
@@ -2338,7 +2292,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1496 (0x5d8)
+		// Code size: 1468 (0x5bc)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -2358,608 +2312,604 @@
 		IL_0000: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldc.r8 1000
-		IL_0011: stfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::NOW_UNITS_PER_SECOND
-		IL_0016: ldloc.0
-		IL_0017: ldc.r8 32
-		IL_0020: stfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::WORD_SIZE
-		IL_0025: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::.ctor()
-		IL_002a: stloc.1
-		IL_002b: ldloc.1
-		IL_002c: ldc.r8 1000
-		IL_0035: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_sieveSize(float64)
-		IL_003a: ldloc.1
-		IL_003b: ldc.r8 5
-		IL_0044: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_timeLimitSeconds(float64)
-		IL_0049: ldloc.1
-		IL_004a: ldc.i4.0
-		IL_004b: box [System.Runtime]System.Boolean
-		IL_0050: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_0055: ldloc.1
-		IL_0056: ldstr ""
-		IL_005b: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
-		IL_0060: ldarg.1
-		IL_0061: ldstr "perf_hooks"
-		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_006b: stloc.s 5
-		IL_006d: ldloc.s 5
-		IL_006f: brfalse IL_0080
+		IL_0007: nop
+		IL_0008: nop
+		IL_0009: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::.ctor()
+		IL_000e: stloc.1
+		IL_000f: ldloc.1
+		IL_0010: ldc.r8 1000
+		IL_0019: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_sieveSize(float64)
+		IL_001e: ldloc.1
+		IL_001f: ldc.r8 5
+		IL_0028: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_timeLimitSeconds(float64)
+		IL_002d: ldloc.1
+		IL_002e: ldc.i4.0
+		IL_002f: box [System.Runtime]System.Boolean
+		IL_0034: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_0039: ldloc.1
+		IL_003a: ldstr ""
+		IL_003f: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
+		IL_0044: ldarg.1
+		IL_0045: ldstr "perf_hooks"
+		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_004f: stloc.s 5
+		IL_0051: ldloc.s 5
+		IL_0053: brfalse IL_0064
 
-		IL_0074: ldloc.s 5
-		IL_0076: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_007b: brfalse IL_0091
+		IL_0058: ldloc.s 5
+		IL_005a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_005f: brfalse IL_0075
 
-		IL_0080: ldloc.s 5
-		IL_0082: ldstr ""
-		IL_0087: ldstr "performance"
-		IL_008c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0064: ldloc.s 5
+		IL_0066: ldstr ""
+		IL_006b: ldstr "performance"
+		IL_0070: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0091: ldloc.s 5
-		IL_0093: ldstr "performance"
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009d: stloc.s 5
-		IL_009f: ldloc.0
-		IL_00a0: ldloc.s 5
-		IL_00a2: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-		IL_00a7: ldstr "process"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b1: ldstr "argv"
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bb: stloc.s 5
-		IL_00bd: ldloc.s 5
-		IL_00bf: ldc.r8 0.0
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00cd: stloc.s 5
-		IL_00cf: ldloc.s 5
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d6: stloc.s 5
-		IL_00d8: ldstr "[\\\\/]"
-		IL_00dd: ldstr ""
-		IL_00e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e7: stloc.s 6
+		IL_0075: ldloc.s 5
+		IL_0077: ldstr "performance"
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0081: stloc.s 5
+		IL_0083: ldloc.0
+		IL_0084: ldloc.s 5
+		IL_0086: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+		IL_008b: ldstr "process"
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0095: ldstr "argv"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009f: stloc.s 5
+		IL_00a1: ldloc.s 5
+		IL_00a3: ldc.r8 0.0
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00b1: stloc.s 5
+		IL_00b3: ldloc.s 5
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ba: stloc.s 5
+		IL_00bc: ldstr "[\\\\/]"
+		IL_00c1: ldstr ""
+		IL_00c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00cb: stloc.s 6
+		IL_00cd: ldloc.s 5
+		IL_00cf: ldstr "split"
+		IL_00d4: ldloc.s 6
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00db: stloc.2
+		IL_00dc: ldloc.2
+		IL_00dd: ldstr "length"
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e7: stloc.s 5
 		IL_00e9: ldloc.s 5
-		IL_00eb: ldstr "split"
-		IL_00f0: ldloc.s 6
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f7: stloc.2
-		IL_00f8: ldloc.2
-		IL_00f9: ldstr "length"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0103: stloc.s 5
-		IL_0105: ldloc.s 5
-		IL_0107: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_010c: ldc.r8 1
-		IL_0115: sub
-		IL_0116: stloc.s 7
-		IL_0118: ldloc.2
-		IL_0119: ldloc.s 7
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0120: stloc.s 5
-		IL_0122: ldloc.1
-		IL_0123: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_0128: ldloc.s 5
-		IL_012a: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
-		IL_012f: ldstr "process"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0139: ldstr "argv"
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0143: stloc.s 5
-		IL_0145: ldloc.s 5
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: ldstr "includes"
-		IL_0151: ldstr "verbose"
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: stloc.s 5
-		IL_015d: ldloc.1
-		IL_015e: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_0163: ldloc.s 5
-		IL_0165: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_016a: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_016f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0174: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0179: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017e: stloc.s 8
-		IL_0180: ldc.i4.1
-		IL_0181: newarr [System.Runtime]System.Object
-		IL_0186: dup
-		IL_0187: ldc.i4.0
-		IL_0188: ldloc.0
-		IL_0189: stelem.ref
-		IL_018a: stloc.s 9
-		IL_018c: ldc.i4.s 10
-		IL_018e: newarr [System.Runtime]System.Object
-		IL_0193: dup
-		IL_0194: ldc.i4.0
-		IL_0195: ldloc.s 8
-		IL_0197: stelem.ref
-		IL_0198: dup
-		IL_0199: ldc.i4.1
-		IL_019a: ldstr "setBitTrue"
-		IL_019f: stelem.ref
-		IL_01a0: dup
-		IL_01a1: ldc.i4.2
-		IL_01a2: ldstr "setBitTrue"
-		IL_01a7: stelem.ref
-		IL_01a8: dup
-		IL_01a9: ldc.i4.3
-		IL_01aa: ldc.r8 1
-		IL_01b3: box [System.Runtime]System.Double
-		IL_01b8: stelem.ref
-		IL_01b9: dup
-		IL_01ba: ldc.i4.4
-		IL_01bb: ldstr "setBitTrue"
-		IL_01c0: stelem.ref
-		IL_01c1: dup
-		IL_01c2: ldc.i4.5
-		IL_01c3: ldc.i4.0
-		IL_01c4: box [System.Runtime]System.Boolean
-		IL_01c9: stelem.ref
-		IL_01ca: dup
-		IL_01cb: ldc.i4.6
-		IL_01cc: ldc.i4.0
-		IL_01cd: box [System.Runtime]System.Boolean
-		IL_01d2: stelem.ref
-		IL_01d3: dup
-		IL_01d4: ldc.i4.7
-		IL_01d5: ldc.i4.0
-		IL_01d6: box [System.Runtime]System.Boolean
-		IL_01db: stelem.ref
+		IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00f0: ldc.r8 1
+		IL_00f9: sub
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.2
+		IL_00fd: ldloc.s 7
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0104: stloc.s 5
+		IL_0106: ldloc.1
+		IL_0107: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_010c: ldloc.s 5
+		IL_010e: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
+		IL_0113: ldstr "process"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011d: ldstr "argv"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0127: stloc.s 5
+		IL_0129: ldloc.s 5
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: ldstr "includes"
+		IL_0135: ldstr "verbose"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013f: stloc.s 5
+		IL_0141: ldloc.1
+		IL_0142: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_0147: ldloc.s 5
+		IL_0149: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_014e: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0153: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0158: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_015d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0162: stloc.s 8
+		IL_0164: ldc.i4.1
+		IL_0165: newarr [System.Runtime]System.Object
+		IL_016a: dup
+		IL_016b: ldc.i4.0
+		IL_016c: ldloc.0
+		IL_016d: stelem.ref
+		IL_016e: stloc.s 9
+		IL_0170: ldc.i4.s 10
+		IL_0172: newarr [System.Runtime]System.Object
+		IL_0177: dup
+		IL_0178: ldc.i4.0
+		IL_0179: ldloc.s 8
+		IL_017b: stelem.ref
+		IL_017c: dup
+		IL_017d: ldc.i4.1
+		IL_017e: ldstr "setBitTrue"
+		IL_0183: stelem.ref
+		IL_0184: dup
+		IL_0185: ldc.i4.2
+		IL_0186: ldstr "setBitTrue"
+		IL_018b: stelem.ref
+		IL_018c: dup
+		IL_018d: ldc.i4.3
+		IL_018e: ldc.r8 1
+		IL_0197: box [System.Runtime]System.Double
+		IL_019c: stelem.ref
+		IL_019d: dup
+		IL_019e: ldc.i4.4
+		IL_019f: ldstr "setBitTrue"
+		IL_01a4: stelem.ref
+		IL_01a5: dup
+		IL_01a6: ldc.i4.5
+		IL_01a7: ldc.i4.0
+		IL_01a8: box [System.Runtime]System.Boolean
+		IL_01ad: stelem.ref
+		IL_01ae: dup
+		IL_01af: ldc.i4.6
+		IL_01b0: ldc.i4.0
+		IL_01b1: box [System.Runtime]System.Boolean
+		IL_01b6: stelem.ref
+		IL_01b7: dup
+		IL_01b8: ldc.i4.7
+		IL_01b9: ldc.i4.0
+		IL_01ba: box [System.Runtime]System.Boolean
+		IL_01bf: stelem.ref
+		IL_01c0: dup
+		IL_01c1: ldc.i4.8
+		IL_01c2: ldc.i4.0
+		IL_01c3: box [System.Runtime]System.Boolean
+		IL_01c8: stelem.ref
+		IL_01c9: dup
+		IL_01ca: ldc.i4.s 9
+		IL_01cc: ldloc.s 9
+		IL_01ce: stelem.ref
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01d4: pop
+		IL_01d5: ldc.i4.s 10
+		IL_01d7: newarr [System.Runtime]System.Object
 		IL_01dc: dup
-		IL_01dd: ldc.i4.8
-		IL_01de: ldc.i4.0
-		IL_01df: box [System.Runtime]System.Boolean
-		IL_01e4: stelem.ref
-		IL_01e5: dup
-		IL_01e6: ldc.i4.s 9
-		IL_01e8: ldloc.s 9
-		IL_01ea: stelem.ref
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01f0: pop
-		IL_01f1: ldc.i4.s 10
-		IL_01f3: newarr [System.Runtime]System.Object
-		IL_01f8: dup
-		IL_01f9: ldc.i4.0
-		IL_01fa: ldloc.s 8
-		IL_01fc: stelem.ref
-		IL_01fd: dup
-		IL_01fe: ldc.i4.1
-		IL_01ff: ldstr "setBitsTrue"
-		IL_0204: stelem.ref
-		IL_0205: dup
-		IL_0206: ldc.i4.2
-		IL_0207: ldstr "setBitsTrue"
-		IL_020c: stelem.ref
-		IL_020d: dup
-		IL_020e: ldc.i4.3
-		IL_020f: ldc.r8 3
-		IL_0218: box [System.Runtime]System.Double
-		IL_021d: stelem.ref
-		IL_021e: dup
-		IL_021f: ldc.i4.4
-		IL_0220: ldstr "setBitsTrue"
-		IL_0225: stelem.ref
-		IL_0226: dup
-		IL_0227: ldc.i4.5
-		IL_0228: ldc.i4.0
-		IL_0229: box [System.Runtime]System.Boolean
-		IL_022e: stelem.ref
-		IL_022f: dup
-		IL_0230: ldc.i4.6
-		IL_0231: ldc.i4.0
-		IL_0232: box [System.Runtime]System.Boolean
-		IL_0237: stelem.ref
-		IL_0238: dup
-		IL_0239: ldc.i4.7
-		IL_023a: ldc.i4.0
-		IL_023b: box [System.Runtime]System.Boolean
-		IL_0240: stelem.ref
+		IL_01dd: ldc.i4.0
+		IL_01de: ldloc.s 8
+		IL_01e0: stelem.ref
+		IL_01e1: dup
+		IL_01e2: ldc.i4.1
+		IL_01e3: ldstr "setBitsTrue"
+		IL_01e8: stelem.ref
+		IL_01e9: dup
+		IL_01ea: ldc.i4.2
+		IL_01eb: ldstr "setBitsTrue"
+		IL_01f0: stelem.ref
+		IL_01f1: dup
+		IL_01f2: ldc.i4.3
+		IL_01f3: ldc.r8 3
+		IL_01fc: box [System.Runtime]System.Double
+		IL_0201: stelem.ref
+		IL_0202: dup
+		IL_0203: ldc.i4.4
+		IL_0204: ldstr "setBitsTrue"
+		IL_0209: stelem.ref
+		IL_020a: dup
+		IL_020b: ldc.i4.5
+		IL_020c: ldc.i4.0
+		IL_020d: box [System.Runtime]System.Boolean
+		IL_0212: stelem.ref
+		IL_0213: dup
+		IL_0214: ldc.i4.6
+		IL_0215: ldc.i4.0
+		IL_0216: box [System.Runtime]System.Boolean
+		IL_021b: stelem.ref
+		IL_021c: dup
+		IL_021d: ldc.i4.7
+		IL_021e: ldc.i4.0
+		IL_021f: box [System.Runtime]System.Boolean
+		IL_0224: stelem.ref
+		IL_0225: dup
+		IL_0226: ldc.i4.8
+		IL_0227: ldc.i4.0
+		IL_0228: box [System.Runtime]System.Boolean
+		IL_022d: stelem.ref
+		IL_022e: dup
+		IL_022f: ldc.i4.s 9
+		IL_0231: ldloc.s 9
+		IL_0233: stelem.ref
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0239: pop
+		IL_023a: ldc.i4.s 10
+		IL_023c: newarr [System.Runtime]System.Object
 		IL_0241: dup
-		IL_0242: ldc.i4.8
-		IL_0243: ldc.i4.0
-		IL_0244: box [System.Runtime]System.Boolean
-		IL_0249: stelem.ref
-		IL_024a: dup
-		IL_024b: ldc.i4.s 9
-		IL_024d: ldloc.s 9
-		IL_024f: stelem.ref
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0255: pop
-		IL_0256: ldc.i4.s 10
-		IL_0258: newarr [System.Runtime]System.Object
-		IL_025d: dup
-		IL_025e: ldc.i4.0
-		IL_025f: ldloc.s 8
-		IL_0261: stelem.ref
-		IL_0262: dup
-		IL_0263: ldc.i4.1
-		IL_0264: ldstr "testBitTrue"
-		IL_0269: stelem.ref
-		IL_026a: dup
-		IL_026b: ldc.i4.2
-		IL_026c: ldstr "testBitTrue"
-		IL_0271: stelem.ref
-		IL_0272: dup
-		IL_0273: ldc.i4.3
-		IL_0274: ldc.r8 1
-		IL_027d: box [System.Runtime]System.Double
-		IL_0282: stelem.ref
-		IL_0283: dup
-		IL_0284: ldc.i4.4
-		IL_0285: ldstr "testBitTrue"
-		IL_028a: stelem.ref
-		IL_028b: dup
-		IL_028c: ldc.i4.5
-		IL_028d: ldc.i4.0
-		IL_028e: box [System.Runtime]System.Boolean
-		IL_0293: stelem.ref
-		IL_0294: dup
-		IL_0295: ldc.i4.6
-		IL_0296: ldc.i4.0
-		IL_0297: box [System.Runtime]System.Boolean
-		IL_029c: stelem.ref
-		IL_029d: dup
-		IL_029e: ldc.i4.7
-		IL_029f: ldc.i4.0
-		IL_02a0: box [System.Runtime]System.Boolean
-		IL_02a5: stelem.ref
+		IL_0242: ldc.i4.0
+		IL_0243: ldloc.s 8
+		IL_0245: stelem.ref
+		IL_0246: dup
+		IL_0247: ldc.i4.1
+		IL_0248: ldstr "testBitTrue"
+		IL_024d: stelem.ref
+		IL_024e: dup
+		IL_024f: ldc.i4.2
+		IL_0250: ldstr "testBitTrue"
+		IL_0255: stelem.ref
+		IL_0256: dup
+		IL_0257: ldc.i4.3
+		IL_0258: ldc.r8 1
+		IL_0261: box [System.Runtime]System.Double
+		IL_0266: stelem.ref
+		IL_0267: dup
+		IL_0268: ldc.i4.4
+		IL_0269: ldstr "testBitTrue"
+		IL_026e: stelem.ref
+		IL_026f: dup
+		IL_0270: ldc.i4.5
+		IL_0271: ldc.i4.0
+		IL_0272: box [System.Runtime]System.Boolean
+		IL_0277: stelem.ref
+		IL_0278: dup
+		IL_0279: ldc.i4.6
+		IL_027a: ldc.i4.0
+		IL_027b: box [System.Runtime]System.Boolean
+		IL_0280: stelem.ref
+		IL_0281: dup
+		IL_0282: ldc.i4.7
+		IL_0283: ldc.i4.0
+		IL_0284: box [System.Runtime]System.Boolean
+		IL_0289: stelem.ref
+		IL_028a: dup
+		IL_028b: ldc.i4.8
+		IL_028c: ldc.i4.0
+		IL_028d: box [System.Runtime]System.Boolean
+		IL_0292: stelem.ref
+		IL_0293: dup
+		IL_0294: ldc.i4.s 9
+		IL_0296: ldloc.s 9
+		IL_0298: stelem.ref
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_029e: pop
+		IL_029f: ldc.i4.s 10
+		IL_02a1: newarr [System.Runtime]System.Object
 		IL_02a6: dup
-		IL_02a7: ldc.i4.8
-		IL_02a8: ldc.i4.0
-		IL_02a9: box [System.Runtime]System.Boolean
-		IL_02ae: stelem.ref
-		IL_02af: dup
-		IL_02b0: ldc.i4.s 9
-		IL_02b2: ldloc.s 9
-		IL_02b4: stelem.ref
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_02ba: pop
-		IL_02bb: ldc.i4.s 10
-		IL_02bd: newarr [System.Runtime]System.Object
-		IL_02c2: dup
-		IL_02c3: ldc.i4.0
-		IL_02c4: ldloc.s 8
-		IL_02c6: stelem.ref
-		IL_02c7: dup
-		IL_02c8: ldc.i4.1
-		IL_02c9: ldstr "searchBitFalse"
-		IL_02ce: stelem.ref
-		IL_02cf: dup
-		IL_02d0: ldc.i4.2
-		IL_02d1: ldstr "searchBitFalse"
-		IL_02d6: stelem.ref
-		IL_02d7: dup
-		IL_02d8: ldc.i4.3
-		IL_02d9: ldc.r8 1
-		IL_02e2: box [System.Runtime]System.Double
-		IL_02e7: stelem.ref
-		IL_02e8: dup
-		IL_02e9: ldc.i4.4
-		IL_02ea: ldstr "searchBitFalse"
-		IL_02ef: stelem.ref
-		IL_02f0: dup
-		IL_02f1: ldc.i4.5
-		IL_02f2: ldc.i4.0
-		IL_02f3: box [System.Runtime]System.Boolean
-		IL_02f8: stelem.ref
-		IL_02f9: dup
-		IL_02fa: ldc.i4.6
-		IL_02fb: ldc.i4.0
-		IL_02fc: box [System.Runtime]System.Boolean
-		IL_0301: stelem.ref
-		IL_0302: dup
-		IL_0303: ldc.i4.7
-		IL_0304: ldc.i4.0
-		IL_0305: box [System.Runtime]System.Boolean
-		IL_030a: stelem.ref
-		IL_030b: dup
-		IL_030c: ldc.i4.8
-		IL_030d: ldc.i4.0
-		IL_030e: box [System.Runtime]System.Boolean
-		IL_0313: stelem.ref
-		IL_0314: dup
-		IL_0315: ldc.i4.s 9
-		IL_0317: ldloc.s 9
-		IL_0319: stelem.ref
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_031f: pop
-		IL_0320: ldc.i4.1
-		IL_0321: newarr [System.Runtime]System.Object
-		IL_0326: dup
-		IL_0327: ldc.i4.0
-		IL_0328: ldloc.0
-		IL_0329: stelem.ref
-		IL_032a: stloc.s 9
-		IL_032c: ldloc.s 8
-		IL_032e: ldloc.s 9
-		IL_0330: ldc.r8 1
-		IL_0339: box [System.Runtime]System.Double
-		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0343: stloc.s 5
-		IL_0345: ldloc.0
-		IL_0346: ldloc.s 5
-		IL_0348: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_034d: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0352: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0357: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_035c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0361: stloc.s 8
-		IL_0363: ldc.i4.1
-		IL_0364: newarr [System.Runtime]System.Object
-		IL_0369: dup
-		IL_036a: ldc.i4.0
-		IL_036b: ldloc.0
-		IL_036c: stelem.ref
-		IL_036d: stloc.s 9
-		IL_036f: ldc.i4.s 10
-		IL_0371: newarr [System.Runtime]System.Object
-		IL_0376: dup
-		IL_0377: ldc.i4.0
-		IL_0378: ldloc.s 8
-		IL_037a: stelem.ref
-		IL_037b: dup
-		IL_037c: ldc.i4.1
-		IL_037d: ldstr "runSieve"
-		IL_0382: stelem.ref
-		IL_0383: dup
-		IL_0384: ldc.i4.2
-		IL_0385: ldstr "runSieve"
-		IL_038a: stelem.ref
-		IL_038b: dup
-		IL_038c: ldc.i4.3
-		IL_038d: ldc.r8 0.0
-		IL_0396: box [System.Runtime]System.Double
-		IL_039b: stelem.ref
-		IL_039c: dup
-		IL_039d: ldc.i4.4
-		IL_039e: ldstr "runSieve"
-		IL_03a3: stelem.ref
-		IL_03a4: dup
-		IL_03a5: ldc.i4.5
-		IL_03a6: ldc.i4.0
-		IL_03a7: box [System.Runtime]System.Boolean
-		IL_03ac: stelem.ref
-		IL_03ad: dup
-		IL_03ae: ldc.i4.6
-		IL_03af: ldc.i4.0
-		IL_03b0: box [System.Runtime]System.Boolean
-		IL_03b5: stelem.ref
-		IL_03b6: dup
-		IL_03b7: ldc.i4.7
-		IL_03b8: ldc.i4.0
-		IL_03b9: box [System.Runtime]System.Boolean
-		IL_03be: stelem.ref
+		IL_02a7: ldc.i4.0
+		IL_02a8: ldloc.s 8
+		IL_02aa: stelem.ref
+		IL_02ab: dup
+		IL_02ac: ldc.i4.1
+		IL_02ad: ldstr "searchBitFalse"
+		IL_02b2: stelem.ref
+		IL_02b3: dup
+		IL_02b4: ldc.i4.2
+		IL_02b5: ldstr "searchBitFalse"
+		IL_02ba: stelem.ref
+		IL_02bb: dup
+		IL_02bc: ldc.i4.3
+		IL_02bd: ldc.r8 1
+		IL_02c6: box [System.Runtime]System.Double
+		IL_02cb: stelem.ref
+		IL_02cc: dup
+		IL_02cd: ldc.i4.4
+		IL_02ce: ldstr "searchBitFalse"
+		IL_02d3: stelem.ref
+		IL_02d4: dup
+		IL_02d5: ldc.i4.5
+		IL_02d6: ldc.i4.0
+		IL_02d7: box [System.Runtime]System.Boolean
+		IL_02dc: stelem.ref
+		IL_02dd: dup
+		IL_02de: ldc.i4.6
+		IL_02df: ldc.i4.0
+		IL_02e0: box [System.Runtime]System.Boolean
+		IL_02e5: stelem.ref
+		IL_02e6: dup
+		IL_02e7: ldc.i4.7
+		IL_02e8: ldc.i4.0
+		IL_02e9: box [System.Runtime]System.Boolean
+		IL_02ee: stelem.ref
+		IL_02ef: dup
+		IL_02f0: ldc.i4.8
+		IL_02f1: ldc.i4.0
+		IL_02f2: box [System.Runtime]System.Boolean
+		IL_02f7: stelem.ref
+		IL_02f8: dup
+		IL_02f9: ldc.i4.s 9
+		IL_02fb: ldloc.s 9
+		IL_02fd: stelem.ref
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0303: pop
+		IL_0304: ldc.i4.1
+		IL_0305: newarr [System.Runtime]System.Object
+		IL_030a: dup
+		IL_030b: ldc.i4.0
+		IL_030c: ldloc.0
+		IL_030d: stelem.ref
+		IL_030e: stloc.s 9
+		IL_0310: ldloc.s 8
+		IL_0312: ldloc.s 9
+		IL_0314: ldc.r8 1
+		IL_031d: box [System.Runtime]System.Double
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0327: stloc.s 5
+		IL_0329: ldloc.0
+		IL_032a: ldloc.s 5
+		IL_032c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_0331: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0336: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_033b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0340: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0345: stloc.s 8
+		IL_0347: ldc.i4.1
+		IL_0348: newarr [System.Runtime]System.Object
+		IL_034d: dup
+		IL_034e: ldc.i4.0
+		IL_034f: ldloc.0
+		IL_0350: stelem.ref
+		IL_0351: stloc.s 9
+		IL_0353: ldc.i4.s 10
+		IL_0355: newarr [System.Runtime]System.Object
+		IL_035a: dup
+		IL_035b: ldc.i4.0
+		IL_035c: ldloc.s 8
+		IL_035e: stelem.ref
+		IL_035f: dup
+		IL_0360: ldc.i4.1
+		IL_0361: ldstr "runSieve"
+		IL_0366: stelem.ref
+		IL_0367: dup
+		IL_0368: ldc.i4.2
+		IL_0369: ldstr "runSieve"
+		IL_036e: stelem.ref
+		IL_036f: dup
+		IL_0370: ldc.i4.3
+		IL_0371: ldc.r8 0.0
+		IL_037a: box [System.Runtime]System.Double
+		IL_037f: stelem.ref
+		IL_0380: dup
+		IL_0381: ldc.i4.4
+		IL_0382: ldstr "runSieve"
+		IL_0387: stelem.ref
+		IL_0388: dup
+		IL_0389: ldc.i4.5
+		IL_038a: ldc.i4.0
+		IL_038b: box [System.Runtime]System.Boolean
+		IL_0390: stelem.ref
+		IL_0391: dup
+		IL_0392: ldc.i4.6
+		IL_0393: ldc.i4.0
+		IL_0394: box [System.Runtime]System.Boolean
+		IL_0399: stelem.ref
+		IL_039a: dup
+		IL_039b: ldc.i4.7
+		IL_039c: ldc.i4.0
+		IL_039d: box [System.Runtime]System.Boolean
+		IL_03a2: stelem.ref
+		IL_03a3: dup
+		IL_03a4: ldc.i4.8
+		IL_03a5: ldc.i4.0
+		IL_03a6: box [System.Runtime]System.Boolean
+		IL_03ab: stelem.ref
+		IL_03ac: dup
+		IL_03ad: ldc.i4.s 9
+		IL_03af: ldloc.s 9
+		IL_03b1: stelem.ref
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_03b7: pop
+		IL_03b8: ldc.i4.s 10
+		IL_03ba: newarr [System.Runtime]System.Object
 		IL_03bf: dup
-		IL_03c0: ldc.i4.8
-		IL_03c1: ldc.i4.0
-		IL_03c2: box [System.Runtime]System.Boolean
-		IL_03c7: stelem.ref
-		IL_03c8: dup
-		IL_03c9: ldc.i4.s 9
-		IL_03cb: ldloc.s 9
-		IL_03cd: stelem.ref
-		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_03d3: pop
-		IL_03d4: ldc.i4.s 10
-		IL_03d6: newarr [System.Runtime]System.Object
-		IL_03db: dup
-		IL_03dc: ldc.i4.0
-		IL_03dd: ldloc.s 8
-		IL_03df: stelem.ref
-		IL_03e0: dup
-		IL_03e1: ldc.i4.1
-		IL_03e2: ldstr "countPrimes"
-		IL_03e7: stelem.ref
-		IL_03e8: dup
-		IL_03e9: ldc.i4.2
-		IL_03ea: ldstr "countPrimes"
-		IL_03ef: stelem.ref
-		IL_03f0: dup
-		IL_03f1: ldc.i4.3
-		IL_03f2: ldc.r8 0.0
-		IL_03fb: box [System.Runtime]System.Double
-		IL_0400: stelem.ref
-		IL_0401: dup
-		IL_0402: ldc.i4.4
-		IL_0403: ldstr "countPrimes"
-		IL_0408: stelem.ref
-		IL_0409: dup
-		IL_040a: ldc.i4.5
-		IL_040b: ldc.i4.0
-		IL_040c: box [System.Runtime]System.Boolean
-		IL_0411: stelem.ref
-		IL_0412: dup
-		IL_0413: ldc.i4.6
-		IL_0414: ldc.i4.0
-		IL_0415: box [System.Runtime]System.Boolean
-		IL_041a: stelem.ref
-		IL_041b: dup
-		IL_041c: ldc.i4.7
-		IL_041d: ldc.i4.0
-		IL_041e: box [System.Runtime]System.Boolean
-		IL_0423: stelem.ref
+		IL_03c0: ldc.i4.0
+		IL_03c1: ldloc.s 8
+		IL_03c3: stelem.ref
+		IL_03c4: dup
+		IL_03c5: ldc.i4.1
+		IL_03c6: ldstr "countPrimes"
+		IL_03cb: stelem.ref
+		IL_03cc: dup
+		IL_03cd: ldc.i4.2
+		IL_03ce: ldstr "countPrimes"
+		IL_03d3: stelem.ref
+		IL_03d4: dup
+		IL_03d5: ldc.i4.3
+		IL_03d6: ldc.r8 0.0
+		IL_03df: box [System.Runtime]System.Double
+		IL_03e4: stelem.ref
+		IL_03e5: dup
+		IL_03e6: ldc.i4.4
+		IL_03e7: ldstr "countPrimes"
+		IL_03ec: stelem.ref
+		IL_03ed: dup
+		IL_03ee: ldc.i4.5
+		IL_03ef: ldc.i4.0
+		IL_03f0: box [System.Runtime]System.Boolean
+		IL_03f5: stelem.ref
+		IL_03f6: dup
+		IL_03f7: ldc.i4.6
+		IL_03f8: ldc.i4.0
+		IL_03f9: box [System.Runtime]System.Boolean
+		IL_03fe: stelem.ref
+		IL_03ff: dup
+		IL_0400: ldc.i4.7
+		IL_0401: ldc.i4.0
+		IL_0402: box [System.Runtime]System.Boolean
+		IL_0407: stelem.ref
+		IL_0408: dup
+		IL_0409: ldc.i4.8
+		IL_040a: ldc.i4.0
+		IL_040b: box [System.Runtime]System.Boolean
+		IL_0410: stelem.ref
+		IL_0411: dup
+		IL_0412: ldc.i4.s 9
+		IL_0414: ldloc.s 9
+		IL_0416: stelem.ref
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_041c: pop
+		IL_041d: ldc.i4.s 10
+		IL_041f: newarr [System.Runtime]System.Object
 		IL_0424: dup
-		IL_0425: ldc.i4.8
-		IL_0426: ldc.i4.0
-		IL_0427: box [System.Runtime]System.Boolean
-		IL_042c: stelem.ref
-		IL_042d: dup
-		IL_042e: ldc.i4.s 9
-		IL_0430: ldloc.s 9
-		IL_0432: stelem.ref
-		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0438: pop
-		IL_0439: ldc.i4.s 10
-		IL_043b: newarr [System.Runtime]System.Object
-		IL_0440: dup
-		IL_0441: ldc.i4.0
-		IL_0442: ldloc.s 8
-		IL_0444: stelem.ref
-		IL_0445: dup
-		IL_0446: ldc.i4.1
-		IL_0447: ldstr "getPrimes"
-		IL_044c: stelem.ref
-		IL_044d: dup
-		IL_044e: ldc.i4.2
-		IL_044f: ldstr "getPrimes"
-		IL_0454: stelem.ref
-		IL_0455: dup
-		IL_0456: ldc.i4.3
-		IL_0457: ldc.r8 0.0
-		IL_0460: box [System.Runtime]System.Double
-		IL_0465: stelem.ref
-		IL_0466: dup
-		IL_0467: ldc.i4.4
-		IL_0468: ldstr "getPrimes"
-		IL_046d: stelem.ref
-		IL_046e: dup
-		IL_046f: ldc.i4.5
-		IL_0470: ldc.i4.0
-		IL_0471: box [System.Runtime]System.Boolean
-		IL_0476: stelem.ref
-		IL_0477: dup
-		IL_0478: ldc.i4.6
-		IL_0479: ldc.i4.0
-		IL_047a: box [System.Runtime]System.Boolean
-		IL_047f: stelem.ref
-		IL_0480: dup
-		IL_0481: ldc.i4.7
-		IL_0482: ldc.i4.0
-		IL_0483: box [System.Runtime]System.Boolean
-		IL_0488: stelem.ref
+		IL_0425: ldc.i4.0
+		IL_0426: ldloc.s 8
+		IL_0428: stelem.ref
+		IL_0429: dup
+		IL_042a: ldc.i4.1
+		IL_042b: ldstr "getPrimes"
+		IL_0430: stelem.ref
+		IL_0431: dup
+		IL_0432: ldc.i4.2
+		IL_0433: ldstr "getPrimes"
+		IL_0438: stelem.ref
+		IL_0439: dup
+		IL_043a: ldc.i4.3
+		IL_043b: ldc.r8 0.0
+		IL_0444: box [System.Runtime]System.Double
+		IL_0449: stelem.ref
+		IL_044a: dup
+		IL_044b: ldc.i4.4
+		IL_044c: ldstr "getPrimes"
+		IL_0451: stelem.ref
+		IL_0452: dup
+		IL_0453: ldc.i4.5
+		IL_0454: ldc.i4.0
+		IL_0455: box [System.Runtime]System.Boolean
+		IL_045a: stelem.ref
+		IL_045b: dup
+		IL_045c: ldc.i4.6
+		IL_045d: ldc.i4.0
+		IL_045e: box [System.Runtime]System.Boolean
+		IL_0463: stelem.ref
+		IL_0464: dup
+		IL_0465: ldc.i4.7
+		IL_0466: ldc.i4.0
+		IL_0467: box [System.Runtime]System.Boolean
+		IL_046c: stelem.ref
+		IL_046d: dup
+		IL_046e: ldc.i4.8
+		IL_046f: ldc.i4.0
+		IL_0470: box [System.Runtime]System.Boolean
+		IL_0475: stelem.ref
+		IL_0476: dup
+		IL_0477: ldc.i4.s 9
+		IL_0479: ldloc.s 9
+		IL_047b: stelem.ref
+		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0481: pop
+		IL_0482: ldc.i4.s 10
+		IL_0484: newarr [System.Runtime]System.Object
 		IL_0489: dup
-		IL_048a: ldc.i4.8
-		IL_048b: ldc.i4.0
-		IL_048c: box [System.Runtime]System.Boolean
-		IL_0491: stelem.ref
-		IL_0492: dup
-		IL_0493: ldc.i4.s 9
-		IL_0495: ldloc.s 9
-		IL_0497: stelem.ref
-		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_049d: pop
-		IL_049e: ldc.i4.s 10
-		IL_04a0: newarr [System.Runtime]System.Object
-		IL_04a5: dup
-		IL_04a6: ldc.i4.0
-		IL_04a7: ldloc.s 8
-		IL_04a9: stelem.ref
-		IL_04aa: dup
-		IL_04ab: ldc.i4.1
-		IL_04ac: ldstr "validatePrimeCount"
-		IL_04b1: stelem.ref
-		IL_04b2: dup
-		IL_04b3: ldc.i4.2
-		IL_04b4: ldstr "validatePrimeCount"
-		IL_04b9: stelem.ref
-		IL_04ba: dup
-		IL_04bb: ldc.i4.3
-		IL_04bc: ldc.r8 1
-		IL_04c5: box [System.Runtime]System.Double
-		IL_04ca: stelem.ref
-		IL_04cb: dup
-		IL_04cc: ldc.i4.4
-		IL_04cd: ldstr "validatePrimeCount"
-		IL_04d2: stelem.ref
-		IL_04d3: dup
-		IL_04d4: ldc.i4.5
-		IL_04d5: ldc.i4.0
-		IL_04d6: box [System.Runtime]System.Boolean
-		IL_04db: stelem.ref
-		IL_04dc: dup
-		IL_04dd: ldc.i4.6
-		IL_04de: ldc.i4.0
-		IL_04df: box [System.Runtime]System.Boolean
-		IL_04e4: stelem.ref
-		IL_04e5: dup
-		IL_04e6: ldc.i4.7
-		IL_04e7: ldc.i4.0
-		IL_04e8: box [System.Runtime]System.Boolean
-		IL_04ed: stelem.ref
-		IL_04ee: dup
-		IL_04ef: ldc.i4.8
-		IL_04f0: ldc.i4.0
-		IL_04f1: box [System.Runtime]System.Boolean
-		IL_04f6: stelem.ref
-		IL_04f7: dup
-		IL_04f8: ldc.i4.s 9
-		IL_04fa: ldloc.s 9
-		IL_04fc: stelem.ref
-		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0502: pop
-		IL_0503: ldc.i4.1
-		IL_0504: newarr [System.Runtime]System.Object
-		IL_0509: dup
-		IL_050a: ldc.i4.0
-		IL_050b: ldloc.0
-		IL_050c: stelem.ref
-		IL_050d: stloc.s 9
-		IL_050f: ldloc.s 8
-		IL_0511: ldloc.s 9
-		IL_0513: ldc.r8 1
-		IL_051c: box [System.Runtime]System.Double
-		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0526: stloc.s 5
-		IL_0528: ldloc.0
-		IL_0529: ldloc.s 5
-		IL_052b: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0530: ldloc.0
-		IL_0531: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0536: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
-		IL_053c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0541: ldc.i4.1
-		IL_0542: newarr [System.Runtime]System.Object
-		IL_0547: dup
-		IL_0548: ldc.i4.0
-		IL_0549: ldloc.0
-		IL_054a: stelem.ref
-		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0555: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_055a: ldc.i4.1
-		IL_055b: conv.r8
-		IL_055c: ldstr ""
-		IL_0561: ldc.i4.0
-		IL_0562: ldc.i4.0
-		IL_0563: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_056d: stloc.s 10
-		IL_056f: ldloc.s 10
-		IL_0571: ldstr "runSieveBatch"
-		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_057b: stloc.3
-		IL_057c: ldloc.0
-		IL_057d: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0582: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_0588: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_058d: ldc.i4.1
-		IL_058e: newarr [System.Runtime]System.Object
-		IL_0593: dup
-		IL_0594: ldc.i4.0
-		IL_0595: ldloc.0
-		IL_0596: stelem.ref
-		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_05a1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_05a6: ldc.i4.1
-		IL_05a7: conv.r8
-		IL_05a8: ldstr ""
-		IL_05ad: ldc.i4.0
-		IL_05ae: ldc.i4.0
-		IL_05af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_05b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_05b9: stloc.s 11
-		IL_05bb: ldloc.s 11
-		IL_05bd: ldstr "main"
-		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_05c7: stloc.s 4
-		IL_05c9: ldloc.0
-		IL_05ca: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_05cf: ldnull
-		IL_05d0: ldloc.1
-		IL_05d1: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_05d6: pop
-		IL_05d7: ret
+		IL_048a: ldc.i4.0
+		IL_048b: ldloc.s 8
+		IL_048d: stelem.ref
+		IL_048e: dup
+		IL_048f: ldc.i4.1
+		IL_0490: ldstr "validatePrimeCount"
+		IL_0495: stelem.ref
+		IL_0496: dup
+		IL_0497: ldc.i4.2
+		IL_0498: ldstr "validatePrimeCount"
+		IL_049d: stelem.ref
+		IL_049e: dup
+		IL_049f: ldc.i4.3
+		IL_04a0: ldc.r8 1
+		IL_04a9: box [System.Runtime]System.Double
+		IL_04ae: stelem.ref
+		IL_04af: dup
+		IL_04b0: ldc.i4.4
+		IL_04b1: ldstr "validatePrimeCount"
+		IL_04b6: stelem.ref
+		IL_04b7: dup
+		IL_04b8: ldc.i4.5
+		IL_04b9: ldc.i4.0
+		IL_04ba: box [System.Runtime]System.Boolean
+		IL_04bf: stelem.ref
+		IL_04c0: dup
+		IL_04c1: ldc.i4.6
+		IL_04c2: ldc.i4.0
+		IL_04c3: box [System.Runtime]System.Boolean
+		IL_04c8: stelem.ref
+		IL_04c9: dup
+		IL_04ca: ldc.i4.7
+		IL_04cb: ldc.i4.0
+		IL_04cc: box [System.Runtime]System.Boolean
+		IL_04d1: stelem.ref
+		IL_04d2: dup
+		IL_04d3: ldc.i4.8
+		IL_04d4: ldc.i4.0
+		IL_04d5: box [System.Runtime]System.Boolean
+		IL_04da: stelem.ref
+		IL_04db: dup
+		IL_04dc: ldc.i4.s 9
+		IL_04de: ldloc.s 9
+		IL_04e0: stelem.ref
+		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_04e6: pop
+		IL_04e7: ldc.i4.1
+		IL_04e8: newarr [System.Runtime]System.Object
+		IL_04ed: dup
+		IL_04ee: ldc.i4.0
+		IL_04ef: ldloc.0
+		IL_04f0: stelem.ref
+		IL_04f1: stloc.s 9
+		IL_04f3: ldloc.s 8
+		IL_04f5: ldloc.s 9
+		IL_04f7: ldc.r8 1
+		IL_0500: box [System.Runtime]System.Double
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_050a: stloc.s 5
+		IL_050c: ldloc.0
+		IL_050d: ldloc.s 5
+		IL_050f: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_0514: ldloc.0
+		IL_0515: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_051a: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
+		IL_0520: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0525: ldc.i4.1
+		IL_0526: newarr [System.Runtime]System.Object
+		IL_052b: dup
+		IL_052c: ldc.i4.0
+		IL_052d: ldloc.0
+		IL_052e: stelem.ref
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0539: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_053e: ldc.i4.1
+		IL_053f: conv.r8
+		IL_0540: ldstr ""
+		IL_0545: ldc.i4.0
+		IL_0546: ldc.i4.0
+		IL_0547: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_054c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_0551: stloc.s 10
+		IL_0553: ldloc.s 10
+		IL_0555: ldstr "runSieveBatch"
+		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_055f: stloc.3
+		IL_0560: ldloc.0
+		IL_0561: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0566: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_056c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0571: ldc.i4.1
+		IL_0572: newarr [System.Runtime]System.Object
+		IL_0577: dup
+		IL_0578: ldc.i4.0
+		IL_0579: ldloc.0
+		IL_057a: stelem.ref
+		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0585: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_058a: ldc.i4.1
+		IL_058b: conv.r8
+		IL_058c: ldstr ""
+		IL_0591: ldc.i4.0
+		IL_0592: ldc.i4.0
+		IL_0593: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0598: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_059d: stloc.s 11
+		IL_059f: ldloc.s 11
+		IL_05a1: ldstr "main"
+		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_05ab: stloc.s 4
+		IL_05ad: ldloc.0
+		IL_05ae: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_05b3: ldnull
+		IL_05b4: ldloc.1
+		IL_05b5: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_05ba: pop
+		IL_05bb: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
@@ -2971,7 +2921,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3322
+		// Method begins at RVA 0x32a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -2292,7 +2292,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1468 (0x5bc)
+		// Code size: 1466 (0x5ba)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -2312,604 +2312,602 @@
 		IL_0000: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: nop
-		IL_0009: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::.ctor()
-		IL_000e: stloc.1
-		IL_000f: ldloc.1
-		IL_0010: ldc.r8 1000
-		IL_0019: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_sieveSize(float64)
-		IL_001e: ldloc.1
-		IL_001f: ldc.r8 5
-		IL_0028: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_timeLimitSeconds(float64)
-		IL_002d: ldloc.1
-		IL_002e: ldc.i4.0
-		IL_002f: box [System.Runtime]System.Boolean
-		IL_0034: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_0039: ldloc.1
-		IL_003a: ldstr ""
-		IL_003f: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
-		IL_0044: ldarg.1
-		IL_0045: ldstr "perf_hooks"
-		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_004f: stloc.s 5
-		IL_0051: ldloc.s 5
-		IL_0053: brfalse IL_0064
+		IL_0007: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::.ctor()
+		IL_000c: stloc.1
+		IL_000d: ldloc.1
+		IL_000e: ldc.r8 1000
+		IL_0017: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_sieveSize(float64)
+		IL_001c: ldloc.1
+		IL_001d: ldc.r8 5
+		IL_0026: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_timeLimitSeconds(float64)
+		IL_002b: ldloc.1
+		IL_002c: ldc.i4.0
+		IL_002d: box [System.Runtime]System.Boolean
+		IL_0032: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_0037: ldloc.1
+		IL_0038: ldstr ""
+		IL_003d: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
+		IL_0042: ldarg.1
+		IL_0043: ldstr "perf_hooks"
+		IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_004d: stloc.s 5
+		IL_004f: ldloc.s 5
+		IL_0051: brfalse IL_0062
 
-		IL_0058: ldloc.s 5
-		IL_005a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_005f: brfalse IL_0075
+		IL_0056: ldloc.s 5
+		IL_0058: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_005d: brfalse IL_0073
 
-		IL_0064: ldloc.s 5
-		IL_0066: ldstr ""
-		IL_006b: ldstr "performance"
-		IL_0070: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0062: ldloc.s 5
+		IL_0064: ldstr ""
+		IL_0069: ldstr "performance"
+		IL_006e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0075: ldloc.s 5
-		IL_0077: ldstr "performance"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0081: stloc.s 5
-		IL_0083: ldloc.0
-		IL_0084: ldloc.s 5
-		IL_0086: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
-		IL_008b: ldstr "process"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0095: ldstr "argv"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009f: stloc.s 5
-		IL_00a1: ldloc.s 5
-		IL_00a3: ldc.r8 0.0
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b1: stloc.s 5
-		IL_00b3: ldloc.s 5
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldstr "[\\\\/]"
-		IL_00c1: ldstr ""
-		IL_00c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00cb: stloc.s 6
-		IL_00cd: ldloc.s 5
-		IL_00cf: ldstr "split"
-		IL_00d4: ldloc.s 6
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00db: stloc.2
-		IL_00dc: ldloc.2
-		IL_00dd: ldstr "length"
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e7: stloc.s 5
-		IL_00e9: ldloc.s 5
-		IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00f0: ldc.r8 1
-		IL_00f9: sub
-		IL_00fa: stloc.s 7
-		IL_00fc: ldloc.2
-		IL_00fd: ldloc.s 7
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0104: stloc.s 5
-		IL_0106: ldloc.1
-		IL_0107: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_010c: ldloc.s 5
-		IL_010e: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
-		IL_0113: ldstr "process"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011d: ldstr "argv"
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0127: stloc.s 5
-		IL_0129: ldloc.s 5
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0130: ldstr "includes"
-		IL_0135: ldstr "verbose"
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013f: stloc.s 5
-		IL_0141: ldloc.1
-		IL_0142: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_0147: ldloc.s 5
-		IL_0149: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_014e: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0153: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0158: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_015d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0162: stloc.s 8
-		IL_0164: ldc.i4.1
-		IL_0165: newarr [System.Runtime]System.Object
-		IL_016a: dup
-		IL_016b: ldc.i4.0
-		IL_016c: ldloc.0
-		IL_016d: stelem.ref
-		IL_016e: stloc.s 9
-		IL_0170: ldc.i4.s 10
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: dup
-		IL_0178: ldc.i4.0
-		IL_0179: ldloc.s 8
-		IL_017b: stelem.ref
-		IL_017c: dup
-		IL_017d: ldc.i4.1
-		IL_017e: ldstr "setBitTrue"
-		IL_0183: stelem.ref
-		IL_0184: dup
-		IL_0185: ldc.i4.2
-		IL_0186: ldstr "setBitTrue"
-		IL_018b: stelem.ref
-		IL_018c: dup
-		IL_018d: ldc.i4.3
-		IL_018e: ldc.r8 1
-		IL_0197: box [System.Runtime]System.Double
-		IL_019c: stelem.ref
-		IL_019d: dup
-		IL_019e: ldc.i4.4
-		IL_019f: ldstr "setBitTrue"
-		IL_01a4: stelem.ref
-		IL_01a5: dup
-		IL_01a6: ldc.i4.5
-		IL_01a7: ldc.i4.0
-		IL_01a8: box [System.Runtime]System.Boolean
-		IL_01ad: stelem.ref
-		IL_01ae: dup
-		IL_01af: ldc.i4.6
-		IL_01b0: ldc.i4.0
-		IL_01b1: box [System.Runtime]System.Boolean
-		IL_01b6: stelem.ref
-		IL_01b7: dup
-		IL_01b8: ldc.i4.7
-		IL_01b9: ldc.i4.0
-		IL_01ba: box [System.Runtime]System.Boolean
-		IL_01bf: stelem.ref
-		IL_01c0: dup
-		IL_01c1: ldc.i4.8
-		IL_01c2: ldc.i4.0
-		IL_01c3: box [System.Runtime]System.Boolean
-		IL_01c8: stelem.ref
-		IL_01c9: dup
-		IL_01ca: ldc.i4.s 9
-		IL_01cc: ldloc.s 9
-		IL_01ce: stelem.ref
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_01d4: pop
-		IL_01d5: ldc.i4.s 10
-		IL_01d7: newarr [System.Runtime]System.Object
-		IL_01dc: dup
-		IL_01dd: ldc.i4.0
-		IL_01de: ldloc.s 8
-		IL_01e0: stelem.ref
-		IL_01e1: dup
-		IL_01e2: ldc.i4.1
-		IL_01e3: ldstr "setBitsTrue"
-		IL_01e8: stelem.ref
-		IL_01e9: dup
-		IL_01ea: ldc.i4.2
-		IL_01eb: ldstr "setBitsTrue"
-		IL_01f0: stelem.ref
-		IL_01f1: dup
-		IL_01f2: ldc.i4.3
-		IL_01f3: ldc.r8 3
-		IL_01fc: box [System.Runtime]System.Double
-		IL_0201: stelem.ref
-		IL_0202: dup
-		IL_0203: ldc.i4.4
-		IL_0204: ldstr "setBitsTrue"
-		IL_0209: stelem.ref
-		IL_020a: dup
-		IL_020b: ldc.i4.5
-		IL_020c: ldc.i4.0
-		IL_020d: box [System.Runtime]System.Boolean
-		IL_0212: stelem.ref
-		IL_0213: dup
-		IL_0214: ldc.i4.6
-		IL_0215: ldc.i4.0
-		IL_0216: box [System.Runtime]System.Boolean
-		IL_021b: stelem.ref
-		IL_021c: dup
-		IL_021d: ldc.i4.7
-		IL_021e: ldc.i4.0
-		IL_021f: box [System.Runtime]System.Boolean
-		IL_0224: stelem.ref
-		IL_0225: dup
-		IL_0226: ldc.i4.8
-		IL_0227: ldc.i4.0
-		IL_0228: box [System.Runtime]System.Boolean
-		IL_022d: stelem.ref
-		IL_022e: dup
-		IL_022f: ldc.i4.s 9
-		IL_0231: ldloc.s 9
-		IL_0233: stelem.ref
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0239: pop
-		IL_023a: ldc.i4.s 10
-		IL_023c: newarr [System.Runtime]System.Object
-		IL_0241: dup
-		IL_0242: ldc.i4.0
-		IL_0243: ldloc.s 8
-		IL_0245: stelem.ref
-		IL_0246: dup
-		IL_0247: ldc.i4.1
-		IL_0248: ldstr "testBitTrue"
-		IL_024d: stelem.ref
-		IL_024e: dup
-		IL_024f: ldc.i4.2
-		IL_0250: ldstr "testBitTrue"
-		IL_0255: stelem.ref
-		IL_0256: dup
-		IL_0257: ldc.i4.3
-		IL_0258: ldc.r8 1
-		IL_0261: box [System.Runtime]System.Double
-		IL_0266: stelem.ref
-		IL_0267: dup
-		IL_0268: ldc.i4.4
-		IL_0269: ldstr "testBitTrue"
-		IL_026e: stelem.ref
-		IL_026f: dup
-		IL_0270: ldc.i4.5
-		IL_0271: ldc.i4.0
-		IL_0272: box [System.Runtime]System.Boolean
-		IL_0277: stelem.ref
-		IL_0278: dup
-		IL_0279: ldc.i4.6
-		IL_027a: ldc.i4.0
-		IL_027b: box [System.Runtime]System.Boolean
-		IL_0280: stelem.ref
-		IL_0281: dup
-		IL_0282: ldc.i4.7
-		IL_0283: ldc.i4.0
-		IL_0284: box [System.Runtime]System.Boolean
-		IL_0289: stelem.ref
-		IL_028a: dup
-		IL_028b: ldc.i4.8
-		IL_028c: ldc.i4.0
-		IL_028d: box [System.Runtime]System.Boolean
-		IL_0292: stelem.ref
-		IL_0293: dup
-		IL_0294: ldc.i4.s 9
-		IL_0296: ldloc.s 9
-		IL_0298: stelem.ref
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_029e: pop
-		IL_029f: ldc.i4.s 10
-		IL_02a1: newarr [System.Runtime]System.Object
-		IL_02a6: dup
-		IL_02a7: ldc.i4.0
-		IL_02a8: ldloc.s 8
-		IL_02aa: stelem.ref
-		IL_02ab: dup
-		IL_02ac: ldc.i4.1
-		IL_02ad: ldstr "searchBitFalse"
-		IL_02b2: stelem.ref
-		IL_02b3: dup
-		IL_02b4: ldc.i4.2
-		IL_02b5: ldstr "searchBitFalse"
-		IL_02ba: stelem.ref
-		IL_02bb: dup
-		IL_02bc: ldc.i4.3
-		IL_02bd: ldc.r8 1
-		IL_02c6: box [System.Runtime]System.Double
-		IL_02cb: stelem.ref
-		IL_02cc: dup
-		IL_02cd: ldc.i4.4
-		IL_02ce: ldstr "searchBitFalse"
-		IL_02d3: stelem.ref
-		IL_02d4: dup
-		IL_02d5: ldc.i4.5
-		IL_02d6: ldc.i4.0
-		IL_02d7: box [System.Runtime]System.Boolean
-		IL_02dc: stelem.ref
-		IL_02dd: dup
-		IL_02de: ldc.i4.6
-		IL_02df: ldc.i4.0
-		IL_02e0: box [System.Runtime]System.Boolean
-		IL_02e5: stelem.ref
-		IL_02e6: dup
-		IL_02e7: ldc.i4.7
-		IL_02e8: ldc.i4.0
-		IL_02e9: box [System.Runtime]System.Boolean
-		IL_02ee: stelem.ref
-		IL_02ef: dup
-		IL_02f0: ldc.i4.8
-		IL_02f1: ldc.i4.0
-		IL_02f2: box [System.Runtime]System.Boolean
-		IL_02f7: stelem.ref
-		IL_02f8: dup
-		IL_02f9: ldc.i4.s 9
-		IL_02fb: ldloc.s 9
-		IL_02fd: stelem.ref
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0303: pop
-		IL_0304: ldc.i4.1
-		IL_0305: newarr [System.Runtime]System.Object
-		IL_030a: dup
-		IL_030b: ldc.i4.0
-		IL_030c: ldloc.0
-		IL_030d: stelem.ref
-		IL_030e: stloc.s 9
-		IL_0310: ldloc.s 8
-		IL_0312: ldloc.s 9
-		IL_0314: ldc.r8 1
-		IL_031d: box [System.Runtime]System.Double
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_0327: stloc.s 5
-		IL_0329: ldloc.0
-		IL_032a: ldloc.s 5
-		IL_032c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_0331: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0336: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_033b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0340: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0345: stloc.s 8
-		IL_0347: ldc.i4.1
-		IL_0348: newarr [System.Runtime]System.Object
-		IL_034d: dup
-		IL_034e: ldc.i4.0
-		IL_034f: ldloc.0
-		IL_0350: stelem.ref
-		IL_0351: stloc.s 9
-		IL_0353: ldc.i4.s 10
-		IL_0355: newarr [System.Runtime]System.Object
-		IL_035a: dup
-		IL_035b: ldc.i4.0
-		IL_035c: ldloc.s 8
-		IL_035e: stelem.ref
-		IL_035f: dup
-		IL_0360: ldc.i4.1
-		IL_0361: ldstr "runSieve"
-		IL_0366: stelem.ref
-		IL_0367: dup
-		IL_0368: ldc.i4.2
-		IL_0369: ldstr "runSieve"
-		IL_036e: stelem.ref
-		IL_036f: dup
-		IL_0370: ldc.i4.3
-		IL_0371: ldc.r8 0.0
-		IL_037a: box [System.Runtime]System.Double
-		IL_037f: stelem.ref
-		IL_0380: dup
-		IL_0381: ldc.i4.4
-		IL_0382: ldstr "runSieve"
-		IL_0387: stelem.ref
-		IL_0388: dup
-		IL_0389: ldc.i4.5
-		IL_038a: ldc.i4.0
-		IL_038b: box [System.Runtime]System.Boolean
-		IL_0390: stelem.ref
-		IL_0391: dup
-		IL_0392: ldc.i4.6
-		IL_0393: ldc.i4.0
-		IL_0394: box [System.Runtime]System.Boolean
-		IL_0399: stelem.ref
-		IL_039a: dup
-		IL_039b: ldc.i4.7
-		IL_039c: ldc.i4.0
-		IL_039d: box [System.Runtime]System.Boolean
-		IL_03a2: stelem.ref
-		IL_03a3: dup
-		IL_03a4: ldc.i4.8
-		IL_03a5: ldc.i4.0
-		IL_03a6: box [System.Runtime]System.Boolean
-		IL_03ab: stelem.ref
-		IL_03ac: dup
-		IL_03ad: ldc.i4.s 9
-		IL_03af: ldloc.s 9
-		IL_03b1: stelem.ref
-		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_03b7: pop
-		IL_03b8: ldc.i4.s 10
-		IL_03ba: newarr [System.Runtime]System.Object
-		IL_03bf: dup
-		IL_03c0: ldc.i4.0
-		IL_03c1: ldloc.s 8
-		IL_03c3: stelem.ref
-		IL_03c4: dup
-		IL_03c5: ldc.i4.1
-		IL_03c6: ldstr "countPrimes"
-		IL_03cb: stelem.ref
-		IL_03cc: dup
-		IL_03cd: ldc.i4.2
-		IL_03ce: ldstr "countPrimes"
-		IL_03d3: stelem.ref
-		IL_03d4: dup
-		IL_03d5: ldc.i4.3
-		IL_03d6: ldc.r8 0.0
-		IL_03df: box [System.Runtime]System.Double
-		IL_03e4: stelem.ref
-		IL_03e5: dup
-		IL_03e6: ldc.i4.4
-		IL_03e7: ldstr "countPrimes"
-		IL_03ec: stelem.ref
-		IL_03ed: dup
-		IL_03ee: ldc.i4.5
-		IL_03ef: ldc.i4.0
-		IL_03f0: box [System.Runtime]System.Boolean
-		IL_03f5: stelem.ref
-		IL_03f6: dup
-		IL_03f7: ldc.i4.6
-		IL_03f8: ldc.i4.0
-		IL_03f9: box [System.Runtime]System.Boolean
-		IL_03fe: stelem.ref
-		IL_03ff: dup
-		IL_0400: ldc.i4.7
-		IL_0401: ldc.i4.0
-		IL_0402: box [System.Runtime]System.Boolean
-		IL_0407: stelem.ref
-		IL_0408: dup
-		IL_0409: ldc.i4.8
-		IL_040a: ldc.i4.0
-		IL_040b: box [System.Runtime]System.Boolean
-		IL_0410: stelem.ref
-		IL_0411: dup
-		IL_0412: ldc.i4.s 9
-		IL_0414: ldloc.s 9
-		IL_0416: stelem.ref
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_041c: pop
-		IL_041d: ldc.i4.s 10
-		IL_041f: newarr [System.Runtime]System.Object
-		IL_0424: dup
-		IL_0425: ldc.i4.0
-		IL_0426: ldloc.s 8
-		IL_0428: stelem.ref
-		IL_0429: dup
-		IL_042a: ldc.i4.1
-		IL_042b: ldstr "getPrimes"
-		IL_0430: stelem.ref
-		IL_0431: dup
-		IL_0432: ldc.i4.2
-		IL_0433: ldstr "getPrimes"
-		IL_0438: stelem.ref
-		IL_0439: dup
-		IL_043a: ldc.i4.3
-		IL_043b: ldc.r8 0.0
-		IL_0444: box [System.Runtime]System.Double
-		IL_0449: stelem.ref
-		IL_044a: dup
-		IL_044b: ldc.i4.4
-		IL_044c: ldstr "getPrimes"
-		IL_0451: stelem.ref
-		IL_0452: dup
-		IL_0453: ldc.i4.5
-		IL_0454: ldc.i4.0
-		IL_0455: box [System.Runtime]System.Boolean
-		IL_045a: stelem.ref
-		IL_045b: dup
-		IL_045c: ldc.i4.6
-		IL_045d: ldc.i4.0
-		IL_045e: box [System.Runtime]System.Boolean
-		IL_0463: stelem.ref
-		IL_0464: dup
-		IL_0465: ldc.i4.7
-		IL_0466: ldc.i4.0
-		IL_0467: box [System.Runtime]System.Boolean
-		IL_046c: stelem.ref
-		IL_046d: dup
-		IL_046e: ldc.i4.8
-		IL_046f: ldc.i4.0
-		IL_0470: box [System.Runtime]System.Boolean
-		IL_0475: stelem.ref
-		IL_0476: dup
-		IL_0477: ldc.i4.s 9
-		IL_0479: ldloc.s 9
-		IL_047b: stelem.ref
-		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0481: pop
-		IL_0482: ldc.i4.s 10
-		IL_0484: newarr [System.Runtime]System.Object
-		IL_0489: dup
-		IL_048a: ldc.i4.0
-		IL_048b: ldloc.s 8
-		IL_048d: stelem.ref
-		IL_048e: dup
-		IL_048f: ldc.i4.1
-		IL_0490: ldstr "validatePrimeCount"
-		IL_0495: stelem.ref
-		IL_0496: dup
-		IL_0497: ldc.i4.2
-		IL_0498: ldstr "validatePrimeCount"
-		IL_049d: stelem.ref
-		IL_049e: dup
-		IL_049f: ldc.i4.3
-		IL_04a0: ldc.r8 1
-		IL_04a9: box [System.Runtime]System.Double
-		IL_04ae: stelem.ref
-		IL_04af: dup
-		IL_04b0: ldc.i4.4
-		IL_04b1: ldstr "validatePrimeCount"
-		IL_04b6: stelem.ref
-		IL_04b7: dup
-		IL_04b8: ldc.i4.5
-		IL_04b9: ldc.i4.0
-		IL_04ba: box [System.Runtime]System.Boolean
-		IL_04bf: stelem.ref
-		IL_04c0: dup
-		IL_04c1: ldc.i4.6
-		IL_04c2: ldc.i4.0
-		IL_04c3: box [System.Runtime]System.Boolean
-		IL_04c8: stelem.ref
-		IL_04c9: dup
-		IL_04ca: ldc.i4.7
-		IL_04cb: ldc.i4.0
-		IL_04cc: box [System.Runtime]System.Boolean
-		IL_04d1: stelem.ref
-		IL_04d2: dup
-		IL_04d3: ldc.i4.8
-		IL_04d4: ldc.i4.0
-		IL_04d5: box [System.Runtime]System.Boolean
-		IL_04da: stelem.ref
-		IL_04db: dup
-		IL_04dc: ldc.i4.s 9
-		IL_04de: ldloc.s 9
-		IL_04e0: stelem.ref
-		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_04e6: pop
-		IL_04e7: ldc.i4.1
-		IL_04e8: newarr [System.Runtime]System.Object
-		IL_04ed: dup
-		IL_04ee: ldc.i4.0
-		IL_04ef: ldloc.0
-		IL_04f0: stelem.ref
-		IL_04f1: stloc.s 9
-		IL_04f3: ldloc.s 8
-		IL_04f5: ldloc.s 9
-		IL_04f7: ldc.r8 1
-		IL_0500: box [System.Runtime]System.Double
-		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_050a: stloc.s 5
-		IL_050c: ldloc.0
-		IL_050d: ldloc.s 5
-		IL_050f: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0514: ldloc.0
-		IL_0515: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_051a: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
-		IL_0520: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0525: ldc.i4.1
-		IL_0526: newarr [System.Runtime]System.Object
-		IL_052b: dup
-		IL_052c: ldc.i4.0
-		IL_052d: ldloc.0
-		IL_052e: stelem.ref
-		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0539: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_053e: ldc.i4.1
-		IL_053f: conv.r8
-		IL_0540: ldstr ""
-		IL_0545: ldc.i4.0
-		IL_0546: ldc.i4.0
-		IL_0547: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_054c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_0551: stloc.s 10
-		IL_0553: ldloc.s 10
-		IL_0555: ldstr "runSieveBatch"
-		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_055f: stloc.3
-		IL_0560: ldloc.0
-		IL_0561: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0566: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_056c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0571: ldc.i4.1
-		IL_0572: newarr [System.Runtime]System.Object
-		IL_0577: dup
-		IL_0578: ldc.i4.0
-		IL_0579: ldloc.0
-		IL_057a: stelem.ref
-		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0585: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_058a: ldc.i4.1
-		IL_058b: conv.r8
-		IL_058c: ldstr ""
-		IL_0591: ldc.i4.0
-		IL_0592: ldc.i4.0
-		IL_0593: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0598: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_059d: stloc.s 11
-		IL_059f: ldloc.s 11
-		IL_05a1: ldstr "main"
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_05ab: stloc.s 4
-		IL_05ad: ldloc.0
-		IL_05ae: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_05b3: ldnull
-		IL_05b4: ldloc.1
-		IL_05b5: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_05ba: pop
-		IL_05bb: ret
+		IL_0073: ldloc.s 5
+		IL_0075: ldstr "performance"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007f: stloc.s 5
+		IL_0081: ldloc.0
+		IL_0082: ldloc.s 5
+		IL_0084: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::performance
+		IL_0089: ldstr "process"
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0093: ldstr "argv"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009d: stloc.s 5
+		IL_009f: ldloc.s 5
+		IL_00a1: ldc.r8 0.0
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00af: stloc.s 5
+		IL_00b1: ldloc.s 5
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b8: stloc.s 5
+		IL_00ba: ldstr "[\\\\/]"
+		IL_00bf: ldstr ""
+		IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c9: stloc.s 6
+		IL_00cb: ldloc.s 5
+		IL_00cd: ldstr "split"
+		IL_00d2: ldloc.s 6
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d9: stloc.2
+		IL_00da: ldloc.2
+		IL_00db: ldstr "length"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e5: stloc.s 5
+		IL_00e7: ldloc.s 5
+		IL_00e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00ee: ldc.r8 1
+		IL_00f7: sub
+		IL_00f8: stloc.s 7
+		IL_00fa: ldloc.2
+		IL_00fb: ldloc.s 7
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0102: stloc.s 5
+		IL_0104: ldloc.1
+		IL_0105: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_010a: ldloc.s 5
+		IL_010c: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
+		IL_0111: ldstr "process"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011b: ldstr "argv"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0125: stloc.s 5
+		IL_0127: ldloc.s 5
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012e: ldstr "includes"
+		IL_0133: ldstr "verbose"
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: stloc.s 5
+		IL_013f: ldloc.1
+		IL_0140: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_0145: ldloc.s 5
+		IL_0147: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_014c: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0151: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0156: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_015b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0160: stloc.s 8
+		IL_0162: ldc.i4.1
+		IL_0163: newarr [System.Runtime]System.Object
+		IL_0168: dup
+		IL_0169: ldc.i4.0
+		IL_016a: ldloc.0
+		IL_016b: stelem.ref
+		IL_016c: stloc.s 9
+		IL_016e: ldc.i4.s 10
+		IL_0170: newarr [System.Runtime]System.Object
+		IL_0175: dup
+		IL_0176: ldc.i4.0
+		IL_0177: ldloc.s 8
+		IL_0179: stelem.ref
+		IL_017a: dup
+		IL_017b: ldc.i4.1
+		IL_017c: ldstr "setBitTrue"
+		IL_0181: stelem.ref
+		IL_0182: dup
+		IL_0183: ldc.i4.2
+		IL_0184: ldstr "setBitTrue"
+		IL_0189: stelem.ref
+		IL_018a: dup
+		IL_018b: ldc.i4.3
+		IL_018c: ldc.r8 1
+		IL_0195: box [System.Runtime]System.Double
+		IL_019a: stelem.ref
+		IL_019b: dup
+		IL_019c: ldc.i4.4
+		IL_019d: ldstr "setBitTrue"
+		IL_01a2: stelem.ref
+		IL_01a3: dup
+		IL_01a4: ldc.i4.5
+		IL_01a5: ldc.i4.0
+		IL_01a6: box [System.Runtime]System.Boolean
+		IL_01ab: stelem.ref
+		IL_01ac: dup
+		IL_01ad: ldc.i4.6
+		IL_01ae: ldc.i4.0
+		IL_01af: box [System.Runtime]System.Boolean
+		IL_01b4: stelem.ref
+		IL_01b5: dup
+		IL_01b6: ldc.i4.7
+		IL_01b7: ldc.i4.0
+		IL_01b8: box [System.Runtime]System.Boolean
+		IL_01bd: stelem.ref
+		IL_01be: dup
+		IL_01bf: ldc.i4.8
+		IL_01c0: ldc.i4.0
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stelem.ref
+		IL_01c7: dup
+		IL_01c8: ldc.i4.s 9
+		IL_01ca: ldloc.s 9
+		IL_01cc: stelem.ref
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_01d2: pop
+		IL_01d3: ldc.i4.s 10
+		IL_01d5: newarr [System.Runtime]System.Object
+		IL_01da: dup
+		IL_01db: ldc.i4.0
+		IL_01dc: ldloc.s 8
+		IL_01de: stelem.ref
+		IL_01df: dup
+		IL_01e0: ldc.i4.1
+		IL_01e1: ldstr "setBitsTrue"
+		IL_01e6: stelem.ref
+		IL_01e7: dup
+		IL_01e8: ldc.i4.2
+		IL_01e9: ldstr "setBitsTrue"
+		IL_01ee: stelem.ref
+		IL_01ef: dup
+		IL_01f0: ldc.i4.3
+		IL_01f1: ldc.r8 3
+		IL_01fa: box [System.Runtime]System.Double
+		IL_01ff: stelem.ref
+		IL_0200: dup
+		IL_0201: ldc.i4.4
+		IL_0202: ldstr "setBitsTrue"
+		IL_0207: stelem.ref
+		IL_0208: dup
+		IL_0209: ldc.i4.5
+		IL_020a: ldc.i4.0
+		IL_020b: box [System.Runtime]System.Boolean
+		IL_0210: stelem.ref
+		IL_0211: dup
+		IL_0212: ldc.i4.6
+		IL_0213: ldc.i4.0
+		IL_0214: box [System.Runtime]System.Boolean
+		IL_0219: stelem.ref
+		IL_021a: dup
+		IL_021b: ldc.i4.7
+		IL_021c: ldc.i4.0
+		IL_021d: box [System.Runtime]System.Boolean
+		IL_0222: stelem.ref
+		IL_0223: dup
+		IL_0224: ldc.i4.8
+		IL_0225: ldc.i4.0
+		IL_0226: box [System.Runtime]System.Boolean
+		IL_022b: stelem.ref
+		IL_022c: dup
+		IL_022d: ldc.i4.s 9
+		IL_022f: ldloc.s 9
+		IL_0231: stelem.ref
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0237: pop
+		IL_0238: ldc.i4.s 10
+		IL_023a: newarr [System.Runtime]System.Object
+		IL_023f: dup
+		IL_0240: ldc.i4.0
+		IL_0241: ldloc.s 8
+		IL_0243: stelem.ref
+		IL_0244: dup
+		IL_0245: ldc.i4.1
+		IL_0246: ldstr "testBitTrue"
+		IL_024b: stelem.ref
+		IL_024c: dup
+		IL_024d: ldc.i4.2
+		IL_024e: ldstr "testBitTrue"
+		IL_0253: stelem.ref
+		IL_0254: dup
+		IL_0255: ldc.i4.3
+		IL_0256: ldc.r8 1
+		IL_025f: box [System.Runtime]System.Double
+		IL_0264: stelem.ref
+		IL_0265: dup
+		IL_0266: ldc.i4.4
+		IL_0267: ldstr "testBitTrue"
+		IL_026c: stelem.ref
+		IL_026d: dup
+		IL_026e: ldc.i4.5
+		IL_026f: ldc.i4.0
+		IL_0270: box [System.Runtime]System.Boolean
+		IL_0275: stelem.ref
+		IL_0276: dup
+		IL_0277: ldc.i4.6
+		IL_0278: ldc.i4.0
+		IL_0279: box [System.Runtime]System.Boolean
+		IL_027e: stelem.ref
+		IL_027f: dup
+		IL_0280: ldc.i4.7
+		IL_0281: ldc.i4.0
+		IL_0282: box [System.Runtime]System.Boolean
+		IL_0287: stelem.ref
+		IL_0288: dup
+		IL_0289: ldc.i4.8
+		IL_028a: ldc.i4.0
+		IL_028b: box [System.Runtime]System.Boolean
+		IL_0290: stelem.ref
+		IL_0291: dup
+		IL_0292: ldc.i4.s 9
+		IL_0294: ldloc.s 9
+		IL_0296: stelem.ref
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_029c: pop
+		IL_029d: ldc.i4.s 10
+		IL_029f: newarr [System.Runtime]System.Object
+		IL_02a4: dup
+		IL_02a5: ldc.i4.0
+		IL_02a6: ldloc.s 8
+		IL_02a8: stelem.ref
+		IL_02a9: dup
+		IL_02aa: ldc.i4.1
+		IL_02ab: ldstr "searchBitFalse"
+		IL_02b0: stelem.ref
+		IL_02b1: dup
+		IL_02b2: ldc.i4.2
+		IL_02b3: ldstr "searchBitFalse"
+		IL_02b8: stelem.ref
+		IL_02b9: dup
+		IL_02ba: ldc.i4.3
+		IL_02bb: ldc.r8 1
+		IL_02c4: box [System.Runtime]System.Double
+		IL_02c9: stelem.ref
+		IL_02ca: dup
+		IL_02cb: ldc.i4.4
+		IL_02cc: ldstr "searchBitFalse"
+		IL_02d1: stelem.ref
+		IL_02d2: dup
+		IL_02d3: ldc.i4.5
+		IL_02d4: ldc.i4.0
+		IL_02d5: box [System.Runtime]System.Boolean
+		IL_02da: stelem.ref
+		IL_02db: dup
+		IL_02dc: ldc.i4.6
+		IL_02dd: ldc.i4.0
+		IL_02de: box [System.Runtime]System.Boolean
+		IL_02e3: stelem.ref
+		IL_02e4: dup
+		IL_02e5: ldc.i4.7
+		IL_02e6: ldc.i4.0
+		IL_02e7: box [System.Runtime]System.Boolean
+		IL_02ec: stelem.ref
+		IL_02ed: dup
+		IL_02ee: ldc.i4.8
+		IL_02ef: ldc.i4.0
+		IL_02f0: box [System.Runtime]System.Boolean
+		IL_02f5: stelem.ref
+		IL_02f6: dup
+		IL_02f7: ldc.i4.s 9
+		IL_02f9: ldloc.s 9
+		IL_02fb: stelem.ref
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0301: pop
+		IL_0302: ldc.i4.1
+		IL_0303: newarr [System.Runtime]System.Object
+		IL_0308: dup
+		IL_0309: ldc.i4.0
+		IL_030a: ldloc.0
+		IL_030b: stelem.ref
+		IL_030c: stloc.s 9
+		IL_030e: ldloc.s 8
+		IL_0310: ldloc.s 9
+		IL_0312: ldc.r8 1
+		IL_031b: box [System.Runtime]System.Double
+		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0325: stloc.s 5
+		IL_0327: ldloc.0
+		IL_0328: ldloc.s 5
+		IL_032a: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_032f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0334: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0339: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_033e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0343: stloc.s 8
+		IL_0345: ldc.i4.1
+		IL_0346: newarr [System.Runtime]System.Object
+		IL_034b: dup
+		IL_034c: ldc.i4.0
+		IL_034d: ldloc.0
+		IL_034e: stelem.ref
+		IL_034f: stloc.s 9
+		IL_0351: ldc.i4.s 10
+		IL_0353: newarr [System.Runtime]System.Object
+		IL_0358: dup
+		IL_0359: ldc.i4.0
+		IL_035a: ldloc.s 8
+		IL_035c: stelem.ref
+		IL_035d: dup
+		IL_035e: ldc.i4.1
+		IL_035f: ldstr "runSieve"
+		IL_0364: stelem.ref
+		IL_0365: dup
+		IL_0366: ldc.i4.2
+		IL_0367: ldstr "runSieve"
+		IL_036c: stelem.ref
+		IL_036d: dup
+		IL_036e: ldc.i4.3
+		IL_036f: ldc.r8 0.0
+		IL_0378: box [System.Runtime]System.Double
+		IL_037d: stelem.ref
+		IL_037e: dup
+		IL_037f: ldc.i4.4
+		IL_0380: ldstr "runSieve"
+		IL_0385: stelem.ref
+		IL_0386: dup
+		IL_0387: ldc.i4.5
+		IL_0388: ldc.i4.0
+		IL_0389: box [System.Runtime]System.Boolean
+		IL_038e: stelem.ref
+		IL_038f: dup
+		IL_0390: ldc.i4.6
+		IL_0391: ldc.i4.0
+		IL_0392: box [System.Runtime]System.Boolean
+		IL_0397: stelem.ref
+		IL_0398: dup
+		IL_0399: ldc.i4.7
+		IL_039a: ldc.i4.0
+		IL_039b: box [System.Runtime]System.Boolean
+		IL_03a0: stelem.ref
+		IL_03a1: dup
+		IL_03a2: ldc.i4.8
+		IL_03a3: ldc.i4.0
+		IL_03a4: box [System.Runtime]System.Boolean
+		IL_03a9: stelem.ref
+		IL_03aa: dup
+		IL_03ab: ldc.i4.s 9
+		IL_03ad: ldloc.s 9
+		IL_03af: stelem.ref
+		IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_03b5: pop
+		IL_03b6: ldc.i4.s 10
+		IL_03b8: newarr [System.Runtime]System.Object
+		IL_03bd: dup
+		IL_03be: ldc.i4.0
+		IL_03bf: ldloc.s 8
+		IL_03c1: stelem.ref
+		IL_03c2: dup
+		IL_03c3: ldc.i4.1
+		IL_03c4: ldstr "countPrimes"
+		IL_03c9: stelem.ref
+		IL_03ca: dup
+		IL_03cb: ldc.i4.2
+		IL_03cc: ldstr "countPrimes"
+		IL_03d1: stelem.ref
+		IL_03d2: dup
+		IL_03d3: ldc.i4.3
+		IL_03d4: ldc.r8 0.0
+		IL_03dd: box [System.Runtime]System.Double
+		IL_03e2: stelem.ref
+		IL_03e3: dup
+		IL_03e4: ldc.i4.4
+		IL_03e5: ldstr "countPrimes"
+		IL_03ea: stelem.ref
+		IL_03eb: dup
+		IL_03ec: ldc.i4.5
+		IL_03ed: ldc.i4.0
+		IL_03ee: box [System.Runtime]System.Boolean
+		IL_03f3: stelem.ref
+		IL_03f4: dup
+		IL_03f5: ldc.i4.6
+		IL_03f6: ldc.i4.0
+		IL_03f7: box [System.Runtime]System.Boolean
+		IL_03fc: stelem.ref
+		IL_03fd: dup
+		IL_03fe: ldc.i4.7
+		IL_03ff: ldc.i4.0
+		IL_0400: box [System.Runtime]System.Boolean
+		IL_0405: stelem.ref
+		IL_0406: dup
+		IL_0407: ldc.i4.8
+		IL_0408: ldc.i4.0
+		IL_0409: box [System.Runtime]System.Boolean
+		IL_040e: stelem.ref
+		IL_040f: dup
+		IL_0410: ldc.i4.s 9
+		IL_0412: ldloc.s 9
+		IL_0414: stelem.ref
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_041a: pop
+		IL_041b: ldc.i4.s 10
+		IL_041d: newarr [System.Runtime]System.Object
+		IL_0422: dup
+		IL_0423: ldc.i4.0
+		IL_0424: ldloc.s 8
+		IL_0426: stelem.ref
+		IL_0427: dup
+		IL_0428: ldc.i4.1
+		IL_0429: ldstr "getPrimes"
+		IL_042e: stelem.ref
+		IL_042f: dup
+		IL_0430: ldc.i4.2
+		IL_0431: ldstr "getPrimes"
+		IL_0436: stelem.ref
+		IL_0437: dup
+		IL_0438: ldc.i4.3
+		IL_0439: ldc.r8 0.0
+		IL_0442: box [System.Runtime]System.Double
+		IL_0447: stelem.ref
+		IL_0448: dup
+		IL_0449: ldc.i4.4
+		IL_044a: ldstr "getPrimes"
+		IL_044f: stelem.ref
+		IL_0450: dup
+		IL_0451: ldc.i4.5
+		IL_0452: ldc.i4.0
+		IL_0453: box [System.Runtime]System.Boolean
+		IL_0458: stelem.ref
+		IL_0459: dup
+		IL_045a: ldc.i4.6
+		IL_045b: ldc.i4.0
+		IL_045c: box [System.Runtime]System.Boolean
+		IL_0461: stelem.ref
+		IL_0462: dup
+		IL_0463: ldc.i4.7
+		IL_0464: ldc.i4.0
+		IL_0465: box [System.Runtime]System.Boolean
+		IL_046a: stelem.ref
+		IL_046b: dup
+		IL_046c: ldc.i4.8
+		IL_046d: ldc.i4.0
+		IL_046e: box [System.Runtime]System.Boolean
+		IL_0473: stelem.ref
+		IL_0474: dup
+		IL_0475: ldc.i4.s 9
+		IL_0477: ldloc.s 9
+		IL_0479: stelem.ref
+		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_047f: pop
+		IL_0480: ldc.i4.s 10
+		IL_0482: newarr [System.Runtime]System.Object
+		IL_0487: dup
+		IL_0488: ldc.i4.0
+		IL_0489: ldloc.s 8
+		IL_048b: stelem.ref
+		IL_048c: dup
+		IL_048d: ldc.i4.1
+		IL_048e: ldstr "validatePrimeCount"
+		IL_0493: stelem.ref
+		IL_0494: dup
+		IL_0495: ldc.i4.2
+		IL_0496: ldstr "validatePrimeCount"
+		IL_049b: stelem.ref
+		IL_049c: dup
+		IL_049d: ldc.i4.3
+		IL_049e: ldc.r8 1
+		IL_04a7: box [System.Runtime]System.Double
+		IL_04ac: stelem.ref
+		IL_04ad: dup
+		IL_04ae: ldc.i4.4
+		IL_04af: ldstr "validatePrimeCount"
+		IL_04b4: stelem.ref
+		IL_04b5: dup
+		IL_04b6: ldc.i4.5
+		IL_04b7: ldc.i4.0
+		IL_04b8: box [System.Runtime]System.Boolean
+		IL_04bd: stelem.ref
+		IL_04be: dup
+		IL_04bf: ldc.i4.6
+		IL_04c0: ldc.i4.0
+		IL_04c1: box [System.Runtime]System.Boolean
+		IL_04c6: stelem.ref
+		IL_04c7: dup
+		IL_04c8: ldc.i4.7
+		IL_04c9: ldc.i4.0
+		IL_04ca: box [System.Runtime]System.Boolean
+		IL_04cf: stelem.ref
+		IL_04d0: dup
+		IL_04d1: ldc.i4.8
+		IL_04d2: ldc.i4.0
+		IL_04d3: box [System.Runtime]System.Boolean
+		IL_04d8: stelem.ref
+		IL_04d9: dup
+		IL_04da: ldc.i4.s 9
+		IL_04dc: ldloc.s 9
+		IL_04de: stelem.ref
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_04e4: pop
+		IL_04e5: ldc.i4.1
+		IL_04e6: newarr [System.Runtime]System.Object
+		IL_04eb: dup
+		IL_04ec: ldc.i4.0
+		IL_04ed: ldloc.0
+		IL_04ee: stelem.ref
+		IL_04ef: stloc.s 9
+		IL_04f1: ldloc.s 8
+		IL_04f3: ldloc.s 9
+		IL_04f5: ldc.r8 1
+		IL_04fe: box [System.Runtime]System.Double
+		IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_0508: stloc.s 5
+		IL_050a: ldloc.0
+		IL_050b: ldloc.s 5
+		IL_050d: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_0512: ldloc.0
+		IL_0513: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0518: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L213C23::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object, object)
+		IL_051e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0523: ldc.i4.1
+		IL_0524: newarr [System.Runtime]System.Object
+		IL_0529: dup
+		IL_052a: ldc.i4.0
+		IL_052b: ldloc.0
+		IL_052c: stelem.ref
+		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0537: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_053c: ldc.i4.1
+		IL_053d: conv.r8
+		IL_053e: ldstr ""
+		IL_0543: ldc.i4.0
+		IL_0544: ldc.i4.0
+		IL_0545: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_054a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_054f: stloc.s 10
+		IL_0551: ldloc.s 10
+		IL_0553: ldstr "runSieveBatch"
+		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_055d: stloc.3
+		IL_055e: ldloc.0
+		IL_055f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0564: ldftn object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_056a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_056f: ldc.i4.1
+		IL_0570: newarr [System.Runtime]System.Object
+		IL_0575: dup
+		IL_0576: ldc.i4.0
+		IL_0577: ldloc.0
+		IL_0578: stelem.ref
+		IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0583: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0588: ldc.i4.1
+		IL_0589: conv.r8
+		IL_058a: ldstr ""
+		IL_058f: ldc.i4.0
+		IL_0590: ldc.i4.0
+		IL_0591: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0596: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_059b: stloc.s 11
+		IL_059d: ldloc.s 11
+		IL_059f: ldstr "main"
+		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_05a9: stloc.s 4
+		IL_05ab: ldloc.0
+		IL_05ac: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_05b1: ldnull
+		IL_05b2: ldloc.1
+		IL_05b3: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_05b8: pop
+		IL_05b9: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -1449,6 +1449,32 @@ public class SymbolTableTypeInferenceTests
     }
 
     [Fact]
+    public void SymbolTable_InferTypes_PrimeJavaScript_SearchBitFalse_InfersNumericParameter()
+    {
+        const string resourceName = "Jroc.Tests.Integration.JavaScript.Compile_Performance_PrimeJavaScript.js";
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var source = reader.ReadToEnd();
+        var symbolTable = BuildSymbolTable(source);
+
+        var classScope = FindClassScope(symbolTable.Root, "BitArray");
+        Assert.NotNull(classScope);
+
+        foreach (var methodName in new[] { "searchBitFalse", "testBitTrue" })
+        {
+            var methodScope = FindFirstScope(classScope!, scope =>
+                scope.Kind == ScopeKind.Function
+                && scope.Parent?.Kind == ScopeKind.Class
+                && string.Equals(scope.Name, methodName, StringComparison.Ordinal));
+
+            Assert.NotNull(methodScope);
+            AssertStableParameterTypes(methodScope!, ("index", typeof(double)));
+        }
+    }
+
+    [Fact]
     public void SymbolTable_InferTypes_PrimeJavaScript_PrimeSieveConstructorInfersNumericParameter()
     {
         const string resourceName = "Jroc.Tests.Integration.JavaScript.Compile_Performance_PrimeJavaScript.js";
@@ -1471,6 +1497,30 @@ public class SymbolTableTypeInferenceTests
         AssertStableParameterTypes(constructorScope!, ("sieveSize", typeof(double)));
         Assert.True(classScope.StableInstanceFieldClrTypes.TryGetValue("sieveSize", out var fieldType));
         Assert.Equal(typeof(double), fieldType);
+    }
+
+    [Fact]
+    public void SymbolTable_InferTypes_UpdateParameterWrittenInsideWith_RemainsObject()
+    {
+        var symbolTable = BuildSymbolTable(
+            """
+            function updateInsideWith(value) {
+                value++;
+                with ({}) {
+                    value = "text";
+                }
+                return value;
+            }
+
+            updateInsideWith(1);
+            """);
+
+        var functionScope = FindFirstScope(symbolTable.Root, scope =>
+            scope.Kind == ScopeKind.Function
+            && string.Equals(scope.Name, "updateInsideWith", StringComparison.Ordinal));
+
+        Assert.NotNull(functionScope);
+        AssertObjectParameter(functionScope!, "value");
     }
 
     [Fact]

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -951,7 +951,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1814 (0x716)
+		// Code size: 1813 (0x715)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -979,618 +979,617 @@
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_000d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0012: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0017: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_001c: stloc.s 7
-		IL_001e: ldc.i4.1
-		IL_001f: newarr [System.Runtime]System.Object
-		IL_0024: dup
-		IL_0025: ldc.i4.0
-		IL_0026: ldloc.0
-		IL_0027: stelem.ref
-		IL_0028: stloc.s 8
-		IL_002a: ldc.i4.s 10
-		IL_002c: newarr [System.Runtime]System.Object
-		IL_0031: dup
-		IL_0032: ldc.i4.0
-		IL_0033: ldloc.s 7
-		IL_0035: stelem.ref
-		IL_0036: dup
-		IL_0037: ldc.i4.1
-		IL_0038: ldstr "setBitTrue"
-		IL_003d: stelem.ref
-		IL_003e: dup
-		IL_003f: ldc.i4.2
-		IL_0040: ldstr "setBitTrue"
-		IL_0045: stelem.ref
-		IL_0046: dup
-		IL_0047: ldc.i4.3
-		IL_0048: ldc.r8 1
-		IL_0051: box [System.Runtime]System.Double
-		IL_0056: stelem.ref
-		IL_0057: dup
-		IL_0058: ldc.i4.4
-		IL_0059: ldstr "setBitTrue"
-		IL_005e: stelem.ref
-		IL_005f: dup
-		IL_0060: ldc.i4.5
-		IL_0061: ldc.i4.0
-		IL_0062: box [System.Runtime]System.Boolean
-		IL_0067: stelem.ref
-		IL_0068: dup
-		IL_0069: ldc.i4.6
-		IL_006a: ldc.i4.0
-		IL_006b: box [System.Runtime]System.Boolean
-		IL_0070: stelem.ref
-		IL_0071: dup
-		IL_0072: ldc.i4.7
-		IL_0073: ldc.i4.0
-		IL_0074: box [System.Runtime]System.Boolean
-		IL_0079: stelem.ref
-		IL_007a: dup
-		IL_007b: ldc.i4.8
-		IL_007c: ldc.i4.0
-		IL_007d: box [System.Runtime]System.Boolean
-		IL_0082: stelem.ref
-		IL_0083: dup
-		IL_0084: ldc.i4.s 9
-		IL_0086: ldloc.s 8
-		IL_0088: stelem.ref
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_008e: pop
-		IL_008f: ldc.i4.s 10
-		IL_0091: newarr [System.Runtime]System.Object
-		IL_0096: dup
-		IL_0097: ldc.i4.0
-		IL_0098: ldloc.s 7
-		IL_009a: stelem.ref
-		IL_009b: dup
-		IL_009c: ldc.i4.1
-		IL_009d: ldstr "setBitsTrue"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.2
-		IL_00a5: ldstr "setBitsTrue"
-		IL_00aa: stelem.ref
-		IL_00ab: dup
-		IL_00ac: ldc.i4.3
-		IL_00ad: ldc.r8 3
-		IL_00b6: box [System.Runtime]System.Double
-		IL_00bb: stelem.ref
-		IL_00bc: dup
-		IL_00bd: ldc.i4.4
-		IL_00be: ldstr "setBitsTrue"
-		IL_00c3: stelem.ref
-		IL_00c4: dup
-		IL_00c5: ldc.i4.5
-		IL_00c6: ldc.i4.0
-		IL_00c7: box [System.Runtime]System.Boolean
-		IL_00cc: stelem.ref
-		IL_00cd: dup
-		IL_00ce: ldc.i4.6
-		IL_00cf: ldc.i4.0
-		IL_00d0: box [System.Runtime]System.Boolean
-		IL_00d5: stelem.ref
-		IL_00d6: dup
-		IL_00d7: ldc.i4.7
-		IL_00d8: ldc.i4.0
-		IL_00d9: box [System.Runtime]System.Boolean
-		IL_00de: stelem.ref
-		IL_00df: dup
-		IL_00e0: ldc.i4.8
-		IL_00e1: ldc.i4.0
-		IL_00e2: box [System.Runtime]System.Boolean
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.s 9
-		IL_00eb: ldloc.s 8
-		IL_00ed: stelem.ref
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00f3: pop
-		IL_00f4: ldc.i4.s 10
-		IL_00f6: newarr [System.Runtime]System.Object
-		IL_00fb: dup
-		IL_00fc: ldc.i4.0
-		IL_00fd: ldloc.s 7
-		IL_00ff: stelem.ref
-		IL_0100: dup
-		IL_0101: ldc.i4.1
-		IL_0102: ldstr "setBitsTrue_Naive"
-		IL_0107: stelem.ref
-		IL_0108: dup
-		IL_0109: ldc.i4.2
-		IL_010a: ldstr "setBitsTrue_Naive"
-		IL_010f: stelem.ref
-		IL_0110: dup
-		IL_0111: ldc.i4.3
-		IL_0112: ldc.r8 3
-		IL_011b: box [System.Runtime]System.Double
-		IL_0120: stelem.ref
-		IL_0121: dup
-		IL_0122: ldc.i4.4
-		IL_0123: ldstr "setBitsTrue_Naive"
-		IL_0128: stelem.ref
-		IL_0129: dup
-		IL_012a: ldc.i4.5
-		IL_012b: ldc.i4.0
-		IL_012c: box [System.Runtime]System.Boolean
-		IL_0131: stelem.ref
-		IL_0132: dup
-		IL_0133: ldc.i4.6
-		IL_0134: ldc.i4.0
-		IL_0135: box [System.Runtime]System.Boolean
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.7
-		IL_013d: ldc.i4.0
-		IL_013e: box [System.Runtime]System.Boolean
-		IL_0143: stelem.ref
-		IL_0144: dup
-		IL_0145: ldc.i4.8
-		IL_0146: ldc.i4.0
-		IL_0147: box [System.Runtime]System.Boolean
-		IL_014c: stelem.ref
-		IL_014d: dup
-		IL_014e: ldc.i4.s 9
-		IL_0150: ldloc.s 8
-		IL_0152: stelem.ref
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0158: pop
-		IL_0159: ldc.i4.1
-		IL_015a: newarr [System.Runtime]System.Object
-		IL_015f: dup
-		IL_0160: ldc.i4.0
-		IL_0161: ldloc.0
-		IL_0162: stelem.ref
-		IL_0163: stloc.s 8
-		IL_0165: ldloc.s 7
-		IL_0167: ldloc.s 8
-		IL_0169: ldc.r8 1
-		IL_0172: box [System.Runtime]System.Double
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_017c: stloc.s 9
-		IL_017e: ldloc.s 9
-		IL_0180: stloc.1
-		IL_0181: ldloc.0
-		IL_0182: ldc.r8 2048
-		IL_018b: box [System.Runtime]System.Double
-		IL_0190: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_0195: ldloc.0
-		IL_0196: ldc.r8 1
-		IL_019f: box [System.Runtime]System.Double
-		IL_01a4: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_01a9: ldloc.0
-		IL_01aa: ldc.r8 17
-		IL_01b3: box [System.Runtime]System.Double
-		IL_01b8: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_01bd: ldloc.0
-		IL_01be: ldc.r8 600
-		IL_01c7: box [System.Runtime]System.Double
-		IL_01cc: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_01d1: ldc.i4.1
-		IL_01d2: newarr [System.Runtime]System.Object
-		IL_01d7: dup
-		IL_01d8: ldc.i4.0
-		IL_01d9: ldloc.0
-		IL_01da: stelem.ref
-		IL_01db: stloc.s 8
-		IL_01dd: ldloc.0
-		IL_01de: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01e3: ldstr "Cannot access 'size' before initialization"
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01ed: stloc.s 9
-		IL_01ef: ldloc.s 8
-		IL_01f1: ldc.i4.1
-		IL_01f2: newarr [System.Runtime]System.Object
-		IL_01f7: dup
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldloc.s 9
-		IL_01fb: stelem.ref
-		IL_01fc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0201: ldloc.s 9
-		IL_0203: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0208: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_020d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0212: stloc.2
-		IL_0213: ldloc.2
-		IL_0214: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0219: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_021e: ldstr "prototype"
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0228: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_022d: ldc.i4.1
-		IL_022e: newarr [System.Runtime]System.Object
-		IL_0233: dup
-		IL_0234: ldc.i4.0
-		IL_0235: ldloc.0
-		IL_0236: stelem.ref
-		IL_0237: stloc.s 8
-		IL_0239: ldloc.0
-		IL_023a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_023f: ldstr "Cannot access 'size' before initialization"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0249: stloc.s 9
-		IL_024b: ldloc.s 8
-		IL_024d: ldc.i4.1
-		IL_024e: newarr [System.Runtime]System.Object
-		IL_0253: dup
-		IL_0254: ldc.i4.0
-		IL_0255: ldloc.s 9
-		IL_0257: stelem.ref
-		IL_0258: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_025d: ldloc.s 9
-		IL_025f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0264: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_0269: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_026e: stloc.3
-		IL_026f: ldloc.3
-		IL_0270: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0275: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_027a: ldstr "prototype"
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0284: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0289: ldstr "console"
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0298: stloc.s 9
-		IL_029a: ldloc.2
-		IL_029b: ldstr "wordArray"
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a5: stloc.s 10
-		IL_02a7: ldloc.s 10
-		IL_02a9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02ae: stloc.s 11
-		IL_02b0: ldloc.3
-		IL_02b1: ldstr "wordArray"
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02bb: stloc.s 10
-		IL_02bd: ldloc.s 10
-		IL_02bf: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02c4: stloc.s 12
-		IL_02c6: ldloc.s 9
-		IL_02c8: ldstr "log"
-		IL_02cd: ldstr "types"
-		IL_02d2: ldloc.s 11
-		IL_02d4: ldloc.s 12
-		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_02db: pop
-		IL_02dc: ldstr "console"
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02eb: stloc.s 9
-		IL_02ed: ldloc.2
-		IL_02ee: ldstr "wordArray"
-		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f8: stloc.s 10
-		IL_02fa: ldloc.s 10
-		IL_02fc: ldstr "length"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0306: stloc.s 10
-		IL_0308: ldloc.3
-		IL_0309: ldstr "wordArray"
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0313: stloc.s 13
-		IL_0315: ldloc.s 13
-		IL_0317: ldstr "length"
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0321: stloc.s 13
-		IL_0323: ldloc.s 9
-		IL_0325: ldstr "log"
-		IL_032a: ldstr "lens"
-		IL_032f: ldloc.s 10
-		IL_0331: ldloc.s 13
-		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0338: pop
-		IL_0339: ldloc.2
-		IL_033a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_033f: stloc.s 14
-		IL_0341: ldloc.0
-		IL_0342: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_0347: ldstr "Cannot access 'range_start' before initialization"
-		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0351: stloc.s 13
-		IL_0353: ldloc.0
-		IL_0354: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0359: ldstr "Cannot access 'step' before initialization"
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0363: stloc.s 10
-		IL_0365: ldloc.0
-		IL_0366: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_036b: ldstr "Cannot access 'range_stop' before initialization"
-		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0375: stloc.s 9
-		IL_0377: ldloc.s 14
-		IL_0379: ldloc.s 13
-		IL_037b: ldloc.s 10
-		IL_037d: ldloc.s 9
-		IL_037f: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_0384: pop
-		IL_0385: ldloc.3
-		IL_0386: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_038b: stloc.s 14
-		IL_038d: ldloc.0
-		IL_038e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_0393: ldstr "Cannot access 'range_start' before initialization"
-		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_039d: stloc.s 9
-		IL_039f: ldloc.0
-		IL_03a0: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_03a5: ldstr "Cannot access 'step' before initialization"
-		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03af: stloc.s 10
-		IL_03b1: ldloc.0
-		IL_03b2: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_03b7: ldstr "Cannot access 'range_stop' before initialization"
-		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03c1: stloc.s 13
-		IL_03c3: ldloc.s 14
-		IL_03c5: ldloc.s 9
-		IL_03c7: ldloc.s 10
-		IL_03c9: ldloc.s 13
-		IL_03cb: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_03d0: pop
-		IL_03d1: ldc.r8 0.0
-		IL_03da: stloc.s 4
-		IL_03dc: ldc.r8 1
-		IL_03e5: neg
-		IL_03e6: stloc.s 15
-		IL_03e8: ldloc.s 15
-		IL_03ea: box [System.Runtime]System.Double
-		IL_03ef: stloc.s 5
-		IL_03f1: ldc.r8 0.0
-		IL_03fa: stloc.s 6
-		// loop start (head: IL_03fc)
-			IL_03fc: ldloc.s 6
-			IL_03fe: stloc.s 15
-			IL_0400: ldloc.2
-			IL_0401: ldstr "wordArray"
-			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040b: stloc.s 13
-			IL_040d: ldloc.s 13
-			IL_040f: ldstr "length"
-			IL_0414: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_0419: stloc.s 16
-			IL_041b: ldloc.s 15
-			IL_041d: ldloc.s 16
-			IL_041f: clt
-			IL_0421: brfalse IL_04c1
+		IL_0007: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_000c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0011: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001b: stloc.s 7
+		IL_001d: ldc.i4.1
+		IL_001e: newarr [System.Runtime]System.Object
+		IL_0023: dup
+		IL_0024: ldc.i4.0
+		IL_0025: ldloc.0
+		IL_0026: stelem.ref
+		IL_0027: stloc.s 8
+		IL_0029: ldc.i4.s 10
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.s 7
+		IL_0034: stelem.ref
+		IL_0035: dup
+		IL_0036: ldc.i4.1
+		IL_0037: ldstr "setBitTrue"
+		IL_003c: stelem.ref
+		IL_003d: dup
+		IL_003e: ldc.i4.2
+		IL_003f: ldstr "setBitTrue"
+		IL_0044: stelem.ref
+		IL_0045: dup
+		IL_0046: ldc.i4.3
+		IL_0047: ldc.r8 1
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: stelem.ref
+		IL_0056: dup
+		IL_0057: ldc.i4.4
+		IL_0058: ldstr "setBitTrue"
+		IL_005d: stelem.ref
+		IL_005e: dup
+		IL_005f: ldc.i4.5
+		IL_0060: ldc.i4.0
+		IL_0061: box [System.Runtime]System.Boolean
+		IL_0066: stelem.ref
+		IL_0067: dup
+		IL_0068: ldc.i4.6
+		IL_0069: ldc.i4.0
+		IL_006a: box [System.Runtime]System.Boolean
+		IL_006f: stelem.ref
+		IL_0070: dup
+		IL_0071: ldc.i4.7
+		IL_0072: ldc.i4.0
+		IL_0073: box [System.Runtime]System.Boolean
+		IL_0078: stelem.ref
+		IL_0079: dup
+		IL_007a: ldc.i4.8
+		IL_007b: ldc.i4.0
+		IL_007c: box [System.Runtime]System.Boolean
+		IL_0081: stelem.ref
+		IL_0082: dup
+		IL_0083: ldc.i4.s 9
+		IL_0085: ldloc.s 8
+		IL_0087: stelem.ref
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_008d: pop
+		IL_008e: ldc.i4.s 10
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.s 7
+		IL_0099: stelem.ref
+		IL_009a: dup
+		IL_009b: ldc.i4.1
+		IL_009c: ldstr "setBitsTrue"
+		IL_00a1: stelem.ref
+		IL_00a2: dup
+		IL_00a3: ldc.i4.2
+		IL_00a4: ldstr "setBitsTrue"
+		IL_00a9: stelem.ref
+		IL_00aa: dup
+		IL_00ab: ldc.i4.3
+		IL_00ac: ldc.r8 3
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: stelem.ref
+		IL_00bb: dup
+		IL_00bc: ldc.i4.4
+		IL_00bd: ldstr "setBitsTrue"
+		IL_00c2: stelem.ref
+		IL_00c3: dup
+		IL_00c4: ldc.i4.5
+		IL_00c5: ldc.i4.0
+		IL_00c6: box [System.Runtime]System.Boolean
+		IL_00cb: stelem.ref
+		IL_00cc: dup
+		IL_00cd: ldc.i4.6
+		IL_00ce: ldc.i4.0
+		IL_00cf: box [System.Runtime]System.Boolean
+		IL_00d4: stelem.ref
+		IL_00d5: dup
+		IL_00d6: ldc.i4.7
+		IL_00d7: ldc.i4.0
+		IL_00d8: box [System.Runtime]System.Boolean
+		IL_00dd: stelem.ref
+		IL_00de: dup
+		IL_00df: ldc.i4.8
+		IL_00e0: ldc.i4.0
+		IL_00e1: box [System.Runtime]System.Boolean
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.s 9
+		IL_00ea: ldloc.s 8
+		IL_00ec: stelem.ref
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_00f2: pop
+		IL_00f3: ldc.i4.s 10
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: dup
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldloc.s 7
+		IL_00fe: stelem.ref
+		IL_00ff: dup
+		IL_0100: ldc.i4.1
+		IL_0101: ldstr "setBitsTrue_Naive"
+		IL_0106: stelem.ref
+		IL_0107: dup
+		IL_0108: ldc.i4.2
+		IL_0109: ldstr "setBitsTrue_Naive"
+		IL_010e: stelem.ref
+		IL_010f: dup
+		IL_0110: ldc.i4.3
+		IL_0111: ldc.r8 3
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: stelem.ref
+		IL_0120: dup
+		IL_0121: ldc.i4.4
+		IL_0122: ldstr "setBitsTrue_Naive"
+		IL_0127: stelem.ref
+		IL_0128: dup
+		IL_0129: ldc.i4.5
+		IL_012a: ldc.i4.0
+		IL_012b: box [System.Runtime]System.Boolean
+		IL_0130: stelem.ref
+		IL_0131: dup
+		IL_0132: ldc.i4.6
+		IL_0133: ldc.i4.0
+		IL_0134: box [System.Runtime]System.Boolean
+		IL_0139: stelem.ref
+		IL_013a: dup
+		IL_013b: ldc.i4.7
+		IL_013c: ldc.i4.0
+		IL_013d: box [System.Runtime]System.Boolean
+		IL_0142: stelem.ref
+		IL_0143: dup
+		IL_0144: ldc.i4.8
+		IL_0145: ldc.i4.0
+		IL_0146: box [System.Runtime]System.Boolean
+		IL_014b: stelem.ref
+		IL_014c: dup
+		IL_014d: ldc.i4.s 9
+		IL_014f: ldloc.s 8
+		IL_0151: stelem.ref
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0157: pop
+		IL_0158: ldc.i4.1
+		IL_0159: newarr [System.Runtime]System.Object
+		IL_015e: dup
+		IL_015f: ldc.i4.0
+		IL_0160: ldloc.0
+		IL_0161: stelem.ref
+		IL_0162: stloc.s 8
+		IL_0164: ldloc.s 7
+		IL_0166: ldloc.s 8
+		IL_0168: ldc.r8 1
+		IL_0171: box [System.Runtime]System.Double
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_017b: stloc.s 9
+		IL_017d: ldloc.s 9
+		IL_017f: stloc.1
+		IL_0180: ldloc.0
+		IL_0181: ldc.r8 2048
+		IL_018a: box [System.Runtime]System.Double
+		IL_018f: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_0194: ldloc.0
+		IL_0195: ldc.r8 1
+		IL_019e: box [System.Runtime]System.Double
+		IL_01a3: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_01a8: ldloc.0
+		IL_01a9: ldc.r8 17
+		IL_01b2: box [System.Runtime]System.Double
+		IL_01b7: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_01bc: ldloc.0
+		IL_01bd: ldc.r8 600
+		IL_01c6: box [System.Runtime]System.Double
+		IL_01cb: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_01d0: ldc.i4.1
+		IL_01d1: newarr [System.Runtime]System.Object
+		IL_01d6: dup
+		IL_01d7: ldc.i4.0
+		IL_01d8: ldloc.0
+		IL_01d9: stelem.ref
+		IL_01da: stloc.s 8
+		IL_01dc: ldloc.0
+		IL_01dd: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01e2: ldstr "Cannot access 'size' before initialization"
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_01ec: stloc.s 9
+		IL_01ee: ldloc.s 8
+		IL_01f0: ldc.i4.1
+		IL_01f1: newarr [System.Runtime]System.Object
+		IL_01f6: dup
+		IL_01f7: ldc.i4.0
+		IL_01f8: ldloc.s 9
+		IL_01fa: stelem.ref
+		IL_01fb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0200: ldloc.s 9
+		IL_0202: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0207: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_020c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0211: stloc.2
+		IL_0212: ldloc.2
+		IL_0213: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0218: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_021d: ldstr "prototype"
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0227: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_022c: ldc.i4.1
+		IL_022d: newarr [System.Runtime]System.Object
+		IL_0232: dup
+		IL_0233: ldc.i4.0
+		IL_0234: ldloc.0
+		IL_0235: stelem.ref
+		IL_0236: stloc.s 8
+		IL_0238: ldloc.0
+		IL_0239: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_023e: ldstr "Cannot access 'size' before initialization"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0248: stloc.s 9
+		IL_024a: ldloc.s 8
+		IL_024c: ldc.i4.1
+		IL_024d: newarr [System.Runtime]System.Object
+		IL_0252: dup
+		IL_0253: ldc.i4.0
+		IL_0254: ldloc.s 9
+		IL_0256: stelem.ref
+		IL_0257: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_025c: ldloc.s 9
+		IL_025e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0263: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_0268: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_026d: stloc.3
+		IL_026e: ldloc.3
+		IL_026f: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0274: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0279: ldstr "prototype"
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0283: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0288: ldstr "console"
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0297: stloc.s 9
+		IL_0299: ldloc.2
+		IL_029a: ldstr "wordArray"
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a4: stloc.s 10
+		IL_02a6: ldloc.s 10
+		IL_02a8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02ad: stloc.s 11
+		IL_02af: ldloc.3
+		IL_02b0: ldstr "wordArray"
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ba: stloc.s 10
+		IL_02bc: ldloc.s 10
+		IL_02be: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02c3: stloc.s 12
+		IL_02c5: ldloc.s 9
+		IL_02c7: ldstr "log"
+		IL_02cc: ldstr "types"
+		IL_02d1: ldloc.s 11
+		IL_02d3: ldloc.s 12
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_02da: pop
+		IL_02db: ldstr "console"
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ea: stloc.s 9
+		IL_02ec: ldloc.2
+		IL_02ed: ldstr "wordArray"
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f7: stloc.s 10
+		IL_02f9: ldloc.s 10
+		IL_02fb: ldstr "length"
+		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0305: stloc.s 10
+		IL_0307: ldloc.3
+		IL_0308: ldstr "wordArray"
+		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0312: stloc.s 13
+		IL_0314: ldloc.s 13
+		IL_0316: ldstr "length"
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0320: stloc.s 13
+		IL_0322: ldloc.s 9
+		IL_0324: ldstr "log"
+		IL_0329: ldstr "lens"
+		IL_032e: ldloc.s 10
+		IL_0330: ldloc.s 13
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0337: pop
+		IL_0338: ldloc.2
+		IL_0339: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_033e: stloc.s 14
+		IL_0340: ldloc.0
+		IL_0341: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_0346: ldstr "Cannot access 'range_start' before initialization"
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0350: stloc.s 13
+		IL_0352: ldloc.0
+		IL_0353: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0358: ldstr "Cannot access 'step' before initialization"
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0362: stloc.s 10
+		IL_0364: ldloc.0
+		IL_0365: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_036a: ldstr "Cannot access 'range_stop' before initialization"
+		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0374: stloc.s 9
+		IL_0376: ldloc.s 14
+		IL_0378: ldloc.s 13
+		IL_037a: ldloc.s 10
+		IL_037c: ldloc.s 9
+		IL_037e: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+		IL_0383: pop
+		IL_0384: ldloc.3
+		IL_0385: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_038a: stloc.s 14
+		IL_038c: ldloc.0
+		IL_038d: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_0392: ldstr "Cannot access 'range_start' before initialization"
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_039c: stloc.s 9
+		IL_039e: ldloc.0
+		IL_039f: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_03a4: ldstr "Cannot access 'step' before initialization"
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_03ae: stloc.s 10
+		IL_03b0: ldloc.0
+		IL_03b1: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_03b6: ldstr "Cannot access 'range_stop' before initialization"
+		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_03c0: stloc.s 13
+		IL_03c2: ldloc.s 14
+		IL_03c4: ldloc.s 9
+		IL_03c6: ldloc.s 10
+		IL_03c8: ldloc.s 13
+		IL_03ca: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+		IL_03cf: pop
+		IL_03d0: ldc.r8 0.0
+		IL_03d9: stloc.s 4
+		IL_03db: ldc.r8 1
+		IL_03e4: neg
+		IL_03e5: stloc.s 15
+		IL_03e7: ldloc.s 15
+		IL_03e9: box [System.Runtime]System.Double
+		IL_03ee: stloc.s 5
+		IL_03f0: ldc.r8 0.0
+		IL_03f9: stloc.s 6
+		// loop start (head: IL_03fb)
+			IL_03fb: ldloc.s 6
+			IL_03fd: stloc.s 15
+			IL_03ff: ldloc.2
+			IL_0400: ldstr "wordArray"
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040a: stloc.s 13
+			IL_040c: ldloc.s 13
+			IL_040e: ldstr "length"
+			IL_0413: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_0418: stloc.s 16
+			IL_041a: ldloc.s 15
+			IL_041c: ldloc.s 16
+			IL_041e: clt
+			IL_0420: brfalse IL_04c0
 
-			IL_0426: ldloc.2
-			IL_0427: ldstr "wordArray"
-			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0431: stloc.s 13
-			IL_0433: ldloc.s 13
-			IL_0435: ldloc.s 6
-			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_043c: stloc.s 13
-			IL_043e: ldloc.3
-			IL_043f: ldstr "wordArray"
-			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0449: stloc.s 10
-			IL_044b: ldloc.s 10
-			IL_044d: ldloc.s 6
-			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0454: stloc.s 10
-			IL_0456: ldloc.s 13
-			IL_0458: ldloc.s 10
-			IL_045a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_045f: stloc.s 17
-			IL_0461: ldloc.s 17
-			IL_0463: brfalse IL_04ae
+			IL_0425: ldloc.2
+			IL_0426: ldstr "wordArray"
+			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0430: stloc.s 13
+			IL_0432: ldloc.s 13
+			IL_0434: ldloc.s 6
+			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_043b: stloc.s 13
+			IL_043d: ldloc.3
+			IL_043e: ldstr "wordArray"
+			IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0448: stloc.s 10
+			IL_044a: ldloc.s 10
+			IL_044c: ldloc.s 6
+			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0453: stloc.s 10
+			IL_0455: ldloc.s 13
+			IL_0457: ldloc.s 10
+			IL_0459: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_045e: stloc.s 17
+			IL_0460: ldloc.s 17
+			IL_0462: brfalse IL_04ad
 
-			IL_0468: ldloc.s 4
-			IL_046a: ldc.r8 1
-			IL_0473: add
-			IL_0474: stloc.s 4
-			IL_0476: ldloc.s 5
-			IL_0478: stloc.s 18
-			IL_047a: ldc.r8 1
-			IL_0483: neg
-			IL_0484: stloc.s 16
-			IL_0486: ldloc.s 16
-			IL_0488: box [System.Runtime]System.Double
-			IL_048d: stloc.s 19
-			IL_048f: ldloc.s 18
-			IL_0491: ldloc.s 19
-			IL_0493: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0498: stloc.s 17
-			IL_049a: ldloc.s 17
-			IL_049c: brfalse IL_04ae
+			IL_0467: ldloc.s 4
+			IL_0469: ldc.r8 1
+			IL_0472: add
+			IL_0473: stloc.s 4
+			IL_0475: ldloc.s 5
+			IL_0477: stloc.s 18
+			IL_0479: ldc.r8 1
+			IL_0482: neg
+			IL_0483: stloc.s 16
+			IL_0485: ldloc.s 16
+			IL_0487: box [System.Runtime]System.Double
+			IL_048c: stloc.s 19
+			IL_048e: ldloc.s 18
+			IL_0490: ldloc.s 19
+			IL_0492: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0497: stloc.s 17
+			IL_0499: ldloc.s 17
+			IL_049b: brfalse IL_04ad
 
-			IL_04a1: ldloc.s 6
-			IL_04a3: box [System.Runtime]System.Double
-			IL_04a8: stloc.s 19
-			IL_04aa: ldloc.s 19
-			IL_04ac: stloc.s 5
+			IL_04a0: ldloc.s 6
+			IL_04a2: box [System.Runtime]System.Double
+			IL_04a7: stloc.s 19
+			IL_04a9: ldloc.s 19
+			IL_04ab: stloc.s 5
 
-			IL_04ae: ldloc.s 6
-			IL_04b0: ldc.r8 1
-			IL_04b9: add
-			IL_04ba: stloc.s 6
-			IL_04bc: br IL_03fc
+			IL_04ad: ldloc.s 6
+			IL_04af: ldc.r8 1
+			IL_04b8: add
+			IL_04b9: stloc.s 6
+			IL_04bb: br IL_03fb
 		// end loop
 
-		IL_04c1: ldstr "console"
-		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04d0: ldloc.s 4
-		IL_04d2: box [System.Runtime]System.Double
-		IL_04d7: stloc.s 19
-		IL_04d9: ldstr "log"
-		IL_04de: ldstr "diffs"
-		IL_04e3: ldloc.s 19
-		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04ea: pop
-		IL_04eb: ldloc.s 5
-		IL_04ed: stloc.s 19
-		IL_04ef: ldc.r8 1
-		IL_04f8: neg
-		IL_04f9: stloc.s 16
-		IL_04fb: ldloc.s 16
-		IL_04fd: box [System.Runtime]System.Double
-		IL_0502: stloc.s 18
-		IL_0504: ldloc.s 19
-		IL_0506: ldloc.s 18
-		IL_0508: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_050d: stloc.s 17
-		IL_050f: ldloc.s 17
-		IL_0511: brfalse IL_0581
+		IL_04c0: ldstr "console"
+		IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04cf: ldloc.s 4
+		IL_04d1: box [System.Runtime]System.Double
+		IL_04d6: stloc.s 19
+		IL_04d8: ldstr "log"
+		IL_04dd: ldstr "diffs"
+		IL_04e2: ldloc.s 19
+		IL_04e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04e9: pop
+		IL_04ea: ldloc.s 5
+		IL_04ec: stloc.s 19
+		IL_04ee: ldc.r8 1
+		IL_04f7: neg
+		IL_04f8: stloc.s 16
+		IL_04fa: ldloc.s 16
+		IL_04fc: box [System.Runtime]System.Double
+		IL_0501: stloc.s 18
+		IL_0503: ldloc.s 19
+		IL_0505: ldloc.s 18
+		IL_0507: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_050c: stloc.s 17
+		IL_050e: ldloc.s 17
+		IL_0510: brfalse IL_0580
 
-		IL_0516: ldstr "console"
-		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0525: stloc.s 10
-		IL_0527: ldloc.2
-		IL_0528: ldstr "wordArray"
-		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0532: stloc.s 13
-		IL_0534: ldloc.s 13
-		IL_0536: ldloc.s 5
-		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_053d: stloc.s 13
-		IL_053f: ldloc.3
-		IL_0540: ldstr "wordArray"
-		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_054a: stloc.s 9
-		IL_054c: ldloc.s 9
-		IL_054e: ldloc.s 5
-		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0555: stloc.s 9
-		IL_0557: ldloc.s 10
-		IL_0559: ldstr "log"
-		IL_055e: ldc.i4.4
-		IL_055f: newarr [System.Runtime]System.Object
-		IL_0564: dup
-		IL_0565: ldc.i4.0
-		IL_0566: ldstr "first"
-		IL_056b: stelem.ref
-		IL_056c: dup
-		IL_056d: ldc.i4.1
-		IL_056e: ldloc.s 5
-		IL_0570: stelem.ref
-		IL_0571: dup
-		IL_0572: ldc.i4.2
-		IL_0573: ldloc.s 13
-		IL_0575: stelem.ref
-		IL_0576: dup
-		IL_0577: ldc.i4.3
-		IL_0578: ldloc.s 9
-		IL_057a: stelem.ref
-		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_0580: pop
+		IL_0515: ldstr "console"
+		IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0524: stloc.s 10
+		IL_0526: ldloc.2
+		IL_0527: ldstr "wordArray"
+		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0531: stloc.s 13
+		IL_0533: ldloc.s 13
+		IL_0535: ldloc.s 5
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_053c: stloc.s 13
+		IL_053e: ldloc.3
+		IL_053f: ldstr "wordArray"
+		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0549: stloc.s 9
+		IL_054b: ldloc.s 9
+		IL_054d: ldloc.s 5
+		IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0554: stloc.s 9
+		IL_0556: ldloc.s 10
+		IL_0558: ldstr "log"
+		IL_055d: ldc.i4.4
+		IL_055e: newarr [System.Runtime]System.Object
+		IL_0563: dup
+		IL_0564: ldc.i4.0
+		IL_0565: ldstr "first"
+		IL_056a: stelem.ref
+		IL_056b: dup
+		IL_056c: ldc.i4.1
+		IL_056d: ldloc.s 5
+		IL_056f: stelem.ref
+		IL_0570: dup
+		IL_0571: ldc.i4.2
+		IL_0572: ldloc.s 13
+		IL_0574: stelem.ref
+		IL_0575: dup
+		IL_0576: ldc.i4.3
+		IL_0577: ldloc.s 9
+		IL_0579: stelem.ref
+		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_057f: pop
 
-		IL_0581: ldstr "console"
-		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0590: stloc.s 10
-		IL_0592: ldloc.2
-		IL_0593: ldstr "wordArray"
-		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_059d: stloc.s 9
-		IL_059f: ldloc.s 9
-		IL_05a1: ldc.r8 0.0
-		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05af: stloc.s 9
-		IL_05b1: ldloc.3
-		IL_05b2: ldstr "wordArray"
-		IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05bc: stloc.s 13
-		IL_05be: ldloc.s 13
-		IL_05c0: ldc.r8 0.0
-		IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05ce: stloc.s 13
-		IL_05d0: ldloc.s 10
-		IL_05d2: ldstr "log"
-		IL_05d7: ldstr "w0"
-		IL_05dc: ldloc.s 9
-		IL_05de: ldloc.s 13
-		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05e5: pop
-		IL_05e6: ldstr "console"
-		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05f5: stloc.s 13
-		IL_05f7: ldloc.2
-		IL_05f8: ldstr "wordArray"
-		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0602: stloc.s 9
-		IL_0604: ldloc.s 9
-		IL_0606: ldc.r8 1
-		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0614: stloc.s 9
-		IL_0616: ldloc.3
-		IL_0617: ldstr "wordArray"
-		IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0621: stloc.s 10
-		IL_0623: ldloc.s 10
-		IL_0625: ldc.r8 1
-		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0633: stloc.s 10
-		IL_0635: ldloc.s 13
-		IL_0637: ldstr "log"
-		IL_063c: ldstr "w1"
-		IL_0641: ldloc.s 9
-		IL_0643: ldloc.s 10
-		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_064a: pop
-		IL_064b: ldstr "console"
-		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_065a: stloc.s 10
-		IL_065c: ldloc.2
-		IL_065d: ldstr "wordArray"
-		IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0667: stloc.s 9
-		IL_0669: ldloc.s 9
-		IL_066b: ldc.r8 2
-		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0679: stloc.s 9
-		IL_067b: ldloc.3
-		IL_067c: ldstr "wordArray"
-		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0686: stloc.s 13
-		IL_0688: ldloc.s 13
-		IL_068a: ldc.r8 2
-		IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0698: stloc.s 13
-		IL_069a: ldloc.s 10
-		IL_069c: ldstr "log"
-		IL_06a1: ldstr "w2"
-		IL_06a6: ldloc.s 9
-		IL_06a8: ldloc.s 13
-		IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_06af: pop
-		IL_06b0: ldstr "console"
-		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06bf: stloc.s 13
-		IL_06c1: ldloc.2
-		IL_06c2: ldstr "wordArray"
-		IL_06c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06cc: stloc.s 9
-		IL_06ce: ldloc.s 9
-		IL_06d0: ldc.r8 3
-		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06de: stloc.s 9
-		IL_06e0: ldloc.3
-		IL_06e1: ldstr "wordArray"
-		IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06eb: stloc.s 10
-		IL_06ed: ldloc.s 10
-		IL_06ef: ldc.r8 3
-		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06fd: stloc.s 10
-		IL_06ff: ldloc.s 13
-		IL_0701: ldstr "log"
-		IL_0706: ldstr "w3"
-		IL_070b: ldloc.s 9
-		IL_070d: ldloc.s 10
-		IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0714: pop
-		IL_0715: ret
+		IL_0580: ldstr "console"
+		IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_058f: stloc.s 10
+		IL_0591: ldloc.2
+		IL_0592: ldstr "wordArray"
+		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_059c: stloc.s 9
+		IL_059e: ldloc.s 9
+		IL_05a0: ldc.r8 0.0
+		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05ae: stloc.s 9
+		IL_05b0: ldloc.3
+		IL_05b1: ldstr "wordArray"
+		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05bb: stloc.s 13
+		IL_05bd: ldloc.s 13
+		IL_05bf: ldc.r8 0.0
+		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05cd: stloc.s 13
+		IL_05cf: ldloc.s 10
+		IL_05d1: ldstr "log"
+		IL_05d6: ldstr "w0"
+		IL_05db: ldloc.s 9
+		IL_05dd: ldloc.s 13
+		IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_05e4: pop
+		IL_05e5: ldstr "console"
+		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f4: stloc.s 13
+		IL_05f6: ldloc.2
+		IL_05f7: ldstr "wordArray"
+		IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0601: stloc.s 9
+		IL_0603: ldloc.s 9
+		IL_0605: ldc.r8 1
+		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0613: stloc.s 9
+		IL_0615: ldloc.3
+		IL_0616: ldstr "wordArray"
+		IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0620: stloc.s 10
+		IL_0622: ldloc.s 10
+		IL_0624: ldc.r8 1
+		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0632: stloc.s 10
+		IL_0634: ldloc.s 13
+		IL_0636: ldstr "log"
+		IL_063b: ldstr "w1"
+		IL_0640: ldloc.s 9
+		IL_0642: ldloc.s 10
+		IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0649: pop
+		IL_064a: ldstr "console"
+		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0659: stloc.s 10
+		IL_065b: ldloc.2
+		IL_065c: ldstr "wordArray"
+		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0666: stloc.s 9
+		IL_0668: ldloc.s 9
+		IL_066a: ldc.r8 2
+		IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0678: stloc.s 9
+		IL_067a: ldloc.3
+		IL_067b: ldstr "wordArray"
+		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0685: stloc.s 13
+		IL_0687: ldloc.s 13
+		IL_0689: ldc.r8 2
+		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0697: stloc.s 13
+		IL_0699: ldloc.s 10
+		IL_069b: ldstr "log"
+		IL_06a0: ldstr "w2"
+		IL_06a5: ldloc.s 9
+		IL_06a7: ldloc.s 13
+		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_06ae: pop
+		IL_06af: ldstr "console"
+		IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06be: stloc.s 13
+		IL_06c0: ldloc.2
+		IL_06c1: ldstr "wordArray"
+		IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06cb: stloc.s 9
+		IL_06cd: ldloc.s 9
+		IL_06cf: ldc.r8 3
+		IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06dd: stloc.s 9
+		IL_06df: ldloc.3
+		IL_06e0: ldstr "wordArray"
+		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ea: stloc.s 10
+		IL_06ec: ldloc.s 10
+		IL_06ee: ldc.r8 3
+		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06fc: stloc.s 10
+		IL_06fe: ldloc.s 13
+		IL_0700: ldstr "log"
+		IL_0705: ldstr "w3"
+		IL_070a: ldloc.s 9
+		IL_070c: ldloc.s 10
+		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0713: pop
+		IL_0714: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad2
+				// Method begins at RVA 0x2aae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2adb
+				// Method begins at RVA 0x2ab7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aed
+					// Method begins at RVA 0x2ac9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae4
+				// Method begins at RVA 0x2ac0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b08
+						// Method begins at RVA 0x2ae4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2b1a
+							// Method begins at RVA 0x2af6
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b11
+						// Method begins at RVA 0x2aed
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aff
+					// Method begins at RVA 0x2adb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2b35
+							// Method begins at RVA 0x2b11
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b2c
+						// Method begins at RVA 0x2b08
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b23
+					// Method begins at RVA 0x2aff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af6
+				// Method begins at RVA 0x2ad2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b47
+					// Method begins at RVA 0x2b23
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3e
+				// Method begins at RVA 0x2b1a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b50
+				// Method begins at RVA 0x2b2c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b62
+					// Method begins at RVA 0x2b3e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b59
+				// Method begins at RVA 0x2b35
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -382,7 +382,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2780
+			// Method begins at RVA 0x2774
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -430,7 +430,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29ec
+			// Method begins at RVA 0x29c8
 			// Header size: 12
 			// Code size: 165 (0xa5)
 			.maxstack 8
@@ -527,9 +527,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27cc
+			// Method begins at RVA 0x27c0
 			// Header size: 12
-			// Code size: 414 (0x19e)
+			// Code size: 391 (0x187)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -544,198 +544,189 @@
 				[9] float64
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::_scopes
-			IL_0006: ldc.i4.0
-			IL_0007: ldelem.ref
-			IL_0008: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope
-			IL_000d: ldfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
-			IL_0012: ldc.r8 2
-			IL_001b: div
+			IL_0000: ldarg.2
+			IL_0001: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0006: ldc.r8 16
+			IL_000f: cgt
+			IL_0011: brfalse IL_014a
+
+			IL_0016: ldarg.2
+			IL_0017: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_001c: stloc.s 8
-			IL_001e: ldarg.2
-			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0024: ldloc.s 8
-			IL_0026: cgt
-			IL_0028: brfalse IL_0161
+			IL_001e: ldc.r8 32
+			IL_0027: ldloc.s 8
+			IL_0029: mul
+			IL_002a: stloc.s 8
+			IL_002c: ldarg.1
+			IL_002d: ldloc.s 8
+			IL_002f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
+			IL_0034: stloc.0
+			IL_0035: ldloc.0
+			IL_0036: stloc.s 8
+			IL_0038: ldarg.3
+			IL_0039: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003e: stloc.s 9
+			IL_0040: ldloc.s 8
+			IL_0042: ldloc.s 9
+			IL_0044: cgt
+			IL_0046: brfalse IL_0083
 
-			IL_002d: ldarg.2
-			IL_002e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0033: stloc.s 8
-			IL_0035: ldc.r8 32
-			IL_003e: ldloc.s 8
-			IL_0040: mul
-			IL_0041: stloc.s 8
-			IL_0043: ldarg.1
-			IL_0044: ldloc.s 8
-			IL_0046: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, float64)
-			IL_004b: stloc.0
-			IL_004c: ldloc.0
-			IL_004d: stloc.s 8
-			IL_004f: ldarg.3
-			IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0055: stloc.s 9
-			IL_0057: ldloc.s 8
-			IL_0059: ldloc.s 9
-			IL_005b: cgt
-			IL_005d: brfalse IL_009a
+			IL_004b: ldarg.1
+			IL_004c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0051: stloc.1
+			// loop start (head: IL_0052)
+				IL_0052: ldloc.1
+				IL_0053: stloc.s 9
+				IL_0055: ldarg.3
+				IL_0056: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005b: stloc.s 8
+				IL_005d: ldloc.s 9
+				IL_005f: ldloc.s 8
+				IL_0061: clt
+				IL_0063: brfalse IL_0081
 
-			IL_0062: ldarg.1
-			IL_0063: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0068: stloc.1
-			// loop start (head: IL_0069)
+				IL_0068: ldarg.0
 				IL_0069: ldloc.1
-				IL_006a: stloc.s 9
-				IL_006c: ldarg.3
-				IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0072: stloc.s 8
-				IL_0074: ldloc.s 9
-				IL_0076: ldloc.s 8
-				IL_0078: clt
-				IL_007a: brfalse IL_0098
-
-				IL_007f: ldarg.0
-				IL_0080: ldloc.1
-				IL_0081: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_0086: pop
-				IL_0087: ldloc.1
-				IL_0088: ldarg.2
-				IL_0089: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_008e: stloc.s 8
-				IL_0090: ldloc.s 8
-				IL_0092: stloc.1
-				IL_0093: br IL_0069
+				IL_006a: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_006f: pop
+				IL_0070: ldloc.1
+				IL_0071: ldarg.2
+				IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0077: stloc.s 8
+				IL_0079: ldloc.s 8
+				IL_007b: stloc.1
+				IL_007c: br IL_0052
 			// end loop
 
-			IL_0098: ldnull
-			IL_0099: ret
+			IL_0081: ldnull
+			IL_0082: ret
 
-			IL_009a: ldarg.3
-			IL_009b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a0: stloc.s 8
-			IL_00a2: ldloc.s 8
-			IL_00a4: conv.i4
-			IL_00a5: conv.u4
-			IL_00a6: ldc.r8 5
-			IL_00af: conv.i4
-			IL_00b0: shr.un
-			IL_00b1: conv.r.un
-			IL_00b2: stloc.2
-			IL_00b3: ldarg.1
-			IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b9: stloc.3
-			// loop start (head: IL_00ba)
-				IL_00ba: ldloc.3
-				IL_00bb: stloc.s 8
-				IL_00bd: ldloc.s 8
-				IL_00bf: ldloc.0
-				IL_00c0: clt
-				IL_00c2: brfalse IL_015f
+			IL_0083: ldarg.3
+			IL_0084: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0089: stloc.s 8
+			IL_008b: ldloc.s 8
+			IL_008d: conv.i4
+			IL_008e: conv.u4
+			IL_008f: ldc.r8 5
+			IL_0098: conv.i4
+			IL_0099: shr.un
+			IL_009a: conv.r.un
+			IL_009b: stloc.2
+			IL_009c: ldarg.1
+			IL_009d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00a2: stloc.3
+			// loop start (head: IL_00a3)
+				IL_00a3: ldloc.3
+				IL_00a4: stloc.s 8
+				IL_00a6: ldloc.s 8
+				IL_00a8: ldloc.0
+				IL_00a9: clt
+				IL_00ab: brfalse IL_0148
 
-				IL_00c7: ldloc.3
-				IL_00c8: stloc.s 8
-				IL_00ca: ldloc.s 8
-				IL_00cc: conv.i4
-				IL_00cd: conv.u4
-				IL_00ce: ldc.r8 5
-				IL_00d7: conv.i4
-				IL_00d8: shr.un
-				IL_00d9: conv.r.un
-				IL_00da: stloc.s 4
-				IL_00dc: ldloc.3
-				IL_00dd: stloc.s 8
-				IL_00df: ldloc.s 8
-				IL_00e1: conv.i4
-				IL_00e2: ldc.r8 31
-				IL_00eb: conv.i4
-				IL_00ec: and
-				IL_00ed: conv.r8
-				IL_00ee: stloc.s 5
-				IL_00f0: ldc.r8 1
-				IL_00f9: conv.i4
-				IL_00fa: ldloc.s 5
-				IL_00fc: conv.i4
-				IL_00fd: shl
-				IL_00fe: conv.r8
-				IL_00ff: stloc.s 6
-				// loop start (head: IL_0101)
-					IL_0101: nop
-					IL_0102: ldarg.0
-					IL_0103: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0108: ldloc.s 4
-					IL_010a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_010f: stloc.s 8
-					IL_0111: ldloc.s 8
-					IL_0113: conv.i4
-					IL_0114: ldloc.s 6
-					IL_0116: conv.i4
-					IL_0117: or
-					IL_0118: conv.r8
-					IL_0119: stloc.s 8
-					IL_011b: ldarg.0
-					IL_011c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+				IL_00b0: ldloc.3
+				IL_00b1: stloc.s 8
+				IL_00b3: ldloc.s 8
+				IL_00b5: conv.i4
+				IL_00b6: conv.u4
+				IL_00b7: ldc.r8 5
+				IL_00c0: conv.i4
+				IL_00c1: shr.un
+				IL_00c2: conv.r.un
+				IL_00c3: stloc.s 4
+				IL_00c5: ldloc.3
+				IL_00c6: stloc.s 8
+				IL_00c8: ldloc.s 8
+				IL_00ca: conv.i4
+				IL_00cb: ldc.r8 31
+				IL_00d4: conv.i4
+				IL_00d5: and
+				IL_00d6: conv.r8
+				IL_00d7: stloc.s 5
+				IL_00d9: ldc.r8 1
+				IL_00e2: conv.i4
+				IL_00e3: ldloc.s 5
+				IL_00e5: conv.i4
+				IL_00e6: shl
+				IL_00e7: conv.r8
+				IL_00e8: stloc.s 6
+				// loop start (head: IL_00ea)
+					IL_00ea: nop
+					IL_00eb: ldarg.0
+					IL_00ec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_00f1: ldloc.s 4
+					IL_00f3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00f8: stloc.s 8
+					IL_00fa: ldloc.s 8
+					IL_00fc: conv.i4
+					IL_00fd: ldloc.s 6
+					IL_00ff: conv.i4
+					IL_0100: or
+					IL_0101: conv.r8
+					IL_0102: stloc.s 8
+					IL_0104: ldarg.0
+					IL_0105: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_010a: ldloc.s 4
+					IL_010c: ldloc.s 8
+					IL_010e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_0113: ldloc.s 4
+					IL_0115: ldarg.2
+					IL_0116: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+					IL_011b: stloc.s 8
+					IL_011d: ldloc.s 8
+					IL_011f: stloc.s 4
 					IL_0121: ldloc.s 4
-					IL_0123: ldloc.s 8
-					IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_012a: ldloc.s 4
-					IL_012c: ldarg.2
-					IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-					IL_0132: stloc.s 8
-					IL_0134: ldloc.s 8
-					IL_0136: stloc.s 4
-					IL_0138: ldloc.s 4
-					IL_013a: stloc.s 8
-					IL_013c: ldloc.s 8
-					IL_013e: ldloc.2
-					IL_013f: cgt
-					IL_0141: ldc.i4.0
-					IL_0142: ceq
-					IL_0144: brfalse IL_014e
+					IL_0123: stloc.s 8
+					IL_0125: ldloc.s 8
+					IL_0127: ldloc.2
+					IL_0128: cgt
+					IL_012a: ldc.i4.0
+					IL_012b: ceq
+					IL_012d: brfalse IL_0137
 
-					IL_0149: br IL_0101
+					IL_0132: br IL_00ea
 				// end loop
 
-				IL_014e: ldloc.3
-				IL_014f: ldarg.2
-				IL_0150: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0155: stloc.s 8
-				IL_0157: ldloc.s 8
-				IL_0159: stloc.3
-				IL_015a: br IL_00ba
+				IL_0137: ldloc.3
+				IL_0138: ldarg.2
+				IL_0139: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_013e: stloc.s 8
+				IL_0140: ldloc.s 8
+				IL_0142: stloc.3
+				IL_0143: br IL_00a3
 			// end loop
 
-			IL_015f: ldnull
-			IL_0160: ret
+			IL_0148: ldnull
+			IL_0149: ret
 
-			IL_0161: ldarg.1
-			IL_0162: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0167: stloc.s 7
-			// loop start (head: IL_0169)
-				IL_0169: ldloc.s 7
-				IL_016b: stloc.s 8
-				IL_016d: ldarg.3
-				IL_016e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0173: stloc.s 9
-				IL_0175: ldloc.s 8
-				IL_0177: ldloc.s 9
-				IL_0179: clt
-				IL_017b: brfalse IL_019c
+			IL_014a: ldarg.1
+			IL_014b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0150: stloc.s 7
+			// loop start (head: IL_0152)
+				IL_0152: ldloc.s 7
+				IL_0154: stloc.s 8
+				IL_0156: ldarg.3
+				IL_0157: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_015c: stloc.s 9
+				IL_015e: ldloc.s 8
+				IL_0160: ldloc.s 9
+				IL_0162: clt
+				IL_0164: brfalse IL_0185
 
-				IL_0180: ldarg.0
-				IL_0181: ldloc.s 7
-				IL_0183: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_0188: pop
-				IL_0189: ldloc.s 7
-				IL_018b: ldarg.2
-				IL_018c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0191: stloc.s 9
-				IL_0193: ldloc.s 9
-				IL_0195: stloc.s 7
-				IL_0197: br IL_0169
+				IL_0169: ldarg.0
+				IL_016a: ldloc.s 7
+				IL_016c: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_0171: pop
+				IL_0172: ldloc.s 7
+				IL_0174: ldarg.2
+				IL_0175: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_017a: stloc.s 9
+				IL_017c: ldloc.s 9
+				IL_017e: stloc.s 7
+				IL_0180: br IL_0152
 			// end loop
 
-			IL_019c: ldnull
-			IL_019d: ret
+			IL_0185: ldnull
+			IL_0186: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -748,7 +739,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2978
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 102 (0x66)
 			.maxstack 8
@@ -819,13 +810,12 @@
 		extends [System.Runtime]System.Object
 	{
 		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 69 53 63 6f 70 65 20 57 4f 52 44 5f 53 49
-			5a 45 3d 7b 57 4f 52 44 5f 53 49 5a 45 7d 2c 20
-			73 69 7a 65 3d 7b 73 69 7a 65 7d 2c 20 72 61 6e
-			67 65 5f 73 74 61 72 74 3d 7b 72 61 6e 67 65 5f
-			73 74 61 72 74 7d 2c 20 73 74 65 70 3d 7b 73 74
-			65 70 7d 2c 20 72 61 6e 67 65 5f 73 74 6f 70 3d
-			7b 72 61 6e 67 65 5f 73 74 6f 70 7d 00 00
+			01 00 52 53 63 6f 70 65 20 73 69 7a 65 3d 7b 73
+			69 7a 65 7d 2c 20 72 61 6e 67 65 5f 73 74 61 72
+			74 3d 7b 72 61 6e 67 65 5f 73 74 61 72 74 7d 2c
+			20 73 74 65 70 3d 7b 73 74 65 70 7d 2c 20 72 61
+			6e 67 65 5f 73 74 6f 70 3d 7b 72 61 6e 67 65 5f
+			73 74 6f 70 7d 00 00
 		)
 		// Nested Types
 		.class nested public auto ansi beforefieldinit Block_L81C18
@@ -835,7 +825,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b86
+				// Method begins at RVA 0x2b62
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -850,7 +840,6 @@
 
 
 		// Fields
-		.field public float64 WORD_SIZE
 		.field public object size
 		.field public object range_start
 		.field public object step
@@ -860,7 +849,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a9d
+			// Method begins at RVA 0x2a79
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -900,7 +889,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b7d
+					// Method begins at RVA 0x2b59
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -918,7 +907,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b74
+				// Method begins at RVA 0x2b50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -936,7 +925,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b6b
+			// Method begins at RVA 0x2b47
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -962,7 +951,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1828 (0x724)
+		// Code size: 1814 (0x716)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope,
@@ -990,620 +979,618 @@
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldc.r8 32
-		IL_0011: stfld float64 Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::WORD_SIZE
-		IL_0016: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_001b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0020: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0025: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002a: stloc.s 7
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
+		IL_0007: nop
+		IL_0008: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_000d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0012: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0017: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001c: stloc.s 7
+		IL_001e: ldc.i4.1
+		IL_001f: newarr [System.Runtime]System.Object
+		IL_0024: dup
+		IL_0025: ldc.i4.0
+		IL_0026: ldloc.0
+		IL_0027: stelem.ref
+		IL_0028: stloc.s 8
+		IL_002a: ldc.i4.s 10
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldloc.s 7
 		IL_0035: stelem.ref
-		IL_0036: stloc.s 8
-		IL_0038: ldc.i4.s 10
-		IL_003a: newarr [System.Runtime]System.Object
-		IL_003f: dup
-		IL_0040: ldc.i4.0
-		IL_0041: ldloc.s 7
-		IL_0043: stelem.ref
-		IL_0044: dup
-		IL_0045: ldc.i4.1
-		IL_0046: ldstr "setBitTrue"
-		IL_004b: stelem.ref
-		IL_004c: dup
-		IL_004d: ldc.i4.2
-		IL_004e: ldstr "setBitTrue"
-		IL_0053: stelem.ref
-		IL_0054: dup
-		IL_0055: ldc.i4.3
-		IL_0056: ldc.r8 1
-		IL_005f: box [System.Runtime]System.Double
-		IL_0064: stelem.ref
-		IL_0065: dup
-		IL_0066: ldc.i4.4
-		IL_0067: ldstr "setBitTrue"
-		IL_006c: stelem.ref
-		IL_006d: dup
-		IL_006e: ldc.i4.5
-		IL_006f: ldc.i4.0
-		IL_0070: box [System.Runtime]System.Boolean
-		IL_0075: stelem.ref
-		IL_0076: dup
-		IL_0077: ldc.i4.6
-		IL_0078: ldc.i4.0
-		IL_0079: box [System.Runtime]System.Boolean
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.7
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.8
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.s 9
-		IL_0094: ldloc.s 8
-		IL_0096: stelem.ref
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_009c: pop
-		IL_009d: ldc.i4.s 10
-		IL_009f: newarr [System.Runtime]System.Object
-		IL_00a4: dup
-		IL_00a5: ldc.i4.0
-		IL_00a6: ldloc.s 7
-		IL_00a8: stelem.ref
-		IL_00a9: dup
-		IL_00aa: ldc.i4.1
-		IL_00ab: ldstr "setBitsTrue"
-		IL_00b0: stelem.ref
-		IL_00b1: dup
-		IL_00b2: ldc.i4.2
-		IL_00b3: ldstr "setBitsTrue"
-		IL_00b8: stelem.ref
-		IL_00b9: dup
-		IL_00ba: ldc.i4.3
-		IL_00bb: ldc.r8 3
-		IL_00c4: box [System.Runtime]System.Double
-		IL_00c9: stelem.ref
-		IL_00ca: dup
-		IL_00cb: ldc.i4.4
-		IL_00cc: ldstr "setBitsTrue"
-		IL_00d1: stelem.ref
-		IL_00d2: dup
-		IL_00d3: ldc.i4.5
-		IL_00d4: ldc.i4.0
-		IL_00d5: box [System.Runtime]System.Boolean
-		IL_00da: stelem.ref
-		IL_00db: dup
-		IL_00dc: ldc.i4.6
-		IL_00dd: ldc.i4.0
-		IL_00de: box [System.Runtime]System.Boolean
-		IL_00e3: stelem.ref
-		IL_00e4: dup
-		IL_00e5: ldc.i4.7
-		IL_00e6: ldc.i4.0
-		IL_00e7: box [System.Runtime]System.Boolean
-		IL_00ec: stelem.ref
-		IL_00ed: dup
-		IL_00ee: ldc.i4.8
-		IL_00ef: ldc.i4.0
-		IL_00f0: box [System.Runtime]System.Boolean
-		IL_00f5: stelem.ref
-		IL_00f6: dup
-		IL_00f7: ldc.i4.s 9
-		IL_00f9: ldloc.s 8
-		IL_00fb: stelem.ref
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0101: pop
-		IL_0102: ldc.i4.s 10
-		IL_0104: newarr [System.Runtime]System.Object
-		IL_0109: dup
-		IL_010a: ldc.i4.0
-		IL_010b: ldloc.s 7
-		IL_010d: stelem.ref
-		IL_010e: dup
-		IL_010f: ldc.i4.1
-		IL_0110: ldstr "setBitsTrue_Naive"
-		IL_0115: stelem.ref
-		IL_0116: dup
-		IL_0117: ldc.i4.2
-		IL_0118: ldstr "setBitsTrue_Naive"
-		IL_011d: stelem.ref
-		IL_011e: dup
-		IL_011f: ldc.i4.3
-		IL_0120: ldc.r8 3
-		IL_0129: box [System.Runtime]System.Double
-		IL_012e: stelem.ref
-		IL_012f: dup
-		IL_0130: ldc.i4.4
-		IL_0131: ldstr "setBitsTrue_Naive"
-		IL_0136: stelem.ref
-		IL_0137: dup
-		IL_0138: ldc.i4.5
-		IL_0139: ldc.i4.0
-		IL_013a: box [System.Runtime]System.Boolean
-		IL_013f: stelem.ref
-		IL_0140: dup
-		IL_0141: ldc.i4.6
-		IL_0142: ldc.i4.0
-		IL_0143: box [System.Runtime]System.Boolean
-		IL_0148: stelem.ref
-		IL_0149: dup
-		IL_014a: ldc.i4.7
-		IL_014b: ldc.i4.0
-		IL_014c: box [System.Runtime]System.Boolean
-		IL_0151: stelem.ref
-		IL_0152: dup
-		IL_0153: ldc.i4.8
-		IL_0154: ldc.i4.0
-		IL_0155: box [System.Runtime]System.Boolean
-		IL_015a: stelem.ref
-		IL_015b: dup
-		IL_015c: ldc.i4.s 9
-		IL_015e: ldloc.s 8
-		IL_0160: stelem.ref
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0166: pop
-		IL_0167: ldc.i4.1
-		IL_0168: newarr [System.Runtime]System.Object
-		IL_016d: dup
-		IL_016e: ldc.i4.0
-		IL_016f: ldloc.0
-		IL_0170: stelem.ref
-		IL_0171: stloc.s 8
-		IL_0173: ldloc.s 7
-		IL_0175: ldloc.s 8
-		IL_0177: ldc.r8 1
-		IL_0180: box [System.Runtime]System.Double
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_018a: stloc.s 9
-		IL_018c: ldloc.s 9
-		IL_018e: stloc.1
-		IL_018f: ldloc.0
-		IL_0190: ldc.r8 2048
-		IL_0199: box [System.Runtime]System.Double
-		IL_019e: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01a3: ldloc.0
-		IL_01a4: ldc.r8 1
-		IL_01ad: box [System.Runtime]System.Double
-		IL_01b2: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_01b7: ldloc.0
-		IL_01b8: ldc.r8 17
-		IL_01c1: box [System.Runtime]System.Double
-		IL_01c6: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_01cb: ldloc.0
-		IL_01cc: ldc.r8 600
-		IL_01d5: box [System.Runtime]System.Double
-		IL_01da: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_01df: ldc.i4.1
-		IL_01e0: newarr [System.Runtime]System.Object
-		IL_01e5: dup
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldloc.0
-		IL_01e8: stelem.ref
-		IL_01e9: stloc.s 8
-		IL_01eb: ldloc.0
-		IL_01ec: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_01f1: ldstr "Cannot access 'size' before initialization"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_01fb: stloc.s 9
-		IL_01fd: ldloc.s 8
-		IL_01ff: ldc.i4.1
-		IL_0200: newarr [System.Runtime]System.Object
-		IL_0205: dup
-		IL_0206: ldc.i4.0
-		IL_0207: ldloc.s 9
-		IL_0209: stelem.ref
-		IL_020a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_020f: ldloc.s 9
-		IL_0211: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0216: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_021b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0220: stloc.2
-		IL_0221: ldloc.2
-		IL_0222: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0227: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_022c: ldstr "prototype"
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0236: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_023b: ldc.i4.1
-		IL_023c: newarr [System.Runtime]System.Object
-		IL_0241: dup
-		IL_0242: ldc.i4.0
-		IL_0243: ldloc.0
-		IL_0244: stelem.ref
-		IL_0245: stloc.s 8
-		IL_0247: ldloc.0
-		IL_0248: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
-		IL_024d: ldstr "Cannot access 'size' before initialization"
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0257: stloc.s 9
-		IL_0259: ldloc.s 8
-		IL_025b: ldc.i4.1
-		IL_025c: newarr [System.Runtime]System.Object
-		IL_0261: dup
-		IL_0262: ldc.i4.0
-		IL_0263: ldloc.s 9
-		IL_0265: stelem.ref
-		IL_0266: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_026b: ldloc.s 9
-		IL_026d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0272: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
-		IL_0277: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_027c: stloc.3
-		IL_027d: ldloc.3
-		IL_027e: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0283: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0288: ldstr "prototype"
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0292: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0297: ldstr "console"
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a6: stloc.s 9
-		IL_02a8: ldloc.2
-		IL_02a9: ldstr "wordArray"
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b3: stloc.s 10
-		IL_02b5: ldloc.s 10
-		IL_02b7: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02bc: stloc.s 11
-		IL_02be: ldloc.3
-		IL_02bf: ldstr "wordArray"
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c9: stloc.s 10
-		IL_02cb: ldloc.s 10
-		IL_02cd: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_02d2: stloc.s 12
-		IL_02d4: ldloc.s 9
-		IL_02d6: ldstr "log"
-		IL_02db: ldstr "types"
-		IL_02e0: ldloc.s 11
-		IL_02e2: ldloc.s 12
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_02e9: pop
-		IL_02ea: ldstr "console"
-		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f9: stloc.s 9
-		IL_02fb: ldloc.2
-		IL_02fc: ldstr "wordArray"
+		IL_0036: dup
+		IL_0037: ldc.i4.1
+		IL_0038: ldstr "setBitTrue"
+		IL_003d: stelem.ref
+		IL_003e: dup
+		IL_003f: ldc.i4.2
+		IL_0040: ldstr "setBitTrue"
+		IL_0045: stelem.ref
+		IL_0046: dup
+		IL_0047: ldc.i4.3
+		IL_0048: ldc.r8 1
+		IL_0051: box [System.Runtime]System.Double
+		IL_0056: stelem.ref
+		IL_0057: dup
+		IL_0058: ldc.i4.4
+		IL_0059: ldstr "setBitTrue"
+		IL_005e: stelem.ref
+		IL_005f: dup
+		IL_0060: ldc.i4.5
+		IL_0061: ldc.i4.0
+		IL_0062: box [System.Runtime]System.Boolean
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.6
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.7
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.8
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.s 9
+		IL_0086: ldloc.s 8
+		IL_0088: stelem.ref
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_008e: pop
+		IL_008f: ldc.i4.s 10
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.s 7
+		IL_009a: stelem.ref
+		IL_009b: dup
+		IL_009c: ldc.i4.1
+		IL_009d: ldstr "setBitsTrue"
+		IL_00a2: stelem.ref
+		IL_00a3: dup
+		IL_00a4: ldc.i4.2
+		IL_00a5: ldstr "setBitsTrue"
+		IL_00aa: stelem.ref
+		IL_00ab: dup
+		IL_00ac: ldc.i4.3
+		IL_00ad: ldc.r8 3
+		IL_00b6: box [System.Runtime]System.Double
+		IL_00bb: stelem.ref
+		IL_00bc: dup
+		IL_00bd: ldc.i4.4
+		IL_00be: ldstr "setBitsTrue"
+		IL_00c3: stelem.ref
+		IL_00c4: dup
+		IL_00c5: ldc.i4.5
+		IL_00c6: ldc.i4.0
+		IL_00c7: box [System.Runtime]System.Boolean
+		IL_00cc: stelem.ref
+		IL_00cd: dup
+		IL_00ce: ldc.i4.6
+		IL_00cf: ldc.i4.0
+		IL_00d0: box [System.Runtime]System.Boolean
+		IL_00d5: stelem.ref
+		IL_00d6: dup
+		IL_00d7: ldc.i4.7
+		IL_00d8: ldc.i4.0
+		IL_00d9: box [System.Runtime]System.Boolean
+		IL_00de: stelem.ref
+		IL_00df: dup
+		IL_00e0: ldc.i4.8
+		IL_00e1: ldc.i4.0
+		IL_00e2: box [System.Runtime]System.Boolean
+		IL_00e7: stelem.ref
+		IL_00e8: dup
+		IL_00e9: ldc.i4.s 9
+		IL_00eb: ldloc.s 8
+		IL_00ed: stelem.ref
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_00f3: pop
+		IL_00f4: ldc.i4.s 10
+		IL_00f6: newarr [System.Runtime]System.Object
+		IL_00fb: dup
+		IL_00fc: ldc.i4.0
+		IL_00fd: ldloc.s 7
+		IL_00ff: stelem.ref
+		IL_0100: dup
+		IL_0101: ldc.i4.1
+		IL_0102: ldstr "setBitsTrue_Naive"
+		IL_0107: stelem.ref
+		IL_0108: dup
+		IL_0109: ldc.i4.2
+		IL_010a: ldstr "setBitsTrue_Naive"
+		IL_010f: stelem.ref
+		IL_0110: dup
+		IL_0111: ldc.i4.3
+		IL_0112: ldc.r8 3
+		IL_011b: box [System.Runtime]System.Double
+		IL_0120: stelem.ref
+		IL_0121: dup
+		IL_0122: ldc.i4.4
+		IL_0123: ldstr "setBitsTrue_Naive"
+		IL_0128: stelem.ref
+		IL_0129: dup
+		IL_012a: ldc.i4.5
+		IL_012b: ldc.i4.0
+		IL_012c: box [System.Runtime]System.Boolean
+		IL_0131: stelem.ref
+		IL_0132: dup
+		IL_0133: ldc.i4.6
+		IL_0134: ldc.i4.0
+		IL_0135: box [System.Runtime]System.Boolean
+		IL_013a: stelem.ref
+		IL_013b: dup
+		IL_013c: ldc.i4.7
+		IL_013d: ldc.i4.0
+		IL_013e: box [System.Runtime]System.Boolean
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.8
+		IL_0146: ldc.i4.0
+		IL_0147: box [System.Runtime]System.Boolean
+		IL_014c: stelem.ref
+		IL_014d: dup
+		IL_014e: ldc.i4.s 9
+		IL_0150: ldloc.s 8
+		IL_0152: stelem.ref
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0158: pop
+		IL_0159: ldc.i4.1
+		IL_015a: newarr [System.Runtime]System.Object
+		IL_015f: dup
+		IL_0160: ldc.i4.0
+		IL_0161: ldloc.0
+		IL_0162: stelem.ref
+		IL_0163: stloc.s 8
+		IL_0165: ldloc.s 7
+		IL_0167: ldloc.s 8
+		IL_0169: ldc.r8 1
+		IL_0172: box [System.Runtime]System.Double
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_017c: stloc.s 9
+		IL_017e: ldloc.s 9
+		IL_0180: stloc.1
+		IL_0181: ldloc.0
+		IL_0182: ldc.r8 2048
+		IL_018b: box [System.Runtime]System.Double
+		IL_0190: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_0195: ldloc.0
+		IL_0196: ldc.r8 1
+		IL_019f: box [System.Runtime]System.Double
+		IL_01a4: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_01a9: ldloc.0
+		IL_01aa: ldc.r8 17
+		IL_01b3: box [System.Runtime]System.Double
+		IL_01b8: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_01bd: ldloc.0
+		IL_01be: ldc.r8 600
+		IL_01c7: box [System.Runtime]System.Double
+		IL_01cc: stfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_01d1: ldc.i4.1
+		IL_01d2: newarr [System.Runtime]System.Object
+		IL_01d7: dup
+		IL_01d8: ldc.i4.0
+		IL_01d9: ldloc.0
+		IL_01da: stelem.ref
+		IL_01db: stloc.s 8
+		IL_01dd: ldloc.0
+		IL_01de: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_01e3: ldstr "Cannot access 'size' before initialization"
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_01ed: stloc.s 9
+		IL_01ef: ldloc.s 8
+		IL_01f1: ldc.i4.1
+		IL_01f2: newarr [System.Runtime]System.Object
+		IL_01f7: dup
+		IL_01f8: ldc.i4.0
+		IL_01f9: ldloc.s 9
+		IL_01fb: stelem.ref
+		IL_01fc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0201: ldloc.s 9
+		IL_0203: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0208: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_020d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0212: stloc.2
+		IL_0213: ldloc.2
+		IL_0214: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0219: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_021e: ldstr "prototype"
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0228: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_022d: ldc.i4.1
+		IL_022e: newarr [System.Runtime]System.Object
+		IL_0233: dup
+		IL_0234: ldc.i4.0
+		IL_0235: ldloc.0
+		IL_0236: stelem.ref
+		IL_0237: stloc.s 8
+		IL_0239: ldloc.0
+		IL_023a: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::size
+		IL_023f: ldstr "Cannot access 'size' before initialization"
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0249: stloc.s 9
+		IL_024b: ldloc.s 8
+		IL_024d: ldc.i4.1
+		IL_024e: newarr [System.Runtime]System.Object
+		IL_0253: dup
+		IL_0254: ldc.i4.0
+		IL_0255: ldloc.s 9
+		IL_0257: stelem.ref
+		IL_0258: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_025d: ldloc.s 9
+		IL_025f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0264: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::.ctor(object[], float64)
+		IL_0269: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_026e: stloc.3
+		IL_026f: ldloc.3
+		IL_0270: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+		IL_0275: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_027a: ldstr "prototype"
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0284: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0289: ldstr "console"
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0298: stloc.s 9
+		IL_029a: ldloc.2
+		IL_029b: ldstr "wordArray"
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a5: stloc.s 10
+		IL_02a7: ldloc.s 10
+		IL_02a9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02ae: stloc.s 11
+		IL_02b0: ldloc.3
+		IL_02b1: ldstr "wordArray"
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bb: stloc.s 10
+		IL_02bd: ldloc.s 10
+		IL_02bf: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_02c4: stloc.s 12
+		IL_02c6: ldloc.s 9
+		IL_02c8: ldstr "log"
+		IL_02cd: ldstr "types"
+		IL_02d2: ldloc.s 11
+		IL_02d4: ldloc.s 12
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_02db: pop
+		IL_02dc: ldstr "console"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02eb: stloc.s 9
+		IL_02ed: ldloc.2
+		IL_02ee: ldstr "wordArray"
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f8: stloc.s 10
+		IL_02fa: ldloc.s 10
+		IL_02fc: ldstr "length"
 		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0306: stloc.s 10
-		IL_0308: ldloc.s 10
-		IL_030a: ldstr "length"
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0314: stloc.s 10
-		IL_0316: ldloc.3
-		IL_0317: ldstr "wordArray"
+		IL_0308: ldloc.3
+		IL_0309: ldstr "wordArray"
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0313: stloc.s 13
+		IL_0315: ldloc.s 13
+		IL_0317: ldstr "length"
 		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0321: stloc.s 13
-		IL_0323: ldloc.s 13
-		IL_0325: ldstr "length"
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_032f: stloc.s 13
-		IL_0331: ldloc.s 9
-		IL_0333: ldstr "log"
-		IL_0338: ldstr "lens"
-		IL_033d: ldloc.s 10
-		IL_033f: ldloc.s 13
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0346: pop
-		IL_0347: ldloc.2
-		IL_0348: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_034d: stloc.s 14
-		IL_034f: ldloc.0
-		IL_0350: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_0355: ldstr "Cannot access 'range_start' before initialization"
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_035f: stloc.s 13
-		IL_0361: ldloc.0
-		IL_0362: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_0367: ldstr "Cannot access 'step' before initialization"
-		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0371: stloc.s 10
-		IL_0373: ldloc.0
-		IL_0374: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_0379: ldstr "Cannot access 'range_stop' before initialization"
-		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0383: stloc.s 9
-		IL_0385: ldloc.s 14
-		IL_0387: ldloc.s 13
-		IL_0389: ldloc.s 10
-		IL_038b: ldloc.s 9
-		IL_038d: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_0392: pop
-		IL_0393: ldloc.3
-		IL_0394: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
-		IL_0399: stloc.s 14
-		IL_039b: ldloc.0
-		IL_039c: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
-		IL_03a1: ldstr "Cannot access 'range_start' before initialization"
-		IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03ab: stloc.s 9
-		IL_03ad: ldloc.0
-		IL_03ae: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
-		IL_03b3: ldstr "Cannot access 'step' before initialization"
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03bd: stloc.s 10
-		IL_03bf: ldloc.0
-		IL_03c0: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
-		IL_03c5: ldstr "Cannot access 'range_stop' before initialization"
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_03cf: stloc.s 13
-		IL_03d1: ldloc.s 14
-		IL_03d3: ldloc.s 9
-		IL_03d5: ldloc.s 10
-		IL_03d7: ldloc.s 13
-		IL_03d9: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_03de: pop
-		IL_03df: ldc.r8 0.0
-		IL_03e8: stloc.s 4
-		IL_03ea: ldc.r8 1
-		IL_03f3: neg
-		IL_03f4: stloc.s 15
-		IL_03f6: ldloc.s 15
-		IL_03f8: box [System.Runtime]System.Double
-		IL_03fd: stloc.s 5
-		IL_03ff: ldc.r8 0.0
-		IL_0408: stloc.s 6
-		// loop start (head: IL_040a)
-			IL_040a: ldloc.s 6
-			IL_040c: stloc.s 15
-			IL_040e: ldloc.2
-			IL_040f: ldstr "wordArray"
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0419: stloc.s 13
-			IL_041b: ldloc.s 13
-			IL_041d: ldstr "length"
-			IL_0422: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_0427: stloc.s 16
-			IL_0429: ldloc.s 15
-			IL_042b: ldloc.s 16
-			IL_042d: clt
-			IL_042f: brfalse IL_04cf
+		IL_0323: ldloc.s 9
+		IL_0325: ldstr "log"
+		IL_032a: ldstr "lens"
+		IL_032f: ldloc.s 10
+		IL_0331: ldloc.s 13
+		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0338: pop
+		IL_0339: ldloc.2
+		IL_033a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_033f: stloc.s 14
+		IL_0341: ldloc.0
+		IL_0342: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_0347: ldstr "Cannot access 'range_start' before initialization"
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0351: stloc.s 13
+		IL_0353: ldloc.0
+		IL_0354: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_0359: ldstr "Cannot access 'step' before initialization"
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0363: stloc.s 10
+		IL_0365: ldloc.0
+		IL_0366: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_036b: ldstr "Cannot access 'range_stop' before initialization"
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0375: stloc.s 9
+		IL_0377: ldloc.s 14
+		IL_0379: ldloc.s 13
+		IL_037b: ldloc.s 10
+		IL_037d: ldloc.s 9
+		IL_037f: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+		IL_0384: pop
+		IL_0385: ldloc.3
+		IL_0386: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray>(!!0)
+		IL_038b: stloc.s 14
+		IL_038d: ldloc.0
+		IL_038e: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_start
+		IL_0393: ldstr "Cannot access 'range_start' before initialization"
+		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_039d: stloc.s 9
+		IL_039f: ldloc.0
+		IL_03a0: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::step
+		IL_03a5: ldstr "Cannot access 'step' before initialization"
+		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_03af: stloc.s 10
+		IL_03b1: ldloc.0
+		IL_03b2: ldfld object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/Scope::range_stop
+		IL_03b7: ldstr "Cannot access 'range_stop' before initialization"
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_03c1: stloc.s 13
+		IL_03c3: ldloc.s 14
+		IL_03c5: ldloc.s 9
+		IL_03c7: ldloc.s 10
+		IL_03c9: ldloc.s 13
+		IL_03cb: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+		IL_03d0: pop
+		IL_03d1: ldc.r8 0.0
+		IL_03da: stloc.s 4
+		IL_03dc: ldc.r8 1
+		IL_03e5: neg
+		IL_03e6: stloc.s 15
+		IL_03e8: ldloc.s 15
+		IL_03ea: box [System.Runtime]System.Double
+		IL_03ef: stloc.s 5
+		IL_03f1: ldc.r8 0.0
+		IL_03fa: stloc.s 6
+		// loop start (head: IL_03fc)
+			IL_03fc: ldloc.s 6
+			IL_03fe: stloc.s 15
+			IL_0400: ldloc.2
+			IL_0401: ldstr "wordArray"
+			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040b: stloc.s 13
+			IL_040d: ldloc.s 13
+			IL_040f: ldstr "length"
+			IL_0414: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_0419: stloc.s 16
+			IL_041b: ldloc.s 15
+			IL_041d: ldloc.s 16
+			IL_041f: clt
+			IL_0421: brfalse IL_04c1
 
-			IL_0434: ldloc.2
-			IL_0435: ldstr "wordArray"
-			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043f: stloc.s 13
-			IL_0441: ldloc.s 13
-			IL_0443: ldloc.s 6
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_044a: stloc.s 13
-			IL_044c: ldloc.3
-			IL_044d: ldstr "wordArray"
-			IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0457: stloc.s 10
-			IL_0459: ldloc.s 10
-			IL_045b: ldloc.s 6
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0462: stloc.s 10
-			IL_0464: ldloc.s 13
-			IL_0466: ldloc.s 10
-			IL_0468: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_046d: stloc.s 17
-			IL_046f: ldloc.s 17
-			IL_0471: brfalse IL_04bc
+			IL_0426: ldloc.2
+			IL_0427: ldstr "wordArray"
+			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0431: stloc.s 13
+			IL_0433: ldloc.s 13
+			IL_0435: ldloc.s 6
+			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_043c: stloc.s 13
+			IL_043e: ldloc.3
+			IL_043f: ldstr "wordArray"
+			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0449: stloc.s 10
+			IL_044b: ldloc.s 10
+			IL_044d: ldloc.s 6
+			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0454: stloc.s 10
+			IL_0456: ldloc.s 13
+			IL_0458: ldloc.s 10
+			IL_045a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_045f: stloc.s 17
+			IL_0461: ldloc.s 17
+			IL_0463: brfalse IL_04ae
 
-			IL_0476: ldloc.s 4
-			IL_0478: ldc.r8 1
-			IL_0481: add
-			IL_0482: stloc.s 4
-			IL_0484: ldloc.s 5
-			IL_0486: stloc.s 18
-			IL_0488: ldc.r8 1
-			IL_0491: neg
-			IL_0492: stloc.s 16
-			IL_0494: ldloc.s 16
-			IL_0496: box [System.Runtime]System.Double
-			IL_049b: stloc.s 19
-			IL_049d: ldloc.s 18
-			IL_049f: ldloc.s 19
-			IL_04a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_04a6: stloc.s 17
-			IL_04a8: ldloc.s 17
-			IL_04aa: brfalse IL_04bc
+			IL_0468: ldloc.s 4
+			IL_046a: ldc.r8 1
+			IL_0473: add
+			IL_0474: stloc.s 4
+			IL_0476: ldloc.s 5
+			IL_0478: stloc.s 18
+			IL_047a: ldc.r8 1
+			IL_0483: neg
+			IL_0484: stloc.s 16
+			IL_0486: ldloc.s 16
+			IL_0488: box [System.Runtime]System.Double
+			IL_048d: stloc.s 19
+			IL_048f: ldloc.s 18
+			IL_0491: ldloc.s 19
+			IL_0493: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0498: stloc.s 17
+			IL_049a: ldloc.s 17
+			IL_049c: brfalse IL_04ae
 
-			IL_04af: ldloc.s 6
-			IL_04b1: box [System.Runtime]System.Double
-			IL_04b6: stloc.s 19
-			IL_04b8: ldloc.s 19
-			IL_04ba: stloc.s 5
+			IL_04a1: ldloc.s 6
+			IL_04a3: box [System.Runtime]System.Double
+			IL_04a8: stloc.s 19
+			IL_04aa: ldloc.s 19
+			IL_04ac: stloc.s 5
 
-			IL_04bc: ldloc.s 6
-			IL_04be: ldc.r8 1
-			IL_04c7: add
-			IL_04c8: stloc.s 6
-			IL_04ca: br IL_040a
+			IL_04ae: ldloc.s 6
+			IL_04b0: ldc.r8 1
+			IL_04b9: add
+			IL_04ba: stloc.s 6
+			IL_04bc: br IL_03fc
 		// end loop
 
-		IL_04cf: ldstr "console"
-		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04de: ldloc.s 4
-		IL_04e0: box [System.Runtime]System.Double
-		IL_04e5: stloc.s 19
-		IL_04e7: ldstr "log"
-		IL_04ec: ldstr "diffs"
-		IL_04f1: ldloc.s 19
-		IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04f8: pop
-		IL_04f9: ldloc.s 5
-		IL_04fb: stloc.s 19
-		IL_04fd: ldc.r8 1
-		IL_0506: neg
-		IL_0507: stloc.s 16
-		IL_0509: ldloc.s 16
-		IL_050b: box [System.Runtime]System.Double
-		IL_0510: stloc.s 18
-		IL_0512: ldloc.s 19
-		IL_0514: ldloc.s 18
-		IL_0516: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_051b: stloc.s 17
-		IL_051d: ldloc.s 17
-		IL_051f: brfalse IL_058f
+		IL_04c1: ldstr "console"
+		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d0: ldloc.s 4
+		IL_04d2: box [System.Runtime]System.Double
+		IL_04d7: stloc.s 19
+		IL_04d9: ldstr "log"
+		IL_04de: ldstr "diffs"
+		IL_04e3: ldloc.s 19
+		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04ea: pop
+		IL_04eb: ldloc.s 5
+		IL_04ed: stloc.s 19
+		IL_04ef: ldc.r8 1
+		IL_04f8: neg
+		IL_04f9: stloc.s 16
+		IL_04fb: ldloc.s 16
+		IL_04fd: box [System.Runtime]System.Double
+		IL_0502: stloc.s 18
+		IL_0504: ldloc.s 19
+		IL_0506: ldloc.s 18
+		IL_0508: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_050d: stloc.s 17
+		IL_050f: ldloc.s 17
+		IL_0511: brfalse IL_0581
 
-		IL_0524: ldstr "console"
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0533: stloc.s 10
-		IL_0535: ldloc.2
-		IL_0536: ldstr "wordArray"
-		IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0540: stloc.s 13
-		IL_0542: ldloc.s 13
-		IL_0544: ldloc.s 5
-		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_054b: stloc.s 13
-		IL_054d: ldloc.3
-		IL_054e: ldstr "wordArray"
-		IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0558: stloc.s 9
-		IL_055a: ldloc.s 9
-		IL_055c: ldloc.s 5
-		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0563: stloc.s 9
-		IL_0565: ldloc.s 10
-		IL_0567: ldstr "log"
-		IL_056c: ldc.i4.4
-		IL_056d: newarr [System.Runtime]System.Object
-		IL_0572: dup
-		IL_0573: ldc.i4.0
-		IL_0574: ldstr "first"
-		IL_0579: stelem.ref
-		IL_057a: dup
-		IL_057b: ldc.i4.1
-		IL_057c: ldloc.s 5
-		IL_057e: stelem.ref
-		IL_057f: dup
-		IL_0580: ldc.i4.2
-		IL_0581: ldloc.s 13
-		IL_0583: stelem.ref
-		IL_0584: dup
-		IL_0585: ldc.i4.3
-		IL_0586: ldloc.s 9
-		IL_0588: stelem.ref
-		IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_058e: pop
+		IL_0516: ldstr "console"
+		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0525: stloc.s 10
+		IL_0527: ldloc.2
+		IL_0528: ldstr "wordArray"
+		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0532: stloc.s 13
+		IL_0534: ldloc.s 13
+		IL_0536: ldloc.s 5
+		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_053d: stloc.s 13
+		IL_053f: ldloc.3
+		IL_0540: ldstr "wordArray"
+		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_054a: stloc.s 9
+		IL_054c: ldloc.s 9
+		IL_054e: ldloc.s 5
+		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0555: stloc.s 9
+		IL_0557: ldloc.s 10
+		IL_0559: ldstr "log"
+		IL_055e: ldc.i4.4
+		IL_055f: newarr [System.Runtime]System.Object
+		IL_0564: dup
+		IL_0565: ldc.i4.0
+		IL_0566: ldstr "first"
+		IL_056b: stelem.ref
+		IL_056c: dup
+		IL_056d: ldc.i4.1
+		IL_056e: ldloc.s 5
+		IL_0570: stelem.ref
+		IL_0571: dup
+		IL_0572: ldc.i4.2
+		IL_0573: ldloc.s 13
+		IL_0575: stelem.ref
+		IL_0576: dup
+		IL_0577: ldc.i4.3
+		IL_0578: ldloc.s 9
+		IL_057a: stelem.ref
+		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_0580: pop
 
-		IL_058f: ldstr "console"
-		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_059e: stloc.s 10
-		IL_05a0: ldloc.2
-		IL_05a1: ldstr "wordArray"
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ab: stloc.s 9
-		IL_05ad: ldloc.s 9
-		IL_05af: ldc.r8 0.0
-		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05bd: stloc.s 9
-		IL_05bf: ldloc.3
-		IL_05c0: ldstr "wordArray"
-		IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ca: stloc.s 13
-		IL_05cc: ldloc.s 13
-		IL_05ce: ldc.r8 0.0
-		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_05dc: stloc.s 13
-		IL_05de: ldloc.s 10
-		IL_05e0: ldstr "log"
-		IL_05e5: ldstr "w0"
-		IL_05ea: ldloc.s 9
-		IL_05ec: ldloc.s 13
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05f3: pop
-		IL_05f4: ldstr "console"
-		IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0603: stloc.s 13
-		IL_0605: ldloc.2
-		IL_0606: ldstr "wordArray"
-		IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0610: stloc.s 9
-		IL_0612: ldloc.s 9
-		IL_0614: ldc.r8 1
-		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0622: stloc.s 9
-		IL_0624: ldloc.3
-		IL_0625: ldstr "wordArray"
-		IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_062f: stloc.s 10
-		IL_0631: ldloc.s 10
-		IL_0633: ldc.r8 1
-		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0641: stloc.s 10
-		IL_0643: ldloc.s 13
-		IL_0645: ldstr "log"
-		IL_064a: ldstr "w1"
-		IL_064f: ldloc.s 9
-		IL_0651: ldloc.s 10
-		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0658: pop
-		IL_0659: ldstr "console"
-		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0668: stloc.s 10
-		IL_066a: ldloc.2
-		IL_066b: ldstr "wordArray"
-		IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0675: stloc.s 9
-		IL_0677: ldloc.s 9
-		IL_0679: ldc.r8 2
-		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0687: stloc.s 9
-		IL_0689: ldloc.3
-		IL_068a: ldstr "wordArray"
-		IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0694: stloc.s 13
-		IL_0696: ldloc.s 13
-		IL_0698: ldc.r8 2
-		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06a6: stloc.s 13
-		IL_06a8: ldloc.s 10
-		IL_06aa: ldstr "log"
-		IL_06af: ldstr "w2"
-		IL_06b4: ldloc.s 9
-		IL_06b6: ldloc.s 13
-		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_06bd: pop
-		IL_06be: ldstr "console"
-		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06cd: stloc.s 13
-		IL_06cf: ldloc.2
-		IL_06d0: ldstr "wordArray"
-		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06da: stloc.s 9
-		IL_06dc: ldloc.s 9
-		IL_06de: ldc.r8 3
-		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06ec: stloc.s 9
-		IL_06ee: ldloc.3
-		IL_06ef: ldstr "wordArray"
-		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06f9: stloc.s 10
-		IL_06fb: ldloc.s 10
-		IL_06fd: ldc.r8 3
-		IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_070b: stloc.s 10
-		IL_070d: ldloc.s 13
-		IL_070f: ldstr "log"
-		IL_0714: ldstr "w3"
-		IL_0719: ldloc.s 9
-		IL_071b: ldloc.s 10
-		IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0722: pop
-		IL_0723: ret
+		IL_0581: ldstr "console"
+		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0590: stloc.s 10
+		IL_0592: ldloc.2
+		IL_0593: ldstr "wordArray"
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_059d: stloc.s 9
+		IL_059f: ldloc.s 9
+		IL_05a1: ldc.r8 0.0
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05af: stloc.s 9
+		IL_05b1: ldloc.3
+		IL_05b2: ldstr "wordArray"
+		IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05bc: stloc.s 13
+		IL_05be: ldloc.s 13
+		IL_05c0: ldc.r8 0.0
+		IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_05ce: stloc.s 13
+		IL_05d0: ldloc.s 10
+		IL_05d2: ldstr "log"
+		IL_05d7: ldstr "w0"
+		IL_05dc: ldloc.s 9
+		IL_05de: ldloc.s 13
+		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_05e5: pop
+		IL_05e6: ldstr "console"
+		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f5: stloc.s 13
+		IL_05f7: ldloc.2
+		IL_05f8: ldstr "wordArray"
+		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0602: stloc.s 9
+		IL_0604: ldloc.s 9
+		IL_0606: ldc.r8 1
+		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0614: stloc.s 9
+		IL_0616: ldloc.3
+		IL_0617: ldstr "wordArray"
+		IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0621: stloc.s 10
+		IL_0623: ldloc.s 10
+		IL_0625: ldc.r8 1
+		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0633: stloc.s 10
+		IL_0635: ldloc.s 13
+		IL_0637: ldstr "log"
+		IL_063c: ldstr "w1"
+		IL_0641: ldloc.s 9
+		IL_0643: ldloc.s 10
+		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_064a: pop
+		IL_064b: ldstr "console"
+		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_065a: stloc.s 10
+		IL_065c: ldloc.2
+		IL_065d: ldstr "wordArray"
+		IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0667: stloc.s 9
+		IL_0669: ldloc.s 9
+		IL_066b: ldc.r8 2
+		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0679: stloc.s 9
+		IL_067b: ldloc.3
+		IL_067c: ldstr "wordArray"
+		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0686: stloc.s 13
+		IL_0688: ldloc.s 13
+		IL_068a: ldc.r8 2
+		IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0698: stloc.s 13
+		IL_069a: ldloc.s 10
+		IL_069c: ldstr "log"
+		IL_06a1: ldstr "w2"
+		IL_06a6: ldloc.s 9
+		IL_06a8: ldloc.s 13
+		IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_06af: pop
+		IL_06b0: ldstr "console"
+		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06bf: stloc.s 13
+		IL_06c1: ldloc.2
+		IL_06c2: ldstr "wordArray"
+		IL_06c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06cc: stloc.s 9
+		IL_06ce: ldloc.s 9
+		IL_06d0: ldc.r8 3
+		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06de: stloc.s 9
+		IL_06e0: ldloc.3
+		IL_06e1: ldstr "wordArray"
+		IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06eb: stloc.s 10
+		IL_06ed: ldloc.s 10
+		IL_06ef: ldc.r8 3
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_06fd: stloc.s 10
+		IL_06ff: ldloc.s 13
+		IL_0701: ldstr "log"
+		IL_0706: ldstr "w3"
+		IL_070b: ldloc.s 9
+		IL_070d: ldloc.s 10
+		IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0714: pop
+		IL_0715: ret
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
@@ -1615,7 +1602,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b8f
+		// Method begins at RVA 0x2b6b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -785,7 +785,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1255 (0x4e7)
+		// Code size: 1254 (0x4e6)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -810,411 +810,410 @@
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: nop
-		IL_0008: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_000d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0012: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0017: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_001c: stloc.s 9
-		IL_001e: ldc.i4.1
-		IL_001f: newarr [System.Runtime]System.Object
-		IL_0024: dup
-		IL_0025: ldc.i4.0
-		IL_0026: ldloc.0
-		IL_0027: stelem.ref
-		IL_0028: stloc.s 10
-		IL_002a: ldc.i4.s 10
-		IL_002c: newarr [System.Runtime]System.Object
-		IL_0031: dup
-		IL_0032: ldc.i4.0
-		IL_0033: ldloc.s 9
-		IL_0035: stelem.ref
-		IL_0036: dup
-		IL_0037: ldc.i4.1
-		IL_0038: ldstr "setBitTrue"
-		IL_003d: stelem.ref
-		IL_003e: dup
-		IL_003f: ldc.i4.2
-		IL_0040: ldstr "setBitTrue"
-		IL_0045: stelem.ref
-		IL_0046: dup
-		IL_0047: ldc.i4.3
-		IL_0048: ldc.r8 1
-		IL_0051: box [System.Runtime]System.Double
-		IL_0056: stelem.ref
-		IL_0057: dup
-		IL_0058: ldc.i4.4
-		IL_0059: ldstr "setBitTrue"
-		IL_005e: stelem.ref
-		IL_005f: dup
-		IL_0060: ldc.i4.5
-		IL_0061: ldc.i4.0
-		IL_0062: box [System.Runtime]System.Boolean
-		IL_0067: stelem.ref
-		IL_0068: dup
-		IL_0069: ldc.i4.6
-		IL_006a: ldc.i4.0
-		IL_006b: box [System.Runtime]System.Boolean
-		IL_0070: stelem.ref
-		IL_0071: dup
-		IL_0072: ldc.i4.7
-		IL_0073: ldc.i4.0
-		IL_0074: box [System.Runtime]System.Boolean
-		IL_0079: stelem.ref
-		IL_007a: dup
-		IL_007b: ldc.i4.8
-		IL_007c: ldc.i4.0
-		IL_007d: box [System.Runtime]System.Boolean
-		IL_0082: stelem.ref
-		IL_0083: dup
-		IL_0084: ldc.i4.s 9
-		IL_0086: ldloc.s 10
-		IL_0088: stelem.ref
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_008e: pop
-		IL_008f: ldc.i4.s 10
-		IL_0091: newarr [System.Runtime]System.Object
-		IL_0096: dup
-		IL_0097: ldc.i4.0
-		IL_0098: ldloc.s 9
-		IL_009a: stelem.ref
-		IL_009b: dup
-		IL_009c: ldc.i4.1
-		IL_009d: ldstr "setBitsTrue"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.2
-		IL_00a5: ldstr "setBitsTrue"
-		IL_00aa: stelem.ref
-		IL_00ab: dup
-		IL_00ac: ldc.i4.3
-		IL_00ad: ldc.r8 3
-		IL_00b6: box [System.Runtime]System.Double
-		IL_00bb: stelem.ref
-		IL_00bc: dup
-		IL_00bd: ldc.i4.4
-		IL_00be: ldstr "setBitsTrue"
-		IL_00c3: stelem.ref
-		IL_00c4: dup
-		IL_00c5: ldc.i4.5
-		IL_00c6: ldc.i4.0
-		IL_00c7: box [System.Runtime]System.Boolean
-		IL_00cc: stelem.ref
-		IL_00cd: dup
-		IL_00ce: ldc.i4.6
-		IL_00cf: ldc.i4.0
-		IL_00d0: box [System.Runtime]System.Boolean
-		IL_00d5: stelem.ref
-		IL_00d6: dup
-		IL_00d7: ldc.i4.7
-		IL_00d8: ldc.i4.0
-		IL_00d9: box [System.Runtime]System.Boolean
-		IL_00de: stelem.ref
-		IL_00df: dup
-		IL_00e0: ldc.i4.8
-		IL_00e1: ldc.i4.0
-		IL_00e2: box [System.Runtime]System.Boolean
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.s 9
-		IL_00eb: ldloc.s 10
-		IL_00ed: stelem.ref
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_00f3: pop
-		IL_00f4: ldc.i4.s 10
-		IL_00f6: newarr [System.Runtime]System.Object
-		IL_00fb: dup
-		IL_00fc: ldc.i4.0
-		IL_00fd: ldloc.s 9
-		IL_00ff: stelem.ref
-		IL_0100: dup
-		IL_0101: ldc.i4.1
-		IL_0102: ldstr "testBitTrue"
-		IL_0107: stelem.ref
-		IL_0108: dup
-		IL_0109: ldc.i4.2
-		IL_010a: ldstr "testBitTrue"
-		IL_010f: stelem.ref
-		IL_0110: dup
-		IL_0111: ldc.i4.3
-		IL_0112: ldc.r8 1
-		IL_011b: box [System.Runtime]System.Double
-		IL_0120: stelem.ref
-		IL_0121: dup
-		IL_0122: ldc.i4.4
-		IL_0123: ldstr "testBitTrue"
-		IL_0128: stelem.ref
-		IL_0129: dup
-		IL_012a: ldc.i4.5
-		IL_012b: ldc.i4.0
-		IL_012c: box [System.Runtime]System.Boolean
-		IL_0131: stelem.ref
-		IL_0132: dup
-		IL_0133: ldc.i4.6
-		IL_0134: ldc.i4.0
-		IL_0135: box [System.Runtime]System.Boolean
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.7
-		IL_013d: ldc.i4.0
-		IL_013e: box [System.Runtime]System.Boolean
-		IL_0143: stelem.ref
-		IL_0144: dup
-		IL_0145: ldc.i4.8
-		IL_0146: ldc.i4.0
-		IL_0147: box [System.Runtime]System.Boolean
-		IL_014c: stelem.ref
-		IL_014d: dup
-		IL_014e: ldc.i4.s 9
-		IL_0150: ldloc.s 10
-		IL_0152: stelem.ref
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0158: pop
-		IL_0159: ldc.i4.1
-		IL_015a: newarr [System.Runtime]System.Object
-		IL_015f: dup
-		IL_0160: ldc.i4.0
-		IL_0161: ldloc.0
-		IL_0162: stelem.ref
-		IL_0163: stloc.s 10
-		IL_0165: ldloc.s 9
-		IL_0167: ldloc.s 10
-		IL_0169: ldc.r8 1
-		IL_0172: box [System.Runtime]System.Double
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_017c: stloc.s 11
-		IL_017e: ldloc.s 11
-		IL_0180: stloc.1
-		IL_0181: ldc.i4.1
-		IL_0182: newarr [System.Runtime]System.Object
-		IL_0187: dup
-		IL_0188: ldc.i4.0
-		IL_0189: ldloc.0
-		IL_018a: stelem.ref
-		IL_018b: stloc.s 10
-		IL_018d: ldloc.s 10
-		IL_018f: ldc.i4.1
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: dup
-		IL_0196: ldc.i4.0
-		IL_0197: ldc.r8 64
-		IL_01a0: box [System.Runtime]System.Double
-		IL_01a5: stelem.ref
-		IL_01a6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01ab: ldc.r8 64
-		IL_01b4: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
-		IL_01b9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01be: stloc.2
-		IL_01bf: ldloc.2
-		IL_01c0: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_01c5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01ca: ldstr "prototype"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01d4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01d9: ldc.r8 3
-		IL_01e2: box [System.Runtime]System.Double
-		IL_01e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_01ec: stloc.3
-		IL_01ed: ldc.r8 0.0
-		IL_01f6: stloc.s 4
-		IL_01f8: ldloc.3
-		IL_01f9: ldloc.s 4
-		IL_01fb: ldc.r8 16
-		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_0209: ldstr "console"
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0218: ldloc.3
-		IL_0219: ldc.r8 0.0
-		IL_0222: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_0227: box [System.Runtime]System.Double
-		IL_022c: stloc.s 12
-		IL_022e: ldstr "log"
-		IL_0233: ldstr "varIndexSet"
-		IL_0238: ldloc.s 12
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_023f: pop
-		IL_0240: ldloc.2
-		IL_0241: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0246: stloc.s 13
-		IL_0248: ldloc.s 13
-		IL_024a: ldc.r8 4
-		IL_0253: box [System.Runtime]System.Double
-		IL_0258: ldc.r8 3
-		IL_0261: box [System.Runtime]System.Double
-		IL_0266: ldc.r8 64
-		IL_026f: box [System.Runtime]System.Double
-		IL_0274: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_0279: pop
-		IL_027a: ldstr "console"
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0289: stloc.s 11
-		IL_028b: ldloc.2
-		IL_028c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0291: stloc.s 13
-		IL_0293: ldloc.s 13
-		IL_0295: ldc.r8 4
-		IL_029e: box [System.Runtime]System.Double
-		IL_02a3: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_02a8: stloc.s 14
-		IL_02aa: ldloc.s 14
-		IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_02b1: stloc.s 15
-		IL_02b3: ldloc.s 15
-		IL_02b5: brfalse IL_02cf
+		IL_0007: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_000c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0011: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0016: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001b: stloc.s 9
+		IL_001d: ldc.i4.1
+		IL_001e: newarr [System.Runtime]System.Object
+		IL_0023: dup
+		IL_0024: ldc.i4.0
+		IL_0025: ldloc.0
+		IL_0026: stelem.ref
+		IL_0027: stloc.s 10
+		IL_0029: ldc.i4.s 10
+		IL_002b: newarr [System.Runtime]System.Object
+		IL_0030: dup
+		IL_0031: ldc.i4.0
+		IL_0032: ldloc.s 9
+		IL_0034: stelem.ref
+		IL_0035: dup
+		IL_0036: ldc.i4.1
+		IL_0037: ldstr "setBitTrue"
+		IL_003c: stelem.ref
+		IL_003d: dup
+		IL_003e: ldc.i4.2
+		IL_003f: ldstr "setBitTrue"
+		IL_0044: stelem.ref
+		IL_0045: dup
+		IL_0046: ldc.i4.3
+		IL_0047: ldc.r8 1
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: stelem.ref
+		IL_0056: dup
+		IL_0057: ldc.i4.4
+		IL_0058: ldstr "setBitTrue"
+		IL_005d: stelem.ref
+		IL_005e: dup
+		IL_005f: ldc.i4.5
+		IL_0060: ldc.i4.0
+		IL_0061: box [System.Runtime]System.Boolean
+		IL_0066: stelem.ref
+		IL_0067: dup
+		IL_0068: ldc.i4.6
+		IL_0069: ldc.i4.0
+		IL_006a: box [System.Runtime]System.Boolean
+		IL_006f: stelem.ref
+		IL_0070: dup
+		IL_0071: ldc.i4.7
+		IL_0072: ldc.i4.0
+		IL_0073: box [System.Runtime]System.Boolean
+		IL_0078: stelem.ref
+		IL_0079: dup
+		IL_007a: ldc.i4.8
+		IL_007b: ldc.i4.0
+		IL_007c: box [System.Runtime]System.Boolean
+		IL_0081: stelem.ref
+		IL_0082: dup
+		IL_0083: ldc.i4.s 9
+		IL_0085: ldloc.s 10
+		IL_0087: stelem.ref
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_008d: pop
+		IL_008e: ldc.i4.s 10
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.s 9
+		IL_0099: stelem.ref
+		IL_009a: dup
+		IL_009b: ldc.i4.1
+		IL_009c: ldstr "setBitsTrue"
+		IL_00a1: stelem.ref
+		IL_00a2: dup
+		IL_00a3: ldc.i4.2
+		IL_00a4: ldstr "setBitsTrue"
+		IL_00a9: stelem.ref
+		IL_00aa: dup
+		IL_00ab: ldc.i4.3
+		IL_00ac: ldc.r8 3
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: stelem.ref
+		IL_00bb: dup
+		IL_00bc: ldc.i4.4
+		IL_00bd: ldstr "setBitsTrue"
+		IL_00c2: stelem.ref
+		IL_00c3: dup
+		IL_00c4: ldc.i4.5
+		IL_00c5: ldc.i4.0
+		IL_00c6: box [System.Runtime]System.Boolean
+		IL_00cb: stelem.ref
+		IL_00cc: dup
+		IL_00cd: ldc.i4.6
+		IL_00ce: ldc.i4.0
+		IL_00cf: box [System.Runtime]System.Boolean
+		IL_00d4: stelem.ref
+		IL_00d5: dup
+		IL_00d6: ldc.i4.7
+		IL_00d7: ldc.i4.0
+		IL_00d8: box [System.Runtime]System.Boolean
+		IL_00dd: stelem.ref
+		IL_00de: dup
+		IL_00df: ldc.i4.8
+		IL_00e0: ldc.i4.0
+		IL_00e1: box [System.Runtime]System.Boolean
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.s 9
+		IL_00ea: ldloc.s 10
+		IL_00ec: stelem.ref
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_00f2: pop
+		IL_00f3: ldc.i4.s 10
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: dup
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldloc.s 9
+		IL_00fe: stelem.ref
+		IL_00ff: dup
+		IL_0100: ldc.i4.1
+		IL_0101: ldstr "testBitTrue"
+		IL_0106: stelem.ref
+		IL_0107: dup
+		IL_0108: ldc.i4.2
+		IL_0109: ldstr "testBitTrue"
+		IL_010e: stelem.ref
+		IL_010f: dup
+		IL_0110: ldc.i4.3
+		IL_0111: ldc.r8 1
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: stelem.ref
+		IL_0120: dup
+		IL_0121: ldc.i4.4
+		IL_0122: ldstr "testBitTrue"
+		IL_0127: stelem.ref
+		IL_0128: dup
+		IL_0129: ldc.i4.5
+		IL_012a: ldc.i4.0
+		IL_012b: box [System.Runtime]System.Boolean
+		IL_0130: stelem.ref
+		IL_0131: dup
+		IL_0132: ldc.i4.6
+		IL_0133: ldc.i4.0
+		IL_0134: box [System.Runtime]System.Boolean
+		IL_0139: stelem.ref
+		IL_013a: dup
+		IL_013b: ldc.i4.7
+		IL_013c: ldc.i4.0
+		IL_013d: box [System.Runtime]System.Boolean
+		IL_0142: stelem.ref
+		IL_0143: dup
+		IL_0144: ldc.i4.8
+		IL_0145: ldc.i4.0
+		IL_0146: box [System.Runtime]System.Boolean
+		IL_014b: stelem.ref
+		IL_014c: dup
+		IL_014d: ldc.i4.s 9
+		IL_014f: ldloc.s 10
+		IL_0151: stelem.ref
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0157: pop
+		IL_0158: ldc.i4.1
+		IL_0159: newarr [System.Runtime]System.Object
+		IL_015e: dup
+		IL_015f: ldc.i4.0
+		IL_0160: ldloc.0
+		IL_0161: stelem.ref
+		IL_0162: stloc.s 10
+		IL_0164: ldloc.s 9
+		IL_0166: ldloc.s 10
+		IL_0168: ldc.r8 1
+		IL_0171: box [System.Runtime]System.Double
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_017b: stloc.s 11
+		IL_017d: ldloc.s 11
+		IL_017f: stloc.1
+		IL_0180: ldc.i4.1
+		IL_0181: newarr [System.Runtime]System.Object
+		IL_0186: dup
+		IL_0187: ldc.i4.0
+		IL_0188: ldloc.0
+		IL_0189: stelem.ref
+		IL_018a: stloc.s 10
+		IL_018c: ldloc.s 10
+		IL_018e: ldc.i4.1
+		IL_018f: newarr [System.Runtime]System.Object
+		IL_0194: dup
+		IL_0195: ldc.i4.0
+		IL_0196: ldc.r8 64
+		IL_019f: box [System.Runtime]System.Double
+		IL_01a4: stelem.ref
+		IL_01a5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01aa: ldc.r8 64
+		IL_01b3: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
+		IL_01b8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01bd: stloc.2
+		IL_01be: ldloc.2
+		IL_01bf: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_01c4: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01c9: ldstr "prototype"
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01d3: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01d8: ldc.r8 3
+		IL_01e1: box [System.Runtime]System.Double
+		IL_01e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_01eb: stloc.3
+		IL_01ec: ldc.r8 0.0
+		IL_01f5: stloc.s 4
+		IL_01f7: ldloc.3
+		IL_01f8: ldloc.s 4
+		IL_01fa: ldc.r8 16
+		IL_0203: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_0208: ldstr "console"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0217: ldloc.3
+		IL_0218: ldc.r8 0.0
+		IL_0221: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0226: box [System.Runtime]System.Double
+		IL_022b: stloc.s 12
+		IL_022d: ldstr "log"
+		IL_0232: ldstr "varIndexSet"
+		IL_0237: ldloc.s 12
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_023e: pop
+		IL_023f: ldloc.2
+		IL_0240: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0245: stloc.s 13
+		IL_0247: ldloc.s 13
+		IL_0249: ldc.r8 4
+		IL_0252: box [System.Runtime]System.Double
+		IL_0257: ldc.r8 3
+		IL_0260: box [System.Runtime]System.Double
+		IL_0265: ldc.r8 64
+		IL_026e: box [System.Runtime]System.Double
+		IL_0273: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+		IL_0278: pop
+		IL_0279: ldstr "console"
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0288: stloc.s 11
+		IL_028a: ldloc.2
+		IL_028b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0290: stloc.s 13
+		IL_0292: ldloc.s 13
+		IL_0294: ldc.r8 4
+		IL_029d: box [System.Runtime]System.Double
+		IL_02a2: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_02a7: stloc.s 14
+		IL_02a9: ldloc.s 14
+		IL_02ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_02b0: stloc.s 15
+		IL_02b2: ldloc.s 15
+		IL_02b4: brfalse IL_02ce
 
-		IL_02ba: ldc.r8 1
-		IL_02c3: box [System.Runtime]System.Double
-		IL_02c8: stloc.s 5
-		IL_02ca: br IL_02df
+		IL_02b9: ldc.r8 1
+		IL_02c2: box [System.Runtime]System.Double
+		IL_02c7: stloc.s 5
+		IL_02c9: br IL_02de
 
-		IL_02cf: ldc.r8 0.0
-		IL_02d8: box [System.Runtime]System.Double
-		IL_02dd: stloc.s 5
+		IL_02ce: ldc.r8 0.0
+		IL_02d7: box [System.Runtime]System.Double
+		IL_02dc: stloc.s 5
 
-		IL_02df: ldloc.s 11
-		IL_02e1: ldstr "log"
-		IL_02e6: ldstr "bit4"
-		IL_02eb: ldloc.s 5
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02f2: pop
-		IL_02f3: ldstr "console"
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0302: stloc.s 11
-		IL_0304: ldloc.2
-		IL_0305: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_030a: stloc.s 13
-		IL_030c: ldloc.s 13
-		IL_030e: ldc.r8 7
-		IL_0317: box [System.Runtime]System.Double
-		IL_031c: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0321: stloc.s 14
-		IL_0323: ldloc.s 14
-		IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_032a: stloc.s 15
-		IL_032c: ldloc.s 15
-		IL_032e: brfalse IL_0348
+		IL_02de: ldloc.s 11
+		IL_02e0: ldstr "log"
+		IL_02e5: ldstr "bit4"
+		IL_02ea: ldloc.s 5
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02f1: pop
+		IL_02f2: ldstr "console"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0301: stloc.s 11
+		IL_0303: ldloc.2
+		IL_0304: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0309: stloc.s 13
+		IL_030b: ldloc.s 13
+		IL_030d: ldc.r8 7
+		IL_0316: box [System.Runtime]System.Double
+		IL_031b: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0320: stloc.s 14
+		IL_0322: ldloc.s 14
+		IL_0324: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_0329: stloc.s 15
+		IL_032b: ldloc.s 15
+		IL_032d: brfalse IL_0347
 
-		IL_0333: ldc.r8 1
-		IL_033c: box [System.Runtime]System.Double
-		IL_0341: stloc.s 6
-		IL_0343: br IL_0358
+		IL_0332: ldc.r8 1
+		IL_033b: box [System.Runtime]System.Double
+		IL_0340: stloc.s 6
+		IL_0342: br IL_0357
 
-		IL_0348: ldc.r8 0.0
-		IL_0351: box [System.Runtime]System.Double
-		IL_0356: stloc.s 6
+		IL_0347: ldc.r8 0.0
+		IL_0350: box [System.Runtime]System.Double
+		IL_0355: stloc.s 6
 
-		IL_0358: ldloc.s 11
-		IL_035a: ldstr "log"
-		IL_035f: ldstr "bit7"
-		IL_0364: ldloc.s 6
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_036b: pop
-		IL_036c: ldstr "console"
-		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037b: stloc.s 11
-		IL_037d: ldloc.2
-		IL_037e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0383: stloc.s 13
-		IL_0385: ldloc.s 13
-		IL_0387: ldc.r8 31
-		IL_0390: box [System.Runtime]System.Double
-		IL_0395: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_039a: stloc.s 14
-		IL_039c: ldloc.s 14
-		IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_03a3: stloc.s 15
-		IL_03a5: ldloc.s 15
-		IL_03a7: brfalse IL_03c1
+		IL_0357: ldloc.s 11
+		IL_0359: ldstr "log"
+		IL_035e: ldstr "bit7"
+		IL_0363: ldloc.s 6
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_036a: pop
+		IL_036b: ldstr "console"
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037a: stloc.s 11
+		IL_037c: ldloc.2
+		IL_037d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0382: stloc.s 13
+		IL_0384: ldloc.s 13
+		IL_0386: ldc.r8 31
+		IL_038f: box [System.Runtime]System.Double
+		IL_0394: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0399: stloc.s 14
+		IL_039b: ldloc.s 14
+		IL_039d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_03a2: stloc.s 15
+		IL_03a4: ldloc.s 15
+		IL_03a6: brfalse IL_03c0
 
-		IL_03ac: ldc.r8 1
-		IL_03b5: box [System.Runtime]System.Double
-		IL_03ba: stloc.s 7
-		IL_03bc: br IL_03d1
+		IL_03ab: ldc.r8 1
+		IL_03b4: box [System.Runtime]System.Double
+		IL_03b9: stloc.s 7
+		IL_03bb: br IL_03d0
 
-		IL_03c1: ldc.r8 0.0
-		IL_03ca: box [System.Runtime]System.Double
-		IL_03cf: stloc.s 7
+		IL_03c0: ldc.r8 0.0
+		IL_03c9: box [System.Runtime]System.Double
+		IL_03ce: stloc.s 7
 
-		IL_03d1: ldloc.s 11
-		IL_03d3: ldstr "log"
-		IL_03d8: ldstr "bit31"
-		IL_03dd: ldloc.s 7
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03e4: pop
-		IL_03e5: ldstr "console"
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f4: stloc.s 11
-		IL_03f6: ldloc.2
-		IL_03f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_03fc: stloc.s 13
-		IL_03fe: ldloc.s 13
-		IL_0400: ldc.r8 5
-		IL_0409: box [System.Runtime]System.Double
-		IL_040e: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0413: stloc.s 14
-		IL_0415: ldloc.s 14
-		IL_0417: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_041c: stloc.s 15
-		IL_041e: ldloc.s 15
-		IL_0420: brfalse IL_043a
+		IL_03d0: ldloc.s 11
+		IL_03d2: ldstr "log"
+		IL_03d7: ldstr "bit31"
+		IL_03dc: ldloc.s 7
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03e3: pop
+		IL_03e4: ldstr "console"
+		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f3: stloc.s 11
+		IL_03f5: ldloc.2
+		IL_03f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_03fb: stloc.s 13
+		IL_03fd: ldloc.s 13
+		IL_03ff: ldc.r8 5
+		IL_0408: box [System.Runtime]System.Double
+		IL_040d: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0412: stloc.s 14
+		IL_0414: ldloc.s 14
+		IL_0416: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_041b: stloc.s 15
+		IL_041d: ldloc.s 15
+		IL_041f: brfalse IL_0439
 
-		IL_0425: ldc.r8 1
-		IL_042e: box [System.Runtime]System.Double
-		IL_0433: stloc.s 8
-		IL_0435: br IL_044a
+		IL_0424: ldc.r8 1
+		IL_042d: box [System.Runtime]System.Double
+		IL_0432: stloc.s 8
+		IL_0434: br IL_0449
 
-		IL_043a: ldc.r8 0.0
-		IL_0443: box [System.Runtime]System.Double
-		IL_0448: stloc.s 8
+		IL_0439: ldc.r8 0.0
+		IL_0442: box [System.Runtime]System.Double
+		IL_0447: stloc.s 8
 
-		IL_044a: ldloc.s 11
-		IL_044c: ldstr "log"
-		IL_0451: ldstr "bit5"
-		IL_0456: ldloc.s 8
-		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_045d: pop
-		IL_045e: ldstr "console"
-		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046d: stloc.s 11
-		IL_046f: ldloc.2
-		IL_0470: ldstr "wordArray"
-		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_047a: stloc.s 16
-		IL_047c: ldloc.s 16
-		IL_047e: ldc.r8 0.0
-		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_048c: stloc.s 16
-		IL_048e: ldloc.s 11
-		IL_0490: ldstr "log"
-		IL_0495: ldstr "word0"
-		IL_049a: ldloc.s 16
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04a1: pop
-		IL_04a2: ldstr "console"
-		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b1: stloc.s 16
-		IL_04b3: ldloc.2
-		IL_04b4: ldstr "wordArray"
-		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04be: stloc.s 11
-		IL_04c0: ldloc.s 11
-		IL_04c2: ldc.r8 1
-		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_04d0: stloc.s 11
-		IL_04d2: ldloc.s 16
-		IL_04d4: ldstr "log"
-		IL_04d9: ldstr "word1"
-		IL_04de: ldloc.s 11
-		IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04e5: pop
-		IL_04e6: ret
+		IL_0449: ldloc.s 11
+		IL_044b: ldstr "log"
+		IL_0450: ldstr "bit5"
+		IL_0455: ldloc.s 8
+		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_045c: pop
+		IL_045d: ldstr "console"
+		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046c: stloc.s 11
+		IL_046e: ldloc.2
+		IL_046f: ldstr "wordArray"
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0479: stloc.s 16
+		IL_047b: ldloc.s 16
+		IL_047d: ldc.r8 0.0
+		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_048b: stloc.s 16
+		IL_048d: ldloc.s 11
+		IL_048f: ldstr "log"
+		IL_0494: ldstr "word0"
+		IL_0499: ldloc.s 16
+		IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04a0: pop
+		IL_04a1: ldstr "console"
+		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04b0: stloc.s 16
+		IL_04b2: ldloc.2
+		IL_04b3: ldstr "wordArray"
+		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04bd: stloc.s 11
+		IL_04bf: ldloc.s 11
+		IL_04c1: ldc.r8 1
+		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04cf: stloc.s 11
+		IL_04d1: ldloc.s 16
+		IL_04d3: ldstr "log"
+		IL_04d8: ldstr "word1"
+		IL_04dd: ldloc.s 11
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04e4: pop
+		IL_04e5: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e8
+				// Method begins at RVA 0x29c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29f1
+				// Method begins at RVA 0x29c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29fa
+				// Method begins at RVA 0x29d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -82,7 +82,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a0c
+					// Method begins at RVA 0x29e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a1e
+						// Method begins at RVA 0x29f6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a27
+						// Method begins at RVA 0x29ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -144,7 +144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a15
+					// Method begins at RVA 0x29ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a03
+				// Method begins at RVA 0x29db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a30
+				// Method begins at RVA 0x2a08
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2554
+			// Method begins at RVA 0x2544
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -258,7 +258,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25a0
+			// Method begins at RVA 0x2590
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -325,9 +325,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2604
+			// Method begins at RVA 0x25f4
 			// Header size: 12
-			// Code size: 886 (0x376)
+			// Code size: 863 (0x35f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -396,307 +396,298 @@
 			IL_0087: ldloc.0
 			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_008d: pop
-			IL_008e: ldarg.0
-			IL_008f: ldfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::_scopes
-			IL_0094: ldc.i4.0
-			IL_0095: ldelem.ref
-			IL_0096: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope
-			IL_009b: ldfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
-			IL_00a0: ldc.r8 2
-			IL_00a9: div
-			IL_00aa: stloc.s 8
-			IL_00ac: ldarg.2
-			IL_00ad: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b2: ldloc.s 8
-			IL_00b4: cgt
-			IL_00b6: brfalse IL_00e0
+			IL_008e: ldarg.2
+			IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0094: ldc.r8 16
+			IL_009d: cgt
+			IL_009f: brfalse IL_00c9
 
-			IL_00bb: ldstr "not used in this test"
-			IL_00c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ca: stloc.1
-			IL_00cb: ldloc.1
-			IL_00cc: isinst [System.Runtime]System.Exception
-			IL_00d1: dup
-			IL_00d2: brtrue IL_00df
+			IL_00a4: ldstr "not used in this test"
+			IL_00a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00b3: stloc.1
+			IL_00b4: ldloc.1
+			IL_00b5: isinst [System.Runtime]System.Exception
+			IL_00ba: dup
+			IL_00bb: brtrue IL_00c8
 
-			IL_00d7: pop
-			IL_00d8: ldloc.1
-			IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00de: throw
+			IL_00c0: pop
+			IL_00c1: ldloc.1
+			IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c7: throw
 
-			IL_00df: throw
+			IL_00c8: throw
 
-			IL_00e0: ldarg.1
-			IL_00e1: stloc.2
-			IL_00e2: ldloc.2
-			IL_00e3: stloc.s 7
-			IL_00e5: ldloc.s 7
-			IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ec: stloc.s 8
-			IL_00ee: ldloc.s 8
-			IL_00f0: conv.i4
-			IL_00f1: conv.u4
-			IL_00f2: ldc.r8 5
-			IL_00fb: conv.i4
-			IL_00fc: shr.un
-			IL_00fd: conv.r.un
-			IL_00fe: stloc.3
-			IL_00ff: ldarg.0
-			IL_0100: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0105: ldloc.3
-			IL_0106: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_010b: stloc.s 4
-			IL_010d: ldstr "console"
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011c: ldstr "log"
-			IL_0121: ldc.i4.4
-			IL_0122: newarr [System.Runtime]System.Object
-			IL_0127: dup
-			IL_0128: ldc.i4.0
-			IL_0129: ldstr "init"
+			IL_00c9: ldarg.1
+			IL_00ca: stloc.2
+			IL_00cb: ldloc.2
+			IL_00cc: stloc.s 7
+			IL_00ce: ldloc.s 7
+			IL_00d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d5: stloc.s 8
+			IL_00d7: ldloc.s 8
+			IL_00d9: conv.i4
+			IL_00da: conv.u4
+			IL_00db: ldc.r8 5
+			IL_00e4: conv.i4
+			IL_00e5: shr.un
+			IL_00e6: conv.r.un
+			IL_00e7: stloc.3
+			IL_00e8: ldarg.0
+			IL_00e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_00ee: ldloc.3
+			IL_00ef: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_00f4: stloc.s 4
+			IL_00f6: ldstr "console"
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0105: ldstr "log"
+			IL_010a: ldc.i4.4
+			IL_010b: newarr [System.Runtime]System.Object
+			IL_0110: dup
+			IL_0111: ldc.i4.0
+			IL_0112: ldstr "init"
+			IL_0117: stelem.ref
+			IL_0118: dup
+			IL_0119: ldc.i4.1
+			IL_011a: ldloc.2
+			IL_011b: stelem.ref
+			IL_011c: dup
+			IL_011d: ldc.i4.2
+			IL_011e: ldloc.3
+			IL_011f: box [System.Runtime]System.Double
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.3
+			IL_0127: ldloc.s 4
+			IL_0129: box [System.Runtime]System.Double
 			IL_012e: stelem.ref
-			IL_012f: dup
-			IL_0130: ldc.i4.1
-			IL_0131: ldloc.2
-			IL_0132: stelem.ref
-			IL_0133: dup
-			IL_0134: ldc.i4.2
-			IL_0135: ldloc.3
-			IL_0136: box [System.Runtime]System.Double
-			IL_013b: stelem.ref
-			IL_013c: dup
-			IL_013d: ldc.i4.3
-			IL_013e: ldloc.s 4
-			IL_0140: box [System.Runtime]System.Double
-			IL_0145: stelem.ref
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_014b: pop
-			// loop start (head: IL_014c)
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0134: pop
+			// loop start (head: IL_0135)
+				IL_0135: ldloc.2
+				IL_0136: stloc.s 7
+				IL_0138: ldloc.s 7
+				IL_013a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_013f: ldarg.3
+				IL_0140: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0145: clt
+				IL_0147: brfalse IL_0288
+
 				IL_014c: ldloc.2
 				IL_014d: stloc.s 7
 				IL_014f: ldloc.s 7
 				IL_0151: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0156: ldarg.3
-				IL_0157: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_015c: clt
-				IL_015e: brfalse IL_029f
+				IL_0156: stloc.s 8
+				IL_0158: ldloc.s 8
+				IL_015a: conv.i4
+				IL_015b: ldc.r8 31
+				IL_0164: conv.i4
+				IL_0165: and
+				IL_0166: conv.r8
+				IL_0167: stloc.s 5
+				IL_0169: ldc.r8 1
+				IL_0172: conv.i4
+				IL_0173: ldloc.s 5
+				IL_0175: conv.i4
+				IL_0176: shl
+				IL_0177: conv.r8
+				IL_0178: stloc.s 8
+				IL_017a: ldloc.s 4
+				IL_017c: conv.i4
+				IL_017d: ldloc.s 8
+				IL_017f: conv.i4
+				IL_0180: or
+				IL_0181: conv.r8
+				IL_0182: stloc.s 8
+				IL_0184: ldloc.s 8
+				IL_0186: stloc.s 4
+				IL_0188: ldloc.2
+				IL_0189: stloc.s 7
+				IL_018b: ldloc.s 7
+				IL_018d: ldarg.1
+				IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0193: stloc.s 9
+				IL_0195: ldloc.s 9
+				IL_0197: brfalse IL_01dc
 
-				IL_0163: ldloc.2
-				IL_0164: stloc.s 7
-				IL_0166: ldloc.s 7
-				IL_0168: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_016d: stloc.s 8
-				IL_016f: ldloc.s 8
-				IL_0171: conv.i4
-				IL_0172: ldc.r8 31
-				IL_017b: conv.i4
-				IL_017c: and
-				IL_017d: conv.r8
-				IL_017e: stloc.s 5
-				IL_0180: ldc.r8 1
-				IL_0189: conv.i4
-				IL_018a: ldloc.s 5
-				IL_018c: conv.i4
-				IL_018d: shl
-				IL_018e: conv.r8
-				IL_018f: stloc.s 8
-				IL_0191: ldloc.s 4
-				IL_0193: conv.i4
-				IL_0194: ldloc.s 8
-				IL_0196: conv.i4
-				IL_0197: or
-				IL_0198: conv.r8
-				IL_0199: stloc.s 8
-				IL_019b: ldloc.s 8
-				IL_019d: stloc.s 4
-				IL_019f: ldloc.2
-				IL_01a0: stloc.s 7
-				IL_01a2: ldloc.s 7
-				IL_01a4: ldarg.1
-				IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01aa: stloc.s 9
-				IL_01ac: ldloc.s 9
-				IL_01ae: brfalse IL_01f3
+				IL_019c: ldstr "console"
+				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01ab: ldstr "log"
+				IL_01b0: ldc.i4.4
+				IL_01b1: newarr [System.Runtime]System.Object
+				IL_01b6: dup
+				IL_01b7: ldc.i4.0
+				IL_01b8: ldstr "iter0"
+				IL_01bd: stelem.ref
+				IL_01be: dup
+				IL_01bf: ldc.i4.1
+				IL_01c0: ldloc.2
+				IL_01c1: stelem.ref
+				IL_01c2: dup
+				IL_01c3: ldc.i4.2
+				IL_01c4: ldloc.s 5
+				IL_01c6: box [System.Runtime]System.Double
+				IL_01cb: stelem.ref
+				IL_01cc: dup
+				IL_01cd: ldc.i4.3
+				IL_01ce: ldloc.s 4
+				IL_01d0: box [System.Runtime]System.Double
+				IL_01d5: stelem.ref
+				IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+				IL_01db: pop
 
-				IL_01b3: ldstr "console"
-				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01c2: ldstr "log"
-				IL_01c7: ldc.i4.4
-				IL_01c8: newarr [System.Runtime]System.Object
-				IL_01cd: dup
-				IL_01ce: ldc.i4.0
-				IL_01cf: ldstr "iter0"
-				IL_01d4: stelem.ref
-				IL_01d5: dup
-				IL_01d6: ldc.i4.1
-				IL_01d7: ldloc.2
-				IL_01d8: stelem.ref
-				IL_01d9: dup
-				IL_01da: ldc.i4.2
-				IL_01db: ldloc.s 5
-				IL_01dd: box [System.Runtime]System.Double
-				IL_01e2: stelem.ref
-				IL_01e3: dup
-				IL_01e4: ldc.i4.3
-				IL_01e5: ldloc.s 4
-				IL_01e7: box [System.Runtime]System.Double
-				IL_01ec: stelem.ref
-				IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-				IL_01f2: pop
+				IL_01dc: ldloc.2
+				IL_01dd: ldarg.2
+				IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01e3: stloc.s 10
+				IL_01e5: ldloc.s 10
+				IL_01e7: stloc.2
+				IL_01e8: ldloc.2
+				IL_01e9: stloc.s 10
+				IL_01eb: ldloc.s 10
+				IL_01ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01f2: stloc.s 8
+				IL_01f4: ldloc.s 8
+				IL_01f6: conv.i4
+				IL_01f7: conv.u4
+				IL_01f8: ldc.r8 5
+				IL_0201: conv.i4
+				IL_0202: shr.un
+				IL_0203: conv.r.un
+				IL_0204: stloc.s 6
+				IL_0206: ldloc.s 6
+				IL_0208: ldloc.3
+				IL_0209: ceq
+				IL_020b: ldc.i4.0
+				IL_020c: ceq
+				IL_020e: brfalse IL_0283
 
-				IL_01f3: ldloc.2
-				IL_01f4: ldarg.2
-				IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01fa: stloc.s 10
-				IL_01fc: ldloc.s 10
-				IL_01fe: stloc.2
-				IL_01ff: ldloc.2
-				IL_0200: stloc.s 10
-				IL_0202: ldloc.s 10
-				IL_0204: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0209: stloc.s 8
-				IL_020b: ldloc.s 8
-				IL_020d: conv.i4
-				IL_020e: conv.u4
-				IL_020f: ldc.r8 5
-				IL_0218: conv.i4
-				IL_0219: shr.un
-				IL_021a: conv.r.un
-				IL_021b: stloc.s 6
-				IL_021d: ldloc.s 6
-				IL_021f: ldloc.3
-				IL_0220: ceq
-				IL_0222: ldc.i4.0
-				IL_0223: ceq
-				IL_0225: brfalse IL_029a
+				IL_0213: ldstr "console"
+				IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0222: ldstr "log"
+				IL_0227: ldc.i4.5
+				IL_0228: newarr [System.Runtime]System.Object
+				IL_022d: dup
+				IL_022e: ldc.i4.0
+				IL_022f: ldstr "commit"
+				IL_0234: stelem.ref
+				IL_0235: dup
+				IL_0236: ldc.i4.1
+				IL_0237: ldloc.3
+				IL_0238: box [System.Runtime]System.Double
+				IL_023d: stelem.ref
+				IL_023e: dup
+				IL_023f: ldc.i4.2
+				IL_0240: ldloc.s 4
+				IL_0242: box [System.Runtime]System.Double
+				IL_0247: stelem.ref
+				IL_0248: dup
+				IL_0249: ldc.i4.3
+				IL_024a: ldstr "->"
+				IL_024f: stelem.ref
+				IL_0250: dup
+				IL_0251: ldc.i4.4
+				IL_0252: ldloc.s 6
+				IL_0254: box [System.Runtime]System.Double
+				IL_0259: stelem.ref
+				IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+				IL_025f: pop
+				IL_0260: ldarg.0
+				IL_0261: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0266: ldloc.3
+				IL_0267: ldloc.s 4
+				IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_026e: ldloc.s 6
+				IL_0270: stloc.3
+				IL_0271: ldarg.0
+				IL_0272: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+				IL_0277: ldloc.3
+				IL_0278: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_027d: stloc.s 8
+				IL_027f: ldloc.s 8
+				IL_0281: stloc.s 4
 
-				IL_022a: ldstr "console"
-				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0239: ldstr "log"
-				IL_023e: ldc.i4.5
-				IL_023f: newarr [System.Runtime]System.Object
-				IL_0244: dup
-				IL_0245: ldc.i4.0
-				IL_0246: ldstr "commit"
-				IL_024b: stelem.ref
-				IL_024c: dup
-				IL_024d: ldc.i4.1
-				IL_024e: ldloc.3
-				IL_024f: box [System.Runtime]System.Double
-				IL_0254: stelem.ref
-				IL_0255: dup
-				IL_0256: ldc.i4.2
-				IL_0257: ldloc.s 4
-				IL_0259: box [System.Runtime]System.Double
-				IL_025e: stelem.ref
-				IL_025f: dup
-				IL_0260: ldc.i4.3
-				IL_0261: ldstr "->"
-				IL_0266: stelem.ref
-				IL_0267: dup
-				IL_0268: ldc.i4.4
-				IL_0269: ldloc.s 6
-				IL_026b: box [System.Runtime]System.Double
-				IL_0270: stelem.ref
-				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-				IL_0276: pop
-				IL_0277: ldarg.0
-				IL_0278: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_027d: ldloc.3
-				IL_027e: ldloc.s 4
-				IL_0280: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_0285: ldloc.s 6
-				IL_0287: stloc.3
-				IL_0288: ldarg.0
-				IL_0289: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-				IL_028e: ldloc.3
-				IL_028f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_0294: stloc.s 8
-				IL_0296: ldloc.s 8
-				IL_0298: stloc.s 4
-
-				IL_029a: br IL_014c
+				IL_0283: br IL_0135
 			// end loop
 
-			IL_029f: ldstr "console"
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: ldstr "log"
-			IL_02b3: ldc.i4.4
-			IL_02b4: newarr [System.Runtime]System.Object
-			IL_02b9: dup
-			IL_02ba: ldc.i4.0
-			IL_02bb: ldstr "end"
+			IL_0288: ldstr "console"
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0297: ldstr "log"
+			IL_029c: ldc.i4.4
+			IL_029d: newarr [System.Runtime]System.Object
+			IL_02a2: dup
+			IL_02a3: ldc.i4.0
+			IL_02a4: ldstr "end"
+			IL_02a9: stelem.ref
+			IL_02aa: dup
+			IL_02ab: ldc.i4.1
+			IL_02ac: ldloc.2
+			IL_02ad: stelem.ref
+			IL_02ae: dup
+			IL_02af: ldc.i4.2
+			IL_02b0: ldloc.3
+			IL_02b1: box [System.Runtime]System.Double
+			IL_02b6: stelem.ref
+			IL_02b7: dup
+			IL_02b8: ldc.i4.3
+			IL_02b9: ldloc.s 4
+			IL_02bb: box [System.Runtime]System.Double
 			IL_02c0: stelem.ref
-			IL_02c1: dup
-			IL_02c2: ldc.i4.1
-			IL_02c3: ldloc.2
-			IL_02c4: stelem.ref
-			IL_02c5: dup
-			IL_02c6: ldc.i4.2
-			IL_02c7: ldloc.3
-			IL_02c8: box [System.Runtime]System.Double
-			IL_02cd: stelem.ref
-			IL_02ce: dup
-			IL_02cf: ldc.i4.3
-			IL_02d0: ldloc.s 4
-			IL_02d2: box [System.Runtime]System.Double
-			IL_02d7: stelem.ref
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_02dd: pop
-			IL_02de: ldarg.0
-			IL_02df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_02e4: ldloc.3
-			IL_02e5: ldloc.s 4
-			IL_02e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_02ec: ldstr "console"
-			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02fb: ldarg.0
-			IL_02fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0301: ldc.r8 0.0
-			IL_030a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_030f: box [System.Runtime]System.Double
-			IL_0314: stloc.s 11
-			IL_0316: ldarg.0
-			IL_0317: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_031c: ldc.r8 1
-			IL_0325: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_032a: box [System.Runtime]System.Double
-			IL_032f: stloc.s 12
-			IL_0331: ldarg.0
-			IL_0332: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
-			IL_0337: ldc.r8 2
-			IL_0340: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0345: box [System.Runtime]System.Double
-			IL_034a: stloc.s 13
-			IL_034c: ldstr "log"
-			IL_0351: ldc.i4.4
-			IL_0352: newarr [System.Runtime]System.Object
-			IL_0357: dup
-			IL_0358: ldc.i4.0
-			IL_0359: ldstr "after"
-			IL_035e: stelem.ref
-			IL_035f: dup
-			IL_0360: ldc.i4.1
-			IL_0361: ldloc.s 11
-			IL_0363: stelem.ref
-			IL_0364: dup
-			IL_0365: ldc.i4.2
-			IL_0366: ldloc.s 12
-			IL_0368: stelem.ref
-			IL_0369: dup
-			IL_036a: ldc.i4.3
-			IL_036b: ldloc.s 13
-			IL_036d: stelem.ref
-			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0373: pop
-			IL_0374: ldnull
-			IL_0375: ret
+			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_02c6: pop
+			IL_02c7: ldarg.0
+			IL_02c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02cd: ldloc.3
+			IL_02ce: ldloc.s 4
+			IL_02d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_02d5: ldstr "console"
+			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e4: ldarg.0
+			IL_02e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_02ea: ldc.r8 0.0
+			IL_02f3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_02f8: box [System.Runtime]System.Double
+			IL_02fd: stloc.s 11
+			IL_02ff: ldarg.0
+			IL_0300: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_0305: ldc.r8 1
+			IL_030e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0313: box [System.Runtime]System.Double
+			IL_0318: stloc.s 12
+			IL_031a: ldarg.0
+			IL_031b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::wordArray
+			IL_0320: ldc.r8 2
+			IL_0329: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_032e: box [System.Runtime]System.Double
+			IL_0333: stloc.s 13
+			IL_0335: ldstr "log"
+			IL_033a: ldc.i4.4
+			IL_033b: newarr [System.Runtime]System.Object
+			IL_0340: dup
+			IL_0341: ldc.i4.0
+			IL_0342: ldstr "after"
+			IL_0347: stelem.ref
+			IL_0348: dup
+			IL_0349: ldc.i4.1
+			IL_034a: ldloc.s 11
+			IL_034c: stelem.ref
+			IL_034d: dup
+			IL_034e: ldc.i4.2
+			IL_034f: ldloc.s 12
+			IL_0351: stelem.ref
+			IL_0352: dup
+			IL_0353: ldc.i4.3
+			IL_0354: ldloc.s 13
+			IL_0356: stelem.ref
+			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_035c: pop
+			IL_035d: ldnull
+			IL_035e: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -707,7 +698,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2988
+			// Method begins at RVA 0x2960
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -764,18 +755,11 @@
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
-		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-			01 00 1b 53 63 6f 70 65 20 57 4f 52 44 5f 53 49
-			5a 45 3d 7b 57 4f 52 44 5f 53 49 5a 45 7d 00 00
-		)
-		// Fields
-		.field public float64 WORD_SIZE
-
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29df
+			// Method begins at RVA 0x29b7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -801,7 +785,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1269 (0x4f5)
+		// Code size: 1255 (0x4e7)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope,
@@ -826,413 +810,411 @@
 		IL_0000: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: nop
-		IL_0007: ldloc.0
-		IL_0008: ldc.r8 32
-		IL_0011: stfld float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/Scope::WORD_SIZE
-		IL_0016: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_001b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0020: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0025: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_002a: stloc.s 9
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
+		IL_0007: nop
+		IL_0008: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_000d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0012: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_0017: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_001c: stloc.s 9
+		IL_001e: ldc.i4.1
+		IL_001f: newarr [System.Runtime]System.Object
+		IL_0024: dup
+		IL_0025: ldc.i4.0
+		IL_0026: ldloc.0
+		IL_0027: stelem.ref
+		IL_0028: stloc.s 10
+		IL_002a: ldc.i4.s 10
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldloc.s 9
 		IL_0035: stelem.ref
-		IL_0036: stloc.s 10
-		IL_0038: ldc.i4.s 10
-		IL_003a: newarr [System.Runtime]System.Object
-		IL_003f: dup
-		IL_0040: ldc.i4.0
-		IL_0041: ldloc.s 9
-		IL_0043: stelem.ref
-		IL_0044: dup
-		IL_0045: ldc.i4.1
-		IL_0046: ldstr "setBitTrue"
-		IL_004b: stelem.ref
-		IL_004c: dup
-		IL_004d: ldc.i4.2
-		IL_004e: ldstr "setBitTrue"
-		IL_0053: stelem.ref
-		IL_0054: dup
-		IL_0055: ldc.i4.3
-		IL_0056: ldc.r8 1
-		IL_005f: box [System.Runtime]System.Double
-		IL_0064: stelem.ref
-		IL_0065: dup
-		IL_0066: ldc.i4.4
-		IL_0067: ldstr "setBitTrue"
-		IL_006c: stelem.ref
-		IL_006d: dup
-		IL_006e: ldc.i4.5
-		IL_006f: ldc.i4.0
-		IL_0070: box [System.Runtime]System.Boolean
-		IL_0075: stelem.ref
-		IL_0076: dup
-		IL_0077: ldc.i4.6
-		IL_0078: ldc.i4.0
-		IL_0079: box [System.Runtime]System.Boolean
-		IL_007e: stelem.ref
-		IL_007f: dup
-		IL_0080: ldc.i4.7
-		IL_0081: ldc.i4.0
-		IL_0082: box [System.Runtime]System.Boolean
-		IL_0087: stelem.ref
-		IL_0088: dup
-		IL_0089: ldc.i4.8
-		IL_008a: ldc.i4.0
-		IL_008b: box [System.Runtime]System.Boolean
-		IL_0090: stelem.ref
-		IL_0091: dup
-		IL_0092: ldc.i4.s 9
-		IL_0094: ldloc.s 10
-		IL_0096: stelem.ref
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_009c: pop
-		IL_009d: ldc.i4.s 10
-		IL_009f: newarr [System.Runtime]System.Object
-		IL_00a4: dup
-		IL_00a5: ldc.i4.0
-		IL_00a6: ldloc.s 9
-		IL_00a8: stelem.ref
-		IL_00a9: dup
-		IL_00aa: ldc.i4.1
-		IL_00ab: ldstr "setBitsTrue"
-		IL_00b0: stelem.ref
-		IL_00b1: dup
-		IL_00b2: ldc.i4.2
-		IL_00b3: ldstr "setBitsTrue"
-		IL_00b8: stelem.ref
-		IL_00b9: dup
-		IL_00ba: ldc.i4.3
-		IL_00bb: ldc.r8 3
-		IL_00c4: box [System.Runtime]System.Double
-		IL_00c9: stelem.ref
-		IL_00ca: dup
-		IL_00cb: ldc.i4.4
-		IL_00cc: ldstr "setBitsTrue"
-		IL_00d1: stelem.ref
-		IL_00d2: dup
-		IL_00d3: ldc.i4.5
-		IL_00d4: ldc.i4.0
-		IL_00d5: box [System.Runtime]System.Boolean
-		IL_00da: stelem.ref
-		IL_00db: dup
-		IL_00dc: ldc.i4.6
-		IL_00dd: ldc.i4.0
-		IL_00de: box [System.Runtime]System.Boolean
-		IL_00e3: stelem.ref
-		IL_00e4: dup
-		IL_00e5: ldc.i4.7
-		IL_00e6: ldc.i4.0
-		IL_00e7: box [System.Runtime]System.Boolean
-		IL_00ec: stelem.ref
-		IL_00ed: dup
-		IL_00ee: ldc.i4.8
-		IL_00ef: ldc.i4.0
-		IL_00f0: box [System.Runtime]System.Boolean
-		IL_00f5: stelem.ref
-		IL_00f6: dup
-		IL_00f7: ldc.i4.s 9
-		IL_00f9: ldloc.s 10
-		IL_00fb: stelem.ref
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0101: pop
-		IL_0102: ldc.i4.s 10
-		IL_0104: newarr [System.Runtime]System.Object
-		IL_0109: dup
-		IL_010a: ldc.i4.0
-		IL_010b: ldloc.s 9
-		IL_010d: stelem.ref
-		IL_010e: dup
-		IL_010f: ldc.i4.1
-		IL_0110: ldstr "testBitTrue"
-		IL_0115: stelem.ref
-		IL_0116: dup
-		IL_0117: ldc.i4.2
-		IL_0118: ldstr "testBitTrue"
-		IL_011d: stelem.ref
-		IL_011e: dup
-		IL_011f: ldc.i4.3
-		IL_0120: ldc.r8 1
-		IL_0129: box [System.Runtime]System.Double
-		IL_012e: stelem.ref
-		IL_012f: dup
-		IL_0130: ldc.i4.4
-		IL_0131: ldstr "testBitTrue"
-		IL_0136: stelem.ref
-		IL_0137: dup
-		IL_0138: ldc.i4.5
-		IL_0139: ldc.i4.0
-		IL_013a: box [System.Runtime]System.Boolean
-		IL_013f: stelem.ref
-		IL_0140: dup
-		IL_0141: ldc.i4.6
-		IL_0142: ldc.i4.0
-		IL_0143: box [System.Runtime]System.Boolean
-		IL_0148: stelem.ref
-		IL_0149: dup
-		IL_014a: ldc.i4.7
-		IL_014b: ldc.i4.0
-		IL_014c: box [System.Runtime]System.Boolean
-		IL_0151: stelem.ref
-		IL_0152: dup
-		IL_0153: ldc.i4.8
-		IL_0154: ldc.i4.0
-		IL_0155: box [System.Runtime]System.Boolean
-		IL_015a: stelem.ref
-		IL_015b: dup
-		IL_015c: ldc.i4.s 9
-		IL_015e: ldloc.s 10
-		IL_0160: stelem.ref
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
-		IL_0166: pop
-		IL_0167: ldc.i4.1
-		IL_0168: newarr [System.Runtime]System.Object
-		IL_016d: dup
-		IL_016e: ldc.i4.0
-		IL_016f: ldloc.0
-		IL_0170: stelem.ref
-		IL_0171: stloc.s 10
-		IL_0173: ldloc.s 9
-		IL_0175: ldloc.s 10
-		IL_0177: ldc.r8 1
-		IL_0180: box [System.Runtime]System.Double
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
-		IL_018a: stloc.s 11
-		IL_018c: ldloc.s 11
-		IL_018e: stloc.1
+		IL_0036: dup
+		IL_0037: ldc.i4.1
+		IL_0038: ldstr "setBitTrue"
+		IL_003d: stelem.ref
+		IL_003e: dup
+		IL_003f: ldc.i4.2
+		IL_0040: ldstr "setBitTrue"
+		IL_0045: stelem.ref
+		IL_0046: dup
+		IL_0047: ldc.i4.3
+		IL_0048: ldc.r8 1
+		IL_0051: box [System.Runtime]System.Double
+		IL_0056: stelem.ref
+		IL_0057: dup
+		IL_0058: ldc.i4.4
+		IL_0059: ldstr "setBitTrue"
+		IL_005e: stelem.ref
+		IL_005f: dup
+		IL_0060: ldc.i4.5
+		IL_0061: ldc.i4.0
+		IL_0062: box [System.Runtime]System.Boolean
+		IL_0067: stelem.ref
+		IL_0068: dup
+		IL_0069: ldc.i4.6
+		IL_006a: ldc.i4.0
+		IL_006b: box [System.Runtime]System.Boolean
+		IL_0070: stelem.ref
+		IL_0071: dup
+		IL_0072: ldc.i4.7
+		IL_0073: ldc.i4.0
+		IL_0074: box [System.Runtime]System.Boolean
+		IL_0079: stelem.ref
+		IL_007a: dup
+		IL_007b: ldc.i4.8
+		IL_007c: ldc.i4.0
+		IL_007d: box [System.Runtime]System.Boolean
+		IL_0082: stelem.ref
+		IL_0083: dup
+		IL_0084: ldc.i4.s 9
+		IL_0086: ldloc.s 10
+		IL_0088: stelem.ref
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_008e: pop
+		IL_008f: ldc.i4.s 10
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.s 9
+		IL_009a: stelem.ref
+		IL_009b: dup
+		IL_009c: ldc.i4.1
+		IL_009d: ldstr "setBitsTrue"
+		IL_00a2: stelem.ref
+		IL_00a3: dup
+		IL_00a4: ldc.i4.2
+		IL_00a5: ldstr "setBitsTrue"
+		IL_00aa: stelem.ref
+		IL_00ab: dup
+		IL_00ac: ldc.i4.3
+		IL_00ad: ldc.r8 3
+		IL_00b6: box [System.Runtime]System.Double
+		IL_00bb: stelem.ref
+		IL_00bc: dup
+		IL_00bd: ldc.i4.4
+		IL_00be: ldstr "setBitsTrue"
+		IL_00c3: stelem.ref
+		IL_00c4: dup
+		IL_00c5: ldc.i4.5
+		IL_00c6: ldc.i4.0
+		IL_00c7: box [System.Runtime]System.Boolean
+		IL_00cc: stelem.ref
+		IL_00cd: dup
+		IL_00ce: ldc.i4.6
+		IL_00cf: ldc.i4.0
+		IL_00d0: box [System.Runtime]System.Boolean
+		IL_00d5: stelem.ref
+		IL_00d6: dup
+		IL_00d7: ldc.i4.7
+		IL_00d8: ldc.i4.0
+		IL_00d9: box [System.Runtime]System.Boolean
+		IL_00de: stelem.ref
+		IL_00df: dup
+		IL_00e0: ldc.i4.8
+		IL_00e1: ldc.i4.0
+		IL_00e2: box [System.Runtime]System.Boolean
+		IL_00e7: stelem.ref
+		IL_00e8: dup
+		IL_00e9: ldc.i4.s 9
+		IL_00eb: ldloc.s 10
+		IL_00ed: stelem.ref
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_00f3: pop
+		IL_00f4: ldc.i4.s 10
+		IL_00f6: newarr [System.Runtime]System.Object
+		IL_00fb: dup
+		IL_00fc: ldc.i4.0
+		IL_00fd: ldloc.s 9
+		IL_00ff: stelem.ref
+		IL_0100: dup
+		IL_0101: ldc.i4.1
+		IL_0102: ldstr "testBitTrue"
+		IL_0107: stelem.ref
+		IL_0108: dup
+		IL_0109: ldc.i4.2
+		IL_010a: ldstr "testBitTrue"
+		IL_010f: stelem.ref
+		IL_0110: dup
+		IL_0111: ldc.i4.3
+		IL_0112: ldc.r8 1
+		IL_011b: box [System.Runtime]System.Double
+		IL_0120: stelem.ref
+		IL_0121: dup
+		IL_0122: ldc.i4.4
+		IL_0123: ldstr "testBitTrue"
+		IL_0128: stelem.ref
+		IL_0129: dup
+		IL_012a: ldc.i4.5
+		IL_012b: ldc.i4.0
+		IL_012c: box [System.Runtime]System.Boolean
+		IL_0131: stelem.ref
+		IL_0132: dup
+		IL_0133: ldc.i4.6
+		IL_0134: ldc.i4.0
+		IL_0135: box [System.Runtime]System.Boolean
+		IL_013a: stelem.ref
+		IL_013b: dup
+		IL_013c: ldc.i4.7
+		IL_013d: ldc.i4.0
+		IL_013e: box [System.Runtime]System.Boolean
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.8
+		IL_0146: ldc.i4.0
+		IL_0147: box [System.Runtime]System.Boolean
+		IL_014c: stelem.ref
+		IL_014d: dup
+		IL_014e: ldc.i4.s 9
+		IL_0150: ldloc.s 10
+		IL_0152: stelem.ref
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RegisterLazyClassMethodDataProperty(object[])
+		IL_0158: pop
+		IL_0159: ldc.i4.1
+		IL_015a: newarr [System.Runtime]System.Object
+		IL_015f: dup
+		IL_0160: ldc.i4.0
+		IL_0161: ldloc.0
+		IL_0162: stelem.ref
+		IL_0163: stloc.s 10
+		IL_0165: ldloc.s 9
+		IL_0167: ldloc.s 10
+		IL_0169: ldc.r8 1
+		IL_0172: box [System.Runtime]System.Double
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateClassConstructorValue(object, object, object)
+		IL_017c: stloc.s 11
+		IL_017e: ldloc.s 11
+		IL_0180: stloc.1
+		IL_0181: ldc.i4.1
+		IL_0182: newarr [System.Runtime]System.Object
+		IL_0187: dup
+		IL_0188: ldc.i4.0
+		IL_0189: ldloc.0
+		IL_018a: stelem.ref
+		IL_018b: stloc.s 10
+		IL_018d: ldloc.s 10
 		IL_018f: ldc.i4.1
 		IL_0190: newarr [System.Runtime]System.Object
 		IL_0195: dup
 		IL_0196: ldc.i4.0
-		IL_0197: ldloc.0
-		IL_0198: stelem.ref
-		IL_0199: stloc.s 10
-		IL_019b: ldloc.s 10
-		IL_019d: ldc.i4.1
-		IL_019e: newarr [System.Runtime]System.Object
-		IL_01a3: dup
-		IL_01a4: ldc.i4.0
-		IL_01a5: ldc.r8 64
-		IL_01ae: box [System.Runtime]System.Double
-		IL_01b3: stelem.ref
-		IL_01b4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01b9: ldc.r8 64
-		IL_01c2: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
-		IL_01c7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01cc: stloc.2
-		IL_01cd: ldloc.2
-		IL_01ce: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_01d3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_01d8: ldstr "prototype"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01e2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_01e7: ldc.r8 3
-		IL_01f0: box [System.Runtime]System.Double
-		IL_01f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_01fa: stloc.3
-		IL_01fb: ldc.r8 0.0
-		IL_0204: stloc.s 4
-		IL_0206: ldloc.3
-		IL_0207: ldloc.s 4
-		IL_0209: ldc.r8 16
-		IL_0212: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-		IL_0217: ldstr "console"
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0226: ldloc.3
-		IL_0227: ldc.r8 0.0
-		IL_0230: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-		IL_0235: box [System.Runtime]System.Double
-		IL_023a: stloc.s 12
-		IL_023c: ldstr "log"
-		IL_0241: ldstr "varIndexSet"
-		IL_0246: ldloc.s 12
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_024d: pop
-		IL_024e: ldloc.2
-		IL_024f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0254: stloc.s 13
-		IL_0256: ldloc.s 13
-		IL_0258: ldc.r8 4
+		IL_0197: ldc.r8 64
+		IL_01a0: box [System.Runtime]System.Double
+		IL_01a5: stelem.ref
+		IL_01a6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01ab: ldc.r8 64
+		IL_01b4: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::.ctor(object[], float64)
+		IL_01b9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_01be: stloc.2
+		IL_01bf: ldloc.2
+		IL_01c0: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+		IL_01c5: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_01ca: ldstr "prototype"
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01d4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_01d9: ldc.r8 3
+		IL_01e2: box [System.Runtime]System.Double
+		IL_01e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_01ec: stloc.3
+		IL_01ed: ldc.r8 0.0
+		IL_01f6: stloc.s 4
+		IL_01f8: ldloc.3
+		IL_01f9: ldloc.s 4
+		IL_01fb: ldc.r8 16
+		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+		IL_0209: ldstr "console"
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0218: ldloc.3
+		IL_0219: ldc.r8 0.0
+		IL_0222: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+		IL_0227: box [System.Runtime]System.Double
+		IL_022c: stloc.s 12
+		IL_022e: ldstr "log"
+		IL_0233: ldstr "varIndexSet"
+		IL_0238: ldloc.s 12
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_023f: pop
+		IL_0240: ldloc.2
+		IL_0241: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0246: stloc.s 13
+		IL_0248: ldloc.s 13
+		IL_024a: ldc.r8 4
+		IL_0253: box [System.Runtime]System.Double
+		IL_0258: ldc.r8 3
 		IL_0261: box [System.Runtime]System.Double
-		IL_0266: ldc.r8 3
+		IL_0266: ldc.r8 64
 		IL_026f: box [System.Runtime]System.Double
-		IL_0274: ldc.r8 64
-		IL_027d: box [System.Runtime]System.Double
-		IL_0282: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_0287: pop
-		IL_0288: ldstr "console"
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0297: stloc.s 11
-		IL_0299: ldloc.2
-		IL_029a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_029f: stloc.s 13
-		IL_02a1: ldloc.s 13
-		IL_02a3: ldc.r8 4
-		IL_02ac: box [System.Runtime]System.Double
-		IL_02b1: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_02b6: stloc.s 14
-		IL_02b8: ldloc.s 14
-		IL_02ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_02bf: stloc.s 15
-		IL_02c1: ldloc.s 15
-		IL_02c3: brfalse IL_02dd
+		IL_0274: callvirt instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+		IL_0279: pop
+		IL_027a: ldstr "console"
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0289: stloc.s 11
+		IL_028b: ldloc.2
+		IL_028c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0291: stloc.s 13
+		IL_0293: ldloc.s 13
+		IL_0295: ldc.r8 4
+		IL_029e: box [System.Runtime]System.Double
+		IL_02a3: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_02a8: stloc.s 14
+		IL_02aa: ldloc.s 14
+		IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_02b1: stloc.s 15
+		IL_02b3: ldloc.s 15
+		IL_02b5: brfalse IL_02cf
 
-		IL_02c8: ldc.r8 1
-		IL_02d1: box [System.Runtime]System.Double
-		IL_02d6: stloc.s 5
-		IL_02d8: br IL_02ed
+		IL_02ba: ldc.r8 1
+		IL_02c3: box [System.Runtime]System.Double
+		IL_02c8: stloc.s 5
+		IL_02ca: br IL_02df
 
-		IL_02dd: ldc.r8 0.0
-		IL_02e6: box [System.Runtime]System.Double
-		IL_02eb: stloc.s 5
+		IL_02cf: ldc.r8 0.0
+		IL_02d8: box [System.Runtime]System.Double
+		IL_02dd: stloc.s 5
 
-		IL_02ed: ldloc.s 11
-		IL_02ef: ldstr "log"
-		IL_02f4: ldstr "bit4"
-		IL_02f9: ldloc.s 5
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0300: pop
-		IL_0301: ldstr "console"
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0310: stloc.s 11
-		IL_0312: ldloc.2
-		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0318: stloc.s 13
-		IL_031a: ldloc.s 13
-		IL_031c: ldc.r8 7
-		IL_0325: box [System.Runtime]System.Double
-		IL_032a: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_032f: stloc.s 14
-		IL_0331: ldloc.s 14
-		IL_0333: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_0338: stloc.s 15
-		IL_033a: ldloc.s 15
-		IL_033c: brfalse IL_0356
+		IL_02df: ldloc.s 11
+		IL_02e1: ldstr "log"
+		IL_02e6: ldstr "bit4"
+		IL_02eb: ldloc.s 5
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02f2: pop
+		IL_02f3: ldstr "console"
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0302: stloc.s 11
+		IL_0304: ldloc.2
+		IL_0305: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_030a: stloc.s 13
+		IL_030c: ldloc.s 13
+		IL_030e: ldc.r8 7
+		IL_0317: box [System.Runtime]System.Double
+		IL_031c: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0321: stloc.s 14
+		IL_0323: ldloc.s 14
+		IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_032a: stloc.s 15
+		IL_032c: ldloc.s 15
+		IL_032e: brfalse IL_0348
 
-		IL_0341: ldc.r8 1
-		IL_034a: box [System.Runtime]System.Double
-		IL_034f: stloc.s 6
-		IL_0351: br IL_0366
+		IL_0333: ldc.r8 1
+		IL_033c: box [System.Runtime]System.Double
+		IL_0341: stloc.s 6
+		IL_0343: br IL_0358
 
-		IL_0356: ldc.r8 0.0
-		IL_035f: box [System.Runtime]System.Double
-		IL_0364: stloc.s 6
+		IL_0348: ldc.r8 0.0
+		IL_0351: box [System.Runtime]System.Double
+		IL_0356: stloc.s 6
 
-		IL_0366: ldloc.s 11
-		IL_0368: ldstr "log"
-		IL_036d: ldstr "bit7"
-		IL_0372: ldloc.s 6
-		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0379: pop
-		IL_037a: ldstr "console"
-		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0389: stloc.s 11
-		IL_038b: ldloc.2
-		IL_038c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_0391: stloc.s 13
-		IL_0393: ldloc.s 13
-		IL_0395: ldc.r8 31
-		IL_039e: box [System.Runtime]System.Double
-		IL_03a3: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_03a8: stloc.s 14
-		IL_03aa: ldloc.s 14
-		IL_03ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_03b1: stloc.s 15
-		IL_03b3: ldloc.s 15
-		IL_03b5: brfalse IL_03cf
+		IL_0358: ldloc.s 11
+		IL_035a: ldstr "log"
+		IL_035f: ldstr "bit7"
+		IL_0364: ldloc.s 6
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_036b: pop
+		IL_036c: ldstr "console"
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037b: stloc.s 11
+		IL_037d: ldloc.2
+		IL_037e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_0383: stloc.s 13
+		IL_0385: ldloc.s 13
+		IL_0387: ldc.r8 31
+		IL_0390: box [System.Runtime]System.Double
+		IL_0395: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_039a: stloc.s 14
+		IL_039c: ldloc.s 14
+		IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_03a3: stloc.s 15
+		IL_03a5: ldloc.s 15
+		IL_03a7: brfalse IL_03c1
 
-		IL_03ba: ldc.r8 1
-		IL_03c3: box [System.Runtime]System.Double
-		IL_03c8: stloc.s 7
-		IL_03ca: br IL_03df
+		IL_03ac: ldc.r8 1
+		IL_03b5: box [System.Runtime]System.Double
+		IL_03ba: stloc.s 7
+		IL_03bc: br IL_03d1
 
-		IL_03cf: ldc.r8 0.0
-		IL_03d8: box [System.Runtime]System.Double
-		IL_03dd: stloc.s 7
+		IL_03c1: ldc.r8 0.0
+		IL_03ca: box [System.Runtime]System.Double
+		IL_03cf: stloc.s 7
 
-		IL_03df: ldloc.s 11
-		IL_03e1: ldstr "log"
-		IL_03e6: ldstr "bit31"
-		IL_03eb: ldloc.s 7
-		IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03f2: pop
-		IL_03f3: ldstr "console"
-		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0402: stloc.s 11
-		IL_0404: ldloc.2
-		IL_0405: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
-		IL_040a: stloc.s 13
-		IL_040c: ldloc.s 13
-		IL_040e: ldc.r8 5
-		IL_0417: box [System.Runtime]System.Double
-		IL_041c: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0421: stloc.s 14
-		IL_0423: ldloc.s 14
-		IL_0425: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
-		IL_042a: stloc.s 15
-		IL_042c: ldloc.s 15
-		IL_042e: brfalse IL_0448
+		IL_03d1: ldloc.s 11
+		IL_03d3: ldstr "log"
+		IL_03d8: ldstr "bit31"
+		IL_03dd: ldloc.s 7
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03e4: pop
+		IL_03e5: ldstr "console"
+		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f4: stloc.s 11
+		IL_03f6: ldloc.2
+		IL_03f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray>(!!0)
+		IL_03fc: stloc.s 13
+		IL_03fe: ldloc.s 13
+		IL_0400: ldc.r8 5
+		IL_0409: box [System.Runtime]System.Double
+		IL_040e: callvirt instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+		IL_0413: stloc.s 14
+		IL_0415: ldloc.s 14
+		IL_0417: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(float64)
+		IL_041c: stloc.s 15
+		IL_041e: ldloc.s 15
+		IL_0420: brfalse IL_043a
 
-		IL_0433: ldc.r8 1
-		IL_043c: box [System.Runtime]System.Double
-		IL_0441: stloc.s 8
-		IL_0443: br IL_0458
+		IL_0425: ldc.r8 1
+		IL_042e: box [System.Runtime]System.Double
+		IL_0433: stloc.s 8
+		IL_0435: br IL_044a
 
-		IL_0448: ldc.r8 0.0
-		IL_0451: box [System.Runtime]System.Double
-		IL_0456: stloc.s 8
+		IL_043a: ldc.r8 0.0
+		IL_0443: box [System.Runtime]System.Double
+		IL_0448: stloc.s 8
 
-		IL_0458: ldloc.s 11
-		IL_045a: ldstr "log"
-		IL_045f: ldstr "bit5"
-		IL_0464: ldloc.s 8
-		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_046b: pop
-		IL_046c: ldstr "console"
-		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_047b: stloc.s 11
-		IL_047d: ldloc.2
-		IL_047e: ldstr "wordArray"
-		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0488: stloc.s 16
-		IL_048a: ldloc.s 16
-		IL_048c: ldc.r8 0.0
-		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_049a: stloc.s 16
-		IL_049c: ldloc.s 11
-		IL_049e: ldstr "log"
-		IL_04a3: ldstr "word0"
-		IL_04a8: ldloc.s 16
-		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04af: pop
-		IL_04b0: ldstr "console"
-		IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04bf: stloc.s 16
-		IL_04c1: ldloc.2
-		IL_04c2: ldstr "wordArray"
-		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04cc: stloc.s 11
-		IL_04ce: ldloc.s 11
-		IL_04d0: ldc.r8 1
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_04de: stloc.s 11
-		IL_04e0: ldloc.s 16
-		IL_04e2: ldstr "log"
-		IL_04e7: ldstr "word1"
-		IL_04ec: ldloc.s 11
-		IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04f3: pop
-		IL_04f4: ret
+		IL_044a: ldloc.s 11
+		IL_044c: ldstr "log"
+		IL_0451: ldstr "bit5"
+		IL_0456: ldloc.s 8
+		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_045d: pop
+		IL_045e: ldstr "console"
+		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046d: stloc.s 11
+		IL_046f: ldloc.2
+		IL_0470: ldstr "wordArray"
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047a: stloc.s 16
+		IL_047c: ldloc.s 16
+		IL_047e: ldc.r8 0.0
+		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_048c: stloc.s 16
+		IL_048e: ldloc.s 11
+		IL_0490: ldstr "log"
+		IL_0495: ldstr "word0"
+		IL_049a: ldloc.s 16
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04a1: pop
+		IL_04a2: ldstr "console"
+		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04b1: stloc.s 16
+		IL_04b3: ldloc.2
+		IL_04b4: ldstr "wordArray"
+		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04be: stloc.s 11
+		IL_04c0: ldloc.s 11
+		IL_04c2: ldc.r8 1
+		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04d0: stloc.s 11
+		IL_04d2: ldloc.s 16
+		IL_04d4: ldstr "log"
+		IL_04d9: ldstr "word1"
+		IL_04de: ldloc.s 11
+		IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04e5: pop
+		IL_04e6: ret
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign
@@ -1244,7 +1226,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a39
+		// Method begins at RVA 0x2a11
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d5
+				// Method begins at RVA 0x24c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24de
+				// Method begins at RVA 0x24d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e7
+				// Method begins at RVA 0x24db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +230,7 @@
 			object __js_call__ (
 				class Modules.UnaryOperator_MinusMinusPostfix/Scope scope,
 				object newTarget,
-				object n
+				float64 n
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -240,75 +240,66 @@
 			)
 			// Method begins at RVA 0x2350
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] float64,
 				[1] object,
-				[2] object,
+				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object,
-				[6] object[]
+				[5] object[]
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: stloc.0
 			IL_0002: ldarg.2
-			IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0008: stloc.3
-			IL_0009: ldloc.3
-			IL_000a: box [System.Runtime]System.Double
-			IL_000f: stloc.s 4
-			IL_0011: ldloc.s 4
-			IL_0013: stloc.s 5
-			IL_0015: ldloc.3
-			IL_0016: ldc.r8 1
-			IL_001f: sub
-			IL_0020: stloc.3
-			IL_0021: ldloc.3
-			IL_0022: box [System.Runtime]System.Double
-			IL_0027: stloc.s 4
-			IL_0029: ldloc.s 4
-			IL_002b: starg.s n
-			IL_002d: ldloc.s 5
-			IL_002f: stloc.1
-			IL_0030: ldarg.2
-			IL_0031: stloc.2
-			IL_0032: ldarg.0
-			IL_0033: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-			IL_0038: stloc.s 5
-			IL_003a: ldc.i4.1
-			IL_003b: newarr [System.Runtime]System.Object
+			IL_0003: stloc.3
+			IL_0004: ldarg.2
+			IL_0005: ldc.r8 1
+			IL_000e: sub
+			IL_000f: starg.s n
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldarg.2
+			IL_0019: stloc.2
+			IL_001a: ldarg.0
+			IL_001b: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_0020: stloc.s 4
+			IL_0022: ldc.i4.1
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldarg.0
+			IL_002b: stelem.ref
+			IL_002c: stloc.s 5
+			IL_002e: ldloc.s 4
+			IL_0030: ldloc.s 5
+			IL_0032: ldc.i4.4
+			IL_0033: newarr [System.Runtime]System.Object
+			IL_0038: dup
+			IL_0039: ldc.i4.0
+			IL_003a: ldstr "arg-double"
+			IL_003f: stelem.ref
 			IL_0040: dup
-			IL_0041: ldc.i4.0
-			IL_0042: ldarg.0
-			IL_0043: stelem.ref
-			IL_0044: stloc.s 6
-			IL_0046: ldloc.s 5
-			IL_0048: ldloc.s 6
-			IL_004a: ldc.i4.4
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldstr "arg-double"
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.1
-			IL_005a: ldloc.0
-			IL_005b: stelem.ref
-			IL_005c: dup
-			IL_005d: ldc.i4.2
-			IL_005e: ldloc.1
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.3
-			IL_0062: ldloc.2
-			IL_0063: stelem.ref
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0069: pop
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_0041: ldc.i4.1
+			IL_0042: ldloc.0
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.2
+			IL_004b: ldloc.1
+			IL_004c: stelem.ref
+			IL_004d: dup
+			IL_004e: ldc.i4.3
+			IL_004f: ldloc.2
+			IL_0050: box [System.Runtime]System.Double
+			IL_0055: stelem.ref
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005b: pop
+			IL_005c: ldnull
+			IL_005d: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -324,7 +315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f0
+				// Method begins at RVA 0x24e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +341,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x23bc
 			// Header size: 12
 			// Code size: 127 (0x7f)
 			.maxstack 8
@@ -440,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f9
+				// Method begins at RVA 0x24ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -467,7 +458,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2454
+			// Method begins at RVA 0x2448
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -575,7 +566,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24cc
+			// Method begins at RVA 0x24c0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -606,7 +597,7 @@
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[2] class [System.Runtime]System.Func`3<object, float64, object>,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[5] float64,
@@ -653,15 +644,15 @@
 		IL_0053: stloc.1
 		IL_0054: ldloc.0
 		IL_0055: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_005a: ldftn object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0065: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_005a: ldftn object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0065: castclass class [System.Runtime]System.Func`3<object, float64, object>
 		IL_006a: ldc.i4.1
 		IL_006b: conv.r8
 		IL_006c: ldstr "argDouble"
 		IL_0071: ldc.i4.0
 		IL_0072: ldc.i4.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
 		IL_0078: stloc.2
 		IL_0079: ldloc.0
 		IL_007a: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
@@ -749,7 +740,7 @@
 		IL_015e: ldloc.s 13
 		IL_0160: ldc.r8 3
 		IL_0169: box [System.Runtime]System.Double
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_0173: pop
 		IL_0174: ldstr "3"
 		IL_0179: stloc.s 9
@@ -831,7 +822,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2502
+		// Method begins at RVA 0x24f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -223,7 +223,7 @@
 			object __js_call__ (
 				class Modules.UnaryOperator_MinusMinusPrefix/Scope scope,
 				object newTarget,
-				object n
+				float64 n
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -236,60 +236,58 @@
 			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] float64,
 				[1] object,
-				[2] object,
+				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object,
-				[6] object[]
+				[5] object[]
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: stloc.0
 			IL_0002: ldarg.2
-			IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0008: ldc.r8 1
-			IL_0011: sub
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: box [System.Runtime]System.Double
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: starg.s n
-			IL_001f: ldloc.s 4
-			IL_0021: stloc.1
-			IL_0022: ldarg.2
-			IL_0023: stloc.2
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-			IL_002a: stloc.s 5
-			IL_002c: ldc.i4.1
-			IL_002d: newarr [System.Runtime]System.Object
-			IL_0032: dup
-			IL_0033: ldc.i4.0
-			IL_0034: ldarg.0
-			IL_0035: stelem.ref
-			IL_0036: stloc.s 6
-			IL_0038: ldloc.s 5
-			IL_003a: ldloc.s 6
-			IL_003c: ldc.i4.4
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldstr "arg-double"
-			IL_0049: stelem.ref
-			IL_004a: dup
-			IL_004b: ldc.i4.1
-			IL_004c: ldloc.0
-			IL_004d: stelem.ref
-			IL_004e: dup
-			IL_004f: ldc.i4.2
-			IL_0050: ldloc.1
-			IL_0051: stelem.ref
-			IL_0052: dup
-			IL_0053: ldc.i4.3
-			IL_0054: ldloc.2
+			IL_0003: ldc.r8 1
+			IL_000c: sub
+			IL_000d: stloc.3
+			IL_000e: ldloc.3
+			IL_000f: starg.s n
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldarg.2
+			IL_0019: stloc.2
+			IL_001a: ldarg.0
+			IL_001b: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0020: stloc.s 4
+			IL_0022: ldc.i4.1
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldarg.0
+			IL_002b: stelem.ref
+			IL_002c: stloc.s 5
+			IL_002e: ldloc.s 4
+			IL_0030: ldloc.s 5
+			IL_0032: ldc.i4.4
+			IL_0033: newarr [System.Runtime]System.Object
+			IL_0038: dup
+			IL_0039: ldc.i4.0
+			IL_003a: ldstr "arg-double"
+			IL_003f: stelem.ref
+			IL_0040: dup
+			IL_0041: ldc.i4.1
+			IL_0042: ldloc.0
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.2
+			IL_004b: ldloc.1
+			IL_004c: stelem.ref
+			IL_004d: dup
+			IL_004e: ldc.i4.3
+			IL_004f: ldloc.2
+			IL_0050: box [System.Runtime]System.Double
 			IL_0055: stelem.ref
 			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 			IL_005b: pop
@@ -578,7 +576,7 @@
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[2] class [System.Runtime]System.Func`3<object, float64, object>,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[5] float64,
@@ -624,15 +622,15 @@
 		IL_0053: stloc.1
 		IL_0054: ldloc.0
 		IL_0055: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_005a: ldftn object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0065: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_005a: ldftn object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0065: castclass class [System.Runtime]System.Func`3<object, float64, object>
 		IL_006a: ldc.i4.1
 		IL_006b: conv.r8
 		IL_006c: ldstr "argDouble"
 		IL_0071: ldc.i4.0
 		IL_0072: ldc.i4.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
 		IL_0078: stloc.2
 		IL_0079: ldloc.0
 		IL_007a: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
@@ -718,7 +716,7 @@
 		IL_015a: ldloc.s 12
 		IL_015c: ldc.r8 3
 		IL_0165: box [System.Runtime]System.Double
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_016f: pop
 		IL_0170: ldstr "3"
 		IL_0175: stloc.s 9

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24d5
+				// Method begins at RVA 0x24c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24de
+				// Method begins at RVA 0x24d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e7
+				// Method begins at RVA 0x24db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -230,7 +230,7 @@
 			object __js_call__ (
 				class Modules.UnaryOperator_PlusPlusPostfix/Scope scope,
 				object newTarget,
-				object n
+				float64 n
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -240,75 +240,66 @@
 			)
 			// Method begins at RVA 0x2350
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] float64,
 				[1] object,
-				[2] object,
+				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object,
-				[6] object[]
+				[5] object[]
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: stloc.0
 			IL_0002: ldarg.2
-			IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0008: stloc.3
-			IL_0009: ldloc.3
-			IL_000a: box [System.Runtime]System.Double
-			IL_000f: stloc.s 4
-			IL_0011: ldloc.s 4
-			IL_0013: stloc.s 5
-			IL_0015: ldloc.3
-			IL_0016: ldc.r8 1
-			IL_001f: add
-			IL_0020: stloc.3
-			IL_0021: ldloc.3
-			IL_0022: box [System.Runtime]System.Double
-			IL_0027: stloc.s 4
-			IL_0029: ldloc.s 4
-			IL_002b: starg.s n
-			IL_002d: ldloc.s 5
-			IL_002f: stloc.1
-			IL_0030: ldarg.2
-			IL_0031: stloc.2
-			IL_0032: ldarg.0
-			IL_0033: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-			IL_0038: stloc.s 5
-			IL_003a: ldc.i4.1
-			IL_003b: newarr [System.Runtime]System.Object
+			IL_0003: stloc.3
+			IL_0004: ldarg.2
+			IL_0005: ldc.r8 1
+			IL_000e: add
+			IL_000f: starg.s n
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldarg.2
+			IL_0019: stloc.2
+			IL_001a: ldarg.0
+			IL_001b: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_0020: stloc.s 4
+			IL_0022: ldc.i4.1
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldarg.0
+			IL_002b: stelem.ref
+			IL_002c: stloc.s 5
+			IL_002e: ldloc.s 4
+			IL_0030: ldloc.s 5
+			IL_0032: ldc.i4.4
+			IL_0033: newarr [System.Runtime]System.Object
+			IL_0038: dup
+			IL_0039: ldc.i4.0
+			IL_003a: ldstr "arg-double"
+			IL_003f: stelem.ref
 			IL_0040: dup
-			IL_0041: ldc.i4.0
-			IL_0042: ldarg.0
-			IL_0043: stelem.ref
-			IL_0044: stloc.s 6
-			IL_0046: ldloc.s 5
-			IL_0048: ldloc.s 6
-			IL_004a: ldc.i4.4
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldstr "arg-double"
-			IL_0057: stelem.ref
-			IL_0058: dup
-			IL_0059: ldc.i4.1
-			IL_005a: ldloc.0
-			IL_005b: stelem.ref
-			IL_005c: dup
-			IL_005d: ldc.i4.2
-			IL_005e: ldloc.1
-			IL_005f: stelem.ref
-			IL_0060: dup
-			IL_0061: ldc.i4.3
-			IL_0062: ldloc.2
-			IL_0063: stelem.ref
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0069: pop
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_0041: ldc.i4.1
+			IL_0042: ldloc.0
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.2
+			IL_004b: ldloc.1
+			IL_004c: stelem.ref
+			IL_004d: dup
+			IL_004e: ldc.i4.3
+			IL_004f: ldloc.2
+			IL_0050: box [System.Runtime]System.Double
+			IL_0055: stelem.ref
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005b: pop
+			IL_005c: ldnull
+			IL_005d: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -324,7 +315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f0
+				// Method begins at RVA 0x24e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +341,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x23bc
 			// Header size: 12
 			// Code size: 127 (0x7f)
 			.maxstack 8
@@ -440,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f9
+				// Method begins at RVA 0x24ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -467,7 +458,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2454
+			// Method begins at RVA 0x2448
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -575,7 +566,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24cc
+			// Method begins at RVA 0x24c0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -606,7 +597,7 @@
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[2] class [System.Runtime]System.Func`3<object, float64, object>,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[5] float64,
@@ -653,15 +644,15 @@
 		IL_0053: stloc.1
 		IL_0054: ldloc.0
 		IL_0055: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_005a: ldftn object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0065: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_005a: ldftn object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0065: castclass class [System.Runtime]System.Func`3<object, float64, object>
 		IL_006a: ldc.i4.1
 		IL_006b: conv.r8
 		IL_006c: ldstr "argDouble"
 		IL_0071: ldc.i4.0
 		IL_0072: ldc.i4.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
 		IL_0078: stloc.2
 		IL_0079: ldloc.0
 		IL_007a: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
@@ -749,7 +740,7 @@
 		IL_015e: ldloc.s 13
 		IL_0160: ldc.r8 3
 		IL_0169: box [System.Runtime]System.Double
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_0173: pop
 		IL_0174: ldstr "3"
 		IL_0179: stloc.s 9
@@ -831,7 +822,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2502
+		// Method begins at RVA 0x24f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -223,7 +223,7 @@
 			object __js_call__ (
 				class Modules.UnaryOperator_PlusPlusPrefix/Scope scope,
 				object newTarget,
-				object n
+				float64 n
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
@@ -236,60 +236,58 @@
 			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
-				[0] object,
+				[0] float64,
 				[1] object,
-				[2] object,
+				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object,
-				[6] object[]
+				[5] object[]
 			)
 
 			IL_0000: ldarg.2
 			IL_0001: stloc.0
 			IL_0002: ldarg.2
-			IL_0003: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0008: ldc.r8 1
-			IL_0011: add
-			IL_0012: stloc.3
-			IL_0013: ldloc.3
-			IL_0014: box [System.Runtime]System.Double
-			IL_0019: stloc.s 4
-			IL_001b: ldloc.s 4
-			IL_001d: starg.s n
-			IL_001f: ldloc.s 4
-			IL_0021: stloc.1
-			IL_0022: ldarg.2
-			IL_0023: stloc.2
-			IL_0024: ldarg.0
-			IL_0025: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-			IL_002a: stloc.s 5
-			IL_002c: ldc.i4.1
-			IL_002d: newarr [System.Runtime]System.Object
-			IL_0032: dup
-			IL_0033: ldc.i4.0
-			IL_0034: ldarg.0
-			IL_0035: stelem.ref
-			IL_0036: stloc.s 6
-			IL_0038: ldloc.s 5
-			IL_003a: ldloc.s 6
-			IL_003c: ldc.i4.4
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldstr "arg-double"
-			IL_0049: stelem.ref
-			IL_004a: dup
-			IL_004b: ldc.i4.1
-			IL_004c: ldloc.0
-			IL_004d: stelem.ref
-			IL_004e: dup
-			IL_004f: ldc.i4.2
-			IL_0050: ldloc.1
-			IL_0051: stelem.ref
-			IL_0052: dup
-			IL_0053: ldc.i4.3
-			IL_0054: ldloc.2
+			IL_0003: ldc.r8 1
+			IL_000c: add
+			IL_000d: stloc.3
+			IL_000e: ldloc.3
+			IL_000f: starg.s n
+			IL_0011: ldloc.3
+			IL_0012: box [System.Runtime]System.Double
+			IL_0017: stloc.1
+			IL_0018: ldarg.2
+			IL_0019: stloc.2
+			IL_001a: ldarg.0
+			IL_001b: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0020: stloc.s 4
+			IL_0022: ldc.i4.1
+			IL_0023: newarr [System.Runtime]System.Object
+			IL_0028: dup
+			IL_0029: ldc.i4.0
+			IL_002a: ldarg.0
+			IL_002b: stelem.ref
+			IL_002c: stloc.s 5
+			IL_002e: ldloc.s 4
+			IL_0030: ldloc.s 5
+			IL_0032: ldc.i4.4
+			IL_0033: newarr [System.Runtime]System.Object
+			IL_0038: dup
+			IL_0039: ldc.i4.0
+			IL_003a: ldstr "arg-double"
+			IL_003f: stelem.ref
+			IL_0040: dup
+			IL_0041: ldc.i4.1
+			IL_0042: ldloc.0
+			IL_0043: box [System.Runtime]System.Double
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.2
+			IL_004b: ldloc.1
+			IL_004c: stelem.ref
+			IL_004d: dup
+			IL_004e: ldc.i4.3
+			IL_004f: ldloc.2
+			IL_0050: box [System.Runtime]System.Double
 			IL_0055: stelem.ref
 			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
 			IL_005b: pop
@@ -578,7 +576,7 @@
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[2] class [System.Runtime]System.Func`3<object, float64, object>,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
 			[5] float64,
@@ -624,15 +622,15 @@
 		IL_0053: stloc.1
 		IL_0054: ldloc.0
 		IL_0055: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_005a: ldftn object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0065: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_005a: ldftn object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
+		IL_0060: newobj instance void class [System.Runtime]System.Func`3<object, float64, object>::.ctor(object, native int)
+		IL_0065: castclass class [System.Runtime]System.Func`3<object, float64, object>
 		IL_006a: ldc.i4.1
 		IL_006b: conv.r8
 		IL_006c: ldstr "argDouble"
 		IL_0071: ldc.i4.0
 		IL_0072: ldc.i4.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [System.Runtime]System.Func`3<object, float64, object>>(!!0, float64, string, bool, bool)
 		IL_0078: stloc.2
 		IL_0079: ldloc.0
 		IL_007a: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
@@ -718,7 +716,7 @@
 		IL_015a: ldloc.s 12
 		IL_015c: ldc.r8 3
 		IL_0165: box [System.Runtime]System.Double
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_016f: pop
 		IL_0170: ldstr "3"
 		IL_0175: stloc.s 9

--- a/tests/Jroc.Tests/Variable/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Variable/ExecutionTests.cs
@@ -12,6 +12,8 @@ namespace Jroc.Tests.Variable
         [Fact] public Task Variable_CapturedConst_NumberFieldType() { var testName = nameof(Variable_CapturedConst_NumberFieldType); return ExecutionTest(testName); }
         [Fact] public Task Variable_CapturedConst_BoolStringFieldType() { var testName = nameof(Variable_CapturedConst_BoolStringFieldType); return ExecutionTest(testName); }
         [Fact] public Task Variable_CapturedConst_SpreadArgument() { var testName = nameof(Variable_CapturedConst_SpreadArgument); return ExecutionTest(testName); }
+        [Fact] public Task Variable_ConstPrimitivePropagation() { var testName = nameof(Variable_ConstPrimitivePropagation); return ExecutionTest(testName); }
+        [Fact] public Task Variable_ConstPrimitivePropagation_With() { var testName = nameof(Variable_ConstPrimitivePropagation_With); return ExecutionTest(testName); }
         [Fact] public Task Variable_LetBlockScope() { var testName = nameof(Variable_LetBlockScope); return ExecutionTest(testName); }
         [Fact] public Task Variable_LetFunctionNestedShadowing() { var testName = nameof(Variable_LetFunctionNestedShadowing); return ExecutionTest(testName); }
         [Fact] public Task Variable_LetNestedShadowingChain() { var testName = nameof(Variable_LetNestedShadowingChain); return ExecutionTest(testName); }

--- a/tests/Jroc.Tests/Variable/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Variable/GeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Jroc.Tests.Variable
@@ -12,6 +13,33 @@ namespace Jroc.Tests.Variable
         [Fact] public Task Variable_CapturedConst_NumberFieldType() { var testName = nameof(Variable_CapturedConst_NumberFieldType); return GenerateTest(testName); }
         [Fact] public Task Variable_CapturedConst_BoolStringFieldType() { var testName = nameof(Variable_CapturedConst_BoolStringFieldType); return GenerateTest(testName); }
         [Fact] public Task Variable_CapturedConst_SpreadArgument() { var testName = nameof(Variable_CapturedConst_SpreadArgument); return GenerateTest(testName); }
+        [Fact]
+        public Task Variable_ConstPrimitivePropagation()
+        {
+            var testName = nameof(Variable_ConstPrimitivePropagation);
+            return GenerateTest(testName, verifyAssembly: assembly =>
+            {
+                var moduleType = assembly.GetType($"Modules.{testName}", throwOnError: true)!;
+                var scopeType = moduleType.GetNestedType("Scope", BindingFlags.Public | BindingFlags.NonPublic)!;
+
+                foreach (var constantName in new[] { "NUMBER", "TEXT", "FLAG", "NULL_VALUE" })
+                {
+                    Assert.Null(scopeType.GetField(constantName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+                }
+
+                Assert.NotNull(scopeType.GetField("LATE", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+                foreach (var constantName in new[] { "WRITTEN", "WRITTEN_PATTERN", "WRITTEN_LOOP" })
+                {
+                    Assert.NotNull(scopeType.GetField(constantName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+                }
+
+                var switchScopeType = Assert.Single(
+                    scopeType.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic),
+                    type => type.Name.StartsWith("Switch_", StringComparison.Ordinal));
+                Assert.NotNull(switchScopeType.GetField("SKIPPED", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+            });
+        }
+        [Fact] public Task Variable_ConstPrimitivePropagation_With() { var testName = nameof(Variable_ConstPrimitivePropagation_With); return GenerateTest(testName); }
         [Fact] public Task Variable_LetBlockScope() { var testName = nameof(Variable_LetBlockScope); return GenerateTest(testName); }
         [Fact] public Task Variable_LetFunctionNestedShadowing() { var testName = nameof(Variable_LetFunctionNestedShadowing); return GenerateTest(testName); }
         [Fact] public Task Variable_LetNestedShadowingChain() { var testName = nameof(Variable_LetNestedShadowingChain); return GenerateTest(testName); }

--- a/tests/Jroc.Tests/Variable/JavaScript/Variable_ConstPrimitivePropagation.js
+++ b/tests/Jroc.Tests/Variable/JavaScript/Variable_ConstPrimitivePropagation.js
@@ -1,0 +1,124 @@
+"use strict";
+
+const NUMBER = 32;
+const TEXT = "constant";
+const FLAG = true;
+const NULL_VALUE = null;
+
+class Reader {
+  read() {
+    console.log(NUMBER / 2);
+    console.log(TEXT);
+    console.log(FLAG);
+    console.log(NULL_VALUE);
+  }
+
+  shadow() {
+    let NUMBER = 7;
+    console.log(NUMBER);
+  }
+}
+
+const reader = new Reader();
+reader.read();
+reader.shadow();
+
+let mutable = 1;
+mutable = 2;
+console.log(mutable);
+
+function readLate() {
+  return LATE;
+}
+
+try {
+  readLate();
+  console.log("NO_TDZ");
+} catch (error) {
+  console.log("TDZ");
+}
+
+const LATE = 99;
+console.log(readLate());
+
+const WRITTEN = 3;
+
+class WrittenReader {
+  read() {
+    return WRITTEN;
+  }
+}
+
+try {
+  WRITTEN = 4;
+  console.log("NO_CONST_ERROR");
+} catch (error) {
+  console.log(error.name);
+}
+
+console.log(new WrittenReader().read());
+
+const WRITTEN_PATTERN = 6;
+
+class PatternReader {
+  read() {
+    return WRITTEN_PATTERN;
+  }
+}
+
+try {
+  [WRITTEN_PATTERN] = [7];
+} catch (error) {
+  console.log(error.name);
+}
+
+console.log(new PatternReader().read());
+
+const WRITTEN_LOOP = 8;
+
+class LoopReader {
+  read() {
+    return WRITTEN_LOOP;
+  }
+}
+
+try {
+  for (WRITTEN_LOOP of [9]) {
+  }
+} catch (error) {
+  console.log(error.name);
+}
+
+console.log(new LoopReader().read());
+
+const [DESTRUCTURED] = "ab";
+
+class DestructuredReader {
+  read() {
+    return DESTRUCTURED;
+  }
+}
+
+console.log(new DestructuredReader().read());
+
+function sameCallableTdz() {
+  try {
+    console.log(SAME_CALLABLE_TDZ);
+  } catch (error) {
+    console.log("SAME_TDZ");
+  }
+
+  const SAME_CALLABLE_TDZ = 11;
+  return () => SAME_CALLABLE_TDZ;
+}
+
+console.log(sameCallableTdz()());
+
+let skippedReader;
+switch (1) {
+  case 0:
+    const SKIPPED = 5;
+  case 1:
+    skippedReader = () => SKIPPED;
+    break;
+}

--- a/tests/Jroc.Tests/Variable/JavaScript/Variable_ConstPrimitivePropagation_With.js
+++ b/tests/Jroc.Tests/Variable/JavaScript/Variable_ConstPrimitivePropagation_With.js
@@ -1,0 +1,26 @@
+const VALUE = 1;
+
+function receive(value) {
+  return value;
+}
+
+function receiveIdentifier(value) {
+  return value;
+}
+
+const makeReader = object => {
+  with (object) {
+    return () => receive(VALUE + 1);
+  }
+};
+
+const makeIdentifierReader = object => {
+  with (object) {
+    return () => receiveIdentifier(VALUE);
+  }
+};
+
+console.log(makeReader({ VALUE: "shadow" })());
+console.log(makeReader({})());
+console.log(makeIdentifierReader({ VALUE: "shadow" })());
+console.log(makeIdentifierReader({})());

--- a/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -1,0 +1,17 @@
+﻿16
+constant
+true
+null
+7
+2
+TDZ
+99
+TypeError
+3
+TypeError
+6
+TypeError
+8
+a
+SAME_TDZ
+11

--- a/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_ConstPrimitivePropagation_With.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/ExecutionTests.Variable_ConstPrimitivePropagation_With.verified.txt
@@ -1,0 +1,4 @@
+﻿shadow1
+2
+shadow
+1

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -1,0 +1,2000 @@
+﻿// IL code: Variable_ConstPrimitivePropagation
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Variable_ConstPrimitivePropagation
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit readLate
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bd9
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_ConstPrimitivePropagation/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x28b4
+			// Header size: 1
+			// Code size: 17 (0x11)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
+			IL_0006: ldstr "Cannot access 'LATE' before initialization"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0010: ret
+		} // end of method readLate::__js_call__
+
+	} // end of class readLate
+
+	.class nested public auto ansi abstract sealed beforefieldinit sameCallableTdz
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L112C10
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2ca1
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x29cc
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldc.i4.1
+				IL_0002: ldelem.ref
+				IL_0003: castclass Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope
+				IL_0008: ldfld object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope::SAME_CALLABLE_TDZ
+				IL_000d: ldstr "Cannot access 'SAME_CALLABLE_TDZ' before initialization"
+				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0017: ret
+			} // end of method ArrowFunction_L112C10::__js_call__
+
+		} // end of class ArrowFunction_L112C10
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 2b 53 63 6f 70 65 20 53 41 4d 45 5f 43 41
+				4c 4c 41 42 4c 45 5f 54 44 5a 3d 7b 53 41 4d 45
+				5f 43 41 4c 4c 41 42 4c 45 5f 54 44 5a 7d 00 00
+			)
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L105C6
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2c8f
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L105C6::.ctor
+
+			} // end of class Block_L105C6
+
+			.class nested public auto ansi beforefieldinit Block_L107C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2c98
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L107C18::.ctor
+
+			} // end of class Block_L107C18
+
+
+			// Fields
+			.field public object SAME_CALLABLE_TDZ
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c7b
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
+				IL_000c: stfld object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope::SAME_CALLABLE_TDZ
+				IL_0011: nop
+				IL_0012: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_ConstPrimitivePropagation/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0c 00 00 02
+			)
+			// Method begins at RVA 0x28c8
+			// Header size: 12
+			// Code size: 232 (0xe8)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope,
+				[1] class [System.Runtime]System.Exception,
+				[2] object,
+				[3] object,
+				[4] object,
+				[5] object,
+				[6] object,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			)
+
+			IL_0000: newobj instance void Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope::.ctor()
+			IL_0005: stloc.0
+			.try
+			{
+				IL_0006: nop
+				IL_0007: ldstr "console"
+				IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0016: stloc.s 5
+				IL_0018: ldloc.0
+				IL_0019: ldfld object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope::SAME_CALLABLE_TDZ
+				IL_001e: ldstr "Cannot access 'SAME_CALLABLE_TDZ' before initialization"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0028: stloc.s 6
+				IL_002a: ldloc.s 5
+				IL_002c: ldstr "log"
+				IL_0031: ldloc.s 6
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0038: pop
+				IL_0039: leave IL_008d
+			} // end .try
+			catch [System.Runtime]System.Exception
+			{
+				IL_003e: stloc.1
+				IL_003f: ldloc.1
+				IL_0040: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0045: dup
+				IL_0046: brtrue IL_005b
+
+				IL_004b: pop
+				IL_004c: ldloc.1
+				IL_004d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0052: dup
+				IL_0053: brtrue IL_0066
+
+				IL_0058: pop
+				IL_0059: rethrow
+
+				IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0060: stloc.2
+				IL_0061: br IL_0067
+
+				IL_0066: stloc.2
+
+				IL_0067: ldloc.2
+				IL_0068: stloc.3
+				IL_0069: ldstr "console"
+				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0078: ldstr "log"
+				IL_007d: ldstr "SAME_TDZ"
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0087: pop
+				IL_0088: leave IL_008d
+			} // end handler
+
+			IL_008d: ldloc.0
+			IL_008e: ldc.r8 11
+			IL_0097: box [System.Runtime]System.Double
+			IL_009c: stfld object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/Scope::SAME_CALLABLE_TDZ
+			IL_00a1: ldnull
+			IL_00a2: ldftn object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/ArrowFunction_L112C10::__js_call__(object[], object)
+			IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00ad: ldc.i4.2
+			IL_00ae: newarr [System.Runtime]System.Object
+			IL_00b3: dup
+			IL_00b4: ldc.i4.0
+			IL_00b5: ldarg.0
+			IL_00b6: stelem.ref
+			IL_00b7: dup
+			IL_00b8: ldc.i4.1
+			IL_00b9: ldloc.0
+			IL_00ba: stelem.ref
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00c5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_00ca: ldc.i4.0
+			IL_00cb: conv.r8
+			IL_00cc: ldstr ""
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldc.i4.0
+			IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_00dd: stloc.s 7
+			IL_00df: ldloc.s 7
+			IL_00e1: ret
+
+			IL_00e2: ldnull
+			IL_00e3: stloc.s 4
+			IL_00e5: ldloc.s 4
+			IL_00e7: ret
+		} // end of method sameCallableTdz::__js_call__
+
+	} // end of class sameCallableTdz
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L122C21
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2cb3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x29e5
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.1
+			IL_0002: ldelem.ref
+			IL_0003: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
+			IL_0008: ldfld float64 Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::SKIPPED
+			IL_000d: box [System.Runtime]System.Double
+			IL_0012: ret
+		} // end of method ArrowFunction_L122C21::__js_call__
+
+	} // end of class ArrowFunction_L122C21
+
+	.class nested public auto ansi beforefieldinit Reader
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bbe
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_read
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bc7
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_read::.ctor
+
+		} // end of class Scope_read
+
+		.class nested public auto ansi beforefieldinit Scope_shadow
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bd0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_shadow::.ctor
+
+		} // end of class Scope_shadow
+
+
+		// Fields
+		.field private object[] _scopes
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a50
+			// Header size: 12
+			// Code size: 16 (0x10)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Variable_ConstPrimitivePropagation/Reader::_scopes
+			IL_000f: ret
+		} // end of method Reader::.ctor
+
+		.method public hidebysig 
+			instance object read () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2ac4
+			// Header size: 12
+			// Code size: 137 (0x89)
+			.maxstack 8
+
+			IL_0000: ldstr "console"
+			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000f: ldstr "log"
+			IL_0014: ldc.r8 16
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0027: pop
+			IL_0028: ldstr "console"
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0037: ldstr "log"
+			IL_003c: ldstr "constant"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0046: pop
+			IL_0047: ldstr "console"
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0056: ldstr "log"
+			IL_005b: ldc.i4.1
+			IL_005c: box [System.Runtime]System.Boolean
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0066: pop
+			IL_0067: ldstr "console"
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0076: ldstr "log"
+			IL_007b: ldc.i4.0
+			IL_007c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0086: pop
+			IL_0087: ldnull
+			IL_0088: ret
+		} // end of method Reader::read
+
+		.method public hidebysig 
+			instance object shadow () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2b5c
+			// Header size: 12
+			// Code size: 46 (0x2e)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldc.r8 7
+			IL_0009: stloc.0
+			IL_000a: ldstr "console"
+			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0019: ldloc.0
+			IL_001a: box [System.Runtime]System.Double
+			IL_001f: stloc.1
+			IL_0020: ldstr "log"
+			IL_0025: ldloc.1
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002b: pop
+			IL_002c: ldnull
+			IL_002d: ret
+		} // end of method Reader::shadow
+
+	} // end of class Reader
+
+	.class nested public auto ansi beforefieldinit WrittenReader
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bf4
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_read
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bfd
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_read::.ctor
+
+		} // end of class Scope_read
+
+
+		// Fields
+		.field private object[] _scopes
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a6c
+			// Header size: 12
+			// Code size: 16 (0x10)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader::_scopes
+			IL_000f: ret
+		} // end of method WrittenReader::.ctor
+
+		.method public hidebysig 
+			instance float64 read () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2b96
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader::_scopes
+			IL_0006: ldc.i4.0
+			IL_0007: ldelem.ref
+			IL_0008: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+			IL_000d: ldfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN
+			IL_0012: ret
+		} // end of method WrittenReader::read
+
+	} // end of class WrittenReader
+
+	.class nested public auto ansi beforefieldinit PatternReader
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c18
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_read
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c21
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_read::.ctor
+
+		} // end of class Scope_read
+
+
+		// Fields
+		.field private object[] _scopes
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a34
+			// Header size: 12
+			// Code size: 16 (0x10)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader::_scopes
+			IL_000f: ret
+		} // end of method PatternReader::.ctor
+
+		.method public hidebysig 
+			instance float64 read () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2ab0
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader::_scopes
+			IL_0006: ldc.i4.0
+			IL_0007: ldelem.ref
+			IL_0008: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+			IL_000d: ldfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_PATTERN
+			IL_0012: ret
+		} // end of method PatternReader::read
+
+	} // end of class PatternReader
+
+	.class nested public auto ansi beforefieldinit LoopReader
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c3c
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_read
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c45
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_read::.ctor
+
+		} // end of class Scope_read
+
+
+		// Fields
+		.field private object[] _scopes
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a18
+			// Header size: 12
+			// Code size: 16 (0x10)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader::_scopes
+			IL_000f: ret
+		} // end of method LoopReader::.ctor
+
+		.method public hidebysig 
+			instance float64 read () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a9c
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader::_scopes
+			IL_0006: ldc.i4.0
+			IL_0007: ldelem.ref
+			IL_0008: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+			IL_000d: ldfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_LOOP
+			IL_0012: ret
+		} // end of method LoopReader::read
+
+	} // end of class LoopReader
+
+	.class nested public auto ansi beforefieldinit DestructuredReader
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c69
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_read
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c72
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_read::.ctor
+
+		} // end of class Scope_read
+
+
+		// Fields
+		.field private object[] _scopes
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor (
+				object[] scopes
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Method begins at RVA 0x29fc
+			// Header size: 12
+			// Code size: 16 (0x10)
+			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.1
+			IL_0007: stloc.0
+			IL_0008: ldarg.0
+			IL_0009: ldloc.0
+			IL_000a: stfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader::_scopes
+			IL_000f: ret
+		} // end of method DestructuredReader::.ctor
+
+		.method public hidebysig 
+			instance object read () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x2a88
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader::_scopes
+			IL_0006: ldc.i4.0
+			IL_0007: ldelem.ref
+			IL_0008: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+			IL_000d: ldfld object Modules.Variable_ConstPrimitivePropagation/Scope::DESTRUCTURED
+			IL_0012: ret
+		} // end of method DestructuredReader::read
+
+	} // end of class DestructuredReader
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 80 b9 53 63 6f 70 65 20 72 65 61 64 4c 61
+			74 65 3d 7b 72 65 61 64 4c 61 74 65 7d 2c 20 4c
+			41 54 45 3d 7b 4c 41 54 45 7d 2c 20 57 52 49 54
+			54 45 4e 3d 7b 57 52 49 54 54 45 4e 7d 2c 20 57
+			52 49 54 54 45 4e 5f 50 41 54 54 45 52 4e 3d 7b
+			57 52 49 54 54 45 4e 5f 50 41 54 54 45 52 4e 7d
+			2c 20 57 52 49 54 54 45 4e 5f 4c 4f 4f 50 3d 7b
+			57 52 49 54 54 45 4e 5f 4c 4f 4f 50 7d 2c 20 44
+			45 53 54 52 55 43 54 55 52 45 44 3d 7b 44 45 53
+			54 52 55 43 54 55 52 45 44 7d 2c 20 73 61 6d 65
+			43 61 6c 6c 61 62 6c 65 54 64 7a 3d 7b 73 61 6d
+			65 43 61 6c 6c 61 62 6c 65 54 64 7a 7d 00 00
+		)
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L34C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2be2
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L34C4::.ctor
+
+		} // end of class Block_L34C4
+
+		.class nested public auto ansi beforefieldinit Block_L37C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2beb
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L37C16::.ctor
+
+		} // end of class Block_L37C16
+
+		.class nested public auto ansi beforefieldinit Block_L52C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c06
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L52C4::.ctor
+
+		} // end of class Block_L52C4
+
+		.class nested public auto ansi beforefieldinit Block_L55C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c0f
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L55C16::.ctor
+
+		} // end of class Block_L55C16
+
+		.class nested public auto ansi beforefieldinit Block_L69C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c2a
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L69C4::.ctor
+
+		} // end of class Block_L69C4
+
+		.class nested public auto ansi beforefieldinit Block_L71C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c33
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L71C16::.ctor
+
+		} // end of class Block_L71C16
+
+		.class nested public auto ansi beforefieldinit Block_L85C4
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L86C28
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2c57
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L86C28::.ctor
+
+			} // end of class Block_L86C28
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c4e
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L85C4::.ctor
+
+		} // end of class Block_L85C4
+
+		.class nested public auto ansi beforefieldinit Block_L88C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c60
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L88C16::.ctor
+
+		} // end of class Block_L88C16
+
+		.class nested public auto ansi beforefieldinit Switch_L118C0
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 1f 53 77 69 74 63 68 5f 4c 31 31 38 43 30
+				20 53 4b 49 50 50 45 44 3d 7b 53 4b 49 50 50 45
+				44 7d 00 00
+			)
+			// Fields
+			.field public float64 SKIPPED
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2caa
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Switch_L118C0::.ctor
+
+		} // end of class Switch_L118C0
+
+
+		// Fields
+		.field public object readLate
+		.field public object LATE
+		.field public float64 WRITTEN
+		.field public float64 WRITTEN_PATTERN
+		.field public float64 WRITTEN_LOOP
+		.field public object DESTRUCTURED
+		.field public object sameCallableTdz
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2baa
+			// Header size: 1
+			// Code size: 19 (0x13)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: ldarg.0
+			IL_0007: ldsfld object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::TemporalDeadZoneSentinel
+			IL_000c: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
+			IL_0011: nop
+			IL_0012: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 2048 (0x800)
+		.maxstack 12
+		.locals init (
+			[0] class Modules.Variable_ConstPrimitivePropagation/Scope,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
+			[3] class Modules.Variable_ConstPrimitivePropagation/Reader,
+			[4] float64,
+			[5] class [System.Runtime]System.Exception,
+			[6] object,
+			[7] object,
+			[8] class [System.Runtime]System.Exception,
+			[9] object,
+			[10] object,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+			[12] bool,
+			[13] bool,
+			[14] class [System.Runtime]System.Exception,
+			[15] object,
+			[16] object,
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+			[18] bool,
+			[19] bool,
+			[20] class [System.Runtime]System.Exception,
+			[21] object,
+			[22] object,
+			[23] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
+			[24] bool,
+			[25] bool,
+			[26] object,
+			[27] class Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0,
+			[28] object,
+			[29] object[],
+			[30] class Modules.Variable_ConstPrimitivePropagation/Reader,
+			[31] object,
+			[32] object,
+			[33] object,
+			[34] class Modules.Variable_ConstPrimitivePropagation/WrittenReader,
+			[35] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[36] class Modules.Variable_ConstPrimitivePropagation/PatternReader,
+			[37] bool,
+			[38] class Modules.Variable_ConstPrimitivePropagation/LoopReader,
+			[39] class Modules.Variable_ConstPrimitivePropagation/DestructuredReader,
+			[40] object,
+			[41] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+		)
+
+		IL_0000: newobj instance void Modules.Variable_ConstPrimitivePropagation/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldloc.0
+		IL_0007: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+		IL_000c: ldftn object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+		IL_0012: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_001c: ldc.i4.0
+		IL_001d: conv.r8
+		IL_001e: ldstr "readLate"
+		IL_0023: ldc.i4.0
+		IL_0024: ldc.i4.1
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_002a: stloc.1
+		IL_002b: ldloc.0
+		IL_002c: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+		IL_0031: ldftn object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+		IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_003c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0041: ldc.i4.0
+		IL_0042: conv.r8
+		IL_0043: ldstr "sameCallableTdz"
+		IL_0048: ldc.i4.0
+		IL_0049: ldc.i4.1
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_004f: stloc.2
+		IL_0050: nop
+		IL_0051: nop
+		IL_0052: nop
+		IL_0053: nop
+		IL_0054: nop
+		IL_0055: nop
+		IL_0056: ldc.i4.1
+		IL_0057: newarr [System.Runtime]System.Object
+		IL_005c: dup
+		IL_005d: ldc.i4.0
+		IL_005e: ldloc.0
+		IL_005f: stelem.ref
+		IL_0060: stloc.s 29
+		IL_0062: ldloc.s 29
+		IL_0064: ldc.i4.0
+		IL_0065: newarr [System.Runtime]System.Object
+		IL_006a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_006f: newobj instance void Modules.Variable_ConstPrimitivePropagation/Reader::.ctor(object[])
+		IL_0074: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0079: stloc.3
+		IL_007a: ldloc.3
+		IL_007b: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
+		IL_0080: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0085: ldstr "prototype"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_008f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0094: ldloc.3
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Variable_ConstPrimitivePropagation/Reader>(!!0)
+		IL_009a: stloc.s 30
+		IL_009c: ldloc.s 30
+		IL_009e: ldstr "read"
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a8: pop
+		IL_00a9: ldloc.3
+		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Variable_ConstPrimitivePropagation/Reader>(!!0)
+		IL_00af: stloc.s 30
+		IL_00b1: ldloc.s 30
+		IL_00b3: callvirt instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
+		IL_00b8: pop
+		IL_00b9: ldc.r8 1
+		IL_00c2: stloc.s 4
+		IL_00c4: ldc.r8 2
+		IL_00cd: stloc.s 4
+		IL_00cf: ldstr "console"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00de: ldloc.s 4
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: stloc.s 31
+		IL_00e7: ldstr "log"
+		IL_00ec: ldloc.s 31
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f3: pop
+		IL_00f4: nop
+		.try
+		{
+			IL_00f5: nop
+			IL_00f6: ldloc.1
+			IL_00f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+			IL_0101: pop
+			IL_0102: ldstr "console"
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0111: ldstr "log"
+			IL_0116: ldstr "NO_TDZ"
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0120: pop
+			IL_0121: leave IL_017c
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0126: stloc.s 5
+			IL_0128: ldloc.s 5
+			IL_012a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_012f: dup
+			IL_0130: brtrue IL_0146
+
+			IL_0135: pop
+			IL_0136: ldloc.s 5
+			IL_0138: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013d: dup
+			IL_013e: brtrue IL_0152
+
+			IL_0143: pop
+			IL_0144: rethrow
+
+			IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_014b: stloc.s 6
+			IL_014d: br IL_0154
+
+			IL_0152: stloc.s 6
+
+			IL_0154: ldloc.s 6
+			IL_0156: stloc.s 7
+			IL_0158: ldstr "console"
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0167: ldstr "log"
+			IL_016c: ldstr "TDZ"
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0176: pop
+			IL_0177: leave IL_017c
+		} // end handler
+
+		IL_017c: ldloc.0
+		IL_017d: ldc.r8 99
+		IL_0186: box [System.Runtime]System.Double
+		IL_018b: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
+		IL_0190: ldstr "console"
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019f: stloc.s 32
+		IL_01a1: ldloc.1
+		IL_01a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_01ac: stloc.s 33
+		IL_01ae: ldloc.s 32
+		IL_01b0: ldstr "log"
+		IL_01b5: ldloc.s 33
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bc: pop
+		IL_01bd: ldloc.0
+		IL_01be: ldc.r8 3
+		IL_01c7: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN
+		IL_01cc: nop
+		.try
+		{
+			IL_01cd: nop
+			IL_01ce: ldstr "Assignment to constant variable."
+			IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+			IL_01d8: throw
+
+			IL_01d9: ldstr "console"
+			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e8: ldstr "log"
+			IL_01ed: ldstr "NO_CONST_ERROR"
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f7: pop
+			IL_01f8: leave IL_0262
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_01fd: stloc.s 8
+			IL_01ff: ldloc.s 8
+			IL_0201: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0206: dup
+			IL_0207: brtrue IL_021d
+
+			IL_020c: pop
+			IL_020d: ldloc.s 8
+			IL_020f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0214: dup
+			IL_0215: brtrue IL_0229
+
+			IL_021a: pop
+			IL_021b: rethrow
+
+			IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0222: stloc.s 9
+			IL_0224: br IL_022b
+
+			IL_0229: stloc.s 9
+
+			IL_022b: ldloc.s 9
+			IL_022d: stloc.s 10
+			IL_022f: ldstr "console"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023e: stloc.s 33
+			IL_0240: ldloc.s 10
+			IL_0242: ldstr "name"
+			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024c: stloc.s 32
+			IL_024e: ldloc.s 33
+			IL_0250: ldstr "log"
+			IL_0255: ldloc.s 32
+			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_025c: pop
+			IL_025d: leave IL_0262
+		} // end handler
+
+		IL_0262: ldstr "console"
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0271: stloc.s 32
+		IL_0273: ldc.i4.1
+		IL_0274: newarr [System.Runtime]System.Object
+		IL_0279: dup
+		IL_027a: ldc.i4.0
+		IL_027b: ldloc.0
+		IL_027c: stelem.ref
+		IL_027d: stloc.s 29
+		IL_027f: ldloc.s 29
+		IL_0281: ldc.i4.0
+		IL_0282: newarr [System.Runtime]System.Object
+		IL_0287: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_028c: newobj instance void Modules.Variable_ConstPrimitivePropagation/WrittenReader::.ctor(object[])
+		IL_0291: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0296: stloc.s 34
+		IL_0298: ldloc.s 34
+		IL_029a: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
+		IL_029f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_02a4: ldstr "prototype"
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_02ae: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_02b3: ldloc.s 34
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ba: ldstr "read"
+		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02c4: stloc.s 33
+		IL_02c6: ldloc.s 32
+		IL_02c8: ldstr "log"
+		IL_02cd: ldloc.s 33
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d4: pop
+		IL_02d5: ldloc.0
+		IL_02d6: ldc.r8 6
+		IL_02df: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_PATTERN
+		IL_02e4: nop
+		.try
+		{
+			IL_02e5: nop
+			IL_02e6: ldc.i4.1
+			IL_02e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02ec: dup
+			IL_02ed: ldc.r8 7
+			IL_02f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_02fb: stloc.s 35
+			IL_02fd: ldloc.s 35
+			IL_02ff: brfalse IL_0310
+
+			IL_0304: ldloc.s 35
+			IL_0306: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_030b: brfalse IL_0321
+
+			IL_0310: ldloc.s 35
+			IL_0312: ldstr ""
+			IL_0317: ldstr "0"
+			IL_031c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+
+			IL_0321: ldloc.s 35
+			IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0328: stloc.s 11
+			IL_032a: ldc.i4.0
+			IL_032b: stloc.s 12
+			IL_032d: ldc.i4.0
+			IL_032e: stloc.s 13
+			.try
+			{
+				IL_0330: ldloc.s 13
+				IL_0332: brtrue IL_0358
+
+				IL_0337: ldloc.s 11
+				IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_033e: stloc.s 33
+				IL_0340: ldloc.s 33
+				IL_0342: brfalse IL_0355
+
+				IL_0347: ldloc.s 33
+				IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_034e: stloc.s 33
+				IL_0350: br IL_0358
+
+				IL_0355: ldc.i4.1
+				IL_0356: stloc.s 13
+
+				IL_0358: ldstr "Assignment to constant variable."
+				IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_0362: throw
+
+				IL_0363: ldloc.s 13
+				IL_0365: brtrue IL_0374
+
+				IL_036a: ldc.i4.1
+				IL_036b: stloc.s 12
+				IL_036d: ldloc.s 11
+				IL_036f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+
+				IL_0374: ldc.i4.1
+				IL_0375: stloc.s 12
+				IL_0377: leave IL_0392
+			} // end .try
+			finally
+			{
+				IL_037c: ldloc.s 12
+				IL_037e: brtrue IL_0391
+
+				IL_0383: ldloc.s 13
+				IL_0385: brtrue IL_0391
+
+				IL_038a: ldloc.s 11
+				IL_038c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+
+				IL_0391: endfinally
+			} // end handler
+
+			IL_0392: leave IL_03fc
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0397: stloc.s 14
+			IL_0399: ldloc.s 14
+			IL_039b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03a0: dup
+			IL_03a1: brtrue IL_03b7
+
+			IL_03a6: pop
+			IL_03a7: ldloc.s 14
+			IL_03a9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03ae: dup
+			IL_03af: brtrue IL_03c3
+
+			IL_03b4: pop
+			IL_03b5: rethrow
+
+			IL_03b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03bc: stloc.s 15
+			IL_03be: br IL_03c5
+
+			IL_03c3: stloc.s 15
+
+			IL_03c5: ldloc.s 15
+			IL_03c7: stloc.s 16
+			IL_03c9: ldstr "console"
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d8: stloc.s 33
+			IL_03da: ldloc.s 16
+			IL_03dc: ldstr "name"
+			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e6: stloc.s 32
+			IL_03e8: ldloc.s 33
+			IL_03ea: ldstr "log"
+			IL_03ef: ldloc.s 32
+			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03f6: pop
+			IL_03f7: leave IL_03fc
+		} // end handler
+
+		IL_03fc: ldstr "console"
+		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040b: stloc.s 32
+		IL_040d: ldc.i4.1
+		IL_040e: newarr [System.Runtime]System.Object
+		IL_0413: dup
+		IL_0414: ldc.i4.0
+		IL_0415: ldloc.0
+		IL_0416: stelem.ref
+		IL_0417: stloc.s 29
+		IL_0419: ldloc.s 29
+		IL_041b: ldc.i4.0
+		IL_041c: newarr [System.Runtime]System.Object
+		IL_0421: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0426: newobj instance void Modules.Variable_ConstPrimitivePropagation/PatternReader::.ctor(object[])
+		IL_042b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0430: stloc.s 36
+		IL_0432: ldloc.s 36
+		IL_0434: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
+		IL_0439: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_043e: ldstr "prototype"
+		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0448: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_044d: ldloc.s 36
+		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0454: ldstr "read"
+		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_045e: stloc.s 33
+		IL_0460: ldloc.s 32
+		IL_0462: ldstr "log"
+		IL_0467: ldloc.s 33
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_046e: pop
+		IL_046f: ldloc.0
+		IL_0470: ldc.r8 8
+		IL_0479: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_LOOP
+		IL_047e: nop
+		.try
+		{
+			IL_047f: nop
+			IL_0480: ldc.i4.1
+			IL_0481: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0486: dup
+			IL_0487: ldc.r8 9
+			IL_0490: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0495: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_049a: stloc.s 17
+			IL_049c: ldc.i4.0
+			IL_049d: stloc.s 18
+			IL_049f: ldc.i4.0
+			IL_04a0: stloc.s 19
+			.try
+			{
+				// loop start (head: IL_04a2)
+					IL_04a2: ldloc.s 17
+					IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_04a9: stloc.s 33
+					IL_04ab: ldloc.s 33
+					IL_04ad: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_04b2: stloc.s 37
+					IL_04b4: ldloc.s 37
+					IL_04b6: brtrue IL_04e2
+
+					IL_04bb: ldloc.s 33
+					IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_04c2: pop
+					IL_04c3: ldstr "Assignment to constant variable."
+					IL_04c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_04cd: throw
+
+					IL_04ce: br IL_04a2
+				// end loop
+				IL_04d3: ldloc.s 17
+				IL_04d5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_04da: ldc.i4.1
+				IL_04db: stloc.s 19
+				IL_04dd: leave IL_0500
+
+				IL_04e2: ldc.i4.1
+				IL_04e3: stloc.s 18
+				IL_04e5: leave IL_0500
+			} // end .try
+			finally
+			{
+				IL_04ea: ldloc.s 18
+				IL_04ec: brtrue IL_04ff
+
+				IL_04f1: ldloc.s 19
+				IL_04f3: brtrue IL_04ff
+
+				IL_04f8: ldloc.s 17
+				IL_04fa: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+
+				IL_04ff: endfinally
+			} // end handler
+
+			IL_0500: leave IL_056a
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0505: stloc.s 20
+			IL_0507: ldloc.s 20
+			IL_0509: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_050e: dup
+			IL_050f: brtrue IL_0525
+
+			IL_0514: pop
+			IL_0515: ldloc.s 20
+			IL_0517: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_051c: dup
+			IL_051d: brtrue IL_0531
+
+			IL_0522: pop
+			IL_0523: rethrow
+
+			IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_052a: stloc.s 21
+			IL_052c: br IL_0533
+
+			IL_0531: stloc.s 21
+
+			IL_0533: ldloc.s 21
+			IL_0535: stloc.s 22
+			IL_0537: ldstr "console"
+			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0546: stloc.s 33
+			IL_0548: ldloc.s 22
+			IL_054a: ldstr "name"
+			IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0554: stloc.s 32
+			IL_0556: ldloc.s 33
+			IL_0558: ldstr "log"
+			IL_055d: ldloc.s 32
+			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0564: pop
+			IL_0565: leave IL_056a
+		} // end handler
+
+		IL_056a: ldstr "console"
+		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0579: stloc.s 32
+		IL_057b: ldc.i4.1
+		IL_057c: newarr [System.Runtime]System.Object
+		IL_0581: dup
+		IL_0582: ldc.i4.0
+		IL_0583: ldloc.0
+		IL_0584: stelem.ref
+		IL_0585: stloc.s 29
+		IL_0587: ldloc.s 29
+		IL_0589: ldc.i4.0
+		IL_058a: newarr [System.Runtime]System.Object
+		IL_058f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0594: newobj instance void Modules.Variable_ConstPrimitivePropagation/LoopReader::.ctor(object[])
+		IL_0599: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_059e: stloc.s 38
+		IL_05a0: ldloc.s 38
+		IL_05a2: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
+		IL_05a7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_05ac: ldstr "prototype"
+		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_05b6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_05bb: ldloc.s 38
+		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c2: ldstr "read"
+		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05cc: stloc.s 33
+		IL_05ce: ldloc.s 32
+		IL_05d0: ldstr "log"
+		IL_05d5: ldloc.s 33
+		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05dc: pop
+		IL_05dd: ldstr "ab"
+		IL_05e2: brfalse IL_05f6
+
+		IL_05e7: ldstr "ab"
+		IL_05ec: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_05f1: brfalse IL_060a
+
+		IL_05f6: ldstr "ab"
+		IL_05fb: ldstr ""
+		IL_0600: ldstr "0"
+		IL_0605: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+
+		IL_060a: ldstr "ab"
+		IL_060f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_0614: stloc.s 23
+		IL_0616: ldc.i4.0
+		IL_0617: stloc.s 24
+		IL_0619: ldc.i4.0
+		IL_061a: stloc.s 25
+		.try
+		{
+			IL_061c: ldloc.s 25
+			IL_061e: brtrue IL_0648
+
+			IL_0623: ldloc.s 23
+			IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+			IL_062a: stloc.s 33
+			IL_062c: ldloc.s 33
+			IL_062e: brfalse IL_0645
+
+			IL_0633: ldloc.s 33
+			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+			IL_063a: stloc.s 33
+			IL_063c: ldloc.s 33
+			IL_063e: stloc.s 32
+			IL_0640: br IL_064b
+
+			IL_0645: ldc.i4.1
+			IL_0646: stloc.s 25
+
+			IL_0648: ldnull
+			IL_0649: stloc.s 32
+
+			IL_064b: ldloc.0
+			IL_064c: ldloc.s 32
+			IL_064e: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::DESTRUCTURED
+			IL_0653: ldloc.s 25
+			IL_0655: brtrue IL_0664
+
+			IL_065a: ldc.i4.1
+			IL_065b: stloc.s 24
+			IL_065d: ldloc.s 23
+			IL_065f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+
+			IL_0664: ldc.i4.1
+			IL_0665: stloc.s 24
+			IL_0667: leave IL_0682
+		} // end .try
+		finally
+		{
+			IL_066c: ldloc.s 24
+			IL_066e: brtrue IL_0681
+
+			IL_0673: ldloc.s 25
+			IL_0675: brtrue IL_0681
+
+			IL_067a: ldloc.s 23
+			IL_067c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+
+			IL_0681: endfinally
+		} // end handler
+
+		IL_0682: nop
+		IL_0683: ldstr "console"
+		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0692: stloc.s 32
+		IL_0694: ldc.i4.1
+		IL_0695: newarr [System.Runtime]System.Object
+		IL_069a: dup
+		IL_069b: ldc.i4.0
+		IL_069c: ldloc.0
+		IL_069d: stelem.ref
+		IL_069e: stloc.s 29
+		IL_06a0: ldloc.s 29
+		IL_06a2: ldc.i4.0
+		IL_06a3: newarr [System.Runtime]System.Object
+		IL_06a8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_06ad: newobj instance void Modules.Variable_ConstPrimitivePropagation/DestructuredReader::.ctor(object[])
+		IL_06b2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_06b7: stloc.s 39
+		IL_06b9: ldloc.s 39
+		IL_06bb: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+		IL_06c0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06c5: ldstr "prototype"
+		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_06cf: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_06d4: ldloc.s 39
+		IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06db: ldstr "read"
+		IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06e5: stloc.s 40
+		IL_06e7: ldloc.s 32
+		IL_06e9: ldstr "log"
+		IL_06ee: ldloc.s 40
+		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06f5: pop
+		IL_06f6: nop
+		IL_06f7: ldstr "console"
+		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0706: stloc.s 40
+		IL_0708: ldloc.2
+		IL_0709: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_0713: stloc.s 32
+		IL_0715: ldc.i4.0
+		IL_0716: newarr [System.Runtime]System.Object
+		IL_071b: stloc.s 29
+		IL_071d: ldloc.s 32
+		IL_071f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0724: ldloc.s 29
+		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_072b: stloc.s 32
+		IL_072d: ldloc.s 40
+		IL_072f: ldstr "log"
+		IL_0734: ldloc.s 32
+		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_073b: pop
+		IL_073c: ldnull
+		IL_073d: stloc.s 26
+		IL_073f: newobj instance void Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::.ctor()
+		IL_0744: stloc.s 27
+		IL_0746: ldc.r8 1
+		IL_074f: box [System.Runtime]System.Double
+		IL_0754: ldc.r8 0.0
+		IL_075d: box [System.Runtime]System.Double
+		IL_0762: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0767: stloc.s 37
+		IL_0769: ldloc.s 37
+		IL_076b: brtrue IL_079f
+
+		IL_0770: ldc.r8 1
+		IL_0779: box [System.Runtime]System.Double
+		IL_077e: ldc.r8 1
+		IL_0787: box [System.Runtime]System.Double
+		IL_078c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0791: stloc.s 37
+		IL_0793: ldloc.s 37
+		IL_0795: brtrue IL_07b4
+
+		IL_079a: br IL_07fc
+
+		IL_079f: ldloc.s 27
+		IL_07a1: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
+		IL_07a6: ldc.r8 5
+		IL_07af: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::SKIPPED
+
+		IL_07b4: ldnull
+		IL_07b5: ldftn object Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21::__js_call__(object[], object)
+		IL_07bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_07c0: ldc.i4.2
+		IL_07c1: newarr [System.Runtime]System.Object
+		IL_07c6: dup
+		IL_07c7: ldc.i4.0
+		IL_07c8: ldloc.0
+		IL_07c9: stelem.ref
+		IL_07ca: dup
+		IL_07cb: ldc.i4.1
+		IL_07cc: ldloc.s 27
+		IL_07ce: stelem.ref
+		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_07d9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+		IL_07de: ldc.i4.0
+		IL_07df: conv.r8
+		IL_07e0: ldstr ""
+		IL_07e5: ldc.i4.0
+		IL_07e6: ldc.i4.0
+		IL_07e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+		IL_07ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+		IL_07f1: stloc.s 41
+		IL_07f3: ldloc.s 41
+		IL_07f5: stloc.s 26
+		IL_07f7: br IL_07fc
+
+		IL_07fc: ldnull
+		IL_07fd: stloc.s 28
+		IL_07ff: ret
+	} // end of method Variable_ConstPrimitivePropagation::__js_module_init__
+
+} // end of class Modules.Variable_ConstPrimitivePropagation
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2cbc
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Variable_ConstPrimitivePropagation::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd9
+				// Method begins at RVA 0x2bd5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x28b4
+			// Method begins at RVA 0x28b0
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ca1
+					// Method begins at RVA 0x2c9d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -97,7 +97,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29cc
+				// Method begins at RVA 0x29c8
 				// Header size: 1
 				// Code size: 24 (0x18)
 				.maxstack 8
@@ -130,7 +130,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c8f
+					// Method begins at RVA 0x2c8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -150,7 +150,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c98
+					// Method begins at RVA 0x2c94
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -171,7 +171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c7b
+				// Method begins at RVA 0x2c77
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -200,7 +200,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28c4
 			// Header size: 12
 			// Code size: 232 (0xe8)
 			.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2cb3
+				// Method begins at RVA 0x2caf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -345,7 +345,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29e5
+			// Method begins at RVA 0x29e1
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -372,7 +372,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bbe
+				// Method begins at RVA 0x2bba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -392,7 +392,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bc7
+				// Method begins at RVA 0x2bc3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -412,7 +412,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bd0
+				// Method begins at RVA 0x2bcc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -438,7 +438,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a50
+			// Method begins at RVA 0x2a4c
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -462,7 +462,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ac4
+			// Method begins at RVA 0x2ac0
 			// Header size: 12
 			// Code size: 137 (0x89)
 			.maxstack 8
@@ -508,7 +508,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b5c
+			// Method begins at RVA 0x2b58
 			// Header size: 12
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -546,7 +546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bf4
+				// Method begins at RVA 0x2bf0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -566,7 +566,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2bfd
+				// Method begins at RVA 0x2bf9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -592,7 +592,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x2a68
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -616,7 +616,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b96
+			// Method begins at RVA 0x2b92
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -643,7 +643,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c18
+				// Method begins at RVA 0x2c14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -663,7 +663,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c21
+				// Method begins at RVA 0x2c1d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -689,7 +689,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a34
+			// Method begins at RVA 0x2a30
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -713,7 +713,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ab0
+			// Method begins at RVA 0x2aac
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -740,7 +740,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c3c
+				// Method begins at RVA 0x2c38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -760,7 +760,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c45
+				// Method begins at RVA 0x2c41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -786,7 +786,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x2a14
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -810,7 +810,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a9c
+			// Method begins at RVA 0x2a98
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -837,7 +837,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c69
+				// Method begins at RVA 0x2c65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -857,7 +857,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c72
+				// Method begins at RVA 0x2c6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -883,7 +883,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29fc
+			// Method begins at RVA 0x29f8
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -907,7 +907,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a88
+			// Method begins at RVA 0x2a84
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -948,7 +948,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2be2
+				// Method begins at RVA 0x2bde
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -968,7 +968,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2beb
+				// Method begins at RVA 0x2be7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -988,7 +988,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c06
+				// Method begins at RVA 0x2c02
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1008,7 +1008,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c0f
+				// Method begins at RVA 0x2c0b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1028,7 +1028,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c2a
+				// Method begins at RVA 0x2c26
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1048,7 +1048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c33
+				// Method begins at RVA 0x2c2f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1072,7 +1072,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2c57
+					// Method begins at RVA 0x2c53
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1090,7 +1090,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c4e
+				// Method begins at RVA 0x2c4a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1110,7 +1110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2c60
+				// Method begins at RVA 0x2c5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1138,7 +1138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2caa
+				// Method begins at RVA 0x2ca6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1165,7 +1165,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2baa
+			// Method begins at RVA 0x2ba6
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1194,7 +1194,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2048 (0x800)
+		// Code size: 2044 (0x7fc)
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Variable_ConstPrimitivePropagation/Scope,
@@ -1269,708 +1269,704 @@
 		IL_004f: stloc.2
 		IL_0050: nop
 		IL_0051: nop
-		IL_0052: nop
-		IL_0053: nop
-		IL_0054: nop
-		IL_0055: nop
-		IL_0056: ldc.i4.1
-		IL_0057: newarr [System.Runtime]System.Object
-		IL_005c: dup
-		IL_005d: ldc.i4.0
-		IL_005e: ldloc.0
-		IL_005f: stelem.ref
-		IL_0060: stloc.s 29
-		IL_0062: ldloc.s 29
-		IL_0064: ldc.i4.0
-		IL_0065: newarr [System.Runtime]System.Object
-		IL_006a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_006f: newobj instance void Modules.Variable_ConstPrimitivePropagation/Reader::.ctor(object[])
-		IL_0074: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0079: stloc.3
-		IL_007a: ldloc.3
-		IL_007b: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
-		IL_0080: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0085: ldstr "prototype"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_008f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0094: ldloc.3
-		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Variable_ConstPrimitivePropagation/Reader>(!!0)
-		IL_009a: stloc.s 30
-		IL_009c: ldloc.s 30
-		IL_009e: ldstr "read"
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00a8: pop
-		IL_00a9: ldloc.3
-		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Variable_ConstPrimitivePropagation/Reader>(!!0)
-		IL_00af: stloc.s 30
-		IL_00b1: ldloc.s 30
-		IL_00b3: callvirt instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
-		IL_00b8: pop
-		IL_00b9: ldc.r8 1
-		IL_00c2: stloc.s 4
-		IL_00c4: ldc.r8 2
-		IL_00cd: stloc.s 4
-		IL_00cf: ldstr "console"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: ldloc.s 4
-		IL_00e0: box [System.Runtime]System.Double
-		IL_00e5: stloc.s 31
-		IL_00e7: ldstr "log"
-		IL_00ec: ldloc.s 31
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f3: pop
-		IL_00f4: nop
+		IL_0052: ldc.i4.1
+		IL_0053: newarr [System.Runtime]System.Object
+		IL_0058: dup
+		IL_0059: ldc.i4.0
+		IL_005a: ldloc.0
+		IL_005b: stelem.ref
+		IL_005c: stloc.s 29
+		IL_005e: ldloc.s 29
+		IL_0060: ldc.i4.0
+		IL_0061: newarr [System.Runtime]System.Object
+		IL_0066: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_006b: newobj instance void Modules.Variable_ConstPrimitivePropagation/Reader::.ctor(object[])
+		IL_0070: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0075: stloc.3
+		IL_0076: ldloc.3
+		IL_0077: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
+		IL_007c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0081: ldstr "prototype"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_008b: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0090: ldloc.3
+		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Variable_ConstPrimitivePropagation/Reader>(!!0)
+		IL_0096: stloc.s 30
+		IL_0098: ldloc.s 30
+		IL_009a: ldstr "read"
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a4: pop
+		IL_00a5: ldloc.3
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Variable_ConstPrimitivePropagation/Reader>(!!0)
+		IL_00ab: stloc.s 30
+		IL_00ad: ldloc.s 30
+		IL_00af: callvirt instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
+		IL_00b4: pop
+		IL_00b5: ldc.r8 1
+		IL_00be: stloc.s 4
+		IL_00c0: ldc.r8 2
+		IL_00c9: stloc.s 4
+		IL_00cb: ldstr "console"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00da: ldloc.s 4
+		IL_00dc: box [System.Runtime]System.Double
+		IL_00e1: stloc.s 31
+		IL_00e3: ldstr "log"
+		IL_00e8: ldloc.s 31
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ef: pop
+		IL_00f0: nop
 		.try
 		{
-			IL_00f5: nop
-			IL_00f6: ldloc.1
-			IL_00f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-			IL_0101: pop
-			IL_0102: ldstr "console"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0111: ldstr "log"
-			IL_0116: ldstr "NO_TDZ"
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0120: pop
-			IL_0121: leave IL_017c
+			IL_00f1: nop
+			IL_00f2: ldloc.1
+			IL_00f3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+			IL_00fd: pop
+			IL_00fe: ldstr "console"
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010d: ldstr "log"
+			IL_0112: ldstr "NO_TDZ"
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011c: pop
+			IL_011d: leave IL_0178
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0126: stloc.s 5
-			IL_0128: ldloc.s 5
-			IL_012a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_012f: dup
-			IL_0130: brtrue IL_0146
+			IL_0122: stloc.s 5
+			IL_0124: ldloc.s 5
+			IL_0126: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_012b: dup
+			IL_012c: brtrue IL_0142
 
-			IL_0135: pop
-			IL_0136: ldloc.s 5
-			IL_0138: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_013d: dup
-			IL_013e: brtrue IL_0152
+			IL_0131: pop
+			IL_0132: ldloc.s 5
+			IL_0134: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0139: dup
+			IL_013a: brtrue IL_014e
 
-			IL_0143: pop
-			IL_0144: rethrow
+			IL_013f: pop
+			IL_0140: rethrow
 
-			IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_014b: stloc.s 6
-			IL_014d: br IL_0154
+			IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0147: stloc.s 6
+			IL_0149: br IL_0150
 
-			IL_0152: stloc.s 6
+			IL_014e: stloc.s 6
 
-			IL_0154: ldloc.s 6
-			IL_0156: stloc.s 7
-			IL_0158: ldstr "console"
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0167: ldstr "log"
-			IL_016c: ldstr "TDZ"
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0176: pop
-			IL_0177: leave IL_017c
+			IL_0150: ldloc.s 6
+			IL_0152: stloc.s 7
+			IL_0154: ldstr "console"
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0163: ldstr "log"
+			IL_0168: ldstr "TDZ"
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0172: pop
+			IL_0173: leave IL_0178
 		} // end handler
 
-		IL_017c: ldloc.0
-		IL_017d: ldc.r8 99
-		IL_0186: box [System.Runtime]System.Double
-		IL_018b: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
-		IL_0190: ldstr "console"
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019f: stloc.s 32
-		IL_01a1: ldloc.1
-		IL_01a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_01ac: stloc.s 33
-		IL_01ae: ldloc.s 32
-		IL_01b0: ldstr "log"
-		IL_01b5: ldloc.s 33
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bc: pop
-		IL_01bd: ldloc.0
-		IL_01be: ldc.r8 3
-		IL_01c7: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN
-		IL_01cc: nop
+		IL_0178: ldloc.0
+		IL_0179: ldc.r8 99
+		IL_0182: box [System.Runtime]System.Double
+		IL_0187: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
+		IL_018c: ldstr "console"
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019b: stloc.s 32
+		IL_019d: ldloc.1
+		IL_019e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_01a8: stloc.s 33
+		IL_01aa: ldloc.s 32
+		IL_01ac: ldstr "log"
+		IL_01b1: ldloc.s 33
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b8: pop
+		IL_01b9: ldloc.0
+		IL_01ba: ldc.r8 3
+		IL_01c3: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN
+		IL_01c8: nop
 		.try
 		{
-			IL_01cd: nop
-			IL_01ce: ldstr "Assignment to constant variable."
-			IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-			IL_01d8: throw
+			IL_01c9: nop
+			IL_01ca: ldstr "Assignment to constant variable."
+			IL_01cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+			IL_01d4: throw
 
-			IL_01d9: ldstr "console"
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e8: ldstr "log"
-			IL_01ed: ldstr "NO_CONST_ERROR"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01f7: pop
-			IL_01f8: leave IL_0262
+			IL_01d5: ldstr "console"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e4: ldstr "log"
+			IL_01e9: ldstr "NO_CONST_ERROR"
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f3: pop
+			IL_01f4: leave IL_025e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01fd: stloc.s 8
-			IL_01ff: ldloc.s 8
-			IL_0201: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0206: dup
-			IL_0207: brtrue IL_021d
+			IL_01f9: stloc.s 8
+			IL_01fb: ldloc.s 8
+			IL_01fd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0202: dup
+			IL_0203: brtrue IL_0219
 
-			IL_020c: pop
-			IL_020d: ldloc.s 8
-			IL_020f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0214: dup
-			IL_0215: brtrue IL_0229
+			IL_0208: pop
+			IL_0209: ldloc.s 8
+			IL_020b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0210: dup
+			IL_0211: brtrue IL_0225
 
-			IL_021a: pop
-			IL_021b: rethrow
+			IL_0216: pop
+			IL_0217: rethrow
 
-			IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0222: stloc.s 9
-			IL_0224: br IL_022b
+			IL_0219: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_021e: stloc.s 9
+			IL_0220: br IL_0227
 
-			IL_0229: stloc.s 9
+			IL_0225: stloc.s 9
 
-			IL_022b: ldloc.s 9
-			IL_022d: stloc.s 10
-			IL_022f: ldstr "console"
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023e: stloc.s 33
-			IL_0240: ldloc.s 10
-			IL_0242: ldstr "name"
-			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024c: stloc.s 32
-			IL_024e: ldloc.s 33
-			IL_0250: ldstr "log"
-			IL_0255: ldloc.s 32
-			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_025c: pop
-			IL_025d: leave IL_0262
+			IL_0227: ldloc.s 9
+			IL_0229: stloc.s 10
+			IL_022b: ldstr "console"
+			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023a: stloc.s 33
+			IL_023c: ldloc.s 10
+			IL_023e: ldstr "name"
+			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0248: stloc.s 32
+			IL_024a: ldloc.s 33
+			IL_024c: ldstr "log"
+			IL_0251: ldloc.s 32
+			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0258: pop
+			IL_0259: leave IL_025e
 		} // end handler
 
-		IL_0262: ldstr "console"
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0271: stloc.s 32
-		IL_0273: ldc.i4.1
-		IL_0274: newarr [System.Runtime]System.Object
-		IL_0279: dup
-		IL_027a: ldc.i4.0
-		IL_027b: ldloc.0
-		IL_027c: stelem.ref
-		IL_027d: stloc.s 29
-		IL_027f: ldloc.s 29
-		IL_0281: ldc.i4.0
-		IL_0282: newarr [System.Runtime]System.Object
-		IL_0287: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_028c: newobj instance void Modules.Variable_ConstPrimitivePropagation/WrittenReader::.ctor(object[])
-		IL_0291: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0296: stloc.s 34
-		IL_0298: ldloc.s 34
-		IL_029a: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
-		IL_029f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02a4: ldstr "prototype"
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_02ae: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_02b3: ldloc.s 34
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ba: ldstr "read"
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02c4: stloc.s 33
-		IL_02c6: ldloc.s 32
-		IL_02c8: ldstr "log"
-		IL_02cd: ldloc.s 33
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d4: pop
-		IL_02d5: ldloc.0
-		IL_02d6: ldc.r8 6
-		IL_02df: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_PATTERN
-		IL_02e4: nop
+		IL_025e: ldstr "console"
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_026d: stloc.s 32
+		IL_026f: ldc.i4.1
+		IL_0270: newarr [System.Runtime]System.Object
+		IL_0275: dup
+		IL_0276: ldc.i4.0
+		IL_0277: ldloc.0
+		IL_0278: stelem.ref
+		IL_0279: stloc.s 29
+		IL_027b: ldloc.s 29
+		IL_027d: ldc.i4.0
+		IL_027e: newarr [System.Runtime]System.Object
+		IL_0283: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0288: newobj instance void Modules.Variable_ConstPrimitivePropagation/WrittenReader::.ctor(object[])
+		IL_028d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0292: stloc.s 34
+		IL_0294: ldloc.s 34
+		IL_0296: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
+		IL_029b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_02a0: ldstr "prototype"
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_02aa: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_02af: ldloc.s 34
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b6: ldstr "read"
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02c0: stloc.s 33
+		IL_02c2: ldloc.s 32
+		IL_02c4: ldstr "log"
+		IL_02c9: ldloc.s 33
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d0: pop
+		IL_02d1: ldloc.0
+		IL_02d2: ldc.r8 6
+		IL_02db: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_PATTERN
+		IL_02e0: nop
 		.try
 		{
-			IL_02e5: nop
-			IL_02e6: ldc.i4.1
-			IL_02e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02ec: dup
-			IL_02ed: ldc.r8 7
-			IL_02f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_02fb: stloc.s 35
-			IL_02fd: ldloc.s 35
-			IL_02ff: brfalse IL_0310
+			IL_02e1: nop
+			IL_02e2: ldc.i4.1
+			IL_02e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02e8: dup
+			IL_02e9: ldc.r8 7
+			IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_02f7: stloc.s 35
+			IL_02f9: ldloc.s 35
+			IL_02fb: brfalse IL_030c
 
-			IL_0304: ldloc.s 35
-			IL_0306: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_030b: brfalse IL_0321
+			IL_0300: ldloc.s 35
+			IL_0302: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0307: brfalse IL_031d
 
-			IL_0310: ldloc.s 35
-			IL_0312: ldstr ""
-			IL_0317: ldstr "0"
-			IL_031c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_030c: ldloc.s 35
+			IL_030e: ldstr ""
+			IL_0313: ldstr "0"
+			IL_0318: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0321: ldloc.s 35
-			IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_0328: stloc.s 11
-			IL_032a: ldc.i4.0
-			IL_032b: stloc.s 12
-			IL_032d: ldc.i4.0
-			IL_032e: stloc.s 13
+			IL_031d: ldloc.s 35
+			IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0324: stloc.s 11
+			IL_0326: ldc.i4.0
+			IL_0327: stloc.s 12
+			IL_0329: ldc.i4.0
+			IL_032a: stloc.s 13
 			.try
 			{
-				IL_0330: ldloc.s 13
-				IL_0332: brtrue IL_0358
+				IL_032c: ldloc.s 13
+				IL_032e: brtrue IL_0354
 
-				IL_0337: ldloc.s 11
-				IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-				IL_033e: stloc.s 33
-				IL_0340: ldloc.s 33
-				IL_0342: brfalse IL_0355
+				IL_0333: ldloc.s 11
+				IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_033a: stloc.s 33
+				IL_033c: ldloc.s 33
+				IL_033e: brfalse IL_0351
 
-				IL_0347: ldloc.s 33
-				IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-				IL_034e: stloc.s 33
-				IL_0350: br IL_0358
+				IL_0343: ldloc.s 33
+				IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_034a: stloc.s 33
+				IL_034c: br IL_0354
 
-				IL_0355: ldc.i4.1
-				IL_0356: stloc.s 13
+				IL_0351: ldc.i4.1
+				IL_0352: stloc.s 13
 
-				IL_0358: ldstr "Assignment to constant variable."
-				IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-				IL_0362: throw
+				IL_0354: ldstr "Assignment to constant variable."
+				IL_0359: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_035e: throw
 
-				IL_0363: ldloc.s 13
-				IL_0365: brtrue IL_0374
+				IL_035f: ldloc.s 13
+				IL_0361: brtrue IL_0370
 
-				IL_036a: ldc.i4.1
-				IL_036b: stloc.s 12
-				IL_036d: ldloc.s 11
-				IL_036f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0366: ldc.i4.1
+				IL_0367: stloc.s 12
+				IL_0369: ldloc.s 11
+				IL_036b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
 
-				IL_0374: ldc.i4.1
-				IL_0375: stloc.s 12
-				IL_0377: leave IL_0392
+				IL_0370: ldc.i4.1
+				IL_0371: stloc.s 12
+				IL_0373: leave IL_038e
 			} // end .try
 			finally
 			{
-				IL_037c: ldloc.s 12
-				IL_037e: brtrue IL_0391
+				IL_0378: ldloc.s 12
+				IL_037a: brtrue IL_038d
 
-				IL_0383: ldloc.s 13
-				IL_0385: brtrue IL_0391
+				IL_037f: ldloc.s 13
+				IL_0381: brtrue IL_038d
 
-				IL_038a: ldloc.s 11
-				IL_038c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0386: ldloc.s 11
+				IL_0388: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0391: endfinally
+				IL_038d: endfinally
 			} // end handler
 
-			IL_0392: leave IL_03fc
+			IL_038e: leave IL_03f8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0397: stloc.s 14
-			IL_0399: ldloc.s 14
-			IL_039b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03a0: dup
-			IL_03a1: brtrue IL_03b7
+			IL_0393: stloc.s 14
+			IL_0395: ldloc.s 14
+			IL_0397: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_039c: dup
+			IL_039d: brtrue IL_03b3
 
-			IL_03a6: pop
-			IL_03a7: ldloc.s 14
-			IL_03a9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03ae: dup
-			IL_03af: brtrue IL_03c3
+			IL_03a2: pop
+			IL_03a3: ldloc.s 14
+			IL_03a5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03aa: dup
+			IL_03ab: brtrue IL_03bf
 
-			IL_03b4: pop
-			IL_03b5: rethrow
+			IL_03b0: pop
+			IL_03b1: rethrow
 
-			IL_03b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03bc: stloc.s 15
-			IL_03be: br IL_03c5
+			IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03b8: stloc.s 15
+			IL_03ba: br IL_03c1
 
-			IL_03c3: stloc.s 15
+			IL_03bf: stloc.s 15
 
-			IL_03c5: ldloc.s 15
-			IL_03c7: stloc.s 16
-			IL_03c9: ldstr "console"
-			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03d8: stloc.s 33
-			IL_03da: ldloc.s 16
-			IL_03dc: ldstr "name"
-			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e6: stloc.s 32
-			IL_03e8: ldloc.s 33
-			IL_03ea: ldstr "log"
-			IL_03ef: ldloc.s 32
-			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03f6: pop
-			IL_03f7: leave IL_03fc
+			IL_03c1: ldloc.s 15
+			IL_03c3: stloc.s 16
+			IL_03c5: ldstr "console"
+			IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d4: stloc.s 33
+			IL_03d6: ldloc.s 16
+			IL_03d8: ldstr "name"
+			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e2: stloc.s 32
+			IL_03e4: ldloc.s 33
+			IL_03e6: ldstr "log"
+			IL_03eb: ldloc.s 32
+			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03f2: pop
+			IL_03f3: leave IL_03f8
 		} // end handler
 
-		IL_03fc: ldstr "console"
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040b: stloc.s 32
-		IL_040d: ldc.i4.1
-		IL_040e: newarr [System.Runtime]System.Object
-		IL_0413: dup
-		IL_0414: ldc.i4.0
-		IL_0415: ldloc.0
-		IL_0416: stelem.ref
-		IL_0417: stloc.s 29
-		IL_0419: ldloc.s 29
-		IL_041b: ldc.i4.0
-		IL_041c: newarr [System.Runtime]System.Object
-		IL_0421: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0426: newobj instance void Modules.Variable_ConstPrimitivePropagation/PatternReader::.ctor(object[])
-		IL_042b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0430: stloc.s 36
-		IL_0432: ldloc.s 36
-		IL_0434: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
-		IL_0439: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_043e: ldstr "prototype"
-		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0448: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_044d: ldloc.s 36
-		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0454: ldstr "read"
-		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_045e: stloc.s 33
-		IL_0460: ldloc.s 32
-		IL_0462: ldstr "log"
-		IL_0467: ldloc.s 33
-		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_046e: pop
-		IL_046f: ldloc.0
-		IL_0470: ldc.r8 8
-		IL_0479: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_LOOP
-		IL_047e: nop
+		IL_03f8: ldstr "console"
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0407: stloc.s 32
+		IL_0409: ldc.i4.1
+		IL_040a: newarr [System.Runtime]System.Object
+		IL_040f: dup
+		IL_0410: ldc.i4.0
+		IL_0411: ldloc.0
+		IL_0412: stelem.ref
+		IL_0413: stloc.s 29
+		IL_0415: ldloc.s 29
+		IL_0417: ldc.i4.0
+		IL_0418: newarr [System.Runtime]System.Object
+		IL_041d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0422: newobj instance void Modules.Variable_ConstPrimitivePropagation/PatternReader::.ctor(object[])
+		IL_0427: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_042c: stloc.s 36
+		IL_042e: ldloc.s 36
+		IL_0430: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
+		IL_0435: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_043a: ldstr "prototype"
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0444: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0449: ldloc.s 36
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0450: ldstr "read"
+		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_045a: stloc.s 33
+		IL_045c: ldloc.s 32
+		IL_045e: ldstr "log"
+		IL_0463: ldloc.s 33
+		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_046a: pop
+		IL_046b: ldloc.0
+		IL_046c: ldc.r8 8
+		IL_0475: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_LOOP
+		IL_047a: nop
 		.try
 		{
-			IL_047f: nop
-			IL_0480: ldc.i4.1
-			IL_0481: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0486: dup
-			IL_0487: ldc.r8 9
-			IL_0490: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0495: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_049a: stloc.s 17
-			IL_049c: ldc.i4.0
-			IL_049d: stloc.s 18
-			IL_049f: ldc.i4.0
-			IL_04a0: stloc.s 19
+			IL_047b: nop
+			IL_047c: ldc.i4.1
+			IL_047d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0482: dup
+			IL_0483: ldc.r8 9
+			IL_048c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0491: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0496: stloc.s 17
+			IL_0498: ldc.i4.0
+			IL_0499: stloc.s 18
+			IL_049b: ldc.i4.0
+			IL_049c: stloc.s 19
 			.try
 			{
-				// loop start (head: IL_04a2)
-					IL_04a2: ldloc.s 17
-					IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_04a9: stloc.s 33
-					IL_04ab: ldloc.s 33
-					IL_04ad: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_04b2: stloc.s 37
-					IL_04b4: ldloc.s 37
-					IL_04b6: brtrue IL_04e2
+				// loop start (head: IL_049e)
+					IL_049e: ldloc.s 17
+					IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_04a5: stloc.s 33
+					IL_04a7: ldloc.s 33
+					IL_04a9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_04ae: stloc.s 37
+					IL_04b0: ldloc.s 37
+					IL_04b2: brtrue IL_04de
 
-					IL_04bb: ldloc.s 33
-					IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_04c2: pop
-					IL_04c3: ldstr "Assignment to constant variable."
-					IL_04c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-					IL_04cd: throw
+					IL_04b7: ldloc.s 33
+					IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_04be: pop
+					IL_04bf: ldstr "Assignment to constant variable."
+					IL_04c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_04c9: throw
 
-					IL_04ce: br IL_04a2
+					IL_04ca: br IL_049e
 				// end loop
-				IL_04d3: ldloc.s 17
-				IL_04d5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_04da: ldc.i4.1
-				IL_04db: stloc.s 19
-				IL_04dd: leave IL_0500
+				IL_04cf: ldloc.s 17
+				IL_04d1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_04d6: ldc.i4.1
+				IL_04d7: stloc.s 19
+				IL_04d9: leave IL_04fc
 
-				IL_04e2: ldc.i4.1
-				IL_04e3: stloc.s 18
-				IL_04e5: leave IL_0500
+				IL_04de: ldc.i4.1
+				IL_04df: stloc.s 18
+				IL_04e1: leave IL_04fc
 			} // end .try
 			finally
 			{
-				IL_04ea: ldloc.s 18
-				IL_04ec: brtrue IL_04ff
+				IL_04e6: ldloc.s 18
+				IL_04e8: brtrue IL_04fb
 
-				IL_04f1: ldloc.s 19
-				IL_04f3: brtrue IL_04ff
+				IL_04ed: ldloc.s 19
+				IL_04ef: brtrue IL_04fb
 
-				IL_04f8: ldloc.s 17
-				IL_04fa: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_04f4: ldloc.s 17
+				IL_04f6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_04ff: endfinally
+				IL_04fb: endfinally
 			} // end handler
 
-			IL_0500: leave IL_056a
+			IL_04fc: leave IL_0566
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0505: stloc.s 20
-			IL_0507: ldloc.s 20
-			IL_0509: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_050e: dup
-			IL_050f: brtrue IL_0525
+			IL_0501: stloc.s 20
+			IL_0503: ldloc.s 20
+			IL_0505: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_050a: dup
+			IL_050b: brtrue IL_0521
 
-			IL_0514: pop
-			IL_0515: ldloc.s 20
-			IL_0517: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_051c: dup
-			IL_051d: brtrue IL_0531
+			IL_0510: pop
+			IL_0511: ldloc.s 20
+			IL_0513: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0518: dup
+			IL_0519: brtrue IL_052d
 
-			IL_0522: pop
-			IL_0523: rethrow
+			IL_051e: pop
+			IL_051f: rethrow
 
-			IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_052a: stloc.s 21
-			IL_052c: br IL_0533
+			IL_0521: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0526: stloc.s 21
+			IL_0528: br IL_052f
 
-			IL_0531: stloc.s 21
+			IL_052d: stloc.s 21
 
-			IL_0533: ldloc.s 21
-			IL_0535: stloc.s 22
-			IL_0537: ldstr "console"
-			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0546: stloc.s 33
-			IL_0548: ldloc.s 22
-			IL_054a: ldstr "name"
-			IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0554: stloc.s 32
-			IL_0556: ldloc.s 33
-			IL_0558: ldstr "log"
-			IL_055d: ldloc.s 32
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0564: pop
-			IL_0565: leave IL_056a
+			IL_052f: ldloc.s 21
+			IL_0531: stloc.s 22
+			IL_0533: ldstr "console"
+			IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0542: stloc.s 33
+			IL_0544: ldloc.s 22
+			IL_0546: ldstr "name"
+			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0550: stloc.s 32
+			IL_0552: ldloc.s 33
+			IL_0554: ldstr "log"
+			IL_0559: ldloc.s 32
+			IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0560: pop
+			IL_0561: leave IL_0566
 		} // end handler
 
-		IL_056a: ldstr "console"
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0579: stloc.s 32
-		IL_057b: ldc.i4.1
-		IL_057c: newarr [System.Runtime]System.Object
-		IL_0581: dup
-		IL_0582: ldc.i4.0
-		IL_0583: ldloc.0
-		IL_0584: stelem.ref
-		IL_0585: stloc.s 29
-		IL_0587: ldloc.s 29
-		IL_0589: ldc.i4.0
-		IL_058a: newarr [System.Runtime]System.Object
-		IL_058f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0594: newobj instance void Modules.Variable_ConstPrimitivePropagation/LoopReader::.ctor(object[])
-		IL_0599: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_059e: stloc.s 38
-		IL_05a0: ldloc.s 38
-		IL_05a2: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
-		IL_05a7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_05ac: ldstr "prototype"
-		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_05b6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_05bb: ldloc.s 38
-		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05c2: ldstr "read"
-		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05cc: stloc.s 33
-		IL_05ce: ldloc.s 32
-		IL_05d0: ldstr "log"
-		IL_05d5: ldloc.s 33
-		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05dc: pop
-		IL_05dd: ldstr "ab"
-		IL_05e2: brfalse IL_05f6
+		IL_0566: ldstr "console"
+		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0575: stloc.s 32
+		IL_0577: ldc.i4.1
+		IL_0578: newarr [System.Runtime]System.Object
+		IL_057d: dup
+		IL_057e: ldc.i4.0
+		IL_057f: ldloc.0
+		IL_0580: stelem.ref
+		IL_0581: stloc.s 29
+		IL_0583: ldloc.s 29
+		IL_0585: ldc.i4.0
+		IL_0586: newarr [System.Runtime]System.Object
+		IL_058b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0590: newobj instance void Modules.Variable_ConstPrimitivePropagation/LoopReader::.ctor(object[])
+		IL_0595: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_059a: stloc.s 38
+		IL_059c: ldloc.s 38
+		IL_059e: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
+		IL_05a3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_05a8: ldstr "prototype"
+		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_05b2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_05b7: ldloc.s 38
+		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05be: ldstr "read"
+		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05c8: stloc.s 33
+		IL_05ca: ldloc.s 32
+		IL_05cc: ldstr "log"
+		IL_05d1: ldloc.s 33
+		IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05d8: pop
+		IL_05d9: ldstr "ab"
+		IL_05de: brfalse IL_05f2
 
-		IL_05e7: ldstr "ab"
-		IL_05ec: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_05f1: brfalse IL_060a
+		IL_05e3: ldstr "ab"
+		IL_05e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_05ed: brfalse IL_0606
 
-		IL_05f6: ldstr "ab"
-		IL_05fb: ldstr ""
-		IL_0600: ldstr "0"
-		IL_0605: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_05f2: ldstr "ab"
+		IL_05f7: ldstr ""
+		IL_05fc: ldstr "0"
+		IL_0601: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_060a: ldstr "ab"
-		IL_060f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_0614: stloc.s 23
-		IL_0616: ldc.i4.0
-		IL_0617: stloc.s 24
-		IL_0619: ldc.i4.0
-		IL_061a: stloc.s 25
+		IL_0606: ldstr "ab"
+		IL_060b: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_0610: stloc.s 23
+		IL_0612: ldc.i4.0
+		IL_0613: stloc.s 24
+		IL_0615: ldc.i4.0
+		IL_0616: stloc.s 25
 		.try
 		{
-			IL_061c: ldloc.s 25
-			IL_061e: brtrue IL_0648
+			IL_0618: ldloc.s 25
+			IL_061a: brtrue IL_0644
 
-			IL_0623: ldloc.s 23
-			IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-			IL_062a: stloc.s 33
-			IL_062c: ldloc.s 33
-			IL_062e: brfalse IL_0645
+			IL_061f: ldloc.s 23
+			IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+			IL_0626: stloc.s 33
+			IL_0628: ldloc.s 33
+			IL_062a: brfalse IL_0641
 
-			IL_0633: ldloc.s 33
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-			IL_063a: stloc.s 33
-			IL_063c: ldloc.s 33
-			IL_063e: stloc.s 32
-			IL_0640: br IL_064b
+			IL_062f: ldloc.s 33
+			IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+			IL_0636: stloc.s 33
+			IL_0638: ldloc.s 33
+			IL_063a: stloc.s 32
+			IL_063c: br IL_0647
 
-			IL_0645: ldc.i4.1
-			IL_0646: stloc.s 25
+			IL_0641: ldc.i4.1
+			IL_0642: stloc.s 25
 
-			IL_0648: ldnull
-			IL_0649: stloc.s 32
+			IL_0644: ldnull
+			IL_0645: stloc.s 32
 
-			IL_064b: ldloc.0
-			IL_064c: ldloc.s 32
-			IL_064e: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::DESTRUCTURED
-			IL_0653: ldloc.s 25
-			IL_0655: brtrue IL_0664
+			IL_0647: ldloc.0
+			IL_0648: ldloc.s 32
+			IL_064a: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::DESTRUCTURED
+			IL_064f: ldloc.s 25
+			IL_0651: brtrue IL_0660
 
-			IL_065a: ldc.i4.1
-			IL_065b: stloc.s 24
-			IL_065d: ldloc.s 23
-			IL_065f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_0656: ldc.i4.1
+			IL_0657: stloc.s 24
+			IL_0659: ldloc.s 23
+			IL_065b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
 
-			IL_0664: ldc.i4.1
-			IL_0665: stloc.s 24
-			IL_0667: leave IL_0682
+			IL_0660: ldc.i4.1
+			IL_0661: stloc.s 24
+			IL_0663: leave IL_067e
 		} // end .try
 		finally
 		{
-			IL_066c: ldloc.s 24
-			IL_066e: brtrue IL_0681
+			IL_0668: ldloc.s 24
+			IL_066a: brtrue IL_067d
 
-			IL_0673: ldloc.s 25
-			IL_0675: brtrue IL_0681
+			IL_066f: ldloc.s 25
+			IL_0671: brtrue IL_067d
 
-			IL_067a: ldloc.s 23
-			IL_067c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_0676: ldloc.s 23
+			IL_0678: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_0681: endfinally
+			IL_067d: endfinally
 		} // end handler
 
-		IL_0682: nop
-		IL_0683: ldstr "console"
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0692: stloc.s 32
-		IL_0694: ldc.i4.1
-		IL_0695: newarr [System.Runtime]System.Object
-		IL_069a: dup
-		IL_069b: ldc.i4.0
-		IL_069c: ldloc.0
-		IL_069d: stelem.ref
-		IL_069e: stloc.s 29
-		IL_06a0: ldloc.s 29
-		IL_06a2: ldc.i4.0
-		IL_06a3: newarr [System.Runtime]System.Object
-		IL_06a8: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_06ad: newobj instance void Modules.Variable_ConstPrimitivePropagation/DestructuredReader::.ctor(object[])
-		IL_06b2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_06b7: stloc.s 39
-		IL_06b9: ldloc.s 39
-		IL_06bb: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-		IL_06c0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_06c5: ldstr "prototype"
-		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_06cf: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_06d4: ldloc.s 39
-		IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06db: ldstr "read"
-		IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06e5: stloc.s 40
-		IL_06e7: ldloc.s 32
-		IL_06e9: ldstr "log"
-		IL_06ee: ldloc.s 40
-		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06f5: pop
-		IL_06f6: nop
-		IL_06f7: ldstr "console"
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0706: stloc.s 40
-		IL_0708: ldloc.2
-		IL_0709: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_0713: stloc.s 32
-		IL_0715: ldc.i4.0
-		IL_0716: newarr [System.Runtime]System.Object
-		IL_071b: stloc.s 29
-		IL_071d: ldloc.s 32
-		IL_071f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0724: ldloc.s 29
-		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_072b: stloc.s 32
-		IL_072d: ldloc.s 40
-		IL_072f: ldstr "log"
-		IL_0734: ldloc.s 32
-		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_073b: pop
-		IL_073c: ldnull
-		IL_073d: stloc.s 26
-		IL_073f: newobj instance void Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::.ctor()
-		IL_0744: stloc.s 27
-		IL_0746: ldc.r8 1
-		IL_074f: box [System.Runtime]System.Double
-		IL_0754: ldc.r8 0.0
-		IL_075d: box [System.Runtime]System.Double
-		IL_0762: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0767: stloc.s 37
-		IL_0769: ldloc.s 37
-		IL_076b: brtrue IL_079f
+		IL_067e: nop
+		IL_067f: ldstr "console"
+		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_068e: stloc.s 32
+		IL_0690: ldc.i4.1
+		IL_0691: newarr [System.Runtime]System.Object
+		IL_0696: dup
+		IL_0697: ldc.i4.0
+		IL_0698: ldloc.0
+		IL_0699: stelem.ref
+		IL_069a: stloc.s 29
+		IL_069c: ldloc.s 29
+		IL_069e: ldc.i4.0
+		IL_069f: newarr [System.Runtime]System.Object
+		IL_06a4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_06a9: newobj instance void Modules.Variable_ConstPrimitivePropagation/DestructuredReader::.ctor(object[])
+		IL_06ae: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_06b3: stloc.s 39
+		IL_06b5: ldloc.s 39
+		IL_06b7: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+		IL_06bc: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06c1: ldstr "prototype"
+		IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_06cb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_06d0: ldloc.s 39
+		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06d7: ldstr "read"
+		IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06e1: stloc.s 40
+		IL_06e3: ldloc.s 32
+		IL_06e5: ldstr "log"
+		IL_06ea: ldloc.s 40
+		IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06f1: pop
+		IL_06f2: nop
+		IL_06f3: ldstr "console"
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0702: stloc.s 40
+		IL_0704: ldloc.2
+		IL_0705: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_070f: stloc.s 32
+		IL_0711: ldc.i4.0
+		IL_0712: newarr [System.Runtime]System.Object
+		IL_0717: stloc.s 29
+		IL_0719: ldloc.s 32
+		IL_071b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0720: ldloc.s 29
+		IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0727: stloc.s 32
+		IL_0729: ldloc.s 40
+		IL_072b: ldstr "log"
+		IL_0730: ldloc.s 32
+		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0737: pop
+		IL_0738: ldnull
+		IL_0739: stloc.s 26
+		IL_073b: newobj instance void Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::.ctor()
+		IL_0740: stloc.s 27
+		IL_0742: ldc.r8 1
+		IL_074b: box [System.Runtime]System.Double
+		IL_0750: ldc.r8 0.0
+		IL_0759: box [System.Runtime]System.Double
+		IL_075e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0763: stloc.s 37
+		IL_0765: ldloc.s 37
+		IL_0767: brtrue IL_079b
 
-		IL_0770: ldc.r8 1
-		IL_0779: box [System.Runtime]System.Double
-		IL_077e: ldc.r8 1
-		IL_0787: box [System.Runtime]System.Double
-		IL_078c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0791: stloc.s 37
-		IL_0793: ldloc.s 37
-		IL_0795: brtrue IL_07b4
+		IL_076c: ldc.r8 1
+		IL_0775: box [System.Runtime]System.Double
+		IL_077a: ldc.r8 1
+		IL_0783: box [System.Runtime]System.Double
+		IL_0788: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_078d: stloc.s 37
+		IL_078f: ldloc.s 37
+		IL_0791: brtrue IL_07b0
 
-		IL_079a: br IL_07fc
+		IL_0796: br IL_07f8
 
-		IL_079f: ldloc.s 27
-		IL_07a1: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
-		IL_07a6: ldc.r8 5
-		IL_07af: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::SKIPPED
+		IL_079b: ldloc.s 27
+		IL_079d: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
+		IL_07a2: ldc.r8 5
+		IL_07ab: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::SKIPPED
 
-		IL_07b4: ldnull
-		IL_07b5: ldftn object Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21::__js_call__(object[], object)
-		IL_07bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-		IL_07c0: ldc.i4.2
-		IL_07c1: newarr [System.Runtime]System.Object
+		IL_07b0: ldnull
+		IL_07b1: ldftn object Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21::__js_call__(object[], object)
+		IL_07b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+		IL_07bc: ldc.i4.2
+		IL_07bd: newarr [System.Runtime]System.Object
+		IL_07c2: dup
+		IL_07c3: ldc.i4.0
+		IL_07c4: ldloc.0
+		IL_07c5: stelem.ref
 		IL_07c6: dup
-		IL_07c7: ldc.i4.0
-		IL_07c8: ldloc.0
-		IL_07c9: stelem.ref
-		IL_07ca: dup
-		IL_07cb: ldc.i4.1
-		IL_07cc: ldloc.s 27
-		IL_07ce: stelem.ref
-		IL_07cf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_07d9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-		IL_07de: ldc.i4.0
-		IL_07df: conv.r8
-		IL_07e0: ldstr ""
-		IL_07e5: ldc.i4.0
-		IL_07e6: ldc.i4.0
-		IL_07e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-		IL_07ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-		IL_07f1: stloc.s 41
-		IL_07f3: ldloc.s 41
-		IL_07f5: stloc.s 26
-		IL_07f7: br IL_07fc
+		IL_07c7: ldc.i4.1
+		IL_07c8: ldloc.s 27
+		IL_07ca: stelem.ref
+		IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_07d5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+		IL_07da: ldc.i4.0
+		IL_07db: conv.r8
+		IL_07dc: ldstr ""
+		IL_07e1: ldc.i4.0
+		IL_07e2: ldc.i4.0
+		IL_07e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+		IL_07e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+		IL_07ed: stloc.s 41
+		IL_07ef: ldloc.s 41
+		IL_07f1: stloc.s 26
+		IL_07f3: br IL_07f8
 
-		IL_07fc: ldnull
-		IL_07fd: stloc.s 28
-		IL_07ff: ret
+		IL_07f8: ldnull
+		IL_07f9: stloc.s 28
+		IL_07fb: ret
 	} // end of method Variable_ConstPrimitivePropagation::__js_module_init__
 
 } // end of class Modules.Variable_ConstPrimitivePropagation
@@ -1982,7 +1978,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2cbc
+		// Method begins at RVA 0x2cb8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
@@ -1,0 +1,744 @@
+﻿// IL code: Variable_ConstPrimitivePropagation_With
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Variable_ConstPrimitivePropagation_With
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit receive
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23f3
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22a4
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method receive::__js_call__
+
+	} // end of class receive
+
+	.class nested public auto ansi abstract sealed beforefieldinit receiveIdentifier
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23fc
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Method begins at RVA 0x22a7
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ret
+		} // end of method receiveIdentifier::__js_call__
+
+	} // end of class receiveIdentifier
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L11C20
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L13C12
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2417
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x235c
+				// Header size: 12
+				// Code size: 66 (0x42)
+				.maxstack 8
+				.locals init (
+					[0] object,
+					[1] object,
+					[2] object[]
+				)
+
+				IL_0000: ldstr "VALUE"
+				IL_0005: ldc.r8 1
+				IL_000e: box [System.Runtime]System.Double
+				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+				IL_0018: stloc.0
+				IL_0019: ldloc.0
+				IL_001a: ldc.r8 1
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0028: stloc.1
+				IL_0029: ldc.i4.1
+				IL_002a: newarr [System.Runtime]System.Object
+				IL_002f: dup
+				IL_0030: ldc.i4.0
+				IL_0031: ldarg.0
+				IL_0032: ldc.i4.0
+				IL_0033: ldelem.ref
+				IL_0034: stelem.ref
+				IL_0035: stloc.2
+				IL_0036: ldnull
+				IL_0037: ldloc.1
+				IL_0038: tail.
+				IL_003a: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
+				IL_003f: ret
+
+				IL_0040: ldnull
+				IL_0041: ret
+			} // end of method ArrowFunction_L13C12::__js_call__
+
+		} // end of class ArrowFunction_L13C12
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 15 53 63 6f 70 65 20 6f 62 6a 65 63 74 3d
+				7b 6f 62 6a 65 63 74 7d 00 00
+			)
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L12C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x240e
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L12C16::.ctor
+
+			} // end of class Block_L12C16
+
+
+			// Fields
+			.field public object 'object'
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2405
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_ConstPrimitivePropagation_With/Scope scope,
+				object newTarget,
+				object 'object'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 09 00 00 02
+			)
+			// Method begins at RVA 0x22ac
+			// Header size: 12
+			// Code size: 76 (0x4c)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20/Scope,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			)
+
+			IL_0000: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: nop
+			IL_0007: ldnull
+			IL_0008: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20/ArrowFunction_L13C12::__js_call__(object[], object)
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0013: ldc.i4.2
+			IL_0014: newarr [System.Runtime]System.Object
+			IL_0019: dup
+			IL_001a: ldc.i4.0
+			IL_001b: ldarg.0
+			IL_001c: stelem.ref
+			IL_001d: dup
+			IL_001e: ldc.i4.1
+			IL_001f: ldloc.0
+			IL_0020: stelem.ref
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_002b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0030: ldc.i4.0
+			IL_0031: conv.r8
+			IL_0032: ldstr ""
+			IL_0037: ldc.i4.0
+			IL_0038: ldc.i4.0
+			IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0043: stloc.1
+			IL_0044: ldloc.1
+			IL_0045: ldarg.2
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Function::BindWithObject(object, object)
+			IL_004b: ret
+		} // end of method ArrowFunction_L11C20::__js_call__
+
+	} // end of class ArrowFunction_L11C20
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L17C30
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L19C12
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2432
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object[] scopes,
+					object newTarget
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 02 00 00 00 00 00
+				)
+				// Method begins at RVA 0x23ac
+				// Header size: 12
+				// Code size: 50 (0x32)
+				.maxstack 8
+				.locals init (
+					[0] object,
+					[1] object[]
+				)
+
+				IL_0000: ldstr "VALUE"
+				IL_0005: ldc.r8 1
+				IL_000e: box [System.Runtime]System.Double
+				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveWithBindingOrDefault(object, object)
+				IL_0018: stloc.0
+				IL_0019: ldc.i4.1
+				IL_001a: newarr [System.Runtime]System.Object
+				IL_001f: dup
+				IL_0020: ldc.i4.0
+				IL_0021: ldarg.0
+				IL_0022: ldc.i4.0
+				IL_0023: ldelem.ref
+				IL_0024: stelem.ref
+				IL_0025: stloc.1
+				IL_0026: ldnull
+				IL_0027: ldloc.0
+				IL_0028: tail.
+				IL_002a: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
+				IL_002f: ret
+
+				IL_0030: ldnull
+				IL_0031: ret
+			} // end of method ArrowFunction_L19C12::__js_call__
+
+		} // end of class ArrowFunction_L19C12
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 15 53 63 6f 70 65 20 6f 62 6a 65 63 74 3d
+				7b 6f 62 6a 65 63 74 7d 00 00
+			)
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L18C16
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2429
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L18C16::.ctor
+
+			} // end of class Block_L18C16
+
+
+			// Fields
+			.field public object 'object'
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2420
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Variable_ConstPrimitivePropagation_With/Scope scope,
+				object newTarget,
+				object 'object'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 09 00 00 02
+			)
+			// Method begins at RVA 0x2304
+			// Header size: 12
+			// Code size: 76 (0x4c)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30/Scope,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			)
+
+			IL_0000: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: nop
+			IL_0007: ldnull
+			IL_0008: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30/ArrowFunction_L19C12::__js_call__(object[], object)
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0013: ldc.i4.2
+			IL_0014: newarr [System.Runtime]System.Object
+			IL_0019: dup
+			IL_001a: ldc.i4.0
+			IL_001b: ldarg.0
+			IL_001c: stelem.ref
+			IL_001d: dup
+			IL_001e: ldc.i4.1
+			IL_001f: ldloc.0
+			IL_0020: stelem.ref
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_002b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0030: ldc.i4.0
+			IL_0031: conv.r8
+			IL_0032: ldstr ""
+			IL_0037: ldc.i4.0
+			IL_0038: ldc.i4.0
+			IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0043: stloc.1
+			IL_0044: ldloc.1
+			IL_0045: ldarg.2
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Function::BindWithObject(object, object)
+			IL_004b: ret
+		} // end of method ArrowFunction_L17C30::__js_call__
+
+	} // end of class ArrowFunction_L17C30
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 3e 53 63 6f 70 65 20 72 65 63 65 69 76 65
+			3d 7b 72 65 63 65 69 76 65 7d 2c 20 72 65 63 65
+			69 76 65 49 64 65 6e 74 69 66 69 65 72 3d 7b 72
+			65 63 65 69 76 65 49 64 65 6e 74 69 66 69 65 72
+			7d 00 00
+		)
+		// Fields
+		.field public object receive
+		.field public object receiveIdentifier
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x23ea
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 584 (0x248)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Variable_ConstPrimitivePropagation_With/Scope,
+			[1] object,
+			[2] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1,
+			[4] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] object,
+			[7] object[]
+		)
+
+		IL_0000: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldnull
+		IL_0007: ldftn object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0017: ldc.i4.1
+		IL_0018: conv.r8
+		IL_0019: ldstr "receive"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.0
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0025: stloc.3
+		IL_0026: ldloc.0
+		IL_0027: ldloc.3
+		IL_0028: stfld object Modules.Variable_ConstPrimitivePropagation_With/Scope::receive
+		IL_002d: ldnull
+		IL_002e: ldftn object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
+		IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0039: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_003e: ldc.i4.1
+		IL_003f: conv.r8
+		IL_0040: ldstr "receiveIdentifier"
+		IL_0045: ldc.i4.0
+		IL_0046: ldc.i4.0
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_004c: stloc.3
+		IL_004d: ldloc.0
+		IL_004e: ldloc.3
+		IL_004f: stfld object Modules.Variable_ConstPrimitivePropagation_With/Scope::receiveIdentifier
+		IL_0054: nop
+		IL_0055: nop
+		IL_0056: nop
+		IL_0057: ldloc.0
+		IL_0058: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_005d: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0068: ldc.i4.1
+		IL_0069: newarr [System.Runtime]System.Object
+		IL_006e: dup
+		IL_006f: ldc.i4.0
+		IL_0070: ldloc.0
+		IL_0071: stelem.ref
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0081: ldc.i4.1
+		IL_0082: conv.r8
+		IL_0083: ldstr ""
+		IL_0088: ldc.i4.0
+		IL_0089: ldc.i4.0
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0094: stloc.3
+		IL_0095: ldloc.3
+		IL_0096: ldstr "makeReader"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_00a0: stloc.1
+		IL_00a1: ldloc.0
+		IL_00a2: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_00a7: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b2: ldc.i4.1
+		IL_00b3: newarr [System.Runtime]System.Object
+		IL_00b8: dup
+		IL_00b9: ldc.i4.0
+		IL_00ba: ldloc.0
+		IL_00bb: stelem.ref
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00c6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00cb: ldc.i4.1
+		IL_00cc: conv.r8
+		IL_00cd: ldstr ""
+		IL_00d2: ldc.i4.0
+		IL_00d3: ldc.i4.0
+		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_00de: stloc.3
+		IL_00df: ldloc.3
+		IL_00e0: ldstr "makeIdentifierReader"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_00ea: stloc.2
+		IL_00eb: ldstr "console"
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fa: stloc.s 4
+		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0101: dup
+		IL_0102: ldstr "VALUE"
+		IL_0107: ldstr "shadow"
+		IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0111: stloc.s 5
+		IL_0113: ldloc.0
+		IL_0114: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_0119: ldnull
+		IL_011a: ldloc.s 5
+		IL_011c: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_0121: stloc.s 6
+		IL_0123: ldc.i4.0
+		IL_0124: newarr [System.Runtime]System.Object
+		IL_0129: stloc.s 7
+		IL_012b: ldloc.s 6
+		IL_012d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0132: ldloc.s 7
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0139: stloc.s 6
+		IL_013b: ldloc.s 4
+		IL_013d: ldstr "log"
+		IL_0142: ldloc.s 6
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0149: pop
+		IL_014a: ldstr "console"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0159: stloc.s 6
+		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0160: stloc.s 5
+		IL_0162: ldloc.0
+		IL_0163: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_0168: ldnull
+		IL_0169: ldloc.s 5
+		IL_016b: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_0170: stloc.s 4
+		IL_0172: ldc.i4.0
+		IL_0173: newarr [System.Runtime]System.Object
+		IL_0178: stloc.s 7
+		IL_017a: ldloc.s 4
+		IL_017c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0181: ldloc.s 7
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0188: stloc.s 4
+		IL_018a: ldloc.s 6
+		IL_018c: ldstr "log"
+		IL_0191: ldloc.s 4
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0198: pop
+		IL_0199: ldstr "console"
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a8: stloc.s 4
+		IL_01aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01af: dup
+		IL_01b0: ldstr "VALUE"
+		IL_01b5: ldstr "shadow"
+		IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01bf: stloc.s 5
+		IL_01c1: ldloc.0
+		IL_01c2: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_01c7: ldnull
+		IL_01c8: ldloc.s 5
+		IL_01ca: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_01cf: stloc.s 6
+		IL_01d1: ldc.i4.0
+		IL_01d2: newarr [System.Runtime]System.Object
+		IL_01d7: stloc.s 7
+		IL_01d9: ldloc.s 6
+		IL_01db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e0: ldloc.s 7
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01e7: stloc.s 6
+		IL_01e9: ldloc.s 4
+		IL_01eb: ldstr "log"
+		IL_01f0: ldloc.s 6
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f7: pop
+		IL_01f8: ldstr "console"
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0207: stloc.s 6
+		IL_0209: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_020e: stloc.s 5
+		IL_0210: ldloc.0
+		IL_0211: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_0216: ldnull
+		IL_0217: ldloc.s 5
+		IL_0219: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_021e: stloc.s 4
+		IL_0220: ldc.i4.0
+		IL_0221: newarr [System.Runtime]System.Object
+		IL_0226: stloc.s 7
+		IL_0228: ldloc.s 4
+		IL_022a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_022f: ldloc.s 7
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0236: stloc.s 4
+		IL_0238: ldloc.s 6
+		IL_023a: ldstr "log"
+		IL_023f: ldloc.s 4
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0246: pop
+		IL_0247: ret
+	} // end of method Variable_ConstPrimitivePropagation_With::__js_module_init__
+
+} // end of class Modules.Variable_ConstPrimitivePropagation_With
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x243b
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Variable_ConstPrimitivePropagation_With::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x22a3
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a7
+			// Method begins at RVA 0x22a6
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -510,7 +510,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 584 (0x248)
+		// Code size: 583 (0x247)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ConstPrimitivePropagation_With/Scope,
@@ -555,166 +555,165 @@
 		IL_004f: stfld object Modules.Variable_ConstPrimitivePropagation_With/Scope::receiveIdentifier
 		IL_0054: nop
 		IL_0055: nop
-		IL_0056: nop
-		IL_0057: ldloc.0
-		IL_0058: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
-		IL_005d: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
-		IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0068: ldc.i4.1
-		IL_0069: newarr [System.Runtime]System.Object
-		IL_006e: dup
-		IL_006f: ldc.i4.0
-		IL_0070: ldloc.0
-		IL_0071: stelem.ref
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0081: ldc.i4.1
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
+		IL_0056: ldloc.0
+		IL_0057: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_005c: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0067: ldc.i4.1
+		IL_0068: newarr [System.Runtime]System.Object
+		IL_006d: dup
+		IL_006e: ldc.i4.0
+		IL_006f: ldloc.0
+		IL_0070: stelem.ref
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_007b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0080: ldc.i4.1
+		IL_0081: conv.r8
+		IL_0082: ldstr ""
+		IL_0087: ldc.i4.0
 		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.0
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0094: stloc.3
-		IL_0095: ldloc.3
-		IL_0096: ldstr "makeReader"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_00a0: stloc.1
-		IL_00a1: ldloc.0
-		IL_00a2: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
-		IL_00a7: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
-		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00b2: ldc.i4.1
-		IL_00b3: newarr [System.Runtime]System.Object
-		IL_00b8: dup
-		IL_00b9: ldc.i4.0
-		IL_00ba: ldloc.0
-		IL_00bb: stelem.ref
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00c6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00cb: ldc.i4.1
-		IL_00cc: conv.r8
-		IL_00cd: ldstr ""
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0093: stloc.3
+		IL_0094: ldloc.3
+		IL_0095: ldstr "makeReader"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_009f: stloc.1
+		IL_00a0: ldloc.0
+		IL_00a1: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_00a6: ldftn object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_00ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b1: ldc.i4.1
+		IL_00b2: newarr [System.Runtime]System.Object
+		IL_00b7: dup
+		IL_00b8: ldc.i4.0
+		IL_00b9: ldloc.0
+		IL_00ba: stelem.ref
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00c5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00ca: ldc.i4.1
+		IL_00cb: conv.r8
+		IL_00cc: ldstr ""
+		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.0
-		IL_00d3: ldc.i4.0
-		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_00de: stloc.3
-		IL_00df: ldloc.3
-		IL_00e0: ldstr "makeIdentifierReader"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_00ea: stloc.2
-		IL_00eb: ldstr "console"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.s 4
-		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0101: dup
-		IL_0102: ldstr "VALUE"
-		IL_0107: ldstr "shadow"
-		IL_010c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0111: stloc.s 5
-		IL_0113: ldloc.0
-		IL_0114: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
-		IL_0119: ldnull
-		IL_011a: ldloc.s 5
-		IL_011c: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
-		IL_0121: stloc.s 6
-		IL_0123: ldc.i4.0
-		IL_0124: newarr [System.Runtime]System.Object
-		IL_0129: stloc.s 7
-		IL_012b: ldloc.s 6
-		IL_012d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0132: ldloc.s 7
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0139: stloc.s 6
-		IL_013b: ldloc.s 4
-		IL_013d: ldstr "log"
-		IL_0142: ldloc.s 6
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0149: pop
-		IL_014a: ldstr "console"
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0159: stloc.s 6
-		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0160: stloc.s 5
-		IL_0162: ldloc.0
-		IL_0163: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
-		IL_0168: ldnull
-		IL_0169: ldloc.s 5
-		IL_016b: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
-		IL_0170: stloc.s 4
-		IL_0172: ldc.i4.0
-		IL_0173: newarr [System.Runtime]System.Object
-		IL_0178: stloc.s 7
-		IL_017a: ldloc.s 4
-		IL_017c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0181: ldloc.s 7
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0188: stloc.s 4
-		IL_018a: ldloc.s 6
-		IL_018c: ldstr "log"
-		IL_0191: ldloc.s 4
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0198: pop
-		IL_0199: ldstr "console"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a8: stloc.s 4
-		IL_01aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01af: dup
-		IL_01b0: ldstr "VALUE"
-		IL_01b5: ldstr "shadow"
-		IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01bf: stloc.s 5
-		IL_01c1: ldloc.0
-		IL_01c2: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
-		IL_01c7: ldnull
-		IL_01c8: ldloc.s 5
-		IL_01ca: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
-		IL_01cf: stloc.s 6
-		IL_01d1: ldc.i4.0
-		IL_01d2: newarr [System.Runtime]System.Object
-		IL_01d7: stloc.s 7
-		IL_01d9: ldloc.s 6
-		IL_01db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01e0: ldloc.s 7
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01e7: stloc.s 6
-		IL_01e9: ldloc.s 4
-		IL_01eb: ldstr "log"
-		IL_01f0: ldloc.s 6
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f7: pop
-		IL_01f8: ldstr "console"
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0207: stloc.s 6
-		IL_0209: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_020e: stloc.s 5
-		IL_0210: ldloc.0
-		IL_0211: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
-		IL_0216: ldnull
-		IL_0217: ldloc.s 5
-		IL_0219: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
-		IL_021e: stloc.s 4
-		IL_0220: ldc.i4.0
-		IL_0221: newarr [System.Runtime]System.Object
-		IL_0226: stloc.s 7
-		IL_0228: ldloc.s 4
-		IL_022a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_022f: ldloc.s 7
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0236: stloc.s 4
-		IL_0238: ldloc.s 6
-		IL_023a: ldstr "log"
-		IL_023f: ldloc.s 4
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0246: pop
-		IL_0247: ret
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_00dd: stloc.3
+		IL_00de: ldloc.3
+		IL_00df: ldstr "makeIdentifierReader"
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_00e9: stloc.2
+		IL_00ea: ldstr "console"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f9: stloc.s 4
+		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0100: dup
+		IL_0101: ldstr "VALUE"
+		IL_0106: ldstr "shadow"
+		IL_010b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0110: stloc.s 5
+		IL_0112: ldloc.0
+		IL_0113: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_0118: ldnull
+		IL_0119: ldloc.s 5
+		IL_011b: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_0120: stloc.s 6
+		IL_0122: ldc.i4.0
+		IL_0123: newarr [System.Runtime]System.Object
+		IL_0128: stloc.s 7
+		IL_012a: ldloc.s 6
+		IL_012c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0131: ldloc.s 7
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0138: stloc.s 6
+		IL_013a: ldloc.s 4
+		IL_013c: ldstr "log"
+		IL_0141: ldloc.s 6
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0148: pop
+		IL_0149: ldstr "console"
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0158: stloc.s 6
+		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_015f: stloc.s 5
+		IL_0161: ldloc.0
+		IL_0162: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_0167: ldnull
+		IL_0168: ldloc.s 5
+		IL_016a: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_016f: stloc.s 4
+		IL_0171: ldc.i4.0
+		IL_0172: newarr [System.Runtime]System.Object
+		IL_0177: stloc.s 7
+		IL_0179: ldloc.s 4
+		IL_017b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0180: ldloc.s 7
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0187: stloc.s 4
+		IL_0189: ldloc.s 6
+		IL_018b: ldstr "log"
+		IL_0190: ldloc.s 4
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0197: pop
+		IL_0198: ldstr "console"
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a7: stloc.s 4
+		IL_01a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01ae: dup
+		IL_01af: ldstr "VALUE"
+		IL_01b4: ldstr "shadow"
+		IL_01b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01be: stloc.s 5
+		IL_01c0: ldloc.0
+		IL_01c1: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_01c6: ldnull
+		IL_01c7: ldloc.s 5
+		IL_01c9: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_01ce: stloc.s 6
+		IL_01d0: ldc.i4.0
+		IL_01d1: newarr [System.Runtime]System.Object
+		IL_01d6: stloc.s 7
+		IL_01d8: ldloc.s 6
+		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01df: ldloc.s 7
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01e6: stloc.s 6
+		IL_01e8: ldloc.s 4
+		IL_01ea: ldstr "log"
+		IL_01ef: ldloc.s 6
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f6: pop
+		IL_01f7: ldstr "console"
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0206: stloc.s 6
+		IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_020d: stloc.s 5
+		IL_020f: ldloc.0
+		IL_0210: castclass Modules.Variable_ConstPrimitivePropagation_With/Scope
+		IL_0215: ldnull
+		IL_0216: ldloc.s 5
+		IL_0218: call object Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30::__js_call__(class Modules.Variable_ConstPrimitivePropagation_With/Scope, object, object)
+		IL_021d: stloc.s 4
+		IL_021f: ldc.i4.0
+		IL_0220: newarr [System.Runtime]System.Object
+		IL_0225: stloc.s 7
+		IL_0227: ldloc.s 4
+		IL_0229: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_022e: ldloc.s 7
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0235: stloc.s 4
+		IL_0237: ldloc.s 6
+		IL_0239: ldstr "log"
+		IL_023e: ldloc.s 4
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0245: pop
+		IL_0246: ret
 	} // end of method Variable_ConstPrimitivePropagation_With::__js_module_init__
 
 } // end of class Modules.Variable_ConstPrimitivePropagation_With


### PR DESCRIPTION
## Summary

- infer safe callable parameter types from recursively proven binary-expression arguments and numeric update-only parameters
- forward typed numeric call values without dead boxing and keep typed parameter updates unboxed
- propagate captured primitive `const` bindings across callable boundaries, fold supported arithmetic/string expressions, and eliminate unused scope fields and initialization stores
- preserve JavaScript semantics for BigInt, string concatenation, assignments, destructuring, loop writes, redeclarations, shadowing, `with`, and temporal dead zones

## PrimeJavaScript IL

- `searchBitFalse(float64)` and `testBitTrue(float64)` are emitted with typed parameters
- the `searchBitFalse(factor + 1)` call has no `Double` box
- `searchBitFalse` has no `TypeUtilities.ToNumber(object)` conversion
- `WORD_SIZE` and `NOW_UNITS_PER_SECOND` fields, loads, and stores are eliminated
- `setBitsTrue` starts with `ldarg.2 / ldc.r8 16 / cgt`

## Performance

Three-run `tests/performance/PrimeJavaScript.js` baseline:

| Passes | Seconds |
| ---: | ---: |
| 595 | 5.004760391 |
| 637 | 5.005890155 |
| 604 | 5.005860762 |

Average: **122.265 passes/sec**

Three-run final Release build:

| Passes | Seconds |
| ---: | ---: |
| 608 | 5.003437466 |
| 605 | 5.009204092 |
| 629 | 5.001341164 |

Average: **122.687 passes/sec** (**+0.34%**)

## Tests

- generator tests: 970 passed
- execution tests: 1,024 passed, 2 skipped
- symbol-table tests: 187 passed
- affected test262 const/block-scope slice: 68 passed, 2 skipped
- Release CLI build: succeeded with no warnings

Closes #1612
Closes #1615
