### PR TITLE
fix: validate decompiler generator test snapshots

### DIFF
--- a/scripts/decompileGeneratorTest.js
+++ b/scripts/decompileGeneratorTest.js
@@ -92,6 +92,17 @@ function findProjectRoot(startDir) {
 
 const projectRoot = findProjectRoot(__dirname);
 
+function getGeneratorTestSnapshotPath(category, testName) {
+  return path.join(
+    projectRoot,
+    'tests',
+    'Jroc.Tests',
+    category,
+    'Snapshots',
+    `GeneratorTests.${testName}.verified.txt`
+  );
+}
+
 function openInIlSpy(assemblyPath) {
   // Launch GUI and let this script exit without waiting.
   const child = childProcess.spawn('ilspy', [assemblyPath], {
@@ -118,6 +129,13 @@ function main() {
 
   const category = args[0];
   const testName = args[1];
+  const snapshotPath = getGeneratorTestSnapshotPath(category, testName);
+  if (!fs.existsSync(snapshotPath)) {
+    console.error(`Generator test snapshot not found: ${snapshotPath}`);
+    console.error('Check the category and test name before running the helper.');
+    process.exit(1);
+  }
+
   const fullTestName = `Jroc.Tests.${category}.GeneratorTests.${testName}`;
   const testProject = path.join(projectRoot, 'tests', 'Jroc.Tests', 'Jroc.Tests.csproj');
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x310a
+				// Method begins at RVA 0x3272
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x223c
 			// Header size: 12
 			// Code size: 185 (0xb9)
 			.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3113
+				// Method begins at RVA 0x327b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,9 +157,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 0c 00 00 02
+				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x22d4
+			// Method begins at RVA 0x2304
 			// Header size: 12
 			// Code size: 167 (0xa7)
 			.maxstack 8
@@ -253,7 +253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x312e
+					// Method begins at RVA 0x3296
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -277,7 +277,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3098
+				// Method begins at RVA 0x3200
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -313,7 +313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3137
+					// Method begins at RVA 0x329f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -338,7 +338,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x30b8
+				// Method begins at RVA 0x3220
 				// Header size: 12
 				// Code size: 61 (0x3d)
 				.maxstack 8
@@ -393,7 +393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3125
+					// Method begins at RVA 0x328d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -414,7 +414,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x311c
+				// Method begins at RVA 0x3284
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -442,7 +442,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3152
+						// Method begins at RVA 0x32ba
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -460,7 +460,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3149
+					// Method begins at RVA 0x32b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -478,7 +478,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3140
+				// Method begins at RVA 0x32a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -504,9 +504,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 0c 00 00 02
+				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2388
+			// Method begins at RVA 0x23b8
 			// Header size: 12
 			// Code size: 591 (0x24f)
 			.maxstack 10
@@ -774,7 +774,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3164
+					// Method begins at RVA 0x32cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -792,7 +792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x315b
+				// Method begins at RVA 0x32c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -818,9 +818,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 0c 00 00 02
+				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x25f4
+			// Method begins at RVA 0x2624
 			// Header size: 12
 			// Code size: 315 (0x13b)
 			.maxstack 10
@@ -1015,7 +1015,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x317f
+						// Method begins at RVA 0x32e7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1033,7 +1033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3176
+					// Method begins at RVA 0x32de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1051,7 +1051,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316d
+				// Method begins at RVA 0x32d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1076,9 +1076,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 0c 00 00 02
+				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x274c
+			// Method begins at RVA 0x277c
 			// Header size: 12
 			// Code size: 343 (0x157)
 			.maxstack 8
@@ -1235,6 +1235,107 @@
 
 	} // end of class findProjectRoot
 
+	.class nested public auto ansi abstract sealed beforefieldinit getGeneratorTestSnapshotPath
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x32f0
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Scripts_DecompileGeneratorTest/Scope scope,
+				object newTarget,
+				object category,
+				object testName
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0d 00 00 02
+			)
+			// Method begins at RVA 0x28e0
+			// Header size: 12
+			// Code size: 104 (0x68)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] string
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: stloc.0
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0012: stloc.1
+			IL_0013: ldarg.3
+			IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0019: stloc.2
+			IL_001a: ldstr "GeneratorTests."
+			IL_001f: ldloc.2
+			IL_0020: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0025: ldstr ".verified.txt"
+			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002f: stloc.2
+			IL_0030: ldloc.0
+			IL_0031: ldstr "join"
+			IL_0036: ldc.i4.6
+			IL_0037: newarr [System.Runtime]System.Object
+			IL_003c: dup
+			IL_003d: ldc.i4.0
+			IL_003e: ldloc.1
+			IL_003f: stelem.ref
+			IL_0040: dup
+			IL_0041: ldc.i4.1
+			IL_0042: ldstr "tests"
+			IL_0047: stelem.ref
+			IL_0048: dup
+			IL_0049: ldc.i4.2
+			IL_004a: ldstr "Jroc.Tests"
+			IL_004f: stelem.ref
+			IL_0050: dup
+			IL_0051: ldc.i4.3
+			IL_0052: ldarg.2
+			IL_0053: stelem.ref
+			IL_0054: dup
+			IL_0055: ldc.i4.4
+			IL_0056: ldstr "Snapshots"
+			IL_005b: stelem.ref
+			IL_005c: dup
+			IL_005d: ldc.i4.5
+			IL_005e: ldloc.2
+			IL_005f: stelem.ref
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0065: stloc.0
+			IL_0066: ldloc.0
+			IL_0067: ret
+		} // end of method getGeneratorTestSnapshotPath::__js_call__
+
+	} // end of class getGeneratorTestSnapshotPath
+
 	.class nested public auto ansi abstract sealed beforefieldinit openInIlSpy
 		extends [System.Runtime]System.Object
 	{
@@ -1246,7 +1347,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3188
+				// Method begins at RVA 0x32f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1271,9 +1372,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 0c 00 00 02
+				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x28b0
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 150 (0x96)
 			.maxstack 8
@@ -1345,14 +1446,14 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
-			.class nested public auto ansi beforefieldinit Block_L110C23
+			.class nested public auto ansi beforefieldinit Block_L121C23
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x319a
+					// Method begins at RVA 0x330b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1361,22 +1462,42 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L110C23::.ctor
+				} // end of method Block_L121C23::.ctor
 
-			} // end of class Block_L110C23
+			} // end of class Block_L121C23
 
-			.class nested public auto ansi beforefieldinit Block_L146C21
+			.class nested public auto ansi beforefieldinit Block_L133C36
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x3314
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L133C36::.ctor
+
+			} // end of class Block_L133C36
+
+			.class nested public auto ansi beforefieldinit Block_L164C21
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested public auto ansi beforefieldinit Block_L158C34
+				.class nested public auto ansi beforefieldinit Block_L176C34
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31ac
+						// Method begins at RVA 0x3326
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1385,16 +1506,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L158C34::.ctor
+					} // end of method Block_L176C34::.ctor
 
-				} // end of class Block_L158C34
+				} // end of class Block_L176C34
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31a3
+					// Method begins at RVA 0x331d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1403,18 +1524,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L146C21::.ctor
+				} // end of method Block_L164C21::.ctor
 
-			} // end of class Block_L146C21
+			} // end of class Block_L164C21
 
-			.class nested public auto ansi beforefieldinit Block_L174C21
+			.class nested public auto ansi beforefieldinit Block_L192C21
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b5
+					// Method begins at RVA 0x332f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1423,22 +1544,22 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L174C21::.ctor
+				} // end of method Block_L192C21::.ctor
 
-			} // end of class Block_L174C21
+			} // end of class Block_L192C21
 
-			.class nested public auto ansi beforefieldinit Scope_For_L178C9
+			.class nested public auto ansi beforefieldinit Scope_For_L196C9
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
-				.class nested public auto ansi beforefieldinit Block_L178C54
+				.class nested public auto ansi beforefieldinit Block_L196C54
 					extends [System.Runtime]System.Object
 				{
 					// Methods
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31c7
+						// Method begins at RVA 0x3341
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1447,16 +1568,16 @@
 						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 						IL_0006: nop
 						IL_0007: ret
-					} // end of method Block_L178C54::.ctor
+					} // end of method Block_L196C54::.ctor
 
-				} // end of class Block_L178C54
+				} // end of class Block_L196C54
 
 
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31be
+					// Method begins at RVA 0x3338
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1465,18 +1586,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Scope_For_L178C9::.ctor
+				} // end of method Scope_For_L196C9::.ctor
 
-			} // end of class Scope_For_L178C9
+			} // end of class Scope_For_L196C9
 
-			.class nested public auto ansi beforefieldinit Block_L188C6
+			.class nested public auto ansi beforefieldinit Block_L206C6
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d0
+					// Method begins at RVA 0x334a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1485,18 +1606,18 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L188C6::.ctor
+				} // end of method Block_L206C6::.ctor
 
-			} // end of class Block_L188C6
+			} // end of class Block_L206C6
 
-			.class nested public auto ansi beforefieldinit Block_L191C16
+			.class nested public auto ansi beforefieldinit Block_L209C16
 				extends [System.Runtime]System.Object
 			{
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d9
+					// Method begins at RVA 0x3353
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1505,16 +1626,16 @@
 					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 					IL_0006: nop
 					IL_0007: ret
-				} // end of method Block_L191C16::.ctor
+				} // end of method Block_L209C16::.ctor
 
-			} // end of class Block_L191C16
+			} // end of class Block_L209C16
 
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3191
+				// Method begins at RVA 0x3302
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1538,45 +1659,46 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 0c 00 00 02
+				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2954
+			// Method begins at RVA 0x29f8
 			// Header size: 12
-			// Code size: 1830 (0x726)
+			// Code size: 2027 (0x7eb)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] string,
-				[4] object,
+				[3] object,
+				[4] string,
 				[5] object,
 				[6] object,
 				[7] object,
 				[8] object,
 				[9] object,
 				[10] object,
-				[11] float64,
-				[12] class [System.Runtime]System.Exception,
-				[13] object,
+				[11] object,
+				[12] float64,
+				[13] class [System.Runtime]System.Exception,
 				[14] object,
 				[15] object,
 				[16] object,
-				[17] string,
-				[18] object,
-				[19] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[21] bool,
-				[22] float64,
-				[23] float64
+				[17] object,
+				[18] bool,
+				[19] string,
+				[20] object,
+				[21] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[23] float64,
+				[24] float64
 			)
 
 			IL_0000: ldstr "process"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: ldstr "argv"
 			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0014: stloc.s 16
-			IL_0016: ldloc.s 16
+			IL_0014: stloc.s 17
+			IL_0016: ldloc.s 17
 			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001d: ldstr "slice"
 			IL_0022: ldc.r8 2
@@ -1586,8 +1708,8 @@
 			IL_0036: ldloc.0
 			IL_0037: ldstr "length"
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 16
-			IL_0043: ldloc.s 16
+			IL_0041: stloc.s 17
+			IL_0043: ldloc.s 17
 			IL_0045: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_004a: ldc.r8 2
 			IL_0053: clt
@@ -1645,493 +1767,552 @@
 			IL_012e: ldc.r8 1
 			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_013c: stloc.2
-			IL_013d: ldloc.1
-			IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0143: stloc.s 17
-			IL_0145: ldstr "Jroc.Tests."
-			IL_014a: ldloc.s 17
-			IL_014c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0151: ldstr ".GeneratorTests."
-			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015b: ldloc.2
-			IL_015c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0161: stloc.s 17
-			IL_0163: ldloc.s 17
-			IL_0165: call string [System.Runtime]System.String::Concat(string, string)
-			IL_016a: stloc.3
-			IL_016b: ldarg.0
-			IL_016c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0176: stloc.s 16
-			IL_0178: ldarg.0
-			IL_0179: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_017e: stloc.s 18
-			IL_0180: ldloc.s 16
-			IL_0182: ldstr "join"
-			IL_0187: ldc.i4.4
-			IL_0188: newarr [System.Runtime]System.Object
-			IL_018d: dup
-			IL_018e: ldc.i4.0
-			IL_018f: ldloc.s 18
-			IL_0191: stelem.ref
-			IL_0192: dup
-			IL_0193: ldc.i4.1
-			IL_0194: ldstr "tests"
-			IL_0199: stelem.ref
-			IL_019a: dup
-			IL_019b: ldc.i4.2
-			IL_019c: ldstr "Jroc.Tests"
-			IL_01a1: stelem.ref
-			IL_01a2: dup
-			IL_01a3: ldc.i4.3
-			IL_01a4: ldstr "Jroc.Tests.csproj"
-			IL_01a9: stelem.ref
-			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_01af: stloc.s 4
-			IL_01b1: ldstr "console"
-			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c0: stloc.s 16
-			IL_01c2: ldloc.3
-			IL_01c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c8: stloc.s 17
-			IL_01ca: ldstr "Running test: "
-			IL_01cf: ldloc.s 17
-			IL_01d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d6: stloc.s 17
-			IL_01d8: ldloc.s 16
-			IL_01da: ldstr "log"
-			IL_01df: ldloc.s 17
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e6: pop
-			IL_01e7: ldarg.0
-			IL_01e8: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f2: stloc.s 16
-			IL_01f4: ldloc.3
-			IL_01f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01fa: stloc.s 17
-			IL_01fc: ldstr "FullyQualifiedName="
-			IL_0201: ldloc.s 17
-			IL_0203: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0208: stloc.s 17
-			IL_020a: ldc.i4.5
-			IL_020b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0210: dup
-			IL_0211: ldstr "test"
-			IL_0216: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_021b: dup
-			IL_021c: ldloc.s 4
-			IL_021e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0223: dup
-			IL_0224: ldstr "--filter"
-			IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_022e: dup
-			IL_022f: ldloc.s 17
-			IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0236: dup
-			IL_0237: ldstr "--no-build"
-			IL_023c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0241: stloc.s 19
-			IL_0243: ldarg.0
-			IL_0244: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0249: stloc.s 18
-			IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0250: dup
-			IL_0251: ldstr "stdio"
-			IL_0256: ldstr "inherit"
-			IL_025b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0260: dup
-			IL_0261: ldstr "shell"
-			IL_0266: ldc.i4.1
-			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_026c: dup
-			IL_026d: ldstr "cwd"
-			IL_0272: ldloc.s 18
-			IL_0274: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0279: stloc.s 20
-			IL_027b: ldloc.s 16
-			IL_027d: ldstr "spawnSync"
-			IL_0282: ldstr "dotnet"
-			IL_0287: ldloc.s 19
-			IL_0289: ldloc.s 20
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0290: stloc.s 5
-			IL_0292: ldarg.0
-			IL_0293: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_0298: ldc.i4.1
-			IL_0299: newarr [System.Runtime]System.Object
-			IL_029e: dup
-			IL_029f: ldc.i4.0
-			IL_02a0: ldarg.0
-			IL_02a1: stelem.ref
-			IL_02a2: ldloc.2
-			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02a8: stloc.s 6
-			IL_02aa: ldloc.s 5
-			IL_02ac: ldstr "status"
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b6: stloc.s 16
-			IL_02b8: ldloc.s 16
-			IL_02ba: ldc.r8 0.0
-			IL_02c3: box [System.Runtime]System.Double
-			IL_02c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_02cd: stloc.s 21
-			IL_02cf: ldloc.s 21
-			IL_02d1: brfalse IL_02f9
+			IL_013d: ldarg.0
+			IL_013e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
+			IL_0143: ldc.i4.1
+			IL_0144: newarr [System.Runtime]System.Object
+			IL_0149: dup
+			IL_014a: ldc.i4.0
+			IL_014b: ldarg.0
+			IL_014c: stelem.ref
+			IL_014d: ldloc.1
+			IL_014e: ldloc.2
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0154: stloc.3
+			IL_0155: ldarg.0
+			IL_0156: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0160: ldstr "existsSync"
+			IL_0165: ldloc.3
+			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_016b: stloc.s 17
+			IL_016d: ldloc.s 17
+			IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0174: ldc.i4.0
+			IL_0175: ceq
+			IL_0177: stloc.s 18
+			IL_0179: ldloc.s 18
+			IL_017b: brfalse IL_01fd
 
-			IL_02d6: ldarg.0
-			IL_02d7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_02dc: ldc.i4.1
-			IL_02dd: newarr [System.Runtime]System.Object
-			IL_02e2: dup
-			IL_02e3: ldc.i4.0
-			IL_02e4: ldarg.0
-			IL_02e5: stelem.ref
-			IL_02e6: ldloc.1
-			IL_02e7: ldloc.s 6
-			IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02ee: stloc.s 16
-			IL_02f0: ldloc.s 16
-			IL_02f2: stloc.s 7
-			IL_02f4: br IL_0301
+			IL_0180: ldstr "console"
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018f: stloc.s 17
+			IL_0191: ldloc.3
+			IL_0192: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0197: stloc.s 19
+			IL_0199: ldstr "Generator test snapshot not found: "
+			IL_019e: ldloc.s 19
+			IL_01a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a5: stloc.s 19
+			IL_01a7: ldloc.s 17
+			IL_01a9: ldstr "error"
+			IL_01ae: ldloc.s 19
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b5: pop
+			IL_01b6: ldstr "console"
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c5: ldstr "error"
+			IL_01ca: ldstr "Check the category and test name before running the helper."
+			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01d4: pop
+			IL_01d5: ldstr "process"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e4: ldstr "exit"
+			IL_01e9: ldc.r8 1
+			IL_01f2: box [System.Runtime]System.Double
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01fc: pop
 
-			IL_02f9: ldc.i4.0
-			IL_02fa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02ff: stloc.s 7
+			IL_01fd: ldloc.1
+			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0203: stloc.s 19
+			IL_0205: ldstr "Jroc.Tests."
+			IL_020a: ldloc.s 19
+			IL_020c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0211: ldstr ".GeneratorTests."
+			IL_0216: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021b: ldloc.2
+			IL_021c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0221: stloc.s 19
+			IL_0223: ldloc.s 19
+			IL_0225: call string [System.Runtime]System.String::Concat(string, string)
+			IL_022a: stloc.s 4
+			IL_022c: ldarg.0
+			IL_022d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0237: stloc.s 17
+			IL_0239: ldarg.0
+			IL_023a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_023f: stloc.s 20
+			IL_0241: ldloc.s 17
+			IL_0243: ldstr "join"
+			IL_0248: ldc.i4.4
+			IL_0249: newarr [System.Runtime]System.Object
+			IL_024e: dup
+			IL_024f: ldc.i4.0
+			IL_0250: ldloc.s 20
+			IL_0252: stelem.ref
+			IL_0253: dup
+			IL_0254: ldc.i4.1
+			IL_0255: ldstr "tests"
+			IL_025a: stelem.ref
+			IL_025b: dup
+			IL_025c: ldc.i4.2
+			IL_025d: ldstr "Jroc.Tests"
+			IL_0262: stelem.ref
+			IL_0263: dup
+			IL_0264: ldc.i4.3
+			IL_0265: ldstr "Jroc.Tests.csproj"
+			IL_026a: stelem.ref
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0270: stloc.s 5
+			IL_0272: ldstr "console"
+			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0281: stloc.s 17
+			IL_0283: ldloc.s 4
+			IL_0285: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_028a: stloc.s 19
+			IL_028c: ldstr "Running test: "
+			IL_0291: ldloc.s 19
+			IL_0293: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0298: stloc.s 19
+			IL_029a: ldloc.s 17
+			IL_029c: ldstr "log"
+			IL_02a1: ldloc.s 19
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02a8: pop
+			IL_02a9: ldarg.0
+			IL_02aa: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b4: stloc.s 17
+			IL_02b6: ldloc.s 4
+			IL_02b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02bd: stloc.s 19
+			IL_02bf: ldstr "FullyQualifiedName="
+			IL_02c4: ldloc.s 19
+			IL_02c6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02cb: stloc.s 19
+			IL_02cd: ldc.i4.5
+			IL_02ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02d3: dup
+			IL_02d4: ldstr "test"
+			IL_02d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02de: dup
+			IL_02df: ldloc.s 5
+			IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e6: dup
+			IL_02e7: ldstr "--filter"
+			IL_02ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f1: dup
+			IL_02f2: ldloc.s 19
+			IL_02f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f9: dup
+			IL_02fa: ldstr "--no-build"
+			IL_02ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0304: stloc.s 21
+			IL_0306: ldarg.0
+			IL_0307: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_030c: stloc.s 20
+			IL_030e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0313: dup
+			IL_0314: ldstr "stdio"
+			IL_0319: ldstr "inherit"
+			IL_031e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0323: dup
+			IL_0324: ldstr "shell"
+			IL_0329: ldc.i4.1
+			IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_032f: dup
+			IL_0330: ldstr "cwd"
+			IL_0335: ldloc.s 20
+			IL_0337: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_033c: stloc.s 22
+			IL_033e: ldloc.s 17
+			IL_0340: ldstr "spawnSync"
+			IL_0345: ldstr "dotnet"
+			IL_034a: ldloc.s 21
+			IL_034c: ldloc.s 22
+			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0353: stloc.s 6
+			IL_0355: ldarg.0
+			IL_0356: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_035b: ldc.i4.1
+			IL_035c: newarr [System.Runtime]System.Object
+			IL_0361: dup
+			IL_0362: ldc.i4.0
+			IL_0363: ldarg.0
+			IL_0364: stelem.ref
+			IL_0365: ldloc.2
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_036b: stloc.s 7
+			IL_036d: ldloc.s 6
+			IL_036f: ldstr "status"
+			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0379: stloc.s 17
+			IL_037b: ldloc.s 17
+			IL_037d: ldc.r8 0.0
+			IL_0386: box [System.Runtime]System.Double
+			IL_038b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0390: stloc.s 18
+			IL_0392: ldloc.s 18
+			IL_0394: brfalse IL_03bc
 
-			IL_0301: ldloc.s 7
-			IL_0303: stloc.s 8
-			IL_0305: ldloc.s 8
-			IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_030c: ldc.i4.0
-			IL_030d: ceq
-			IL_030f: stloc.s 21
-			IL_0311: ldloc.s 21
-			IL_0313: brfalse IL_0489
-
-			IL_0318: ldstr "console"
-			IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0327: ldstr "log"
-			IL_032c: ldstr "Test did not produce an assembly, retrying with build..."
-			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0336: pop
-			IL_0337: ldarg.0
-			IL_0338: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0342: stloc.s 16
-			IL_0344: ldloc.3
-			IL_0345: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_034a: stloc.s 17
-			IL_034c: ldstr "FullyQualifiedName="
-			IL_0351: ldloc.s 17
-			IL_0353: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0358: stloc.s 17
-			IL_035a: ldc.i4.4
-			IL_035b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0360: dup
-			IL_0361: ldstr "test"
-			IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_036b: dup
-			IL_036c: ldloc.s 4
-			IL_036e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0373: dup
-			IL_0374: ldstr "--filter"
-			IL_0379: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_037e: dup
-			IL_037f: ldloc.s 17
-			IL_0381: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0386: stloc.s 19
-			IL_0388: ldarg.0
-			IL_0389: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_038e: stloc.s 18
-			IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0395: dup
-			IL_0396: ldstr "stdio"
-			IL_039b: ldstr "inherit"
-			IL_03a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0399: ldarg.0
+			IL_039a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_039f: ldc.i4.1
+			IL_03a0: newarr [System.Runtime]System.Object
 			IL_03a5: dup
-			IL_03a6: ldstr "shell"
-			IL_03ab: ldc.i4.1
-			IL_03ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03b1: dup
-			IL_03b2: ldstr "cwd"
-			IL_03b7: ldloc.s 18
-			IL_03b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03be: stloc.s 20
-			IL_03c0: ldloc.s 16
-			IL_03c2: ldstr "spawnSync"
-			IL_03c7: ldstr "dotnet"
-			IL_03cc: ldloc.s 19
-			IL_03ce: ldloc.s 20
-			IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_03d5: stloc.s 9
-			IL_03d7: ldloc.s 9
-			IL_03d9: ldstr "status"
-			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e3: stloc.s 16
-			IL_03e5: ldloc.s 16
-			IL_03e7: ldc.r8 0.0
-			IL_03f0: box [System.Runtime]System.Double
-			IL_03f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03fa: stloc.s 21
-			IL_03fc: ldloc.s 21
-			IL_03fe: brfalse IL_046b
+			IL_03a6: ldc.i4.0
+			IL_03a7: ldarg.0
+			IL_03a8: stelem.ref
+			IL_03a9: ldloc.1
+			IL_03aa: ldloc.s 7
+			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03b1: stloc.s 17
+			IL_03b3: ldloc.s 17
+			IL_03b5: stloc.s 8
+			IL_03b7: br IL_03c4
 
-			IL_0403: ldstr "console"
-			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0412: stloc.s 16
-			IL_0414: ldloc.3
-			IL_0415: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_041a: stloc.s 17
-			IL_041c: ldstr "Test "
-			IL_0421: ldloc.s 17
-			IL_0423: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0428: ldstr " failed or not found."
-			IL_042d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0432: stloc.s 17
-			IL_0434: ldloc.s 16
-			IL_0436: ldstr "error"
-			IL_043b: ldloc.s 17
-			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0442: pop
-			IL_0443: ldstr "process"
-			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0452: ldstr "exit"
-			IL_0457: ldc.r8 1
-			IL_0460: box [System.Runtime]System.Double
-			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_046a: pop
+			IL_03bc: ldc.i4.0
+			IL_03bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03c2: stloc.s 8
 
-			IL_046b: ldarg.0
-			IL_046c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_0471: ldc.i4.1
-			IL_0472: newarr [System.Runtime]System.Object
-			IL_0477: dup
-			IL_0478: ldc.i4.0
-			IL_0479: ldarg.0
-			IL_047a: stelem.ref
-			IL_047b: ldloc.1
-			IL_047c: ldloc.s 6
-			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0483: stloc.s 16
-			IL_0485: ldloc.s 16
-			IL_0487: stloc.s 8
+			IL_03c4: ldloc.s 8
+			IL_03c6: stloc.s 9
+			IL_03c8: ldloc.s 9
+			IL_03ca: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03cf: ldc.i4.0
+			IL_03d0: ceq
+			IL_03d2: stloc.s 18
+			IL_03d4: ldloc.s 18
+			IL_03d6: brfalse IL_054e
 
-			IL_0489: ldloc.s 8
-			IL_048b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0490: ldc.i4.0
-			IL_0491: ceq
-			IL_0493: stloc.s 21
-			IL_0495: ldloc.s 21
-			IL_0497: brfalse IL_05ef
+			IL_03db: ldstr "console"
+			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ea: ldstr "log"
+			IL_03ef: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03f9: pop
+			IL_03fa: ldarg.0
+			IL_03fb: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0405: stloc.s 17
+			IL_0407: ldloc.s 4
+			IL_0409: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040e: stloc.s 19
+			IL_0410: ldstr "FullyQualifiedName="
+			IL_0415: ldloc.s 19
+			IL_0417: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041c: stloc.s 19
+			IL_041e: ldc.i4.4
+			IL_041f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0424: dup
+			IL_0425: ldstr "test"
+			IL_042a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_042f: dup
+			IL_0430: ldloc.s 5
+			IL_0432: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0437: dup
+			IL_0438: ldstr "--filter"
+			IL_043d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0442: dup
+			IL_0443: ldloc.s 19
+			IL_0445: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_044a: stloc.s 21
+			IL_044c: ldarg.0
+			IL_044d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0452: stloc.s 20
+			IL_0454: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0459: dup
+			IL_045a: ldstr "stdio"
+			IL_045f: ldstr "inherit"
+			IL_0464: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0469: dup
+			IL_046a: ldstr "shell"
+			IL_046f: ldc.i4.1
+			IL_0470: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0475: dup
+			IL_0476: ldstr "cwd"
+			IL_047b: ldloc.s 20
+			IL_047d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0482: stloc.s 22
+			IL_0484: ldloc.s 17
+			IL_0486: ldstr "spawnSync"
+			IL_048b: ldstr "dotnet"
+			IL_0490: ldloc.s 21
+			IL_0492: ldloc.s 22
+			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0499: stloc.s 10
+			IL_049b: ldloc.s 10
+			IL_049d: ldstr "status"
+			IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a7: stloc.s 17
+			IL_04a9: ldloc.s 17
+			IL_04ab: ldc.r8 0.0
+			IL_04b4: box [System.Runtime]System.Double
+			IL_04b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_04be: stloc.s 18
+			IL_04c0: ldloc.s 18
+			IL_04c2: brfalse IL_0530
 
-			IL_049c: ldstr "console"
-			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ab: stloc.s 16
-			IL_04ad: ldloc.1
-			IL_04ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04b3: stloc.s 17
-			IL_04b5: ldstr "Assembly not found for category '"
-			IL_04ba: ldloc.s 17
-			IL_04bc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04c1: ldstr "' and test '"
-			IL_04c6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04cb: ldloc.2
-			IL_04cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04d1: stloc.s 17
-			IL_04d3: ldloc.s 17
-			IL_04d5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04da: ldstr "'."
-			IL_04df: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04e4: stloc.s 17
-			IL_04e6: ldloc.s 16
-			IL_04e8: ldstr "error"
-			IL_04ed: ldloc.s 17
-			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04f4: pop
-			IL_04f5: ldstr "console"
-			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0504: ldstr "error"
-			IL_0509: ldstr "Looked under:"
-			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0513: pop
-			IL_0514: ldarg.0
-			IL_0515: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_051a: ldc.i4.1
-			IL_051b: newarr [System.Runtime]System.Object
-			IL_0520: dup
-			IL_0521: ldc.i4.0
-			IL_0522: ldarg.0
-			IL_0523: stelem.ref
-			IL_0524: ldloc.1
-			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_052a: stloc.s 10
-			IL_052c: ldc.r8 0.0
-			IL_0535: stloc.s 11
-			// loop start (head: IL_0537)
-				IL_0537: ldloc.s 11
-				IL_0539: stloc.s 22
-				IL_053b: ldloc.s 10
-				IL_053d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_0542: stloc.s 23
-				IL_0544: ldloc.s 22
-				IL_0546: ldloc.s 23
-				IL_0548: clt
-				IL_054a: brfalse IL_05a8
+			IL_04c7: ldstr "console"
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04d6: stloc.s 17
+			IL_04d8: ldloc.s 4
+			IL_04da: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04df: stloc.s 19
+			IL_04e1: ldstr "Test "
+			IL_04e6: ldloc.s 19
+			IL_04e8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04ed: ldstr " failed or not found."
+			IL_04f2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04f7: stloc.s 19
+			IL_04f9: ldloc.s 17
+			IL_04fb: ldstr "error"
+			IL_0500: ldloc.s 19
+			IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0507: pop
+			IL_0508: ldstr "process"
+			IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0517: ldstr "exit"
+			IL_051c: ldc.r8 1
+			IL_0525: box [System.Runtime]System.Double
+			IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_052f: pop
 
-				IL_054f: ldstr "console"
-				IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_055e: stloc.s 16
-				IL_0560: ldloc.s 10
-				IL_0562: ldloc.s 11
-				IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0569: stloc.s 18
-				IL_056b: ldloc.s 18
-				IL_056d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0572: stloc.s 17
-				IL_0574: ldstr "  - "
-				IL_0579: ldloc.s 17
-				IL_057b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0580: stloc.s 17
-				IL_0582: ldloc.s 16
-				IL_0584: ldstr "error"
-				IL_0589: ldloc.s 17
-				IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0590: pop
-				IL_0591: ldloc.s 11
-				IL_0593: ldc.r8 1
-				IL_059c: add
-				IL_059d: stloc.s 23
-				IL_059f: ldloc.s 23
-				IL_05a1: stloc.s 11
-				IL_05a3: br IL_0537
+			IL_0530: ldarg.0
+			IL_0531: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_0536: ldc.i4.1
+			IL_0537: newarr [System.Runtime]System.Object
+			IL_053c: dup
+			IL_053d: ldc.i4.0
+			IL_053e: ldarg.0
+			IL_053f: stelem.ref
+			IL_0540: ldloc.1
+			IL_0541: ldloc.s 7
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0548: stloc.s 17
+			IL_054a: ldloc.s 17
+			IL_054c: stloc.s 9
+
+			IL_054e: ldloc.s 9
+			IL_0550: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0555: ldc.i4.0
+			IL_0556: ceq
+			IL_0558: stloc.s 18
+			IL_055a: ldloc.s 18
+			IL_055c: brfalse IL_06b4
+
+			IL_0561: ldstr "console"
+			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0570: stloc.s 17
+			IL_0572: ldloc.1
+			IL_0573: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0578: stloc.s 19
+			IL_057a: ldstr "Assembly not found for category '"
+			IL_057f: ldloc.s 19
+			IL_0581: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0586: ldstr "' and test '"
+			IL_058b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0590: ldloc.2
+			IL_0591: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0596: stloc.s 19
+			IL_0598: ldloc.s 19
+			IL_059a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_059f: ldstr "'."
+			IL_05a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05a9: stloc.s 19
+			IL_05ab: ldloc.s 17
+			IL_05ad: ldstr "error"
+			IL_05b2: ldloc.s 19
+			IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05b9: pop
+			IL_05ba: ldstr "console"
+			IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c9: ldstr "error"
+			IL_05ce: ldstr "Looked under:"
+			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05d8: pop
+			IL_05d9: ldarg.0
+			IL_05da: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_05df: ldc.i4.1
+			IL_05e0: newarr [System.Runtime]System.Object
+			IL_05e5: dup
+			IL_05e6: ldc.i4.0
+			IL_05e7: ldarg.0
+			IL_05e8: stelem.ref
+			IL_05e9: ldloc.1
+			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_05ef: stloc.s 11
+			IL_05f1: ldc.r8 0.0
+			IL_05fa: stloc.s 12
+			// loop start (head: IL_05fc)
+				IL_05fc: ldloc.s 12
+				IL_05fe: stloc.s 23
+				IL_0600: ldloc.s 11
+				IL_0602: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+				IL_0607: stloc.s 24
+				IL_0609: ldloc.s 23
+				IL_060b: ldloc.s 24
+				IL_060d: clt
+				IL_060f: brfalse IL_066d
+
+				IL_0614: ldstr "console"
+				IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0623: stloc.s 17
+				IL_0625: ldloc.s 11
+				IL_0627: ldloc.s 12
+				IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_062e: stloc.s 20
+				IL_0630: ldloc.s 20
+				IL_0632: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0637: stloc.s 19
+				IL_0639: ldstr "  - "
+				IL_063e: ldloc.s 19
+				IL_0640: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0645: stloc.s 19
+				IL_0647: ldloc.s 17
+				IL_0649: ldstr "error"
+				IL_064e: ldloc.s 19
+				IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0655: pop
+				IL_0656: ldloc.s 12
+				IL_0658: ldc.r8 1
+				IL_0661: add
+				IL_0662: stloc.s 24
+				IL_0664: ldloc.s 24
+				IL_0666: stloc.s 12
+				IL_0668: br IL_05fc
 			// end loop
 
-			IL_05a8: ldstr "console"
-			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05b7: ldstr "error"
-			IL_05bc: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05c6: pop
-			IL_05c7: ldstr "process"
-			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05d6: ldstr "exit"
-			IL_05db: ldc.r8 1
-			IL_05e4: box [System.Runtime]System.Double
-			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05ee: pop
+			IL_066d: ldstr "console"
+			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_067c: ldstr "error"
+			IL_0681: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_068b: pop
+			IL_068c: ldstr "process"
+			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_069b: ldstr "exit"
+			IL_06a0: ldc.r8 1
+			IL_06a9: box [System.Runtime]System.Double
+			IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06b3: pop
 
-			IL_05ef: ldstr "console"
-			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05fe: stloc.s 16
-			IL_0600: ldloc.s 8
-			IL_0602: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0607: stloc.s 17
-			IL_0609: ldstr "Found assembly: "
-			IL_060e: ldloc.s 17
-			IL_0610: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0615: stloc.s 17
-			IL_0617: ldloc.s 16
-			IL_0619: ldstr "log"
-			IL_061e: ldloc.s 17
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0625: pop
+			IL_06b4: ldstr "console"
+			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06c3: stloc.s 17
+			IL_06c5: ldloc.s 9
+			IL_06c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06cc: stloc.s 19
+			IL_06ce: ldstr "Found assembly: "
+			IL_06d3: ldloc.s 19
+			IL_06d5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06da: stloc.s 19
+			IL_06dc: ldloc.s 17
+			IL_06de: ldstr "log"
+			IL_06e3: ldloc.s 19
+			IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06ea: pop
 			.try
 			{
-				IL_0626: nop
-				IL_0627: ldstr "console"
-				IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0636: ldstr "log"
-				IL_063b: ldstr "Opening in ILSpy..."
-				IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0645: pop
-				IL_0646: ldarg.0
-				IL_0647: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_064c: stloc.s 16
-				IL_064e: ldloc.s 16
-				IL_0650: ldc.i4.1
-				IL_0651: newarr [System.Runtime]System.Object
-				IL_0656: dup
-				IL_0657: ldc.i4.0
-				IL_0658: ldarg.0
-				IL_0659: stelem.ref
-				IL_065a: ldloc.s 8
-				IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0661: pop
-				IL_0662: leave IL_0701
+				IL_06eb: nop
+				IL_06ec: ldstr "console"
+				IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06fb: ldstr "log"
+				IL_0700: ldstr "Opening in ILSpy..."
+				IL_0705: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_070a: pop
+				IL_070b: ldarg.0
+				IL_070c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_0711: stloc.s 17
+				IL_0713: ldloc.s 17
+				IL_0715: ldc.i4.1
+				IL_0716: newarr [System.Runtime]System.Object
+				IL_071b: dup
+				IL_071c: ldc.i4.0
+				IL_071d: ldarg.0
+				IL_071e: stelem.ref
+				IL_071f: ldloc.s 9
+				IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0726: pop
+				IL_0727: leave IL_07c6
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0667: stloc.s 12
-				IL_0669: ldloc.s 12
-				IL_066b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0670: dup
-				IL_0671: brtrue IL_0687
+				IL_072c: stloc.s 13
+				IL_072e: ldloc.s 13
+				IL_0730: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0735: dup
+				IL_0736: brtrue IL_074c
 
-				IL_0676: pop
-				IL_0677: ldloc.s 12
-				IL_0679: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_067e: dup
-				IL_067f: brtrue IL_0693
+				IL_073b: pop
+				IL_073c: ldloc.s 13
+				IL_073e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0743: dup
+				IL_0744: brtrue IL_0758
 
-				IL_0684: pop
-				IL_0685: rethrow
+				IL_0749: pop
+				IL_074a: rethrow
 
-				IL_0687: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_068c: stloc.s 13
-				IL_068e: br IL_0695
+				IL_074c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0751: stloc.s 14
+				IL_0753: br IL_075a
 
-				IL_0693: stloc.s 13
+				IL_0758: stloc.s 14
 
-				IL_0695: ldloc.s 13
-				IL_0697: stloc.s 14
-				IL_0699: ldstr "console"
-				IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06a8: ldstr "error"
-				IL_06ad: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06b7: pop
-				IL_06b8: ldstr "console"
-				IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06c7: ldstr "error"
-				IL_06cc: ldloc.s 14
-				IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06d3: pop
-				IL_06d4: ldstr "process"
-				IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06e3: ldstr "exit"
-				IL_06e8: ldc.r8 1
-				IL_06f1: box [System.Runtime]System.Double
-				IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06fb: pop
-				IL_06fc: leave IL_0701
+				IL_075a: ldloc.s 14
+				IL_075c: stloc.s 15
+				IL_075e: ldstr "console"
+				IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_076d: ldstr "error"
+				IL_0772: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_077c: pop
+				IL_077d: ldstr "console"
+				IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_078c: ldstr "error"
+				IL_0791: ldloc.s 15
+				IL_0793: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0798: pop
+				IL_0799: ldstr "process"
+				IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_07a8: ldstr "exit"
+				IL_07ad: ldc.r8 1
+				IL_07b6: box [System.Runtime]System.Double
+				IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_07c0: pop
+				IL_07c1: leave IL_07c6
 			} // end handler
 
-			IL_0701: ldstr "console"
-			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0710: ldstr "log"
-			IL_0715: ldstr "Done!"
-			IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_071f: pop
-			IL_0720: ldnull
-			IL_0721: stloc.s 15
-			IL_0723: ldloc.s 15
-			IL_0725: ret
+			IL_07c6: ldstr "console"
+			IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07d5: ldstr "log"
+			IL_07da: ldstr "Done!"
+			IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07e4: pop
+			IL_07e5: ldnull
+			IL_07e6: stloc.s 16
+			IL_07e8: ldloc.s 16
+			IL_07ea: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2173,6 +2354,7 @@
 		.field public object tryFindLatestGeneratedAssembly
 		.field public object findProjectRoot
 		.field public object projectRoot
+		.field public object getGeneratorTestSnapshotPath
 		.field public object openInIlSpy
 		.field public object main
 
@@ -2180,7 +2362,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3101
+			// Method begins at RVA 0x3269
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2206,7 +2388,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 431 (0x1af)
+		// Code size: 478 (0x1de)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_DecompileGeneratorTest/Scope,
@@ -2293,82 +2475,98 @@
 		IL_00d9: stloc.1
 		IL_00da: ldloc.0
 		IL_00db: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_00e0: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00eb: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00f0: ldc.i4.1
+		IL_00e0: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+		IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00eb: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_00f0: ldc.i4.2
 		IL_00f1: conv.r8
-		IL_00f2: ldstr "openInIlSpy"
+		IL_00f2: ldstr "getGeneratorTestSnapshotPath"
 		IL_00f7: ldc.i4.0
 		IL_00f8: ldc.i4.1
-		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00fe: stloc.3
-		IL_00ff: ldloc.0
-		IL_0100: ldloc.3
-		IL_0101: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-		IL_0106: ldloc.0
-		IL_0107: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_010c: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
-		IL_0112: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0117: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_011c: ldc.i4.0
-		IL_011d: conv.r8
-		IL_011e: ldstr "main"
-		IL_0123: ldc.i4.0
-		IL_0124: ldc.i4.1
-		IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_012a: stloc.2
-		IL_012b: nop
-		IL_012c: ldarg.1
-		IL_012d: ldstr "node:child_process"
-		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0137: stloc.s 5
-		IL_0139: ldloc.0
-		IL_013a: ldloc.s 5
-		IL_013c: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-		IL_0141: ldarg.1
-		IL_0142: ldstr "node:fs"
-		IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_014c: stloc.s 5
-		IL_014e: ldloc.0
-		IL_014f: ldloc.s 5
-		IL_0151: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-		IL_0156: ldarg.1
-		IL_0157: ldstr "node:path"
-		IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0161: stloc.s 5
-		IL_0163: ldloc.0
-		IL_0164: ldloc.s 5
-		IL_0166: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-		IL_016b: ldarg.1
-		IL_016c: ldstr "node:os"
-		IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0176: stloc.s 5
-		IL_0178: ldloc.0
-		IL_0179: ldloc.s 5
-		IL_017b: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-		IL_0180: nop
-		IL_0181: nop
-		IL_0182: nop
-		IL_0183: nop
-		IL_0184: nop
-		IL_0185: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_018a: stloc.s 6
-		IL_018c: ldloc.1
-		IL_018d: ldloc.s 6
-		IL_018f: ldarg.s __dirname
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
-		IL_0196: stloc.s 5
-		IL_0198: ldloc.0
-		IL_0199: ldloc.s 5
-		IL_019b: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-		IL_01a0: nop
-		IL_01a1: nop
-		IL_01a2: ldloc.2
-		IL_01a3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_01ad: pop
-		IL_01ae: ret
+		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_00fe: stloc.s 4
+		IL_0100: ldloc.0
+		IL_0101: ldloc.s 4
+		IL_0103: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
+		IL_0108: ldloc.0
+		IL_0109: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+		IL_010e: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+		IL_0114: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0119: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_011e: ldc.i4.1
+		IL_011f: conv.r8
+		IL_0120: ldstr "openInIlSpy"
+		IL_0125: ldc.i4.0
+		IL_0126: ldc.i4.1
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_012c: stloc.3
+		IL_012d: ldloc.0
+		IL_012e: ldloc.3
+		IL_012f: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+		IL_0134: ldloc.0
+		IL_0135: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+		IL_013a: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
+		IL_0140: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0145: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_014a: ldc.i4.0
+		IL_014b: conv.r8
+		IL_014c: ldstr "main"
+		IL_0151: ldc.i4.0
+		IL_0152: ldc.i4.1
+		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0158: stloc.2
+		IL_0159: nop
+		IL_015a: ldarg.1
+		IL_015b: ldstr "node:child_process"
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0165: stloc.s 5
+		IL_0167: ldloc.0
+		IL_0168: ldloc.s 5
+		IL_016a: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+		IL_016f: ldarg.1
+		IL_0170: ldstr "node:fs"
+		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_017a: stloc.s 5
+		IL_017c: ldloc.0
+		IL_017d: ldloc.s 5
+		IL_017f: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+		IL_0184: ldarg.1
+		IL_0185: ldstr "node:path"
+		IL_018a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_018f: stloc.s 5
+		IL_0191: ldloc.0
+		IL_0192: ldloc.s 5
+		IL_0194: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+		IL_0199: ldarg.1
+		IL_019a: ldstr "node:os"
+		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_01a4: stloc.s 5
+		IL_01a6: ldloc.0
+		IL_01a7: ldloc.s 5
+		IL_01a9: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
+		IL_01ae: nop
+		IL_01af: nop
+		IL_01b0: nop
+		IL_01b1: nop
+		IL_01b2: nop
+		IL_01b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01b8: stloc.s 6
+		IL_01ba: ldloc.1
+		IL_01bb: ldloc.s 6
+		IL_01bd: ldarg.s __dirname
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[], object)
+		IL_01c4: stloc.s 5
+		IL_01c6: ldloc.0
+		IL_01c7: ldloc.s 5
+		IL_01c9: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+		IL_01ce: nop
+		IL_01cf: nop
+		IL_01d0: nop
+		IL_01d1: ldloc.2
+		IL_01d2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_01dc: pop
+		IL_01dd: ret
 	} // end of method Compile_Scripts_DecompileGeneratorTest::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_DecompileGeneratorTest
@@ -2380,7 +2578,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31e2
+		// Method begins at RVA 0x335c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
Adds an early, actionable snapshot-existence check to the decompiler generator-test helper and updates its verified generator snapshot.

Tested: dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --filter FullyQualifiedName=Jroc.Tests.Integration.GeneratorTests.Compile_Scripts_DecompileGeneratorTest --nologo