### PR TITLE
fix(compiler): preserve captured node contract field types

### DIFF
--- a/src/Compiler/Services/TypeGenerator.cs
+++ b/src/Compiler/Services/TypeGenerator.cs
@@ -166,14 +166,7 @@ namespace Jroc.Services
 
             if (binding.IsStableType && binding.ClrType != null)
             {
-                if (binding.ClrType == typeof(double)
-                    || binding.ClrType == typeof(bool)
-                    || binding.ClrType == typeof(string)
-                    || binding.ClrType == typeof(JavaScriptRuntime.Array)
-                    || binding.ClrType == typeof(JavaScriptRuntime.RegExp))
-                {
-                    return binding.ClrType;
-                }
+                return binding.ClrType;
             }
 
             return typeof(object);

--- a/src/Compiler/Services/TypeGenerator.cs
+++ b/src/Compiler/Services/TypeGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection;
+using Jroc.Runtime.Node.Contracts;
 using Jroc.SymbolTables;
 using Jroc.Services.VariableBindings;
 using System.Linq;
@@ -152,6 +153,13 @@ namespace Jroc.Services
                 && !binding.HasWrite;
         }
 
+        private static bool IsNodeModuleContractType(Type type)
+            => type.IsInterface
+                && type.GetCustomAttributes(
+                        typeof(NodeModuleInterfaceAttribute),
+                        inherit: false)
+                    .Length == 1;
+
         private static Type GetDeclaredScopeFieldClrType(Scope scope, BindingInfo binding)
         {
             if (IsSafeInjectedCommonJsRequireBinding(scope, binding))
@@ -166,7 +174,15 @@ namespace Jroc.Services
 
             if (binding.IsStableType && binding.ClrType != null)
             {
-                return binding.ClrType;
+                if (binding.ClrType == typeof(double)
+                    || binding.ClrType == typeof(bool)
+                    || binding.ClrType == typeof(string)
+                    || binding.ClrType == typeof(JavaScriptRuntime.Array)
+                    || binding.ClrType == typeof(JavaScriptRuntime.RegExp)
+                    || IsNodeModuleContractType(binding.ClrType))
+                {
+                    return binding.ClrType;
+                }
             }
 
             return typeof(object);

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52d9
+				// Method begins at RVA 0x5279
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52f4
+						// Method begins at RVA 0x5294
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x52fd
+						// Method begins at RVA 0x529d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5306
+						// Method begins at RVA 0x52a6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x530f
+						// Method begins at RVA 0x52af
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5318
+						// Method begins at RVA 0x52b8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5321
+						// Method begins at RVA 0x52c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52eb
+					// Method begins at RVA 0x528b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52e2
+				// Method begins at RVA 0x5282
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -500,7 +500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x532a
+				// Method begins at RVA 0x52ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -610,7 +610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5333
+				// Method begins at RVA 0x52d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -638,7 +638,7 @@
 			)
 			// Method begins at RVA 0x2a80
 			// Header size: 12
-			// Code size: 161 (0xa1)
+			// Code size: 156 (0x9c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -646,81 +646,80 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: stloc.0
-			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
-			IL_0012: stloc.1
-			IL_0013: ldloc.0
-			IL_0014: ldstr "resolve"
-			IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_001e: brtrue IL_0061
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::__dirname
+			IL_000d: stloc.1
+			IL_000e: ldloc.0
+			IL_000f: ldstr "resolve"
+			IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0019: brtrue IL_005c
 
-			IL_0023: ldloc.0
-			IL_0024: ldc.i4.6
-			IL_0025: newarr [System.Runtime]System.Object
-			IL_002a: dup
-			IL_002b: ldc.i4.0
-			IL_002c: ldloc.1
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.1
-			IL_0030: ldstr ".."
-			IL_0035: stelem.ref
-			IL_0036: dup
-			IL_0037: ldc.i4.2
-			IL_0038: ldstr ".."
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.3
-			IL_0040: ldstr "tests"
-			IL_0045: stelem.ref
-			IL_0046: dup
-			IL_0047: ldc.i4.4
-			IL_0048: ldstr "test262"
-			IL_004d: stelem.ref
-			IL_004e: dup
-			IL_004f: ldc.i4.5
-			IL_0050: ldstr "test262.pin.json"
-			IL_0055: stelem.ref
-			IL_0056: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_005b: stloc.1
-			IL_005c: br IL_009f
+			IL_001e: ldloc.0
+			IL_001f: ldc.i4.6
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldloc.1
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
+			IL_002b: ldstr ".."
+			IL_0030: stelem.ref
+			IL_0031: dup
+			IL_0032: ldc.i4.2
+			IL_0033: ldstr ".."
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.3
+			IL_003b: ldstr "tests"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.4
+			IL_0043: ldstr "test262"
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.5
+			IL_004b: ldstr "test262.pin.json"
+			IL_0050: stelem.ref
+			IL_0051: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_0056: stloc.1
+			IL_0057: br IL_009a
 
-			IL_0061: ldloc.0
-			IL_0062: ldstr "resolve"
-			IL_0067: ldc.i4.6
-			IL_0068: newarr [System.Runtime]System.Object
-			IL_006d: dup
-			IL_006e: ldc.i4.0
-			IL_006f: ldloc.1
-			IL_0070: stelem.ref
-			IL_0071: dup
-			IL_0072: ldc.i4.1
-			IL_0073: ldstr ".."
-			IL_0078: stelem.ref
-			IL_0079: dup
-			IL_007a: ldc.i4.2
-			IL_007b: ldstr ".."
-			IL_0080: stelem.ref
-			IL_0081: dup
-			IL_0082: ldc.i4.3
-			IL_0083: ldstr "tests"
-			IL_0088: stelem.ref
-			IL_0089: dup
-			IL_008a: ldc.i4.4
-			IL_008b: ldstr "test262"
-			IL_0090: stelem.ref
-			IL_0091: dup
-			IL_0092: ldc.i4.5
-			IL_0093: ldstr "test262.pin.json"
-			IL_0098: stelem.ref
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_009e: stloc.1
+			IL_005c: ldloc.0
+			IL_005d: ldstr "resolve"
+			IL_0062: ldc.i4.6
+			IL_0063: newarr [System.Runtime]System.Object
+			IL_0068: dup
+			IL_0069: ldc.i4.0
+			IL_006a: ldloc.1
+			IL_006b: stelem.ref
+			IL_006c: dup
+			IL_006d: ldc.i4.1
+			IL_006e: ldstr ".."
+			IL_0073: stelem.ref
+			IL_0074: dup
+			IL_0075: ldc.i4.2
+			IL_0076: ldstr ".."
+			IL_007b: stelem.ref
+			IL_007c: dup
+			IL_007d: ldc.i4.3
+			IL_007e: ldstr "tests"
+			IL_0083: stelem.ref
+			IL_0084: dup
+			IL_0085: ldc.i4.4
+			IL_0086: ldstr "test262"
+			IL_008b: stelem.ref
+			IL_008c: dup
+			IL_008d: ldc.i4.5
+			IL_008e: ldstr "test262.pin.json"
+			IL_0093: stelem.ref
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0099: stloc.1
 
-			IL_009f: ldloc.1
-			IL_00a0: ret
+			IL_009a: ldloc.1
+			IL_009b: ret
 		} // end of method defaultPinPath::__js_call__
 
 	} // end of class defaultPinPath
@@ -740,7 +739,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5345
+					// Method begins at RVA 0x52e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -758,7 +757,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x533c
+				// Method begins at RVA 0x52dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -785,9 +784,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2b30
+			// Method begins at RVA 0x2b28
 			// Header size: 12
-			// Code size: 168 (0xa8)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -807,68 +806,66 @@
 			IL_0015: ret
 
 			IL_0016: ldarg.0
-			IL_0017: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_001c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0021: ldstr "isAbsolute"
-			IL_0026: ldarg.2
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002c: stloc.1
-			IL_002d: ldloc.1
-			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0033: stloc.0
-			IL_0034: ldloc.0
-			IL_0035: brfalse IL_003c
+			IL_0017: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_001c: ldstr "isAbsolute"
+			IL_0021: ldarg.2
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0027: stloc.1
+			IL_0028: ldloc.1
+			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_002e: stloc.0
+			IL_002f: ldloc.0
+			IL_0030: brfalse IL_0037
 
-			IL_003a: ldarg.2
-			IL_003b: ret
+			IL_0035: ldarg.2
+			IL_0036: ret
 
-			IL_003c: ldarg.0
-			IL_003d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0042: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0047: stloc.2
-			IL_0048: ldstr "process"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0057: ldstr "cwd"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0061: stloc.1
-			IL_0062: ldloc.2
-			IL_0063: ldstr "resolve"
-			IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_006d: brtrue IL_008c
+			IL_0037: ldarg.0
+			IL_0038: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_003d: stloc.2
+			IL_003e: ldstr "process"
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004d: ldstr "cwd"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0057: stloc.1
+			IL_0058: ldloc.2
+			IL_0059: ldstr "resolve"
+			IL_005e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0063: brtrue IL_0082
 
-			IL_0072: ldloc.2
-			IL_0073: ldc.i4.2
-			IL_0074: newarr [System.Runtime]System.Object
-			IL_0079: dup
-			IL_007a: ldc.i4.0
-			IL_007b: ldloc.1
-			IL_007c: stelem.ref
-			IL_007d: dup
-			IL_007e: ldc.i4.1
-			IL_007f: ldarg.2
-			IL_0080: stelem.ref
-			IL_0081: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_0086: stloc.1
-			IL_0087: br IL_00a6
+			IL_0068: ldloc.2
+			IL_0069: ldc.i4.2
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldloc.1
+			IL_0072: stelem.ref
+			IL_0073: dup
+			IL_0074: ldc.i4.1
+			IL_0075: ldarg.2
+			IL_0076: stelem.ref
+			IL_0077: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_007c: stloc.1
+			IL_007d: br IL_009c
 
-			IL_008c: ldloc.2
-			IL_008d: ldstr "resolve"
-			IL_0092: ldc.i4.2
-			IL_0093: newarr [System.Runtime]System.Object
-			IL_0098: dup
-			IL_0099: ldc.i4.0
-			IL_009a: ldloc.1
-			IL_009b: stelem.ref
-			IL_009c: dup
-			IL_009d: ldc.i4.1
-			IL_009e: ldarg.2
-			IL_009f: stelem.ref
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00a5: stloc.1
+			IL_0082: ldloc.2
+			IL_0083: ldstr "resolve"
+			IL_0088: ldc.i4.2
+			IL_0089: newarr [System.Runtime]System.Object
+			IL_008e: dup
+			IL_008f: ldc.i4.0
+			IL_0090: ldloc.1
+			IL_0091: stelem.ref
+			IL_0092: dup
+			IL_0093: ldc.i4.1
+			IL_0094: ldarg.2
+			IL_0095: stelem.ref
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_009b: stloc.1
 
-			IL_00a6: ldloc.1
-			IL_00a7: ret
+			IL_009c: ldloc.1
+			IL_009d: ret
 		} // end of method resolvePathFromCwd::__js_call__
 
 	} // end of class resolvePathFromCwd
@@ -884,7 +881,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x534e
+				// Method begins at RVA 0x52ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -908,7 +905,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2be4
+			// Method begins at RVA 0x2bd4
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -947,7 +944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5357
+				// Method begins at RVA 0x52f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -974,7 +971,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2c1c
+			// Method begins at RVA 0x2c0c
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -1044,7 +1041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5369
+					// Method begins at RVA 0x5309
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1062,7 +1059,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5360
+				// Method begins at RVA 0x5300
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1087,7 +1084,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c98
+			// Method begins at RVA 0x2c88
 			// Header size: 12
 			// Code size: 168 (0xa8)
 			.maxstack 8
@@ -1189,7 +1186,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x537b
+					// Method begins at RVA 0x531b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1207,7 +1204,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5372
+				// Method begins at RVA 0x5312
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1235,7 +1232,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5396
+						// Method begins at RVA 0x5336
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1253,7 +1250,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x538d
+					// Method begins at RVA 0x532d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1271,7 +1268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5384
+				// Method begins at RVA 0x5324
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1296,7 +1293,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d4c
+			// Method begins at RVA 0x2d3c
 			// Header size: 12
 			// Code size: 462 (0x1ce)
 			.maxstack 10
@@ -1516,7 +1513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x539f
+				// Method begins at RVA 0x533f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1544,7 +1541,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x53ba
+						// Method begins at RVA 0x535a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1562,7 +1559,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53b1
+					// Method begins at RVA 0x5351
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1580,7 +1577,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53a8
+				// Method begins at RVA 0x5348
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1607,7 +1604,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2f38
+			// Method begins at RVA 0x2f28
 			// Header size: 12
 			// Code size: 208 (0xd0)
 			.maxstack 10
@@ -1737,7 +1734,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53cc
+					// Method begins at RVA 0x536c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1757,7 +1754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53d5
+					// Method begins at RVA 0x5375
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1777,7 +1774,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x53de
+					// Method begins at RVA 0x537e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1795,7 +1792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53c3
+				// Method begins at RVA 0x5363
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1822,7 +1819,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3024
+			// Method begins at RVA 0x3014
 			// Header size: 12
 			// Code size: 1268 (0x4f4)
 			.maxstack 8
@@ -2357,7 +2354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53e7
+				// Method begins at RVA 0x5387
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2384,9 +2381,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3524
+			// Method begins at RVA 0x3514
 			// Header size: 12
-			// Code size: 110 (0x6e)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2396,54 +2393,53 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.2
-			IL_000c: ldloc.2
-			IL_000d: ldstr "readFileSync"
-			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0017: brtrue IL_002e
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0006: stloc.2
+			IL_0007: ldloc.2
+			IL_0008: ldstr "readFileSync"
+			IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0012: brtrue IL_0029
 
-			IL_001c: ldloc.2
-			IL_001d: ldarg.2
-			IL_001e: ldstr "utf8"
-			IL_0023: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0028: stloc.0
-			IL_0029: br IL_004c
+			IL_0017: ldloc.2
+			IL_0018: ldarg.2
+			IL_0019: ldstr "utf8"
+			IL_001e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0023: stloc.0
+			IL_0024: br IL_0047
 
-			IL_002e: ldloc.2
-			IL_002f: ldstr "readFileSync"
-			IL_0034: ldc.i4.2
-			IL_0035: newarr [System.Runtime]System.Object
-			IL_003a: dup
-			IL_003b: ldc.i4.0
-			IL_003c: ldarg.2
-			IL_003d: stelem.ref
-			IL_003e: dup
-			IL_003f: ldc.i4.1
-			IL_0040: ldstr "utf8"
-			IL_0045: stelem.ref
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_004b: stloc.0
+			IL_0029: ldloc.2
+			IL_002a: ldstr "readFileSync"
+			IL_002f: ldc.i4.2
+			IL_0030: newarr [System.Runtime]System.Object
+			IL_0035: dup
+			IL_0036: ldc.i4.0
+			IL_0037: ldarg.2
+			IL_0038: stelem.ref
+			IL_0039: dup
+			IL_003a: ldc.i4.1
+			IL_003b: ldstr "utf8"
+			IL_0040: stelem.ref
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0046: stloc.0
 
-			IL_004c: ldloc.0
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_0052: stloc.1
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
-			IL_0059: stloc.3
-			IL_005a: ldloc.3
-			IL_005b: ldc.i4.1
-			IL_005c: newarr [System.Runtime]System.Object
-			IL_0061: dup
-			IL_0062: ldc.i4.0
-			IL_0063: ldarg.0
-			IL_0064: stelem.ref
-			IL_0065: ldloc.1
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_006b: pop
-			IL_006c: ldloc.1
-			IL_006d: ret
+			IL_0047: ldloc.0
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_004d: stloc.1
+			IL_004e: ldarg.0
+			IL_004f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
+			IL_0054: stloc.3
+			IL_0055: ldloc.3
+			IL_0056: ldc.i4.1
+			IL_0057: newarr [System.Runtime]System.Object
+			IL_005c: dup
+			IL_005d: ldc.i4.0
+			IL_005e: ldarg.0
+			IL_005f: stelem.ref
+			IL_0060: ldloc.1
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0066: pop
+			IL_0067: ldloc.1
+			IL_0068: ret
 		} // end of method loadPin::__js_call__
 
 	} // end of class loadPin
@@ -2459,7 +2455,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53f0
+				// Method begins at RVA 0x5390
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2487,9 +2483,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x35a0
+			// Method begins at RVA 0x358c
 			// Header size: 12
-			// Code size: 149 (0x95)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2499,73 +2495,71 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: ldstr "dirname"
-			IL_0010: ldarg.2
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0016: stloc.0
-			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_001d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0022: stloc.1
-			IL_0023: ldarg.3
-			IL_0024: ldstr "managedRoot"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002e: stloc.2
-			IL_002f: ldarg.3
-			IL_0030: ldstr "upstream"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003a: stloc.3
-			IL_003b: ldloc.3
-			IL_003c: ldstr "commit"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0046: stloc.3
-			IL_0047: ldloc.1
-			IL_0048: ldstr "resolve"
-			IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0052: brtrue IL_0075
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0006: ldstr "dirname"
+			IL_000b: ldarg.2
+			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0011: stloc.0
+			IL_0012: ldarg.0
+			IL_0013: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0018: stloc.1
+			IL_0019: ldarg.3
+			IL_001a: ldstr "managedRoot"
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0024: stloc.2
+			IL_0025: ldarg.3
+			IL_0026: ldstr "upstream"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0030: stloc.3
+			IL_0031: ldloc.3
+			IL_0032: ldstr "commit"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: stloc.3
+			IL_003d: ldloc.1
+			IL_003e: ldstr "resolve"
+			IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0048: brtrue IL_006b
 
-			IL_0057: ldloc.1
-			IL_0058: ldc.i4.3
-			IL_0059: newarr [System.Runtime]System.Object
-			IL_005e: dup
-			IL_005f: ldc.i4.0
-			IL_0060: ldloc.0
-			IL_0061: stelem.ref
-			IL_0062: dup
-			IL_0063: ldc.i4.1
-			IL_0064: ldloc.2
-			IL_0065: stelem.ref
-			IL_0066: dup
-			IL_0067: ldc.i4.2
-			IL_0068: ldloc.3
-			IL_0069: stelem.ref
-			IL_006a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_006f: stloc.3
-			IL_0070: br IL_0093
+			IL_004d: ldloc.1
+			IL_004e: ldc.i4.3
+			IL_004f: newarr [System.Runtime]System.Object
+			IL_0054: dup
+			IL_0055: ldc.i4.0
+			IL_0056: ldloc.0
+			IL_0057: stelem.ref
+			IL_0058: dup
+			IL_0059: ldc.i4.1
+			IL_005a: ldloc.2
+			IL_005b: stelem.ref
+			IL_005c: dup
+			IL_005d: ldc.i4.2
+			IL_005e: ldloc.3
+			IL_005f: stelem.ref
+			IL_0060: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_0065: stloc.3
+			IL_0066: br IL_0089
 
-			IL_0075: ldloc.1
-			IL_0076: ldstr "resolve"
-			IL_007b: ldc.i4.3
-			IL_007c: newarr [System.Runtime]System.Object
-			IL_0081: dup
-			IL_0082: ldc.i4.0
-			IL_0083: ldloc.0
-			IL_0084: stelem.ref
-			IL_0085: dup
-			IL_0086: ldc.i4.1
-			IL_0087: ldloc.2
-			IL_0088: stelem.ref
-			IL_0089: dup
-			IL_008a: ldc.i4.2
-			IL_008b: ldloc.3
-			IL_008c: stelem.ref
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0092: stloc.3
+			IL_006b: ldloc.1
+			IL_006c: ldstr "resolve"
+			IL_0071: ldc.i4.3
+			IL_0072: newarr [System.Runtime]System.Object
+			IL_0077: dup
+			IL_0078: ldc.i4.0
+			IL_0079: ldloc.0
+			IL_007a: stelem.ref
+			IL_007b: dup
+			IL_007c: ldc.i4.1
+			IL_007d: ldloc.2
+			IL_007e: stelem.ref
+			IL_007f: dup
+			IL_0080: ldc.i4.2
+			IL_0081: ldloc.3
+			IL_0082: stelem.ref
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0088: stloc.3
 
-			IL_0093: ldloc.3
-			IL_0094: ret
+			IL_0089: ldloc.3
+			IL_008a: ret
 		} // end of method resolveManagedCheckoutRoot::__js_call__
 
 	} // end of class resolveManagedCheckoutRoot
@@ -2581,7 +2575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x53f9
+				// Method begins at RVA 0x5399
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2608,9 +2602,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3644
+			// Method begins at RVA 0x3624
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -2621,73 +2615,72 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "posix"
-			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0017: brtrue IL_0028
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "posix"
+			IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0012: brtrue IL_0023
 
-			IL_001c: ldloc.0
-			IL_001d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_posix()
-			IL_0022: stloc.1
-			IL_0023: br IL_0034
+			IL_0017: ldloc.0
+			IL_0018: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_posix()
+			IL_001d: stloc.1
+			IL_001e: br IL_002f
 
-			IL_0028: ldloc.0
-			IL_0029: ldstr "posix"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_0033: stloc.1
+			IL_0023: ldloc.0
+			IL_0024: ldstr "posix"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_002e: stloc.1
 
-			IL_0034: ldloc.1
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003a: stloc.1
-			IL_003b: ldarg.0
-			IL_003c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-			IL_0041: ldc.i4.1
-			IL_0042: newarr [System.Runtime]System.Object
-			IL_0047: dup
-			IL_0048: ldc.i4.0
-			IL_0049: ldarg.0
-			IL_004a: stelem.ref
-			IL_004b: stloc.2
-			IL_004c: ldarg.2
-			IL_004d: ldstr "managedRoot"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0057: stloc.3
-			IL_0058: ldloc.2
-			IL_0059: ldloc.3
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_005f: stloc.3
-			IL_0060: ldarg.2
-			IL_0061: ldstr "upstream"
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006b: stloc.s 4
-			IL_006d: ldloc.s 4
-			IL_006f: ldstr "commit"
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0079: stloc.s 4
-			IL_007b: ldloc.1
-			IL_007c: ldstr "join"
-			IL_0081: ldloc.3
-			IL_0082: ldloc.s 4
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0089: stloc.s 4
-			IL_008b: ldc.i4.1
-			IL_008c: newarr [System.Runtime]System.Object
-			IL_0091: dup
-			IL_0092: ldc.i4.0
-			IL_0093: ldarg.0
-			IL_0094: stelem.ref
-			IL_0095: stloc.2
-			IL_0096: ldnull
-			IL_0097: ldloc.s 4
-			IL_0099: tail.
-			IL_009b: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_00a0: ret
+			IL_002f: ldloc.1
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0035: stloc.1
+			IL_0036: ldarg.0
+			IL_0037: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+			IL_003c: ldc.i4.1
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldarg.0
+			IL_0045: stelem.ref
+			IL_0046: stloc.2
+			IL_0047: ldarg.2
+			IL_0048: ldstr "managedRoot"
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0052: stloc.3
+			IL_0053: ldloc.2
+			IL_0054: ldloc.3
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_005a: stloc.3
+			IL_005b: ldarg.2
+			IL_005c: ldstr "upstream"
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0066: stloc.s 4
+			IL_0068: ldloc.s 4
+			IL_006a: ldstr "commit"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0074: stloc.s 4
+			IL_0076: ldloc.1
+			IL_0077: ldstr "join"
+			IL_007c: ldloc.3
+			IL_007d: ldloc.s 4
+			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0084: stloc.s 4
+			IL_0086: ldc.i4.1
+			IL_0087: newarr [System.Runtime]System.Object
+			IL_008c: dup
+			IL_008d: ldc.i4.0
+			IL_008e: ldarg.0
+			IL_008f: stelem.ref
+			IL_0090: stloc.2
+			IL_0091: ldnull
+			IL_0092: ldloc.s 4
+			IL_0094: tail.
+			IL_0096: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_009b: ret
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_009c: ldnull
+			IL_009d: ret
 		} // end of method resolveManagedCheckoutLabel::__js_call__
 
 	} // end of class resolveManagedCheckoutLabel
@@ -2707,7 +2700,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x540b
+					// Method begins at RVA 0x53ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2725,7 +2718,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5402
+				// Method begins at RVA 0x53a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2753,7 +2746,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x36f4
+			// Method begins at RVA 0x36d0
 			// Header size: 12
 			// Code size: 242 (0xf2)
 			.maxstack 8
@@ -2887,7 +2880,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x541d
+					// Method begins at RVA 0x53bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2905,7 +2898,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5414
+				// Method begins at RVA 0x53b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2933,7 +2926,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x37f4
+			// Method begins at RVA 0x37d0
 			// Header size: 12
 			// Code size: 1135 (0x46f)
 			.maxstack 8
@@ -3349,7 +3342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5426
+				// Method begins at RVA 0x53c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3376,9 +3369,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3c70
+			// Method begins at RVA 0x3c4c
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 83 (0x53)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
@@ -3386,44 +3379,43 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0011: dup
-			IL_0012: ldstr "recursive"
-			IL_0017: ldc.i4.1
-			IL_0018: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_001d: stloc.1
-			IL_001e: ldloc.0
-			IL_001f: ldstr "mkdirSync"
-			IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0029: brtrue IL_003c
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0006: stloc.0
+			IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_000c: dup
+			IL_000d: ldstr "recursive"
+			IL_0012: ldc.i4.1
+			IL_0013: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0018: stloc.1
+			IL_0019: ldloc.0
+			IL_001a: ldstr "mkdirSync"
+			IL_001f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0024: brtrue IL_0037
 
-			IL_002e: ldloc.0
-			IL_002f: ldarg.2
-			IL_0030: ldloc.1
-			IL_0031: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_0036: pop
-			IL_0037: br IL_0056
+			IL_0029: ldloc.0
+			IL_002a: ldarg.2
+			IL_002b: ldloc.1
+			IL_002c: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_0031: pop
+			IL_0032: br IL_0051
 
-			IL_003c: ldloc.0
-			IL_003d: ldstr "mkdirSync"
-			IL_0042: ldc.i4.2
-			IL_0043: newarr [System.Runtime]System.Object
-			IL_0048: dup
-			IL_0049: ldc.i4.0
-			IL_004a: ldarg.2
-			IL_004b: stelem.ref
-			IL_004c: dup
-			IL_004d: ldc.i4.1
-			IL_004e: ldloc.1
-			IL_004f: stelem.ref
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0055: pop
+			IL_0037: ldloc.0
+			IL_0038: ldstr "mkdirSync"
+			IL_003d: ldc.i4.2
+			IL_003e: newarr [System.Runtime]System.Object
+			IL_0043: dup
+			IL_0044: ldc.i4.0
+			IL_0045: ldarg.2
+			IL_0046: stelem.ref
+			IL_0047: dup
+			IL_0048: ldc.i4.1
+			IL_0049: ldloc.1
+			IL_004a: stelem.ref
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0050: pop
 
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0051: ldnull
+			IL_0052: ret
 		} // end of method ensureDir::__js_call__
 
 	} // end of class ensureDir
@@ -3443,7 +3435,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5438
+					// Method begins at RVA 0x53d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3461,7 +3453,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x542f
+				// Method begins at RVA 0x53cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3488,9 +3480,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3cd4
+			// Method begins at RVA 0x3cac
 			// Header size: 12
-			// Code size: 185 (0xb9)
+			// Code size: 175 (0xaf)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
@@ -3500,85 +3492,83 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "existsSync"
-			IL_0012: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0017: brtrue IL_002e
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "existsSync"
+			IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0012: brtrue IL_0029
 
-			IL_001c: ldloc.0
-			IL_001d: ldarg.2
-			IL_001e: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0023: box [System.Runtime]System.Boolean
-			IL_0028: stloc.1
-			IL_0029: br IL_0044
+			IL_0017: ldloc.0
+			IL_0018: ldarg.2
+			IL_0019: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_001e: box [System.Runtime]System.Boolean
+			IL_0023: stloc.1
+			IL_0024: br IL_003f
 
-			IL_002e: ldloc.0
-			IL_002f: ldstr "existsSync"
-			IL_0034: ldc.i4.1
-			IL_0035: newarr [System.Runtime]System.Object
-			IL_003a: dup
-			IL_003b: ldc.i4.0
-			IL_003c: ldarg.2
-			IL_003d: stelem.ref
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0043: stloc.1
+			IL_0029: ldloc.0
+			IL_002a: ldstr "existsSync"
+			IL_002f: ldc.i4.1
+			IL_0030: newarr [System.Runtime]System.Object
+			IL_0035: dup
+			IL_0036: ldc.i4.0
+			IL_0037: ldarg.2
+			IL_0038: stelem.ref
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_003e: stloc.1
 
-			IL_0044: ldloc.1
-			IL_0045: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_004a: ldc.i4.0
-			IL_004b: ceq
-			IL_004d: stloc.2
-			IL_004e: ldloc.2
-			IL_004f: brfalse IL_0056
+			IL_003f: ldloc.1
+			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0045: ldc.i4.0
+			IL_0046: ceq
+			IL_0048: stloc.2
+			IL_0049: ldloc.2
+			IL_004a: brfalse IL_0051
 
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_004f: ldnull
+			IL_0050: ret
 
-			IL_0056: ldarg.0
-			IL_0057: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_005c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0061: stloc.0
-			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0067: dup
-			IL_0068: ldstr "recursive"
-			IL_006d: ldc.i4.1
-			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0073: dup
-			IL_0074: ldstr "force"
-			IL_0079: ldc.i4.1
-			IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_007f: stloc.3
-			IL_0080: ldloc.0
-			IL_0081: ldstr "rmSync"
-			IL_0086: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_008b: brtrue IL_009d
+			IL_0051: ldarg.0
+			IL_0052: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0057: stloc.0
+			IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005d: dup
+			IL_005e: ldstr "recursive"
+			IL_0063: ldc.i4.1
+			IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0069: dup
+			IL_006a: ldstr "force"
+			IL_006f: ldc.i4.1
+			IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0075: stloc.3
+			IL_0076: ldloc.0
+			IL_0077: ldstr "rmSync"
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0081: brtrue IL_0093
 
-			IL_0090: ldloc.0
-			IL_0091: ldarg.2
-			IL_0092: ldloc.3
-			IL_0093: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0098: br IL_00b7
+			IL_0086: ldloc.0
+			IL_0087: ldarg.2
+			IL_0088: ldloc.3
+			IL_0089: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_008e: br IL_00ad
 
-			IL_009d: ldloc.0
-			IL_009e: ldstr "rmSync"
-			IL_00a3: ldc.i4.2
-			IL_00a4: newarr [System.Runtime]System.Object
-			IL_00a9: dup
-			IL_00aa: ldc.i4.0
-			IL_00ab: ldarg.2
-			IL_00ac: stelem.ref
-			IL_00ad: dup
-			IL_00ae: ldc.i4.1
-			IL_00af: ldloc.3
-			IL_00b0: stelem.ref
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00b6: pop
+			IL_0093: ldloc.0
+			IL_0094: ldstr "rmSync"
+			IL_0099: ldc.i4.2
+			IL_009a: newarr [System.Runtime]System.Object
+			IL_009f: dup
+			IL_00a0: ldc.i4.0
+			IL_00a1: ldarg.2
+			IL_00a2: stelem.ref
+			IL_00a3: dup
+			IL_00a4: ldc.i4.1
+			IL_00a5: ldloc.3
+			IL_00a6: stelem.ref
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_00ac: pop
 
-			IL_00b7: ldnull
-			IL_00b8: ret
+			IL_00ad: ldnull
+			IL_00ae: ret
 		} // end of method removeDir::__js_call__
 
 	} // end of class removeDir
@@ -3598,7 +3588,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x544a
+					// Method begins at RVA 0x53ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3618,7 +3608,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5453
+					// Method begins at RVA 0x53f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3636,7 +3626,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5441
+				// Method begins at RVA 0x53e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3664,9 +3654,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3d9c
+			// Method begins at RVA 0x3d68
 			// Header size: 12
-			// Code size: 696 (0x2b8)
+			// Code size: 691 (0x2b3)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3689,252 +3679,251 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
-			IL_000b: stloc.s 7
-			IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0012: dup
-			IL_0013: ldstr "cwd"
-			IL_0018: ldarg.3
-			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_001e: dup
-			IL_001f: ldstr "encoding"
-			IL_0024: ldstr "utf8"
-			IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_002e: dup
-			IL_002f: ldstr "maxBuffer"
-			IL_0034: ldc.r8 4
-			IL_003d: ldc.r8 1024
-			IL_0046: mul
-			IL_0047: ldc.r8 1024
-			IL_0050: mul
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0056: dup
-			IL_0057: ldstr "shell"
-			IL_005c: ldc.i4.0
-			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0062: stloc.s 8
-			IL_0064: ldloc.s 7
-			IL_0066: ldstr "spawnSync"
-			IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0070: brtrue IL_008a
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
+			IL_0006: stloc.s 7
+			IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_000d: dup
+			IL_000e: ldstr "cwd"
+			IL_0013: ldarg.3
+			IL_0014: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0019: dup
+			IL_001a: ldstr "encoding"
+			IL_001f: ldstr "utf8"
+			IL_0024: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0029: dup
+			IL_002a: ldstr "maxBuffer"
+			IL_002f: ldc.r8 4
+			IL_0038: ldc.r8 1024
+			IL_0041: mul
+			IL_0042: ldc.r8 1024
+			IL_004b: mul
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0051: dup
+			IL_0052: ldstr "shell"
+			IL_0057: ldc.i4.0
+			IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005d: stloc.s 8
+			IL_005f: ldloc.s 7
+			IL_0061: ldstr "spawnSync"
+			IL_0066: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_006b: brtrue IL_0085
 
-			IL_0075: ldloc.s 7
-			IL_0077: ldstr "git"
-			IL_007c: ldarg.2
-			IL_007d: ldloc.s 8
-			IL_007f: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_0084: stloc.0
-			IL_0085: br IL_00ae
+			IL_0070: ldloc.s 7
+			IL_0072: ldstr "git"
+			IL_0077: ldarg.2
+			IL_0078: ldloc.s 8
+			IL_007a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_007f: stloc.0
+			IL_0080: br IL_00a9
 
-			IL_008a: ldloc.s 7
-			IL_008c: ldstr "spawnSync"
-			IL_0091: ldc.i4.3
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldstr "git"
-			IL_009e: stelem.ref
-			IL_009f: dup
-			IL_00a0: ldc.i4.1
-			IL_00a1: ldarg.2
+			IL_0085: ldloc.s 7
+			IL_0087: ldstr "spawnSync"
+			IL_008c: ldc.i4.3
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldstr "git"
+			IL_0099: stelem.ref
+			IL_009a: dup
+			IL_009b: ldc.i4.1
+			IL_009c: ldarg.2
+			IL_009d: stelem.ref
+			IL_009e: dup
+			IL_009f: ldc.i4.2
+			IL_00a0: ldloc.s 8
 			IL_00a2: stelem.ref
-			IL_00a3: dup
-			IL_00a4: ldc.i4.2
-			IL_00a5: ldloc.s 8
-			IL_00a7: stelem.ref
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00ad: stloc.0
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_00a8: stloc.0
 
-			IL_00ae: ldloc.0
-			IL_00af: ldstr "error"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b9: stloc.s 9
-			IL_00bb: ldloc.s 9
-			IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00c2: stloc.s 10
-			IL_00c4: ldloc.s 10
-			IL_00c6: brfalse IL_00ec
+			IL_00a9: ldloc.0
+			IL_00aa: ldstr "error"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b4: stloc.s 9
+			IL_00b6: ldloc.s 9
+			IL_00b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00bd: stloc.s 10
+			IL_00bf: ldloc.s 10
+			IL_00c1: brfalse IL_00e7
 
-			IL_00cb: ldloc.0
-			IL_00cc: ldstr "error"
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d6: stloc.1
-			IL_00d7: ldloc.1
-			IL_00d8: isinst [System.Runtime]System.Exception
-			IL_00dd: dup
-			IL_00de: brtrue IL_00eb
+			IL_00c6: ldloc.0
+			IL_00c7: ldstr "error"
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d1: stloc.1
+			IL_00d2: ldloc.1
+			IL_00d3: isinst [System.Runtime]System.Exception
+			IL_00d8: dup
+			IL_00d9: brtrue IL_00e6
 
-			IL_00e3: pop
-			IL_00e4: ldloc.1
-			IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00ea: throw
+			IL_00de: pop
+			IL_00df: ldloc.1
+			IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00e5: throw
 
-			IL_00eb: throw
+			IL_00e6: throw
 
-			IL_00ec: ldloc.0
-			IL_00ed: ldstr "status"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f7: stloc.s 9
-			IL_00f9: ldloc.s 9
-			IL_00fb: ldc.r8 0.0
-			IL_0104: box [System.Runtime]System.Double
-			IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_010e: stloc.s 10
-			IL_0110: ldloc.s 10
-			IL_0112: brfalse IL_0292
+			IL_00e7: ldloc.0
+			IL_00e8: ldstr "status"
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f2: stloc.s 9
+			IL_00f4: ldloc.s 9
+			IL_00f6: ldc.r8 0.0
+			IL_00ff: box [System.Runtime]System.Double
+			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0109: stloc.s 10
+			IL_010b: ldloc.s 10
+			IL_010d: brfalse IL_028d
 
-			IL_0117: ldloc.0
-			IL_0118: ldstr "stderr"
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0122: stloc.s 9
-			IL_0124: ldloc.s 9
-			IL_0126: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012b: stloc.s 10
-			IL_012d: ldloc.s 10
-			IL_012f: brtrue IL_0140
+			IL_0112: ldloc.0
+			IL_0113: ldstr "stderr"
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011d: stloc.s 9
+			IL_011f: ldloc.s 9
+			IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0126: stloc.s 10
+			IL_0128: ldloc.s 10
+			IL_012a: brtrue IL_013b
 
-			IL_0134: ldstr ""
-			IL_0139: stloc.s 12
-			IL_013b: br IL_0144
+			IL_012f: ldstr ""
+			IL_0134: stloc.s 12
+			IL_0136: br IL_013f
 
-			IL_0140: ldloc.s 9
-			IL_0142: stloc.s 12
+			IL_013b: ldloc.s 9
+			IL_013d: stloc.s 12
 
-			IL_0144: ldloc.s 12
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014b: castclass [System.Runtime]System.String
-			IL_0150: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0155: stloc.s 13
-			IL_0157: ldloc.s 13
-			IL_0159: stloc.2
-			IL_015a: ldloc.0
-			IL_015b: ldstr "stdout"
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0165: stloc.s 9
-			IL_0167: ldloc.s 9
-			IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_016e: stloc.s 10
-			IL_0170: ldloc.s 10
-			IL_0172: brtrue IL_0183
+			IL_013f: ldloc.s 12
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: castclass [System.Runtime]System.String
+			IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0150: stloc.s 13
+			IL_0152: ldloc.s 13
+			IL_0154: stloc.2
+			IL_0155: ldloc.0
+			IL_0156: ldstr "stdout"
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0160: stloc.s 9
+			IL_0162: ldloc.s 9
+			IL_0164: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0169: stloc.s 10
+			IL_016b: ldloc.s 10
+			IL_016d: brtrue IL_017e
 
-			IL_0177: ldstr ""
-			IL_017c: stloc.s 14
-			IL_017e: br IL_0187
+			IL_0172: ldstr ""
+			IL_0177: stloc.s 14
+			IL_0179: br IL_0182
 
-			IL_0183: ldloc.s 9
-			IL_0185: stloc.s 14
+			IL_017e: ldloc.s 9
+			IL_0180: stloc.s 14
 
-			IL_0187: ldloc.s 14
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018e: castclass [System.Runtime]System.String
-			IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0198: stloc.s 13
-			IL_019a: ldloc.s 13
-			IL_019c: stloc.3
-			IL_019d: ldc.i4.2
-			IL_019e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01a3: dup
-			IL_01a4: ldloc.2
-			IL_01a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01aa: dup
-			IL_01ab: ldloc.3
-			IL_01ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01b1: stloc.s 15
-			IL_01b3: ldstr "Boolean"
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01bd: stloc.s 9
-			IL_01bf: ldloc.s 15
-			IL_01c1: ldc.i4.1
-			IL_01c2: newarr [System.Runtime]System.Object
-			IL_01c7: dup
-			IL_01c8: ldc.i4.0
-			IL_01c9: ldloc.s 9
-			IL_01cb: stelem.ref
-			IL_01cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
-			IL_01d1: stloc.s 15
-			IL_01d3: ldloc.s 15
-			IL_01d5: ldc.i4.1
-			IL_01d6: newarr [System.Runtime]System.Object
-			IL_01db: dup
-			IL_01dc: ldc.i4.0
-			IL_01dd: ldstr "\n"
-			IL_01e2: stelem.ref
-			IL_01e3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01e8: stloc.s 4
-			IL_01ea: ldarg.2
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f0: ldstr "join"
-			IL_01f5: ldstr " "
-			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01ff: stloc.s 9
-			IL_0201: ldloc.s 9
-			IL_0203: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0208: stloc.s 13
-			IL_020a: ldstr "git "
-			IL_020f: ldloc.s 13
-			IL_0211: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0216: ldstr " failed"
-			IL_021b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0220: stloc.s 13
-			IL_0222: ldloc.s 4
-			IL_0224: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0229: stloc.s 10
-			IL_022b: ldloc.s 10
-			IL_022d: brfalse IL_0252
+			IL_0182: ldloc.s 14
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0189: castclass [System.Runtime]System.String
+			IL_018e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0193: stloc.s 13
+			IL_0195: ldloc.s 13
+			IL_0197: stloc.3
+			IL_0198: ldc.i4.2
+			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_019e: dup
+			IL_019f: ldloc.2
+			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a5: dup
+			IL_01a6: ldloc.3
+			IL_01a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ac: stloc.s 15
+			IL_01ae: ldstr "Boolean"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b8: stloc.s 9
+			IL_01ba: ldloc.s 15
+			IL_01bc: ldc.i4.1
+			IL_01bd: newarr [System.Runtime]System.Object
+			IL_01c2: dup
+			IL_01c3: ldc.i4.0
+			IL_01c4: ldloc.s 9
+			IL_01c6: stelem.ref
+			IL_01c7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
+			IL_01cc: stloc.s 15
+			IL_01ce: ldloc.s 15
+			IL_01d0: ldc.i4.1
+			IL_01d1: newarr [System.Runtime]System.Object
+			IL_01d6: dup
+			IL_01d7: ldc.i4.0
+			IL_01d8: ldstr "\n"
+			IL_01dd: stelem.ref
+			IL_01de: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01e3: stloc.s 4
+			IL_01e5: ldarg.2
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: ldstr "join"
+			IL_01f0: ldstr " "
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01fa: stloc.s 9
+			IL_01fc: ldloc.s 9
+			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0203: stloc.s 13
+			IL_0205: ldstr "git "
+			IL_020a: ldloc.s 13
+			IL_020c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0211: ldstr " failed"
+			IL_0216: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021b: stloc.s 13
+			IL_021d: ldloc.s 4
+			IL_021f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0224: stloc.s 10
+			IL_0226: ldloc.s 10
+			IL_0228: brfalse IL_024d
 
-			IL_0232: ldloc.s 4
-			IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0239: stloc.s 16
-			IL_023b: ldstr ":\n"
-			IL_0240: ldloc.s 16
-			IL_0242: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0247: stloc.s 16
-			IL_0249: ldloc.s 16
-			IL_024b: stloc.s 5
-			IL_024d: br IL_0259
+			IL_022d: ldloc.s 4
+			IL_022f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0234: stloc.s 16
+			IL_0236: ldstr ":\n"
+			IL_023b: ldloc.s 16
+			IL_023d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0242: stloc.s 16
+			IL_0244: ldloc.s 16
+			IL_0246: stloc.s 5
+			IL_0248: br IL_0254
 
-			IL_0252: ldstr "."
-			IL_0257: stloc.s 5
+			IL_024d: ldstr "."
+			IL_0252: stloc.s 5
 
-			IL_0259: ldloc.s 5
-			IL_025b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0260: stloc.s 16
-			IL_0262: ldloc.s 13
-			IL_0264: ldloc.s 16
-			IL_0266: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026b: stloc.s 16
-			IL_026d: ldloc.s 16
-			IL_026f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0274: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0279: stloc.s 6
-			IL_027b: ldloc.s 6
-			IL_027d: isinst [System.Runtime]System.Exception
-			IL_0282: dup
-			IL_0283: brtrue IL_0291
+			IL_0254: ldloc.s 5
+			IL_0256: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_025b: stloc.s 16
+			IL_025d: ldloc.s 13
+			IL_025f: ldloc.s 16
+			IL_0261: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0266: stloc.s 16
+			IL_0268: ldloc.s 16
+			IL_026a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0274: stloc.s 6
+			IL_0276: ldloc.s 6
+			IL_0278: isinst [System.Runtime]System.Exception
+			IL_027d: dup
+			IL_027e: brtrue IL_028c
 
-			IL_0288: pop
-			IL_0289: ldloc.s 6
-			IL_028b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0290: throw
+			IL_0283: pop
+			IL_0284: ldloc.s 6
+			IL_0286: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_028b: throw
 
-			IL_0291: throw
+			IL_028c: throw
 
-			IL_0292: ldloc.0
-			IL_0293: ldstr "stdout"
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029d: stloc.s 9
-			IL_029f: ldloc.s 9
-			IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02a6: stloc.s 10
-			IL_02a8: ldloc.s 10
-			IL_02aa: brtrue IL_02b5
+			IL_028d: ldloc.0
+			IL_028e: ldstr "stdout"
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0298: stloc.s 9
+			IL_029a: ldloc.s 9
+			IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a1: stloc.s 10
+			IL_02a3: ldloc.s 10
+			IL_02a5: brtrue IL_02b0
 
-			IL_02af: ldstr ""
-			IL_02b4: ret
+			IL_02aa: ldstr ""
+			IL_02af: ret
 
-			IL_02b5: ldloc.s 9
-			IL_02b7: ret
+			IL_02b0: ldloc.s 9
+			IL_02b2: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -3950,7 +3939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x545c
+				// Method begins at RVA 0x53fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3974,7 +3963,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x546e
+					// Method begins at RVA 0x540e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3992,7 +3981,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5465
+				// Method begins at RVA 0x5405
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4016,7 +4005,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5480
+					// Method begins at RVA 0x5420
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4034,7 +4023,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5477
+				// Method begins at RVA 0x5417
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4061,7 +4050,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4060
+			// Method begins at RVA 0x4028
 			// Header size: 12
 			// Code size: 397 (0x18d)
 			.maxstack 11
@@ -4276,7 +4265,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54d1
+						// Method begins at RVA 0x5471
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4296,7 +4285,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54da
+						// Method begins at RVA 0x547a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4314,7 +4303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54c8
+					// Method begins at RVA 0x5468
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4334,7 +4323,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54e3
+					// Method begins at RVA 0x5483
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4352,7 +4341,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5489
+				// Method begins at RVA 0x5429
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4380,7 +4369,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54a4
+						// Method begins at RVA 0x5444
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4398,7 +4387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x549b
+					// Method begins at RVA 0x543b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4416,7 +4405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5492
+				// Method begins at RVA 0x5432
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4444,7 +4433,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54bf
+						// Method begins at RVA 0x545f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4462,7 +4451,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54b6
+					// Method begins at RVA 0x5456
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4480,7 +4469,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54ad
+				// Method begins at RVA 0x544d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4508,9 +4497,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4218
+			// Method begins at RVA 0x41e0
 			// Header size: 12
-			// Code size: 1868 (0x74c)
+			// Code size: 1828 (0x724)
 			.maxstack 11
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4576,7 +4565,7 @@
 					IL_0032: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0037: stloc.s 17
 					IL_0039: ldloc.s 17
-					IL_003b: brtrue IL_01da
+					IL_003b: brtrue IL_01cb
 
 					IL_0040: ldloc.s 16
 					IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -4584,673 +4573,665 @@
 					IL_0049: ldloc.s 16
 					IL_004b: stloc.s 5
 					IL_004d: ldarg.0
-					IL_004e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0053: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-					IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_005d: stloc.s 16
-					IL_005f: ldc.i4.1
-					IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0065: dup
-					IL_0066: ldarg.2
-					IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_006c: stloc.s 18
-					IL_006e: ldarg.0
-					IL_006f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_0074: ldc.i4.1
-					IL_0075: newarr [System.Runtime]System.Object
-					IL_007a: dup
-					IL_007b: ldc.i4.0
-					IL_007c: ldarg.0
-					IL_007d: stelem.ref
-					IL_007e: ldloc.s 5
-					IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0085: stloc.s 19
-					IL_0087: ldloc.s 19
-					IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_008e: ldstr "split"
-					IL_0093: ldstr "/"
-					IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_009d: stloc.s 19
-					IL_009f: ldloc.s 18
-					IL_00a1: ldloc.s 19
-					IL_00a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00a8: ldloc.s 18
-					IL_00aa: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00af: stloc.s 20
-					IL_00b1: ldloc.s 16
-					IL_00b3: ldstr "join"
-					IL_00b8: ldloc.s 20
-					IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_00bf: stloc.s 6
-					IL_00c1: ldarg.0
-					IL_00c2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00c7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_00cc: stloc.s 21
-					IL_00ce: ldloc.s 21
-					IL_00d0: ldstr "existsSync"
-					IL_00d5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_00da: brtrue IL_00f4
+					IL_004e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0058: stloc.s 16
+					IL_005a: ldc.i4.1
+					IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0060: dup
+					IL_0061: ldarg.2
+					IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_0067: stloc.s 18
+					IL_0069: ldarg.0
+					IL_006a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_006f: ldc.i4.1
+					IL_0070: newarr [System.Runtime]System.Object
+					IL_0075: dup
+					IL_0076: ldc.i4.0
+					IL_0077: ldarg.0
+					IL_0078: stelem.ref
+					IL_0079: ldloc.s 5
+					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0080: stloc.s 19
+					IL_0082: ldloc.s 19
+					IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0089: ldstr "split"
+					IL_008e: ldstr "/"
+					IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0098: stloc.s 19
+					IL_009a: ldloc.s 18
+					IL_009c: ldloc.s 19
+					IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00a3: ldloc.s 18
+					IL_00a5: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00aa: stloc.s 20
+					IL_00ac: ldloc.s 16
+					IL_00ae: ldstr "join"
+					IL_00b3: ldloc.s 20
+					IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_00ba: stloc.s 6
+					IL_00bc: ldarg.0
+					IL_00bd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00c2: stloc.s 21
+					IL_00c4: ldloc.s 21
+					IL_00c6: ldstr "existsSync"
+					IL_00cb: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_00d0: brtrue IL_00ea
 
-					IL_00df: ldloc.s 21
-					IL_00e1: ldloc.s 6
-					IL_00e3: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_00e8: box [System.Runtime]System.Boolean
-					IL_00ed: stloc.s 16
-					IL_00ef: br IL_010d
+					IL_00d5: ldloc.s 21
+					IL_00d7: ldloc.s 6
+					IL_00d9: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_00de: box [System.Runtime]System.Boolean
+					IL_00e3: stloc.s 16
+					IL_00e5: br IL_0103
 
-					IL_00f4: ldloc.s 21
-					IL_00f6: ldstr "existsSync"
-					IL_00fb: ldc.i4.1
-					IL_00fc: newarr [System.Runtime]System.Object
-					IL_0101: dup
-					IL_0102: ldc.i4.0
-					IL_0103: ldloc.s 6
-					IL_0105: stelem.ref
-					IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_010b: stloc.s 16
+					IL_00ea: ldloc.s 21
+					IL_00ec: ldstr "existsSync"
+					IL_00f1: ldc.i4.1
+					IL_00f2: newarr [System.Runtime]System.Object
+					IL_00f7: dup
+					IL_00f8: ldc.i4.0
+					IL_00f9: ldloc.s 6
+					IL_00fb: stelem.ref
+					IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_0101: stloc.s 16
 
-					IL_010d: ldloc.s 16
-					IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0114: ldc.i4.0
-					IL_0115: ceq
-					IL_0117: stloc.s 17
-					IL_0119: ldloc.s 17
-					IL_011b: box [System.Runtime]System.Boolean
-					IL_0120: stloc.s 22
-					IL_0122: ldloc.s 22
-					IL_0124: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0129: stloc.s 17
-					IL_012b: ldloc.s 17
-					IL_012d: brtrue IL_01aa
+					IL_0103: ldloc.s 16
+					IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_010a: ldc.i4.0
+					IL_010b: ceq
+					IL_010d: stloc.s 17
+					IL_010f: ldloc.s 17
+					IL_0111: box [System.Runtime]System.Boolean
+					IL_0116: stloc.s 22
+					IL_0118: ldloc.s 22
+					IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_011f: stloc.s 17
+					IL_0121: ldloc.s 17
+					IL_0123: brtrue IL_019b
 
-					IL_0132: ldarg.0
-					IL_0133: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0138: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_013d: stloc.s 21
-					IL_013f: ldloc.s 21
-					IL_0141: ldstr "statSync"
-					IL_0146: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_014b: brtrue IL_0160
+					IL_0128: ldarg.0
+					IL_0129: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_012e: stloc.s 21
+					IL_0130: ldloc.s 21
+					IL_0132: ldstr "statSync"
+					IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_013c: brtrue IL_0151
 
-					IL_0150: ldloc.s 21
-					IL_0152: ldloc.s 6
-					IL_0154: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_0159: stloc.s 16
-					IL_015b: br IL_0179
+					IL_0141: ldloc.s 21
+					IL_0143: ldloc.s 6
+					IL_0145: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_014a: stloc.s 16
+					IL_014c: br IL_016a
 
-					IL_0160: ldloc.s 21
-					IL_0162: ldstr "statSync"
-					IL_0167: ldc.i4.1
-					IL_0168: newarr [System.Runtime]System.Object
-					IL_016d: dup
-					IL_016e: ldc.i4.0
-					IL_016f: ldloc.s 6
-					IL_0171: stelem.ref
-					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0177: stloc.s 16
+					IL_0151: ldloc.s 21
+					IL_0153: ldstr "statSync"
+					IL_0158: ldc.i4.1
+					IL_0159: newarr [System.Runtime]System.Object
+					IL_015e: dup
+					IL_015f: ldc.i4.0
+					IL_0160: ldloc.s 6
+					IL_0162: stelem.ref
+					IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_0168: stloc.s 16
 
-					IL_0179: ldloc.s 16
-					IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0180: ldstr "isFile"
-					IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_018a: stloc.s 16
-					IL_018c: ldloc.s 16
-					IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0193: ldc.i4.0
-					IL_0194: ceq
-					IL_0196: stloc.s 17
-					IL_0198: ldloc.s 17
-					IL_019a: box [System.Runtime]System.Boolean
-					IL_019f: stloc.s 23
-					IL_01a1: ldloc.s 23
-					IL_01a3: stloc.s 25
-					IL_01a5: br IL_01ae
+					IL_016a: ldloc.s 16
+					IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0171: ldstr "isFile"
+					IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_017b: stloc.s 16
+					IL_017d: ldloc.s 16
+					IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0184: ldc.i4.0
+					IL_0185: ceq
+					IL_0187: stloc.s 17
+					IL_0189: ldloc.s 17
+					IL_018b: box [System.Runtime]System.Boolean
+					IL_0190: stloc.s 23
+					IL_0192: ldloc.s 23
+					IL_0194: stloc.s 25
+					IL_0196: br IL_019f
 
-					IL_01aa: ldloc.s 22
-					IL_01ac: stloc.s 25
+					IL_019b: ldloc.s 22
+					IL_019d: stloc.s 25
 
-					IL_01ae: ldloc.s 25
-					IL_01b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01b5: stloc.s 17
-					IL_01b7: ldloc.s 17
-					IL_01b9: brfalse IL_01c7
+					IL_019f: ldloc.s 25
+					IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01a6: stloc.s 17
+					IL_01a8: ldloc.s 17
+					IL_01aa: brfalse IL_01b8
 
-					IL_01be: ldloc.0
-					IL_01bf: ldloc.s 5
-					IL_01c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01c6: pop
+					IL_01af: ldloc.0
+					IL_01b0: ldloc.s 5
+					IL_01b2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01b7: pop
 
-					IL_01c7: br IL_0028
+					IL_01b8: br IL_0028
 				// end loop
-				IL_01cc: ldloc.2
-				IL_01cd: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_01d2: ldc.i4.1
-				IL_01d3: stloc.s 4
-				IL_01d5: leave IL_01f5
+				IL_01bd: ldloc.2
+				IL_01be: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_01c3: ldc.i4.1
+				IL_01c4: stloc.s 4
+				IL_01c6: leave IL_01e6
 
-				IL_01da: ldc.i4.1
-				IL_01db: stloc.3
-				IL_01dc: leave IL_01f5
+				IL_01cb: ldc.i4.1
+				IL_01cc: stloc.3
+				IL_01cd: leave IL_01e6
 			} // end .try
 			finally
 			{
-				IL_01e1: ldloc.3
-				IL_01e2: brtrue IL_01f4
+				IL_01d2: ldloc.3
+				IL_01d3: brtrue IL_01e5
 
-				IL_01e7: ldloc.s 4
-				IL_01e9: brtrue IL_01f4
+				IL_01d8: ldloc.s 4
+				IL_01da: brtrue IL_01e5
 
-				IL_01ee: ldloc.2
-				IL_01ef: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01df: ldloc.2
+				IL_01e0: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_01f4: endfinally
+				IL_01e5: endfinally
 			} // end handler
 
-			IL_01f5: ldarg.3
-			IL_01f6: ldstr "requiredDirectories"
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0200: stloc.s 16
-			IL_0202: ldloc.s 16
-			IL_0204: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_0209: stloc.s 7
-			IL_020b: ldc.i4.0
-			IL_020c: stloc.s 8
-			IL_020e: ldc.i4.0
-			IL_020f: stloc.s 9
+			IL_01e6: ldarg.3
+			IL_01e7: ldstr "requiredDirectories"
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f1: stloc.s 16
+			IL_01f3: ldloc.s 16
+			IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_01fa: stloc.s 7
+			IL_01fc: ldc.i4.0
+			IL_01fd: stloc.s 8
+			IL_01ff: ldc.i4.0
+			IL_0200: stloc.s 9
 			.try
 			{
-				// loop start (head: IL_0211)
-					IL_0211: ldloc.s 7
-					IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0218: stloc.s 16
-					IL_021a: ldloc.s 16
-					IL_021c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0221: stloc.s 17
-					IL_0223: ldloc.s 17
-					IL_0225: brtrue IL_03c5
+				// loop start (head: IL_0202)
+					IL_0202: ldloc.s 7
+					IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0209: stloc.s 16
+					IL_020b: ldloc.s 16
+					IL_020d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0212: stloc.s 17
+					IL_0214: ldloc.s 17
+					IL_0216: brtrue IL_03a7
 
-					IL_022a: ldloc.s 16
-					IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0231: stloc.s 16
-					IL_0233: ldloc.s 16
-					IL_0235: stloc.s 10
-					IL_0237: ldarg.0
-					IL_0238: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_023d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-					IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0247: stloc.s 16
-					IL_0249: ldc.i4.1
-					IL_024a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_024f: dup
-					IL_0250: ldarg.2
-					IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0256: stloc.s 18
-					IL_0258: ldarg.0
-					IL_0259: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_025e: ldc.i4.1
-					IL_025f: newarr [System.Runtime]System.Object
-					IL_0264: dup
-					IL_0265: ldc.i4.0
-					IL_0266: ldarg.0
-					IL_0267: stelem.ref
-					IL_0268: ldloc.s 10
-					IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_026f: stloc.s 19
-					IL_0271: ldloc.s 19
-					IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0278: ldstr "split"
-					IL_027d: ldstr "/"
-					IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0287: stloc.s 19
-					IL_0289: ldloc.s 18
-					IL_028b: ldloc.s 19
-					IL_028d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_0292: ldloc.s 18
-					IL_0294: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_0299: stloc.s 20
-					IL_029b: ldloc.s 16
-					IL_029d: ldstr "join"
-					IL_02a2: ldloc.s 20
-					IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_02a9: stloc.s 11
-					IL_02ab: ldarg.0
-					IL_02ac: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_02b1: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_02b6: stloc.s 21
-					IL_02b8: ldloc.s 21
-					IL_02ba: ldstr "existsSync"
-					IL_02bf: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_02c4: brtrue IL_02de
+					IL_021b: ldloc.s 16
+					IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0222: stloc.s 16
+					IL_0224: ldloc.s 16
+					IL_0226: stloc.s 10
+					IL_0228: ldarg.0
+					IL_0229: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0233: stloc.s 16
+					IL_0235: ldc.i4.1
+					IL_0236: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_023b: dup
+					IL_023c: ldarg.2
+					IL_023d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_0242: stloc.s 18
+					IL_0244: ldarg.0
+					IL_0245: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_024a: ldc.i4.1
+					IL_024b: newarr [System.Runtime]System.Object
+					IL_0250: dup
+					IL_0251: ldc.i4.0
+					IL_0252: ldarg.0
+					IL_0253: stelem.ref
+					IL_0254: ldloc.s 10
+					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_025b: stloc.s 19
+					IL_025d: ldloc.s 19
+					IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0264: ldstr "split"
+					IL_0269: ldstr "/"
+					IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0273: stloc.s 19
+					IL_0275: ldloc.s 18
+					IL_0277: ldloc.s 19
+					IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_027e: ldloc.s 18
+					IL_0280: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0285: stloc.s 20
+					IL_0287: ldloc.s 16
+					IL_0289: ldstr "join"
+					IL_028e: ldloc.s 20
+					IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_0295: stloc.s 11
+					IL_0297: ldarg.0
+					IL_0298: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_029d: stloc.s 21
+					IL_029f: ldloc.s 21
+					IL_02a1: ldstr "existsSync"
+					IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_02ab: brtrue IL_02c5
 
-					IL_02c9: ldloc.s 21
-					IL_02cb: ldloc.s 11
-					IL_02cd: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_02d2: box [System.Runtime]System.Boolean
-					IL_02d7: stloc.s 16
-					IL_02d9: br IL_02f7
+					IL_02b0: ldloc.s 21
+					IL_02b2: ldloc.s 11
+					IL_02b4: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_02b9: box [System.Runtime]System.Boolean
+					IL_02be: stloc.s 16
+					IL_02c0: br IL_02de
 
-					IL_02de: ldloc.s 21
-					IL_02e0: ldstr "existsSync"
-					IL_02e5: ldc.i4.1
-					IL_02e6: newarr [System.Runtime]System.Object
-					IL_02eb: dup
-					IL_02ec: ldc.i4.0
-					IL_02ed: ldloc.s 11
-					IL_02ef: stelem.ref
-					IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_02f5: stloc.s 16
+					IL_02c5: ldloc.s 21
+					IL_02c7: ldstr "existsSync"
+					IL_02cc: ldc.i4.1
+					IL_02cd: newarr [System.Runtime]System.Object
+					IL_02d2: dup
+					IL_02d3: ldc.i4.0
+					IL_02d4: ldloc.s 11
+					IL_02d6: stelem.ref
+					IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_02dc: stloc.s 16
 
-					IL_02f7: ldloc.s 16
-					IL_02f9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02fe: ldc.i4.0
-					IL_02ff: ceq
-					IL_0301: stloc.s 17
-					IL_0303: ldloc.s 17
-					IL_0305: box [System.Runtime]System.Boolean
-					IL_030a: stloc.s 22
-					IL_030c: ldloc.s 22
-					IL_030e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0313: stloc.s 17
-					IL_0315: ldloc.s 17
-					IL_0317: brtrue IL_0394
+					IL_02de: ldloc.s 16
+					IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02e5: ldc.i4.0
+					IL_02e6: ceq
+					IL_02e8: stloc.s 17
+					IL_02ea: ldloc.s 17
+					IL_02ec: box [System.Runtime]System.Boolean
+					IL_02f1: stloc.s 22
+					IL_02f3: ldloc.s 22
+					IL_02f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02fa: stloc.s 17
+					IL_02fc: ldloc.s 17
+					IL_02fe: brtrue IL_0376
 
-					IL_031c: ldarg.0
-					IL_031d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0322: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_0327: stloc.s 21
-					IL_0329: ldloc.s 21
-					IL_032b: ldstr "statSync"
-					IL_0330: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_0335: brtrue IL_034a
+					IL_0303: ldarg.0
+					IL_0304: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0309: stloc.s 21
+					IL_030b: ldloc.s 21
+					IL_030d: ldstr "statSync"
+					IL_0312: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_0317: brtrue IL_032c
 
-					IL_033a: ldloc.s 21
-					IL_033c: ldloc.s 11
-					IL_033e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_031c: ldloc.s 21
+					IL_031e: ldloc.s 11
+					IL_0320: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_0325: stloc.s 16
+					IL_0327: br IL_0345
+
+					IL_032c: ldloc.s 21
+					IL_032e: ldstr "statSync"
+					IL_0333: ldc.i4.1
+					IL_0334: newarr [System.Runtime]System.Object
+					IL_0339: dup
+					IL_033a: ldc.i4.0
+					IL_033b: ldloc.s 11
+					IL_033d: stelem.ref
+					IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
 					IL_0343: stloc.s 16
-					IL_0345: br IL_0363
 
-					IL_034a: ldloc.s 21
-					IL_034c: ldstr "statSync"
-					IL_0351: ldc.i4.1
-					IL_0352: newarr [System.Runtime]System.Object
-					IL_0357: dup
-					IL_0358: ldc.i4.0
-					IL_0359: ldloc.s 11
-					IL_035b: stelem.ref
-					IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0361: stloc.s 16
+					IL_0345: ldloc.s 16
+					IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_034c: ldstr "isDirectory"
+					IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0356: stloc.s 16
+					IL_0358: ldloc.s 16
+					IL_035a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_035f: ldc.i4.0
+					IL_0360: ceq
+					IL_0362: stloc.s 17
+					IL_0364: ldloc.s 17
+					IL_0366: box [System.Runtime]System.Boolean
+					IL_036b: stloc.s 23
+					IL_036d: ldloc.s 23
+					IL_036f: stloc.s 26
+					IL_0371: br IL_037a
 
-					IL_0363: ldloc.s 16
-					IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_036a: ldstr "isDirectory"
-					IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_0374: stloc.s 16
-					IL_0376: ldloc.s 16
-					IL_0378: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_037d: ldc.i4.0
-					IL_037e: ceq
-					IL_0380: stloc.s 17
-					IL_0382: ldloc.s 17
-					IL_0384: box [System.Runtime]System.Boolean
-					IL_0389: stloc.s 23
-					IL_038b: ldloc.s 23
-					IL_038d: stloc.s 26
-					IL_038f: br IL_0398
+					IL_0376: ldloc.s 22
+					IL_0378: stloc.s 26
 
-					IL_0394: ldloc.s 22
-					IL_0396: stloc.s 26
+					IL_037a: ldloc.s 26
+					IL_037c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0381: stloc.s 17
+					IL_0383: ldloc.s 17
+					IL_0385: brfalse IL_0393
 
-					IL_0398: ldloc.s 26
-					IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_039f: stloc.s 17
-					IL_03a1: ldloc.s 17
-					IL_03a3: brfalse IL_03b1
+					IL_038a: ldloc.1
+					IL_038b: ldloc.s 10
+					IL_038d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0392: pop
 
-					IL_03a8: ldloc.1
-					IL_03a9: ldloc.s 10
-					IL_03ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_03b0: pop
-
-					IL_03b1: br IL_0211
+					IL_0393: br IL_0202
 				// end loop
-				IL_03b6: ldloc.s 7
-				IL_03b8: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_03bd: ldc.i4.1
-				IL_03be: stloc.s 9
-				IL_03c0: leave IL_03e3
+				IL_0398: ldloc.s 7
+				IL_039a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_039f: ldc.i4.1
+				IL_03a0: stloc.s 9
+				IL_03a2: leave IL_03c5
 
-				IL_03c5: ldc.i4.1
-				IL_03c6: stloc.s 8
-				IL_03c8: leave IL_03e3
+				IL_03a7: ldc.i4.1
+				IL_03a8: stloc.s 8
+				IL_03aa: leave IL_03c5
 			} // end .try
 			finally
 			{
-				IL_03cd: ldloc.s 8
-				IL_03cf: brtrue IL_03e2
+				IL_03af: ldloc.s 8
+				IL_03b1: brtrue IL_03c4
 
-				IL_03d4: ldloc.s 9
-				IL_03d6: brtrue IL_03e2
+				IL_03b6: ldloc.s 9
+				IL_03b8: brtrue IL_03c4
 
-				IL_03db: ldloc.s 7
-				IL_03dd: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_03bd: ldloc.s 7
+				IL_03bf: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_03e2: endfinally
+				IL_03c4: endfinally
 			} // end handler
 
-			IL_03e3: ldloc.0
-			IL_03e4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_03e9: ldc.r8 0.0
-			IL_03f2: cgt
-			IL_03f4: stloc.s 17
-			IL_03f6: ldloc.s 17
-			IL_03f8: box [System.Runtime]System.Boolean
-			IL_03fd: stloc.s 22
-			IL_03ff: ldloc.s 22
-			IL_0401: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0406: stloc.s 17
-			IL_0408: ldloc.s 17
-			IL_040a: brtrue IL_0434
+			IL_03c5: ldloc.0
+			IL_03c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_03cb: ldc.r8 0.0
+			IL_03d4: cgt
+			IL_03d6: stloc.s 17
+			IL_03d8: ldloc.s 17
+			IL_03da: box [System.Runtime]System.Boolean
+			IL_03df: stloc.s 22
+			IL_03e1: ldloc.s 22
+			IL_03e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03e8: stloc.s 17
+			IL_03ea: ldloc.s 17
+			IL_03ec: brtrue IL_0416
 
-			IL_040f: ldloc.1
-			IL_0410: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0415: ldc.r8 0.0
-			IL_041e: cgt
-			IL_0420: stloc.s 17
-			IL_0422: ldloc.s 17
-			IL_0424: box [System.Runtime]System.Boolean
-			IL_0429: stloc.s 23
-			IL_042b: ldloc.s 23
-			IL_042d: stloc.s 27
-			IL_042f: br IL_0438
+			IL_03f1: ldloc.1
+			IL_03f2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_03f7: ldc.r8 0.0
+			IL_0400: cgt
+			IL_0402: stloc.s 17
+			IL_0404: ldloc.s 17
+			IL_0406: box [System.Runtime]System.Boolean
+			IL_040b: stloc.s 23
+			IL_040d: ldloc.s 23
+			IL_040f: stloc.s 27
+			IL_0411: br IL_041a
 
-			IL_0434: ldloc.s 22
-			IL_0436: stloc.s 27
+			IL_0416: ldloc.s 22
+			IL_0418: stloc.s 27
 
-			IL_0438: ldloc.s 27
-			IL_043a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_043f: stloc.s 17
-			IL_0441: ldloc.s 17
-			IL_0443: brfalse IL_0524
+			IL_041a: ldloc.s 27
+			IL_041c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0421: stloc.s 17
+			IL_0423: ldloc.s 17
+			IL_0425: brfalse IL_0506
 
-			IL_0448: ldc.i4.0
-			IL_0449: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_044e: stloc.s 12
-			IL_0450: ldloc.0
-			IL_0451: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0456: ldc.r8 0.0
-			IL_045f: cgt
-			IL_0461: brfalse IL_049d
+			IL_042a: ldc.i4.0
+			IL_042b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0430: stloc.s 12
+			IL_0432: ldloc.0
+			IL_0433: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0438: ldc.r8 0.0
+			IL_0441: cgt
+			IL_0443: brfalse IL_047f
 
-			IL_0466: ldloc.0
-			IL_0467: ldc.i4.1
-			IL_0468: newarr [System.Runtime]System.Object
-			IL_046d: dup
-			IL_046e: ldc.i4.0
-			IL_046f: ldstr ", "
-			IL_0474: stelem.ref
-			IL_0475: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_047a: stloc.s 28
-			IL_047c: ldloc.s 28
-			IL_047e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0483: stloc.s 28
-			IL_0485: ldstr "missing files: "
-			IL_048a: ldloc.s 28
-			IL_048c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0491: stloc.s 28
-			IL_0493: ldloc.s 12
-			IL_0495: ldloc.s 28
-			IL_0497: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_049c: pop
+			IL_0448: ldloc.0
+			IL_0449: ldc.i4.1
+			IL_044a: newarr [System.Runtime]System.Object
+			IL_044f: dup
+			IL_0450: ldc.i4.0
+			IL_0451: ldstr ", "
+			IL_0456: stelem.ref
+			IL_0457: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_045c: stloc.s 28
+			IL_045e: ldloc.s 28
+			IL_0460: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0465: stloc.s 28
+			IL_0467: ldstr "missing files: "
+			IL_046c: ldloc.s 28
+			IL_046e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0473: stloc.s 28
+			IL_0475: ldloc.s 12
+			IL_0477: ldloc.s 28
+			IL_0479: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_047e: pop
 
-			IL_049d: ldloc.1
-			IL_049e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_04a3: ldc.r8 0.0
-			IL_04ac: cgt
-			IL_04ae: brfalse IL_04ea
+			IL_047f: ldloc.1
+			IL_0480: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0485: ldc.r8 0.0
+			IL_048e: cgt
+			IL_0490: brfalse IL_04cc
 
-			IL_04b3: ldloc.1
-			IL_04b4: ldc.i4.1
-			IL_04b5: newarr [System.Runtime]System.Object
-			IL_04ba: dup
-			IL_04bb: ldc.i4.0
-			IL_04bc: ldstr ", "
-			IL_04c1: stelem.ref
-			IL_04c2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04c7: stloc.s 28
-			IL_04c9: ldloc.s 28
-			IL_04cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04d0: stloc.s 28
-			IL_04d2: ldstr "missing directories: "
-			IL_04d7: ldloc.s 28
-			IL_04d9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04de: stloc.s 28
-			IL_04e0: ldloc.s 12
-			IL_04e2: ldloc.s 28
-			IL_04e4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_04e9: pop
+			IL_0495: ldloc.1
+			IL_0496: ldc.i4.1
+			IL_0497: newarr [System.Runtime]System.Object
+			IL_049c: dup
+			IL_049d: ldc.i4.0
+			IL_049e: ldstr ", "
+			IL_04a3: stelem.ref
+			IL_04a4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_04a9: stloc.s 28
+			IL_04ab: ldloc.s 28
+			IL_04ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04b2: stloc.s 28
+			IL_04b4: ldstr "missing directories: "
+			IL_04b9: ldloc.s 28
+			IL_04bb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c0: stloc.s 28
+			IL_04c2: ldloc.s 12
+			IL_04c4: ldloc.s 28
+			IL_04c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_04cb: pop
 
-			IL_04ea: ldloc.s 12
-			IL_04ec: ldc.i4.1
-			IL_04ed: newarr [System.Runtime]System.Object
-			IL_04f2: dup
-			IL_04f3: ldc.i4.0
-			IL_04f4: ldstr "; "
-			IL_04f9: stelem.ref
-			IL_04fa: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04ff: stloc.s 28
-			IL_0501: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0506: dup
-			IL_0507: ldstr "ok"
-			IL_050c: ldc.i4.0
-			IL_050d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0512: dup
-			IL_0513: ldstr "message"
-			IL_0518: ldloc.s 28
-			IL_051a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_051f: stloc.s 29
-			IL_0521: ldloc.s 29
-			IL_0523: ret
+			IL_04cc: ldloc.s 12
+			IL_04ce: ldc.i4.1
+			IL_04cf: newarr [System.Runtime]System.Object
+			IL_04d4: dup
+			IL_04d5: ldc.i4.0
+			IL_04d6: ldstr "; "
+			IL_04db: stelem.ref
+			IL_04dc: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_04e1: stloc.s 28
+			IL_04e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04e8: dup
+			IL_04e9: ldstr "ok"
+			IL_04ee: ldc.i4.0
+			IL_04ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04f4: dup
+			IL_04f5: ldstr "message"
+			IL_04fa: ldloc.s 28
+			IL_04fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0501: stloc.s 29
+			IL_0503: ldloc.s 29
+			IL_0505: ret
 
-			IL_0524: ldarg.0
-			IL_0525: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_052a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_052f: stloc.s 30
-			IL_0531: ldloc.s 30
-			IL_0533: ldstr "join"
-			IL_0538: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_053d: brtrue IL_0562
+			IL_0506: ldarg.0
+			IL_0507: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_050c: stloc.s 30
+			IL_050e: ldloc.s 30
+			IL_0510: ldstr "join"
+			IL_0515: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_051a: brtrue IL_053f
 
-			IL_0542: ldloc.s 30
-			IL_0544: ldc.i4.2
-			IL_0545: newarr [System.Runtime]System.Object
-			IL_054a: dup
-			IL_054b: ldc.i4.0
-			IL_054c: ldarg.2
-			IL_054d: stelem.ref
-			IL_054e: dup
-			IL_054f: ldc.i4.1
-			IL_0550: ldstr "package.json"
-			IL_0555: stelem.ref
-			IL_0556: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_055b: stloc.s 13
-			IL_055d: br IL_0582
+			IL_051f: ldloc.s 30
+			IL_0521: ldc.i4.2
+			IL_0522: newarr [System.Runtime]System.Object
+			IL_0527: dup
+			IL_0528: ldc.i4.0
+			IL_0529: ldarg.2
+			IL_052a: stelem.ref
+			IL_052b: dup
+			IL_052c: ldc.i4.1
+			IL_052d: ldstr "package.json"
+			IL_0532: stelem.ref
+			IL_0533: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0538: stloc.s 13
+			IL_053a: br IL_055f
 
-			IL_0562: ldloc.s 30
-			IL_0564: ldstr "join"
-			IL_0569: ldc.i4.2
-			IL_056a: newarr [System.Runtime]System.Object
-			IL_056f: dup
-			IL_0570: ldc.i4.0
-			IL_0571: ldarg.2
-			IL_0572: stelem.ref
-			IL_0573: dup
-			IL_0574: ldc.i4.1
-			IL_0575: ldstr "package.json"
-			IL_057a: stelem.ref
-			IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0580: stloc.s 13
+			IL_053f: ldloc.s 30
+			IL_0541: ldstr "join"
+			IL_0546: ldc.i4.2
+			IL_0547: newarr [System.Runtime]System.Object
+			IL_054c: dup
+			IL_054d: ldc.i4.0
+			IL_054e: ldarg.2
+			IL_054f: stelem.ref
+			IL_0550: dup
+			IL_0551: ldc.i4.1
+			IL_0552: ldstr "package.json"
+			IL_0557: stelem.ref
+			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_055d: stloc.s 13
 
-			IL_0582: ldarg.0
-			IL_0583: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0588: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_058d: stloc.s 21
-			IL_058f: ldloc.s 21
-			IL_0591: ldstr "readFileSync"
-			IL_0596: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_059b: brtrue IL_05b5
+			IL_055f: ldarg.0
+			IL_0560: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0565: stloc.s 21
+			IL_0567: ldloc.s 21
+			IL_0569: ldstr "readFileSync"
+			IL_056e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0573: brtrue IL_058d
 
-			IL_05a0: ldloc.s 21
-			IL_05a2: ldloc.s 13
-			IL_05a4: ldstr "utf8"
-			IL_05a9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_05ae: stloc.s 16
-			IL_05b0: br IL_05d6
+			IL_0578: ldloc.s 21
+			IL_057a: ldloc.s 13
+			IL_057c: ldstr "utf8"
+			IL_0581: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0586: stloc.s 16
+			IL_0588: br IL_05ae
 
-			IL_05b5: ldloc.s 21
-			IL_05b7: ldstr "readFileSync"
-			IL_05bc: ldc.i4.2
-			IL_05bd: newarr [System.Runtime]System.Object
-			IL_05c2: dup
-			IL_05c3: ldc.i4.0
-			IL_05c4: ldloc.s 13
-			IL_05c6: stelem.ref
-			IL_05c7: dup
-			IL_05c8: ldc.i4.1
-			IL_05c9: ldstr "utf8"
-			IL_05ce: stelem.ref
-			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_05d4: stloc.s 16
+			IL_058d: ldloc.s 21
+			IL_058f: ldstr "readFileSync"
+			IL_0594: ldc.i4.2
+			IL_0595: newarr [System.Runtime]System.Object
+			IL_059a: dup
+			IL_059b: ldc.i4.0
+			IL_059c: ldloc.s 13
+			IL_059e: stelem.ref
+			IL_059f: dup
+			IL_05a0: ldc.i4.1
+			IL_05a1: ldstr "utf8"
+			IL_05a6: stelem.ref
+			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_05ac: stloc.s 16
 
-			IL_05d6: ldloc.s 16
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_05dd: stloc.s 14
-			IL_05df: ldloc.s 14
-			IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05e6: ldc.i4.0
-			IL_05e7: ceq
-			IL_05e9: stloc.s 17
-			IL_05eb: ldloc.s 17
-			IL_05ed: box [System.Runtime]System.Boolean
-			IL_05f2: stloc.s 22
-			IL_05f4: ldloc.s 22
-			IL_05f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05fb: stloc.s 17
-			IL_05fd: ldloc.s 17
-			IL_05ff: brtrue IL_064a
+			IL_05ae: ldloc.s 16
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_05b5: stloc.s 14
+			IL_05b7: ldloc.s 14
+			IL_05b9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05be: ldc.i4.0
+			IL_05bf: ceq
+			IL_05c1: stloc.s 17
+			IL_05c3: ldloc.s 17
+			IL_05c5: box [System.Runtime]System.Boolean
+			IL_05ca: stloc.s 22
+			IL_05cc: ldloc.s 22
+			IL_05ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05d3: stloc.s 17
+			IL_05d5: ldloc.s 17
+			IL_05d7: brtrue IL_0622
 
-			IL_0604: ldloc.s 14
-			IL_0606: ldstr "version"
-			IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0610: stloc.s 16
-			IL_0612: ldarg.3
-			IL_0613: ldstr "upstream"
-			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_061d: stloc.s 19
-			IL_061f: ldloc.s 19
-			IL_0621: ldstr "packageVersion"
-			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_062b: stloc.s 19
-			IL_062d: ldloc.s 16
-			IL_062f: ldloc.s 19
-			IL_0631: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0636: stloc.s 17
-			IL_0638: ldloc.s 17
-			IL_063a: box [System.Runtime]System.Boolean
-			IL_063f: stloc.s 23
-			IL_0641: ldloc.s 23
-			IL_0643: stloc.s 31
-			IL_0645: br IL_064e
+			IL_05dc: ldloc.s 14
+			IL_05de: ldstr "version"
+			IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e8: stloc.s 16
+			IL_05ea: ldarg.3
+			IL_05eb: ldstr "upstream"
+			IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f5: stloc.s 19
+			IL_05f7: ldloc.s 19
+			IL_05f9: ldstr "packageVersion"
+			IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0603: stloc.s 19
+			IL_0605: ldloc.s 16
+			IL_0607: ldloc.s 19
+			IL_0609: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_060e: stloc.s 17
+			IL_0610: ldloc.s 17
+			IL_0612: box [System.Runtime]System.Boolean
+			IL_0617: stloc.s 23
+			IL_0619: ldloc.s 23
+			IL_061b: stloc.s 31
+			IL_061d: br IL_0626
 
-			IL_064a: ldloc.s 22
-			IL_064c: stloc.s 31
+			IL_0622: ldloc.s 22
+			IL_0624: stloc.s 31
 
-			IL_064e: ldloc.s 31
-			IL_0650: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0655: stloc.s 17
-			IL_0657: ldloc.s 17
-			IL_0659: brfalse IL_072a
+			IL_0626: ldloc.s 31
+			IL_0628: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_062d: stloc.s 17
+			IL_062f: ldloc.s 17
+			IL_0631: brfalse IL_0702
 
-			IL_065e: ldarg.3
-			IL_065f: ldstr "upstream"
-			IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0669: stloc.s 19
-			IL_066b: ldloc.s 19
-			IL_066d: ldstr "packageVersion"
-			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0677: stloc.s 19
-			IL_0679: ldloc.s 19
-			IL_067b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0680: stloc.s 28
-			IL_0682: ldstr "package.json version mismatch: expected "
-			IL_0687: ldloc.s 28
-			IL_0689: call string [System.Runtime]System.String::Concat(string, string)
-			IL_068e: ldstr ", got "
-			IL_0693: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0698: stloc.s 28
-			IL_069a: ldloc.s 14
-			IL_069c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06a1: stloc.s 17
-			IL_06a3: ldloc.s 17
-			IL_06a5: brfalse IL_06c1
+			IL_0636: ldarg.3
+			IL_0637: ldstr "upstream"
+			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0641: stloc.s 19
+			IL_0643: ldloc.s 19
+			IL_0645: ldstr "packageVersion"
+			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_064f: stloc.s 19
+			IL_0651: ldloc.s 19
+			IL_0653: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0658: stloc.s 28
+			IL_065a: ldstr "package.json version mismatch: expected "
+			IL_065f: ldloc.s 28
+			IL_0661: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0666: ldstr ", got "
+			IL_066b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0670: stloc.s 28
+			IL_0672: ldloc.s 14
+			IL_0674: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0679: stloc.s 17
+			IL_067b: ldloc.s 17
+			IL_067d: brfalse IL_0699
 
-			IL_06aa: ldloc.s 14
-			IL_06ac: ldstr "version"
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b6: stloc.s 19
-			IL_06b8: ldloc.s 19
-			IL_06ba: stloc.s 32
-			IL_06bc: br IL_06c5
+			IL_0682: ldloc.s 14
+			IL_0684: ldstr "version"
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_068e: stloc.s 19
+			IL_0690: ldloc.s 19
+			IL_0692: stloc.s 32
+			IL_0694: br IL_069d
 
-			IL_06c1: ldloc.s 14
-			IL_06c3: stloc.s 32
+			IL_0699: ldloc.s 14
+			IL_069b: stloc.s 32
 
-			IL_06c5: ldloc.s 32
-			IL_06c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06cc: stloc.s 17
-			IL_06ce: ldloc.s 17
-			IL_06d0: brfalse IL_06ec
+			IL_069d: ldloc.s 32
+			IL_069f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_06a4: stloc.s 17
+			IL_06a6: ldloc.s 17
+			IL_06a8: brfalse IL_06c4
 
-			IL_06d5: ldloc.s 14
-			IL_06d7: ldstr "version"
-			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e1: stloc.s 19
-			IL_06e3: ldloc.s 19
-			IL_06e5: stloc.s 15
-			IL_06e7: br IL_06f3
+			IL_06ad: ldloc.s 14
+			IL_06af: ldstr "version"
+			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b9: stloc.s 19
+			IL_06bb: ldloc.s 19
+			IL_06bd: stloc.s 15
+			IL_06bf: br IL_06cb
 
-			IL_06ec: ldstr "<missing>"
-			IL_06f1: stloc.s 15
+			IL_06c4: ldstr "<missing>"
+			IL_06c9: stloc.s 15
 
-			IL_06f3: ldloc.s 15
-			IL_06f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06fa: stloc.s 33
-			IL_06fc: ldloc.s 28
-			IL_06fe: ldloc.s 33
-			IL_0700: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0705: stloc.s 33
-			IL_0707: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_070c: dup
-			IL_070d: ldstr "ok"
-			IL_0712: ldc.i4.0
-			IL_0713: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0718: dup
-			IL_0719: ldstr "message"
-			IL_071e: ldloc.s 33
-			IL_0720: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0725: stloc.s 29
-			IL_0727: ldloc.s 29
-			IL_0729: ret
+			IL_06cb: ldloc.s 15
+			IL_06cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06d2: stloc.s 33
+			IL_06d4: ldloc.s 28
+			IL_06d6: ldloc.s 33
+			IL_06d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06dd: stloc.s 33
+			IL_06df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_06e4: dup
+			IL_06e5: ldstr "ok"
+			IL_06ea: ldc.i4.0
+			IL_06eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_06f0: dup
+			IL_06f1: ldstr "message"
+			IL_06f6: ldloc.s 33
+			IL_06f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06fd: stloc.s 29
+			IL_06ff: ldloc.s 29
+			IL_0701: ret
 
-			IL_072a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_072f: dup
-			IL_0730: ldstr "ok"
-			IL_0735: ldc.i4.1
-			IL_0736: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_073b: dup
-			IL_073c: ldstr "message"
-			IL_0741: ldstr ""
-			IL_0746: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_074b: ret
+			IL_0702: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0707: dup
+			IL_0708: ldstr "ok"
+			IL_070d: ldc.i4.1
+			IL_070e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0713: dup
+			IL_0714: ldstr "message"
+			IL_0719: ldstr ""
+			IL_071e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0723: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -5274,7 +5255,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x54fe
+						// Method begins at RVA 0x549e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5292,7 +5273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x54f5
+					// Method begins at RVA 0x5495
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5312,7 +5293,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5507
+					// Method begins at RVA 0x54a7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5330,7 +5311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x54ec
+				// Method begins at RVA 0x548c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5359,7 +5340,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x49a4
+			// Method begins at RVA 0x4944
 			// Header size: 12
 			// Code size: 1053 (0x41d)
 			.maxstack 8
@@ -5808,7 +5789,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5522
+						// Method begins at RVA 0x54c2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5826,7 +5807,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5519
+					// Method begins at RVA 0x54b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5844,7 +5825,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5510
+				// Method begins at RVA 0x54b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5873,7 +5854,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4dd0
+			// Method begins at RVA 0x4d70
 			// Header size: 12
 			// Code size: 373 (0x175)
 			.maxstack 8
@@ -6060,7 +6041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5534
+					// Method begins at RVA 0x54d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6078,7 +6059,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x552b
+				// Method begins at RVA 0x54cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6107,7 +6088,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4f54
+			// Method begins at RVA 0x4ef4
 			// Header size: 12
 			// Code size: 419 (0x1a3)
 			.maxstack 8
@@ -6296,7 +6277,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5546
+					// Method begins at RVA 0x54e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6316,7 +6297,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x554f
+					// Method begins at RVA 0x54ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6334,7 +6315,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x553d
+				// Method begins at RVA 0x54dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6360,7 +6341,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x5104
+			// Method begins at RVA 0x50a4
 			// Header size: 12
 			// Code size: 448 (0x1c0)
 			.maxstack 9
@@ -6599,7 +6580,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5561
+					// Method begins at RVA 0x5501
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6619,7 +6600,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x556a
+					// Method begins at RVA 0x550a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6637,7 +6618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5558
+				// Method begins at RVA 0x54f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6653,9 +6634,9 @@
 
 		// Fields
 		.field public object __dirname
-		.field public object childProcess
-		.field public object fs
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule childProcess
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object parseArgs
 		.field public object printHelp
 		.field public object defaultPinPath
@@ -6685,7 +6666,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x52d0
+			// Method begins at RVA 0x5270
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -7112,21 +7093,21 @@
 		IL_044d: stloc.s 13
 		IL_044f: ldloc.0
 		IL_0450: ldloc.s 13
-		IL_0452: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
+		IL_0452: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_Test262Bootstrap/Scope::childProcess
 		IL_0457: ldarg.1
 		IL_0458: ldstr "node:fs"
 		IL_045d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0462: stloc.s 14
 		IL_0464: ldloc.0
 		IL_0465: ldloc.s 14
-		IL_0467: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+		IL_0467: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
 		IL_046c: ldarg.1
 		IL_046d: ldstr "node:path"
 		IL_0472: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0477: stloc.s 15
 		IL_0479: ldloc.0
 		IL_047a: ldloc.s 15
-		IL_047c: stfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+		IL_047c: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
 		IL_0481: nop
 		IL_0482: nop
 		IL_0483: nop
@@ -7343,7 +7324,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5573
+		// Method begins at RVA 0x5513
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65c4
+				// Method begins at RVA 0x65bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65d6
+					// Method begins at RVA 0x65d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65df
+					// Method begins at RVA 0x65da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65e8
+					// Method begins at RVA 0x65e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65cd
+				// Method begins at RVA 0x65c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -296,7 +296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65fa
+					// Method begins at RVA 0x65f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -314,7 +314,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65f1
+				// Method begins at RVA 0x65ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +434,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x660c
+					// Method begins at RVA 0x6607
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -452,7 +452,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6603
+				// Method begins at RVA 0x65fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -593,7 +593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6615
+				// Method begins at RVA 0x6610
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2459,7 +2459,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x65bb
+			// Method begins at RVA 0x65b6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2759,7 +2759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6627
+				// Method begins at RVA 0x6622
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2847,7 +2847,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6642
+						// Method begins at RVA 0x663d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2865,7 +2865,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6639
+					// Method begins at RVA 0x6634
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2883,7 +2883,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6630
+				// Method begins at RVA 0x662b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3012,7 +3012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x665d
+						// Method begins at RVA 0x6658
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3030,7 +3030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6654
+					// Method begins at RVA 0x664f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3048,7 +3048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x664b
+				// Method begins at RVA 0x6646
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3240,7 +3240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x666f
+					// Method begins at RVA 0x666a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3258,7 +3258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6666
+				// Method begins at RVA 0x6661
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3286,7 +3286,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x668a
+						// Method begins at RVA 0x6685
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3304,7 +3304,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6681
+					// Method begins at RVA 0x667c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3322,7 +3322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6678
+				// Method begins at RVA 0x6673
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3491,7 +3491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x669c
+					// Method begins at RVA 0x6697
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3509,7 +3509,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6693
+				// Method begins at RVA 0x668e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3637,7 +3637,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66a5
+				// Method begins at RVA 0x66a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3665,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66c0
+						// Method begins at RVA 0x66bb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3685,7 +3685,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66c9
+						// Method begins at RVA 0x66c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3705,7 +3705,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66d2
+						// Method begins at RVA 0x66cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3725,7 +3725,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66db
+						// Method begins at RVA 0x66d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3743,7 +3743,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66b7
+					// Method begins at RVA 0x66b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3761,7 +3761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66ae
+				// Method begins at RVA 0x66a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3940,7 +3940,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66f6
+						// Method begins at RVA 0x66f1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3960,7 +3960,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66ff
+						// Method begins at RVA 0x66fa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3980,7 +3980,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6708
+						// Method begins at RVA 0x6703
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3998,7 +3998,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66ed
+					// Method begins at RVA 0x66e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4016,7 +4016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66e4
+				// Method begins at RVA 0x66df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4248,7 +4248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x671a
+					// Method begins at RVA 0x6715
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4268,7 +4268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6723
+					// Method begins at RVA 0x671e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4288,7 +4288,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x672c
+					// Method begins at RVA 0x6727
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4306,7 +4306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6711
+				// Method begins at RVA 0x670c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4535,7 +4535,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6747
+						// Method begins at RVA 0x6742
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4555,7 +4555,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6750
+						// Method begins at RVA 0x674b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4575,7 +4575,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6759
+						// Method begins at RVA 0x6754
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4595,7 +4595,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6762
+						// Method begins at RVA 0x675d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4615,7 +4615,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x676b
+						// Method begins at RVA 0x6766
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4635,7 +4635,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6774
+						// Method begins at RVA 0x676f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4655,7 +4655,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x677d
+						// Method begins at RVA 0x6778
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4673,7 +4673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x673e
+					// Method begins at RVA 0x6739
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4691,7 +4691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6735
+				// Method begins at RVA 0x6730
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5091,7 +5091,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6786
+				// Method begins at RVA 0x6781
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5194,7 +5194,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6798
+					// Method begins at RVA 0x6793
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5214,7 +5214,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67a1
+					// Method begins at RVA 0x679c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5234,7 +5234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67aa
+					// Method begins at RVA 0x67a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5252,7 +5252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x678f
+				// Method begins at RVA 0x678a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5411,7 +5411,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67b3
+				// Method begins at RVA 0x67ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5494,7 +5494,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67c5
+					// Method begins at RVA 0x67c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5512,7 +5512,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67bc
+				// Method begins at RVA 0x67b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5604,7 +5604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67ce
+				// Method begins at RVA 0x67c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5666,7 +5666,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67d7
+				// Method begins at RVA 0x67d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5740,7 +5740,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67e9
+					// Method begins at RVA 0x67e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5760,7 +5760,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67f2
+					// Method begins at RVA 0x67ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5778,7 +5778,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67e0
+				// Method begins at RVA 0x67db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5806,7 +5806,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x680d
+						// Method begins at RVA 0x6808
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5824,7 +5824,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6804
+					// Method begins at RVA 0x67ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5842,7 +5842,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67fb
+				// Method begins at RVA 0x67f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6114,7 +6114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x681f
+					// Method begins at RVA 0x681a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6134,7 +6134,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6828
+					// Method begins at RVA 0x6823
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6152,7 +6152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6816
+				// Method begins at RVA 0x6811
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6328,7 +6328,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x683a
+					// Method begins at RVA 0x6835
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6348,7 +6348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6843
+					// Method begins at RVA 0x683e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6368,7 +6368,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x684c
+					// Method begins at RVA 0x6847
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6388,7 +6388,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6870
+					// Method begins at RVA 0x686b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6406,7 +6406,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6831
+				// Method begins at RVA 0x682c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6434,7 +6434,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6867
+						// Method begins at RVA 0x6862
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6452,7 +6452,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x685e
+					// Method begins at RVA 0x6859
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6470,7 +6470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6855
+				// Method begins at RVA 0x6850
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6982,7 +6982,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68a6
+						// Method begins at RVA 0x68a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7002,7 +7002,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68af
+						// Method begins at RVA 0x68aa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7022,7 +7022,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68b8
+						// Method begins at RVA 0x68b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7040,7 +7040,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x689d
+					// Method begins at RVA 0x6898
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7060,7 +7060,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68c1
+					// Method begins at RVA 0x68bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7080,7 +7080,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68ca
+					// Method begins at RVA 0x68c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7098,7 +7098,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6879
+				// Method begins at RVA 0x6874
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7126,7 +7126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6894
+						// Method begins at RVA 0x688f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7144,7 +7144,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x688b
+					// Method begins at RVA 0x6886
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7162,7 +7162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6882
+				// Method begins at RVA 0x687d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7190,7 +7190,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x68e5
+						// Method begins at RVA 0x68e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7208,7 +7208,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68dc
+					// Method begins at RVA 0x68d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7226,7 +7226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68d3
+				// Method begins at RVA 0x68ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7914,7 +7914,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x68f7
+					// Method begins at RVA 0x68f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7934,7 +7934,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6900
+					// Method begins at RVA 0x68fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7954,7 +7954,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6909
+					// Method begins at RVA 0x6904
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7974,7 +7974,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6912
+					// Method begins at RVA 0x690d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7994,7 +7994,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x691b
+					// Method begins at RVA 0x6916
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8014,7 +8014,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6924
+					// Method begins at RVA 0x691f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8034,7 +8034,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x692d
+					// Method begins at RVA 0x6928
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8052,7 +8052,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x68ee
+				// Method begins at RVA 0x68e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8483,7 +8483,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6975
+					// Method begins at RVA 0x6970
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8501,7 +8501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6936
+				// Method begins at RVA 0x6931
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8529,7 +8529,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6951
+						// Method begins at RVA 0x694c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8547,7 +8547,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6948
+					// Method begins at RVA 0x6943
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8565,7 +8565,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x693f
+				// Method begins at RVA 0x693a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8593,7 +8593,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x696c
+						// Method begins at RVA 0x6967
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8611,7 +8611,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6963
+					// Method begins at RVA 0x695e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8629,7 +8629,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x695a
+				// Method begins at RVA 0x6955
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9422,7 +9422,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x697e
+				// Method begins at RVA 0x6979
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -9451,7 +9451,7 @@
 			)
 			// Method begins at RVA 0x6564
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 70 (0x46)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -9461,40 +9461,39 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.1
-			IL_000c: ldloc.1
-			IL_000d: ldarg.2
-			IL_000e: ldstr "utf8"
-			IL_0013: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0018: stloc.0
-			IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001e: dup
-			IL_001f: ldstr "filePath"
-			IL_0024: ldarg.2
-			IL_0025: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_002a: stloc.2
-			IL_002b: ldc.i4.1
-			IL_002c: newarr [System.Runtime]System.Object
-			IL_0031: dup
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.test262_metadataParser/Scope::fs
+			IL_0006: stloc.1
+			IL_0007: ldloc.1
+			IL_0008: ldarg.2
+			IL_0009: ldstr "utf8"
+			IL_000e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0013: stloc.0
+			IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0019: dup
+			IL_001a: ldstr "filePath"
+			IL_001f: ldarg.2
+			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0025: stloc.2
+			IL_0026: ldc.i4.1
+			IL_0027: newarr [System.Runtime]System.Object
+			IL_002c: dup
+			IL_002d: ldc.i4.0
+			IL_002e: ldarg.0
+			IL_002f: stelem.ref
+			IL_0030: stloc.3
+			IL_0031: ldloc.3
 			IL_0032: ldc.i4.0
-			IL_0033: ldarg.0
-			IL_0034: stelem.ref
-			IL_0035: stloc.3
-			IL_0036: ldloc.3
-			IL_0037: ldc.i4.0
-			IL_0038: ldelem.ref
-			IL_0039: castclass Modules.test262_metadataParser/Scope
-			IL_003e: ldnull
-			IL_003f: ldloc.0
-			IL_0040: ldloc.2
-			IL_0041: tail.
-			IL_0043: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_0048: ret
+			IL_0033: ldelem.ref
+			IL_0034: castclass Modules.test262_metadataParser/Scope
+			IL_0039: ldnull
+			IL_003a: ldloc.0
+			IL_003b: ldloc.2
+			IL_003c: tail.
+			IL_003e: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+			IL_0043: ret
 
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0044: ldnull
+			IL_0045: ret
 		} // end of method parseTest262File::__js_call__
 
 	} // end of class parseTest262File
@@ -9524,7 +9523,7 @@
 			75 6e 71 75 6f 74 65 7d 2c 20 e2 80 a6 00 00
 		)
 		// Fields
-		.field public object fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array DEFAULT_HARNESS_INCLUDES
 		.field public string ASYNC_HARNESS_INCLUDE
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array KNOWN_FRONTMATTER_KEYS
@@ -9556,7 +9555,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x661e
+			// Method begins at RVA 0x6619
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -9937,7 +9936,7 @@
 		IL_03d0: stloc.s 13
 		IL_03d2: ldloc.0
 		IL_03d3: ldloc.s 13
-		IL_03d5: stfld object Modules.test262_metadataParser/Scope::fs
+		IL_03d5: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.test262_metadataParser/Scope::fs
 		IL_03da: ldc.i4.2
 		IL_03db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_03e0: dup
@@ -10095,7 +10094,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6987
+		// Method begins at RVA 0x6982
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37fa
+				// Method begins at RVA 0x37f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x2450
 			// Header size: 12
-			// Code size: 27 (0x1b)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
@@ -55,16 +55,15 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldarg.2
-			IL_000e: ldstr "utf8"
-			IL_0013: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0018: stloc.1
-			IL_0019: ldloc.1
-			IL_001a: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_BumpVersion/Scope::fs
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldarg.2
+			IL_0009: ldstr "utf8"
+			IL_000e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0013: stloc.1
+			IL_0014: ldloc.1
+			IL_0015: ret
 		} // end of method readFile::__js_call__
 
 	} // end of class readFile
@@ -80,7 +79,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3803
+				// Method begins at RVA 0x37fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,25 +107,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2478
+			// Method begins at RVA 0x2474
 			// Header size: 12
-			// Code size: 27 (0x1b)
+			// Code size: 22 (0x16)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldarg.2
-			IL_000e: ldarg.3
-			IL_000f: ldstr "utf8"
-			IL_0014: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0019: ldnull
-			IL_001a: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_BumpVersion/Scope::fs
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldarg.2
+			IL_0009: ldarg.3
+			IL_000a: ldstr "utf8"
+			IL_000f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0014: ldnull
+			IL_0015: ret
 		} // end of method writeFile::__js_call__
 
 	} // end of class writeFile
@@ -142,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x380c
+				// Method begins at RVA 0x3804
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -166,7 +164,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24a0
+			// Method begins at RVA 0x2498
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -250,7 +248,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x381e
+					// Method begins at RVA 0x3816
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -274,7 +272,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36bc
+				// Method begins at RVA 0x36b4
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -311,7 +309,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3827
+					// Method begins at RVA 0x381f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -335,7 +333,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36e4
+				// Method begins at RVA 0x36dc
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -359,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3830
+					// Method begins at RVA 0x3828
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -377,7 +375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3815
+				// Method begins at RVA 0x380d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -402,7 +400,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x252c
+			// Method begins at RVA 0x2524
 			// Header size: 12
 			// Code size: 901 (0x385)
 			.maxstack 10
@@ -774,7 +772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3839
+				// Method begins at RVA 0x3831
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -802,7 +800,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x28d0
+			// Method begins at RVA 0x28c8
 			// Header size: 12
 			// Code size: 216 (0xd8)
 			.maxstack 8
@@ -924,7 +922,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x384b
+					// Method begins at RVA 0x3843
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -942,7 +940,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3842
+				// Method begins at RVA 0x383a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -967,7 +965,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b4
+			// Method begins at RVA 0x29ac
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1058,7 +1056,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x385d
+					// Method begins at RVA 0x3855
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1076,7 +1074,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3854
+				// Method begins at RVA 0x384c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1101,7 +1099,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x2a64
 			// Header size: 12
 			// Code size: 143 (0x8f)
 			.maxstack 8
@@ -1186,7 +1184,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x386f
+					// Method begins at RVA 0x3867
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1204,7 +1202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3866
+				// Method begins at RVA 0x385e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1231,7 +1229,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2b08
+			// Method begins at RVA 0x2b00
 			// Header size: 12
 			// Code size: 534 (0x216)
 			.maxstack 8
@@ -1441,7 +1439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3878
+				// Method begins at RVA 0x3870
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1465,7 +1463,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d2c
+			// Method begins at RVA 0x2d24
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -1519,7 +1517,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x388a
+					// Method begins at RVA 0x3882
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1544,7 +1542,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36f4
+				// Method begins at RVA 0x36ec
 				// Header size: 12
 				// Code size: 126 (0x7e)
 				.maxstack 8
@@ -1624,7 +1622,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3881
+				// Method begins at RVA 0x3879
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1652,7 +1650,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2d70
+			// Method begins at RVA 0x2d68
 			// Header size: 12
 			// Code size: 324 (0x144)
 			.maxstack 8
@@ -1794,7 +1792,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38a5
+					// Method begins at RVA 0x389d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1819,7 +1817,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3780
+				// Method begins at RVA 0x3778
 				// Header size: 12
 				// Code size: 101 (0x65)
 				.maxstack 8
@@ -1895,7 +1893,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x389c
+					// Method begins at RVA 0x3894
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1915,7 +1913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38ae
+					// Method begins at RVA 0x38a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1933,7 +1931,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3893
+				// Method begins at RVA 0x388b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1959,7 +1957,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2ec0
+			// Method begins at RVA 0x2eb8
 			// Header size: 12
 			// Code size: 2030 (0x7ee)
 			.maxstack 8
@@ -2796,7 +2794,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38b7
+				// Method begins at RVA 0x38af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2816,7 +2814,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38c0
+				// Method begins at RVA 0x38b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2831,7 +2829,7 @@
 
 
 		// Fields
-		.field public object fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
 		.field public object CSPROJ_PATH
 		.field public object CORE_CSPROJ_PATH
 		.field public object SDK_CSPROJ_PATH
@@ -2854,7 +2852,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x37f1
+			// Method begins at RVA 0x37e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3064,7 +3062,7 @@
 		IL_01ea: stloc.s 10
 		IL_01ec: ldloc.0
 		IL_01ed: ldloc.s 10
-		IL_01ef: stfld object Modules.Compile_Scripts_BumpVersion/Scope::fs
+		IL_01ef: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_BumpVersion/Scope::fs
 		IL_01f4: ldarg.1
 		IL_01f5: ldstr "path"
 		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -3298,7 +3296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x38c9
+		// Method begins at RVA 0x38c1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3181
+				// Method begins at RVA 0x3161
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x319c
+						// Method begins at RVA 0x317c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a5
+						// Method begins at RVA 0x3185
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31ae
+						// Method begins at RVA 0x318e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31b7
+						// Method begins at RVA 0x3197
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3193
+					// Method begins at RVA 0x3173
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318a
+				// Method begins at RVA 0x316a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +445,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31c9
+					// Method begins at RVA 0x31a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -470,7 +470,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bdc
+				// Method begins at RVA 0x2bbc
 				// Header size: 12
 				// Code size: 405 (0x195)
 				.maxstack 8
@@ -637,7 +637,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31d2
+					// Method begins at RVA 0x31b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -661,7 +661,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d80
+				// Method begins at RVA 0x2d60
 				// Header size: 12
 				// Code size: 140 (0x8c)
 				.maxstack 8
@@ -739,7 +739,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31db
+					// Method begins at RVA 0x31bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -763,7 +763,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e18
+				// Method begins at RVA 0x2df8
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -809,7 +809,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31ed
+						// Method begins at RVA 0x31cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -833,7 +833,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3038
+					// Method begins at RVA 0x3018
 					// Header size: 12
 					// Code size: 221 (0xdd)
 					.maxstack 8
@@ -956,7 +956,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31f6
+						// Method begins at RVA 0x31d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -974,7 +974,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31e4
+					// Method begins at RVA 0x31c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1000,7 +1000,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e44
+				// Method begins at RVA 0x2e24
 				// Header size: 12
 				// Code size: 488 (0x1e8)
 				.maxstack 8
@@ -1203,7 +1203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c0
+				// Method begins at RVA 0x31a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1468,7 +1468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ff
+				// Method begins at RVA 0x31df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1496,7 +1496,7 @@
 			)
 			// Method begins at RVA 0x280c
 			// Header size: 12
-			// Code size: 962 (0x3c2)
+			// Code size: 932 (0x3a4)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1592,282 +1592,276 @@
 			IL_00bb: throw
 
 			IL_00bc: ldarg.0
-			IL_00bd: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00c2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_00c7: stloc.s 10
-			IL_00c9: ldstr "process"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d8: ldstr "cwd"
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00e2: stloc.s 8
-			IL_00e4: ldloc.0
-			IL_00e5: ldstr "inFile"
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ef: stloc.s 11
-			IL_00f1: ldloc.s 10
-			IL_00f3: ldstr "resolve"
-			IL_00f8: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_00fd: brtrue IL_011f
+			IL_00bd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00c2: stloc.s 10
+			IL_00c4: ldstr "process"
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d3: ldstr "cwd"
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00dd: stloc.s 8
+			IL_00df: ldloc.0
+			IL_00e0: ldstr "inFile"
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ea: stloc.s 11
+			IL_00ec: ldloc.s 10
+			IL_00ee: ldstr "resolve"
+			IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_00f8: brtrue IL_011a
 
-			IL_0102: ldloc.s 10
-			IL_0104: ldc.i4.2
-			IL_0105: newarr [System.Runtime]System.Object
+			IL_00fd: ldloc.s 10
+			IL_00ff: ldc.i4.2
+			IL_0100: newarr [System.Runtime]System.Object
+			IL_0105: dup
+			IL_0106: ldc.i4.0
+			IL_0107: ldloc.s 8
+			IL_0109: stelem.ref
 			IL_010a: dup
-			IL_010b: ldc.i4.0
-			IL_010c: ldloc.s 8
+			IL_010b: ldc.i4.1
+			IL_010c: ldloc.s 11
 			IL_010e: stelem.ref
-			IL_010f: dup
-			IL_0110: ldc.i4.1
-			IL_0111: ldloc.s 11
-			IL_0113: stelem.ref
-			IL_0114: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_0119: stloc.3
-			IL_011a: br IL_013c
+			IL_010f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_0114: stloc.3
+			IL_0115: br IL_0137
 
-			IL_011f: ldloc.s 10
-			IL_0121: ldstr "resolve"
-			IL_0126: ldc.i4.2
-			IL_0127: newarr [System.Runtime]System.Object
+			IL_011a: ldloc.s 10
+			IL_011c: ldstr "resolve"
+			IL_0121: ldc.i4.2
+			IL_0122: newarr [System.Runtime]System.Object
+			IL_0127: dup
+			IL_0128: ldc.i4.0
+			IL_0129: ldloc.s 8
+			IL_012b: stelem.ref
 			IL_012c: dup
-			IL_012d: ldc.i4.0
-			IL_012e: ldloc.s 8
+			IL_012d: ldc.i4.1
+			IL_012e: ldloc.s 11
 			IL_0130: stelem.ref
-			IL_0131: dup
-			IL_0132: ldc.i4.1
-			IL_0133: ldloc.s 11
-			IL_0135: stelem.ref
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_013b: stloc.3
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0136: stloc.3
 
-			IL_013c: ldarg.0
-			IL_013d: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0142: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0147: stloc.s 10
-			IL_0149: ldstr "process"
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0158: ldstr "cwd"
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0162: stloc.s 11
-			IL_0164: ldloc.0
-			IL_0165: ldstr "outFile"
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016f: stloc.s 8
-			IL_0171: ldloc.s 10
-			IL_0173: ldstr "resolve"
-			IL_0178: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_017d: brtrue IL_01a0
+			IL_0137: ldarg.0
+			IL_0138: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_013d: stloc.s 10
+			IL_013f: ldstr "process"
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014e: ldstr "cwd"
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0158: stloc.s 11
+			IL_015a: ldloc.0
+			IL_015b: ldstr "outFile"
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0165: stloc.s 8
+			IL_0167: ldloc.s 10
+			IL_0169: ldstr "resolve"
+			IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0173: brtrue IL_0196
 
-			IL_0182: ldloc.s 10
-			IL_0184: ldc.i4.2
-			IL_0185: newarr [System.Runtime]System.Object
-			IL_018a: dup
-			IL_018b: ldc.i4.0
-			IL_018c: ldloc.s 11
-			IL_018e: stelem.ref
-			IL_018f: dup
-			IL_0190: ldc.i4.1
-			IL_0191: ldloc.s 8
-			IL_0193: stelem.ref
-			IL_0194: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_0199: stloc.s 4
-			IL_019b: br IL_01be
+			IL_0178: ldloc.s 10
+			IL_017a: ldc.i4.2
+			IL_017b: newarr [System.Runtime]System.Object
+			IL_0180: dup
+			IL_0181: ldc.i4.0
+			IL_0182: ldloc.s 11
+			IL_0184: stelem.ref
+			IL_0185: dup
+			IL_0186: ldc.i4.1
+			IL_0187: ldloc.s 8
+			IL_0189: stelem.ref
+			IL_018a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_018f: stloc.s 4
+			IL_0191: br IL_01b4
 
-			IL_01a0: ldloc.s 10
-			IL_01a2: ldstr "resolve"
-			IL_01a7: ldc.i4.2
-			IL_01a8: newarr [System.Runtime]System.Object
-			IL_01ad: dup
-			IL_01ae: ldc.i4.0
-			IL_01af: ldloc.s 11
-			IL_01b1: stelem.ref
-			IL_01b2: dup
-			IL_01b3: ldc.i4.1
-			IL_01b4: ldloc.s 8
-			IL_01b6: stelem.ref
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_01bc: stloc.s 4
+			IL_0196: ldloc.s 10
+			IL_0198: ldstr "resolve"
+			IL_019d: ldc.i4.2
+			IL_019e: newarr [System.Runtime]System.Object
+			IL_01a3: dup
+			IL_01a4: ldc.i4.0
+			IL_01a5: ldloc.s 11
+			IL_01a7: stelem.ref
+			IL_01a8: dup
+			IL_01a9: ldc.i4.1
+			IL_01aa: ldloc.s 8
+			IL_01ac: stelem.ref
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_01b2: stloc.s 4
 
-			IL_01be: ldarg.0
-			IL_01bf: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_01c4: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_01c9: stloc.s 12
-			IL_01cb: ldloc.s 12
-			IL_01cd: ldstr "readFileSync"
-			IL_01d2: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_01d7: brtrue IL_01f0
+			IL_01b4: ldarg.0
+			IL_01b5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01ba: stloc.s 12
+			IL_01bc: ldloc.s 12
+			IL_01be: ldstr "readFileSync"
+			IL_01c3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_01c8: brtrue IL_01e1
 
-			IL_01dc: ldloc.s 12
-			IL_01de: ldloc.3
-			IL_01df: ldstr "utf8"
-			IL_01e4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_01e9: stloc.s 5
-			IL_01eb: br IL_0210
+			IL_01cd: ldloc.s 12
+			IL_01cf: ldloc.3
+			IL_01d0: ldstr "utf8"
+			IL_01d5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_01da: stloc.s 5
+			IL_01dc: br IL_0201
 
-			IL_01f0: ldloc.s 12
-			IL_01f2: ldstr "readFileSync"
-			IL_01f7: ldc.i4.2
-			IL_01f8: newarr [System.Runtime]System.Object
-			IL_01fd: dup
-			IL_01fe: ldc.i4.0
-			IL_01ff: ldloc.3
-			IL_0200: stelem.ref
-			IL_0201: dup
-			IL_0202: ldc.i4.1
-			IL_0203: ldstr "utf8"
-			IL_0208: stelem.ref
-			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_020e: stloc.s 5
+			IL_01e1: ldloc.s 12
+			IL_01e3: ldstr "readFileSync"
+			IL_01e8: ldc.i4.2
+			IL_01e9: newarr [System.Runtime]System.Object
+			IL_01ee: dup
+			IL_01ef: ldc.i4.0
+			IL_01f0: ldloc.3
+			IL_01f1: stelem.ref
+			IL_01f2: dup
+			IL_01f3: ldc.i4.1
+			IL_01f4: ldstr "utf8"
+			IL_01f9: stelem.ref
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_01ff: stloc.s 5
 
-			IL_0210: ldarg.0
-			IL_0211: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
-			IL_0216: ldc.i4.1
-			IL_0217: newarr [System.Runtime]System.Object
-			IL_021c: dup
-			IL_021d: ldc.i4.0
-			IL_021e: ldarg.0
-			IL_021f: stelem.ref
-			IL_0220: ldloc.s 5
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0227: stloc.s 6
-			IL_0229: ldarg.0
-			IL_022a: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_022f: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0234: stloc.s 12
-			IL_0236: ldarg.0
-			IL_0237: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_023c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0241: ldstr "dirname"
-			IL_0246: ldloc.s 4
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_024d: stloc.s 8
-			IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0254: dup
-			IL_0255: ldstr "recursive"
-			IL_025a: ldc.i4.1
-			IL_025b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0260: stloc.s 13
-			IL_0262: ldloc.s 12
-			IL_0264: ldstr "mkdirSync"
-			IL_0269: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_026e: brtrue IL_0284
+			IL_0201: ldarg.0
+			IL_0202: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
+			IL_0207: ldc.i4.1
+			IL_0208: newarr [System.Runtime]System.Object
+			IL_020d: dup
+			IL_020e: ldc.i4.0
+			IL_020f: ldarg.0
+			IL_0210: stelem.ref
+			IL_0211: ldloc.s 5
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0218: stloc.s 6
+			IL_021a: ldarg.0
+			IL_021b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_0220: stloc.s 12
+			IL_0222: ldarg.0
+			IL_0223: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_0228: ldstr "dirname"
+			IL_022d: ldloc.s 4
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0234: stloc.s 8
+			IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_023b: dup
+			IL_023c: ldstr "recursive"
+			IL_0241: ldc.i4.1
+			IL_0242: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0247: stloc.s 13
+			IL_0249: ldloc.s 12
+			IL_024b: ldstr "mkdirSync"
+			IL_0250: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0255: brtrue IL_026b
 
-			IL_0273: ldloc.s 12
-			IL_0275: ldloc.s 8
-			IL_0277: ldloc.s 13
-			IL_0279: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_027e: pop
-			IL_027f: br IL_02a1
+			IL_025a: ldloc.s 12
+			IL_025c: ldloc.s 8
+			IL_025e: ldloc.s 13
+			IL_0260: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_0265: pop
+			IL_0266: br IL_0288
 
-			IL_0284: ldloc.s 12
-			IL_0286: ldstr "mkdirSync"
-			IL_028b: ldc.i4.2
-			IL_028c: newarr [System.Runtime]System.Object
-			IL_0291: dup
-			IL_0292: ldc.i4.0
-			IL_0293: ldloc.s 8
-			IL_0295: stelem.ref
-			IL_0296: dup
-			IL_0297: ldc.i4.1
-			IL_0298: ldloc.s 13
-			IL_029a: stelem.ref
-			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_02a0: pop
+			IL_026b: ldloc.s 12
+			IL_026d: ldstr "mkdirSync"
+			IL_0272: ldc.i4.2
+			IL_0273: newarr [System.Runtime]System.Object
+			IL_0278: dup
+			IL_0279: ldc.i4.0
+			IL_027a: ldloc.s 8
+			IL_027c: stelem.ref
+			IL_027d: dup
+			IL_027e: ldc.i4.1
+			IL_027f: ldloc.s 13
+			IL_0281: stelem.ref
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0287: pop
 
-			IL_02a1: ldarg.0
-			IL_02a2: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_02a7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02ac: stloc.s 12
-			IL_02ae: ldloc.s 12
-			IL_02b0: ldstr "writeFileSync"
-			IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_02ba: brtrue IL_02d4
+			IL_0288: ldarg.0
+			IL_0289: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_028e: stloc.s 12
+			IL_0290: ldloc.s 12
+			IL_0292: ldstr "writeFileSync"
+			IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_029c: brtrue IL_02b6
 
-			IL_02bf: ldloc.s 12
-			IL_02c1: ldloc.s 4
-			IL_02c3: ldloc.s 6
-			IL_02c5: ldstr "utf8"
-			IL_02ca: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_02cf: br IL_02f9
+			IL_02a1: ldloc.s 12
+			IL_02a3: ldloc.s 4
+			IL_02a5: ldloc.s 6
+			IL_02a7: ldstr "utf8"
+			IL_02ac: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_02b1: br IL_02db
 
-			IL_02d4: ldloc.s 12
-			IL_02d6: ldstr "writeFileSync"
-			IL_02db: ldc.i4.3
-			IL_02dc: newarr [System.Runtime]System.Object
-			IL_02e1: dup
-			IL_02e2: ldc.i4.0
-			IL_02e3: ldloc.s 4
-			IL_02e5: stelem.ref
-			IL_02e6: dup
-			IL_02e7: ldc.i4.1
-			IL_02e8: ldloc.s 6
-			IL_02ea: stelem.ref
-			IL_02eb: dup
-			IL_02ec: ldc.i4.2
-			IL_02ed: ldstr "utf8"
-			IL_02f2: stelem.ref
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_02f8: pop
+			IL_02b6: ldloc.s 12
+			IL_02b8: ldstr "writeFileSync"
+			IL_02bd: ldc.i4.3
+			IL_02be: newarr [System.Runtime]System.Object
+			IL_02c3: dup
+			IL_02c4: ldc.i4.0
+			IL_02c5: ldloc.s 4
+			IL_02c7: stelem.ref
+			IL_02c8: dup
+			IL_02c9: ldc.i4.1
+			IL_02ca: ldloc.s 6
+			IL_02cc: stelem.ref
+			IL_02cd: dup
+			IL_02ce: ldc.i4.2
+			IL_02cf: ldstr "utf8"
+			IL_02d4: stelem.ref
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_02da: pop
 
-			IL_02f9: ldstr "console"
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0308: stloc.s 8
-			IL_030a: ldloc.0
-			IL_030b: ldstr "inFile"
-			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0315: stloc.s 11
-			IL_0317: ldloc.s 11
-			IL_0319: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_031e: stloc.s 14
-			IL_0320: ldstr "Converted "
-			IL_0325: ldloc.s 14
-			IL_0327: call string [System.Runtime]System.String::Concat(string, string)
-			IL_032c: ldstr " -> "
-			IL_0331: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0336: ldloc.0
-			IL_0337: ldstr "outFile"
-			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0341: stloc.s 11
-			IL_0343: ldloc.s 11
-			IL_0345: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_034a: stloc.s 14
-			IL_034c: ldloc.s 14
-			IL_034e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0353: ldstr " ("
-			IL_0358: call string [System.Runtime]System.String::Concat(string, string)
-			IL_035d: ldloc.s 6
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0364: stloc.s 11
-			IL_0366: ldstr "\\n"
-			IL_036b: ldstr ""
-			IL_0370: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0375: stloc.s 15
+			IL_02db: ldstr "console"
+			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ea: stloc.s 8
+			IL_02ec: ldloc.0
+			IL_02ed: ldstr "inFile"
+			IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f7: stloc.s 11
+			IL_02f9: ldloc.s 11
+			IL_02fb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0300: stloc.s 14
+			IL_0302: ldstr "Converted "
+			IL_0307: ldloc.s 14
+			IL_0309: call string [System.Runtime]System.String::Concat(string, string)
+			IL_030e: ldstr " -> "
+			IL_0313: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0318: ldloc.0
+			IL_0319: ldstr "outFile"
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0323: stloc.s 11
+			IL_0325: ldloc.s 11
+			IL_0327: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_032c: stloc.s 14
+			IL_032e: ldloc.s 14
+			IL_0330: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0335: ldstr " ("
+			IL_033a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_033f: ldloc.s 6
+			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0346: stloc.s 11
+			IL_0348: ldstr "\\n"
+			IL_034d: ldstr ""
+			IL_0352: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0357: stloc.s 15
+			IL_0359: ldloc.s 11
+			IL_035b: ldstr "split"
+			IL_0360: ldloc.s 15
+			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0367: stloc.s 11
+			IL_0369: ldloc.s 11
+			IL_036b: ldstr "length"
+			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0375: stloc.s 11
 			IL_0377: ldloc.s 11
-			IL_0379: ldstr "split"
-			IL_037e: ldloc.s 15
-			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0385: stloc.s 11
-			IL_0387: ldloc.s 11
-			IL_0389: ldstr "length"
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0393: stloc.s 11
-			IL_0395: ldloc.s 11
-			IL_0397: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_039c: stloc.s 14
-			IL_039e: ldloc.s 14
-			IL_03a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03a5: ldstr " lines)"
-			IL_03aa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03af: stloc.s 14
-			IL_03b1: ldloc.s 8
-			IL_03b3: ldstr "log"
-			IL_03b8: ldloc.s 14
-			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03bf: pop
-			IL_03c0: ldnull
-			IL_03c1: ret
+			IL_0379: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_037e: stloc.s 14
+			IL_0380: ldloc.s 14
+			IL_0382: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0387: ldstr " lines)"
+			IL_038c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0391: stloc.s 14
+			IL_0393: ldloc.s 8
+			IL_0395: ldstr "log"
+			IL_039a: ldloc.s 14
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03a1: pop
+			IL_03a2: ldnull
+			IL_03a3: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1899,7 +1893,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3211
+					// Method begins at RVA 0x31f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1919,7 +1913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321a
+					// Method begins at RVA 0x31fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1937,7 +1931,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3208
+				// Method begins at RVA 0x31e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1952,8 +1946,8 @@
 
 
 		// Fields
-		.field public object fs
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object TurndownService
 		.field public object parseArgs
 		.field public object convertHtmlToMarkdown
@@ -1963,7 +1957,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3178
+			// Method begins at RVA 0x3158
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2060,14 +2054,14 @@
 		IL_0093: stloc.s 8
 		IL_0095: ldloc.0
 		IL_0096: ldloc.s 8
-		IL_0098: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+		IL_0098: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
 		IL_009d: ldarg.1
 		IL_009e: ldstr "path"
 		IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_00a8: stloc.s 9
 		IL_00aa: ldloc.0
 		IL_00ab: ldloc.s 9
-		IL_00ad: stfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+		IL_00ad: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
 		IL_00b2: ldarg.1
 		IL_00b3: ldstr "turndown"
 		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
@@ -2197,7 +2191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x322c
+				// Method begins at RVA 0x320c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2220,7 +2214,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3121
+			// Method begins at RVA 0x3101
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2249,7 +2243,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3235
+				// Method begins at RVA 0x3215
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2274,7 +2268,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3124
+			// Method begins at RVA 0x3104
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2311,7 +2305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x323e
+				// Method begins at RVA 0x321e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2335,7 +2329,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x313c
+			// Method begins at RVA 0x311c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2389,7 +2383,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3223
+			// Method begins at RVA 0x3203
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2500,7 +2494,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3247
+		// Method begins at RVA 0x3227
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3475
+				// Method begins at RVA 0x3414
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3487
+					// Method begins at RVA 0x3426
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -154,7 +154,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x347e
+				// Method begins at RVA 0x341d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -301,7 +301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3490
+				// Method begins at RVA 0x342f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -330,7 +330,7 @@
 			)
 			// Method begins at RVA 0x2454
 			// Header size: 12
-			// Code size: 188 (0xbc)
+			// Code size: 173 (0xad)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -343,83 +343,80 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule
-			IL_000b: stloc.1
-			IL_000c: ldloc.1
-			IL_000d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_0012: stloc.0
-			IL_0013: ldarg.0
-			IL_0014: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0019: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_001e: stloc.2
-			IL_001f: ldarg.2
-			IL_0020: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0025: stloc.3
-			IL_0026: ldstr ""
-			IL_002b: ldloc.3
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
+			IL_0006: stloc.1
+			IL_0007: ldloc.1
+			IL_0008: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_000d: stloc.0
+			IL_000e: ldarg.0
+			IL_000f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0014: stloc.2
+			IL_0015: ldarg.2
+			IL_0016: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_001b: stloc.3
+			IL_001c: ldstr ""
+			IL_0021: ldloc.3
+			IL_0022: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0027: ldstr ".GeneratorTests"
 			IL_002c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0031: ldstr ".GeneratorTests"
-			IL_0036: call string [System.Runtime]System.String::Concat(string, string)
-			IL_003b: stloc.3
-			IL_003c: ldloc.2
-			IL_003d: ldc.i4.3
-			IL_003e: newarr [System.Runtime]System.Object
-			IL_0043: dup
-			IL_0044: ldc.i4.0
-			IL_0045: ldloc.0
-			IL_0046: stelem.ref
-			IL_0047: dup
-			IL_0048: ldc.i4.1
-			IL_0049: ldstr "Jroc.Tests"
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.2
-			IL_0051: ldloc.3
-			IL_0052: stelem.ref
-			IL_0053: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0058: stloc.s 4
-			IL_005a: ldarg.0
-			IL_005b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0060: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0065: stloc.2
-			IL_0066: ldarg.2
-			IL_0067: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_006c: stloc.3
-			IL_006d: ldstr ""
-			IL_0072: ldloc.3
-			IL_0073: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0078: ldstr ".ExecutionTests"
-			IL_007d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0082: stloc.3
-			IL_0083: ldloc.2
-			IL_0084: ldc.i4.3
-			IL_0085: newarr [System.Runtime]System.Object
-			IL_008a: dup
-			IL_008b: ldc.i4.0
-			IL_008c: ldloc.0
-			IL_008d: stelem.ref
-			IL_008e: dup
-			IL_008f: ldc.i4.1
-			IL_0090: ldstr "Jroc.Tests"
-			IL_0095: stelem.ref
-			IL_0096: dup
-			IL_0097: ldc.i4.2
-			IL_0098: ldloc.3
-			IL_0099: stelem.ref
-			IL_009a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_009f: stloc.s 5
-			IL_00a1: ldc.i4.2
-			IL_00a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00a7: dup
-			IL_00a8: ldloc.s 4
-			IL_00aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00af: dup
-			IL_00b0: ldloc.s 5
-			IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b7: stloc.s 6
-			IL_00b9: ldloc.s 6
-			IL_00bb: ret
+			IL_0031: stloc.3
+			IL_0032: ldloc.2
+			IL_0033: ldc.i4.3
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldloc.0
+			IL_003c: stelem.ref
+			IL_003d: dup
+			IL_003e: ldc.i4.1
+			IL_003f: ldstr "Jroc.Tests"
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.3
+			IL_0048: stelem.ref
+			IL_0049: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_004e: stloc.s 4
+			IL_0050: ldarg.0
+			IL_0051: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0056: stloc.2
+			IL_0057: ldarg.2
+			IL_0058: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_005d: stloc.3
+			IL_005e: ldstr ""
+			IL_0063: ldloc.3
+			IL_0064: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0069: ldstr ".ExecutionTests"
+			IL_006e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0073: stloc.3
+			IL_0074: ldloc.2
+			IL_0075: ldc.i4.3
+			IL_0076: newarr [System.Runtime]System.Object
+			IL_007b: dup
+			IL_007c: ldc.i4.0
+			IL_007d: ldloc.0
+			IL_007e: stelem.ref
+			IL_007f: dup
+			IL_0080: ldc.i4.1
+			IL_0081: ldstr "Jroc.Tests"
+			IL_0086: stelem.ref
+			IL_0087: dup
+			IL_0088: ldc.i4.2
+			IL_0089: ldloc.3
+			IL_008a: stelem.ref
+			IL_008b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0090: stloc.s 5
+			IL_0092: ldc.i4.2
+			IL_0093: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0098: dup
+			IL_0099: ldloc.s 4
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a0: dup
+			IL_00a1: ldloc.s 5
+			IL_00a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a8: stloc.s 6
+			IL_00aa: ldloc.s 6
+			IL_00ac: ret
 		} // end of method getCandidateCategoryRoots::__js_call__
 
 	} // end of class getCandidateCategoryRoots
@@ -445,7 +442,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ab
+					// Method begins at RVA 0x344a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -469,7 +466,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33fc
+				// Method begins at RVA 0x33a0
 				// Header size: 12
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -505,7 +502,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34b4
+					// Method begins at RVA 0x3453
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -530,9 +527,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x341c
+				// Method begins at RVA 0x33c0
 				// Header size: 12
-				// Code size: 68 (0x44)
+				// Code size: 63 (0x3f)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -544,34 +541,33 @@
 				IL_0001: ldc.i4.0
 				IL_0002: ldelem.ref
 				IL_0003: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-				IL_0008: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_000d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-				IL_0012: stloc.0
-				IL_0013: ldarg.0
-				IL_0014: ldc.i4.1
-				IL_0015: ldelem.ref
-				IL_0016: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
-				IL_001b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-				IL_0020: stloc.1
-				IL_0021: ldarg.2
-				IL_0022: ldstr "name"
-				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_002c: stloc.2
-				IL_002d: ldloc.0
-				IL_002e: ldc.i4.2
-				IL_002f: newarr [System.Runtime]System.Object
-				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldloc.1
-				IL_0037: stelem.ref
-				IL_0038: dup
-				IL_0039: ldc.i4.1
-				IL_003a: ldloc.2
-				IL_003b: stelem.ref
-				IL_003c: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-				IL_0041: stloc.2
-				IL_0042: ldloc.2
-				IL_0043: ret
+				IL_0008: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_000d: stloc.0
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
+				IL_0016: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+				IL_001b: stloc.1
+				IL_001c: ldarg.2
+				IL_001d: ldstr "name"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0027: stloc.2
+				IL_0028: ldloc.0
+				IL_0029: ldc.i4.2
+				IL_002a: newarr [System.Runtime]System.Object
+				IL_002f: dup
+				IL_0030: ldc.i4.0
+				IL_0031: ldloc.1
+				IL_0032: stelem.ref
+				IL_0033: dup
+				IL_0034: ldc.i4.1
+				IL_0035: ldloc.2
+				IL_0036: stelem.ref
+				IL_0037: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+				IL_003c: stloc.2
+				IL_003d: ldloc.2
+				IL_003e: ret
 			} // end of method ArrowFunction_L66C10::__js_call__
 
 		} // end of class ArrowFunction_L66C10
@@ -592,7 +588,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a2
+					// Method begins at RVA 0x3441
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -613,7 +609,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3499
+				// Method begins at RVA 0x3438
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -641,7 +637,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34cf
+						// Method begins at RVA 0x346e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -659,7 +655,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34c6
+					// Method begins at RVA 0x3465
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -677,7 +673,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34bd
+				// Method begins at RVA 0x345c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -705,9 +701,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x251c
+			// Method begins at RVA 0x2510
 			// Header size: 12
-			// Code size: 600 (0x258)
+			// Code size: 575 (0x23f)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope,
@@ -737,235 +733,230 @@
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
 			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0013: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0018: stloc.s 10
-			IL_001a: ldloc.0
-			IL_001b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_0020: stloc.s 11
-			IL_0022: ldloc.s 10
-			IL_0024: ldloc.s 11
-			IL_0026: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_002b: box [System.Runtime]System.Boolean
-			IL_0030: stloc.s 11
-			IL_0032: ldloc.s 11
-			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0039: ldc.i4.0
-			IL_003a: ceq
-			IL_003c: stloc.s 12
-			IL_003e: ldloc.s 12
-			IL_0040: brfalse IL_004c
+			IL_000e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_0013: stloc.s 10
+			IL_0015: ldloc.0
+			IL_0016: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+			IL_001b: stloc.s 11
+			IL_001d: ldloc.s 10
+			IL_001f: ldloc.s 11
+			IL_0021: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0026: box [System.Runtime]System.Boolean
+			IL_002b: stloc.s 11
+			IL_002d: ldloc.s 11
+			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0034: ldc.i4.0
+			IL_0035: ceq
+			IL_0037: stloc.s 12
+			IL_0039: ldloc.s 12
+			IL_003b: brfalse IL_0047
 
-			IL_0045: ldc.i4.0
-			IL_0046: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_004b: ret
+			IL_0040: ldc.i4.0
+			IL_0041: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0046: ret
 
-			IL_004c: ldarg.0
-			IL_004d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0052: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0057: stloc.s 10
-			IL_0059: ldloc.0
-			IL_005a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
-			IL_005f: stloc.s 11
-			IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0066: dup
-			IL_0067: ldstr "withFileTypes"
-			IL_006c: ldc.i4.1
-			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0072: stloc.s 13
-			IL_0074: ldloc.s 10
-			IL_0076: ldloc.s 11
-			IL_0078: ldloc.s 13
-			IL_007a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptArray [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readdirSync(object, object)
-			IL_007f: stloc.s 11
-			IL_0081: ldloc.s 11
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0088: stloc.s 11
-			IL_008a: ldnull
-			IL_008b: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L65C13::__js_call__(object, object)
-			IL_0091: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0096: ldc.i4.1
-			IL_0097: newarr [System.Runtime]System.Object
-			IL_009c: dup
-			IL_009d: ldc.i4.0
-			IL_009e: ldarg.0
-			IL_009f: stelem.ref
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00aa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00af: ldc.i4.1
-			IL_00b0: conv.r8
-			IL_00b1: ldstr ""
-			IL_00b6: ldc.i4.0
-			IL_00b7: ldc.i4.0
-			IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-			IL_00c2: stloc.s 14
-			IL_00c4: ldloc.s 11
-			IL_00c6: ldstr "filter"
-			IL_00cb: ldloc.s 14
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d2: stloc.s 11
-			IL_00d4: ldloc.s 11
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00db: stloc.s 11
-			IL_00dd: ldnull
-			IL_00de: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L66C10::__js_call__(object[], object, object)
-			IL_00e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00e9: ldc.i4.2
-			IL_00ea: newarr [System.Runtime]System.Object
-			IL_00ef: dup
-			IL_00f0: ldc.i4.0
-			IL_00f1: ldarg.0
-			IL_00f2: stelem.ref
-			IL_00f3: dup
-			IL_00f4: ldc.i4.1
-			IL_00f5: ldloc.0
-			IL_00f6: stelem.ref
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0101: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_0106: ldc.i4.1
-			IL_0107: conv.r8
-			IL_0108: ldstr ""
-			IL_010d: ldc.i4.0
-			IL_010e: ldc.i4.0
-			IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_0119: stloc.s 15
-			IL_011b: ldloc.s 11
-			IL_011d: ldstr "map"
-			IL_0122: ldloc.s 15
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0129: stloc.1
-			IL_012a: ldc.i4.0
-			IL_012b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0130: stloc.2
-			IL_0131: ldc.r8 1
-			IL_013a: neg
-			IL_013b: stloc.s 16
-			IL_013d: ldloc.s 16
-			IL_013f: box [System.Runtime]System.Double
-			IL_0144: stloc.3
-			IL_0145: ldloc.1
-			IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_014b: stloc.s 4
-			IL_014d: ldc.i4.0
-			IL_014e: stloc.s 5
-			IL_0150: ldc.i4.0
-			IL_0151: stloc.s 6
+			IL_0047: ldarg.0
+			IL_0048: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_004d: stloc.s 10
+			IL_004f: ldloc.0
+			IL_0050: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
+			IL_0055: stloc.s 11
+			IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005c: dup
+			IL_005d: ldstr "withFileTypes"
+			IL_0062: ldc.i4.1
+			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0068: stloc.s 13
+			IL_006a: ldloc.s 10
+			IL_006c: ldloc.s 11
+			IL_006e: ldloc.s 13
+			IL_0070: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptArray [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readdirSync(object, object)
+			IL_0075: stloc.s 11
+			IL_0077: ldloc.s 11
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007e: stloc.s 11
+			IL_0080: ldnull
+			IL_0081: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L65C13::__js_call__(object, object)
+			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_008c: ldc.i4.1
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: stelem.ref
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00a0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00a5: ldc.i4.1
+			IL_00a6: conv.r8
+			IL_00a7: ldstr ""
+			IL_00ac: ldc.i4.0
+			IL_00ad: ldc.i4.0
+			IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+			IL_00b8: stloc.s 14
+			IL_00ba: ldloc.s 11
+			IL_00bc: ldstr "filter"
+			IL_00c1: ldloc.s 14
+			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c8: stloc.s 11
+			IL_00ca: ldloc.s 11
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d1: stloc.s 11
+			IL_00d3: ldnull
+			IL_00d4: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L66C10::__js_call__(object[], object, object)
+			IL_00da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00df: ldc.i4.2
+			IL_00e0: newarr [System.Runtime]System.Object
+			IL_00e5: dup
+			IL_00e6: ldc.i4.0
+			IL_00e7: ldarg.0
+			IL_00e8: stelem.ref
+			IL_00e9: dup
+			IL_00ea: ldc.i4.1
+			IL_00eb: ldloc.0
+			IL_00ec: stelem.ref
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00f7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_00fc: ldc.i4.1
+			IL_00fd: conv.r8
+			IL_00fe: ldstr ""
+			IL_0103: ldc.i4.0
+			IL_0104: ldc.i4.0
+			IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_010f: stloc.s 15
+			IL_0111: ldloc.s 11
+			IL_0113: ldstr "map"
+			IL_0118: ldloc.s 15
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011f: stloc.1
+			IL_0120: ldc.i4.0
+			IL_0121: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0126: stloc.2
+			IL_0127: ldc.r8 1
+			IL_0130: neg
+			IL_0131: stloc.s 16
+			IL_0133: ldloc.s 16
+			IL_0135: box [System.Runtime]System.Double
+			IL_013a: stloc.3
+			IL_013b: ldloc.1
+			IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0141: stloc.s 4
+			IL_0143: ldc.i4.0
+			IL_0144: stloc.s 5
+			IL_0146: ldc.i4.0
+			IL_0147: stloc.s 6
 			.try
 			{
-				// loop start (head: IL_0153)
-					IL_0153: ldloc.s 4
-					IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_015a: stloc.s 11
-					IL_015c: ldloc.s 11
-					IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0163: stloc.s 12
-					IL_0165: ldloc.s 12
-					IL_0167: brtrue IL_0238
+				// loop start (head: IL_0149)
+					IL_0149: ldloc.s 4
+					IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0150: stloc.s 11
+					IL_0152: ldloc.s 11
+					IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0159: stloc.s 12
+					IL_015b: ldloc.s 12
+					IL_015d: brtrue IL_021f
 
-					IL_016c: ldloc.s 11
-					IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0173: stloc.s 11
-					IL_0175: ldloc.s 11
-					IL_0177: stloc.s 7
-					IL_0179: ldarg.0
-					IL_017a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-					IL_017f: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-					IL_0184: stloc.s 17
-					IL_0186: ldloc.s 17
-					IL_0188: ldc.i4.2
-					IL_0189: newarr [System.Runtime]System.Object
-					IL_018e: dup
-					IL_018f: ldc.i4.0
-					IL_0190: ldloc.s 7
-					IL_0192: stelem.ref
-					IL_0193: dup
-					IL_0194: ldc.i4.1
-					IL_0195: ldarg.3
-					IL_0196: stelem.ref
-					IL_0197: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-					IL_019c: stloc.s 8
-					IL_019e: ldarg.0
-					IL_019f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_01a4: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_01a9: stloc.s 10
-					IL_01ab: ldloc.s 10
-					IL_01ad: ldloc.s 8
-					IL_01af: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_01b4: box [System.Runtime]System.Boolean
-					IL_01b9: stloc.s 11
-					IL_01bb: ldloc.s 11
-					IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_01c2: ldc.i4.0
-					IL_01c3: ceq
-					IL_01c5: stloc.s 12
-					IL_01c7: ldloc.s 12
-					IL_01c9: brfalse IL_01d3
+					IL_0162: ldloc.s 11
+					IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0169: stloc.s 11
+					IL_016b: ldloc.s 11
+					IL_016d: stloc.s 7
+					IL_016f: ldarg.0
+					IL_0170: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+					IL_0175: stloc.s 17
+					IL_0177: ldloc.s 17
+					IL_0179: ldc.i4.2
+					IL_017a: newarr [System.Runtime]System.Object
+					IL_017f: dup
+					IL_0180: ldc.i4.0
+					IL_0181: ldloc.s 7
+					IL_0183: stelem.ref
+					IL_0184: dup
+					IL_0185: ldc.i4.1
+					IL_0186: ldarg.3
+					IL_0187: stelem.ref
+					IL_0188: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+					IL_018d: stloc.s 8
+					IL_018f: ldarg.0
+					IL_0190: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_0195: stloc.s 10
+					IL_0197: ldloc.s 10
+					IL_0199: ldloc.s 8
+					IL_019b: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_01a0: box [System.Runtime]System.Boolean
+					IL_01a5: stloc.s 11
+					IL_01a7: ldloc.s 11
+					IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_01ae: ldc.i4.0
+					IL_01af: ceq
+					IL_01b1: stloc.s 12
+					IL_01b3: ldloc.s 12
+					IL_01b5: brfalse IL_01bf
 
-					IL_01ce: br IL_0224
+					IL_01ba: br IL_020b
 
-					IL_01d3: ldarg.0
-					IL_01d4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_01d9: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_01de: stloc.s 10
-					IL_01e0: ldloc.s 10
-					IL_01e2: ldloc.s 8
-					IL_01e4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_01e9: stloc.s 9
-					IL_01eb: ldloc.s 9
-					IL_01ed: ldstr "mtimeMs"
-					IL_01f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_01f7: stloc.s 16
-					IL_01f9: ldloc.3
-					IL_01fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01ff: stloc.s 18
-					IL_0201: ldloc.s 16
-					IL_0203: ldloc.s 18
-					IL_0205: cgt
-					IL_0207: brfalse IL_0224
+					IL_01bf: ldarg.0
+					IL_01c0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_01c5: stloc.s 10
+					IL_01c7: ldloc.s 10
+					IL_01c9: ldloc.s 8
+					IL_01cb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_01d0: stloc.s 9
+					IL_01d2: ldloc.s 9
+					IL_01d4: ldstr "mtimeMs"
+					IL_01d9: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+					IL_01de: stloc.s 16
+					IL_01e0: ldloc.3
+					IL_01e1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_01e6: stloc.s 18
+					IL_01e8: ldloc.s 16
+					IL_01ea: ldloc.s 18
+					IL_01ec: cgt
+					IL_01ee: brfalse IL_020b
 
-					IL_020c: ldloc.s 9
-					IL_020e: ldstr "mtimeMs"
-					IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0218: stloc.s 11
-					IL_021a: ldloc.s 11
-					IL_021c: stloc.3
-					IL_021d: ldloc.s 8
-					IL_021f: stloc.s 11
-					IL_0221: ldloc.s 11
-					IL_0223: stloc.2
+					IL_01f3: ldloc.s 9
+					IL_01f5: ldstr "mtimeMs"
+					IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01ff: stloc.s 11
+					IL_0201: ldloc.s 11
+					IL_0203: stloc.3
+					IL_0204: ldloc.s 8
+					IL_0206: stloc.s 11
+					IL_0208: ldloc.s 11
+					IL_020a: stloc.2
 
-					IL_0224: br IL_0153
+					IL_020b: br IL_0149
 				// end loop
-				IL_0229: ldloc.s 4
-				IL_022b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0230: ldc.i4.1
-				IL_0231: stloc.s 6
-				IL_0233: leave IL_0256
+				IL_0210: ldloc.s 4
+				IL_0212: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0217: ldc.i4.1
+				IL_0218: stloc.s 6
+				IL_021a: leave IL_023d
 
-				IL_0238: ldc.i4.1
-				IL_0239: stloc.s 5
-				IL_023b: leave IL_0256
+				IL_021f: ldc.i4.1
+				IL_0220: stloc.s 5
+				IL_0222: leave IL_023d
 			} // end .try
 			finally
 			{
-				IL_0240: ldloc.s 5
-				IL_0242: brtrue IL_0255
+				IL_0227: ldloc.s 5
+				IL_0229: brtrue IL_023c
 
-				IL_0247: ldloc.s 6
-				IL_0249: brtrue IL_0255
+				IL_022e: ldloc.s 6
+				IL_0230: brtrue IL_023c
 
-				IL_024e: ldloc.s 4
-				IL_0250: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0235: ldloc.s 4
+				IL_0237: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0255: endfinally
+				IL_023c: endfinally
 			} // end handler
 
-			IL_0256: ldloc.2
-			IL_0257: ret
+			IL_023d: ldloc.2
+			IL_023e: ret
 		} // end of method tryFindLatestGeneratedAssemblyInRoot::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssemblyInRoot
@@ -985,7 +976,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e1
+					// Method begins at RVA 0x3480
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1003,7 +994,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34d8
+				// Method begins at RVA 0x3477
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1031,7 +1022,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2790
+			// Method begins at RVA 0x276c
 			// Header size: 12
 			// Code size: 315 (0x13b)
 			.maxstack 10
@@ -1226,7 +1217,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34fc
+						// Method begins at RVA 0x349b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1244,7 +1235,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34f3
+					// Method begins at RVA 0x3492
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1262,7 +1253,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34ea
+				// Method begins at RVA 0x3489
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1289,9 +1280,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x28e8
+			// Method begins at RVA 0x28c4
 			// Header size: 12
-			// Code size: 376 (0x178)
+			// Code size: 351 (0x15f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1316,159 +1307,154 @@
 			IL_0001: stloc.0
 			// loop start (head: IL_0002)
 				IL_0002: ldc.i4.1
-				IL_0003: brfalse IL_013b
+				IL_0003: brfalse IL_0122
 
 				IL_0008: ldarg.0
-				IL_0009: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_000e: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-				IL_0013: stloc.s 5
-				IL_0015: ldloc.s 5
-				IL_0017: ldc.i4.2
-				IL_0018: newarr [System.Runtime]System.Object
-				IL_001d: dup
-				IL_001e: ldc.i4.0
-				IL_001f: ldloc.0
-				IL_0020: stelem.ref
-				IL_0021: dup
-				IL_0022: ldc.i4.1
-				IL_0023: ldstr "jroc.sln"
-				IL_0028: stelem.ref
-				IL_0029: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-				IL_002e: stloc.1
-				IL_002f: ldarg.0
-				IL_0030: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_0035: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-				IL_003a: stloc.s 5
-				IL_003c: ldloc.s 5
-				IL_003e: ldc.i4.3
-				IL_003f: newarr [System.Runtime]System.Object
-				IL_0044: dup
-				IL_0045: ldc.i4.0
-				IL_0046: ldloc.0
-				IL_0047: stelem.ref
-				IL_0048: dup
-				IL_0049: ldc.i4.1
-				IL_004a: ldstr "tests"
-				IL_004f: stelem.ref
-				IL_0050: dup
-				IL_0051: ldc.i4.2
-				IL_0052: ldstr "Jroc.Tests"
-				IL_0057: stelem.ref
-				IL_0058: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-				IL_005d: stloc.2
-				IL_005e: ldarg.0
-				IL_005f: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_0064: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_0069: stloc.s 6
-				IL_006b: ldloc.s 6
-				IL_006d: ldloc.1
-				IL_006e: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-				IL_0073: box [System.Runtime]System.Boolean
-				IL_0078: stloc.s 7
-				IL_007a: ldloc.s 7
-				IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0081: stloc.s 8
-				IL_0083: ldloc.s 8
-				IL_0085: brfalse IL_00af
+				IL_0009: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_000e: stloc.s 5
+				IL_0010: ldloc.s 5
+				IL_0012: ldc.i4.2
+				IL_0013: newarr [System.Runtime]System.Object
+				IL_0018: dup
+				IL_0019: ldc.i4.0
+				IL_001a: ldloc.0
+				IL_001b: stelem.ref
+				IL_001c: dup
+				IL_001d: ldc.i4.1
+				IL_001e: ldstr "jroc.sln"
+				IL_0023: stelem.ref
+				IL_0024: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+				IL_0029: stloc.1
+				IL_002a: ldarg.0
+				IL_002b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_0030: stloc.s 5
+				IL_0032: ldloc.s 5
+				IL_0034: ldc.i4.3
+				IL_0035: newarr [System.Runtime]System.Object
+				IL_003a: dup
+				IL_003b: ldc.i4.0
+				IL_003c: ldloc.0
+				IL_003d: stelem.ref
+				IL_003e: dup
+				IL_003f: ldc.i4.1
+				IL_0040: ldstr "tests"
+				IL_0045: stelem.ref
+				IL_0046: dup
+				IL_0047: ldc.i4.2
+				IL_0048: ldstr "Jroc.Tests"
+				IL_004d: stelem.ref
+				IL_004e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+				IL_0053: stloc.2
+				IL_0054: ldarg.0
+				IL_0055: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_005a: stloc.s 6
+				IL_005c: ldloc.s 6
+				IL_005e: ldloc.1
+				IL_005f: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+				IL_0064: box [System.Runtime]System.Boolean
+				IL_0069: stloc.s 7
+				IL_006b: ldloc.s 7
+				IL_006d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0072: stloc.s 8
+				IL_0074: ldloc.s 8
+				IL_0076: brfalse IL_009b
 
-				IL_008a: ldarg.0
-				IL_008b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-				IL_0090: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_0095: stloc.s 6
-				IL_0097: ldloc.s 6
-				IL_0099: ldloc.2
-				IL_009a: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-				IL_009f: box [System.Runtime]System.Boolean
-				IL_00a4: stloc.s 9
-				IL_00a6: ldloc.s 9
-				IL_00a8: stloc.s 11
-				IL_00aa: br IL_00b3
+				IL_007b: ldarg.0
+				IL_007c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+				IL_0081: stloc.s 6
+				IL_0083: ldloc.s 6
+				IL_0085: ldloc.2
+				IL_0086: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+				IL_008b: box [System.Runtime]System.Boolean
+				IL_0090: stloc.s 9
+				IL_0092: ldloc.s 9
+				IL_0094: stloc.s 11
+				IL_0096: br IL_009f
 
-				IL_00af: ldloc.s 7
-				IL_00b1: stloc.s 11
+				IL_009b: ldloc.s 7
+				IL_009d: stloc.s 11
 
-				IL_00b3: ldloc.s 11
-				IL_00b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00ba: stloc.s 8
-				IL_00bc: ldloc.s 8
-				IL_00be: brfalse IL_00c5
+				IL_009f: ldloc.s 11
+				IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00a6: stloc.s 8
+				IL_00a8: ldloc.s 8
+				IL_00aa: brfalse IL_00b1
 
-				IL_00c3: ldloc.0
-				IL_00c4: ret
+				IL_00af: ldloc.0
+				IL_00b0: ret
 
-				IL_00c5: ldarg.0
-				IL_00c6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_00cb: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-				IL_00d0: ldstr "dirname"
-				IL_00d5: ldloc.0
-				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00db: stloc.3
-				IL_00dc: ldloc.3
-				IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_00e2: ldc.i4.0
-				IL_00e3: ceq
-				IL_00e5: stloc.s 8
-				IL_00e7: ldloc.s 8
-				IL_00e9: box [System.Runtime]System.Boolean
-				IL_00ee: stloc.s 12
-				IL_00f0: ldloc.s 12
-				IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00f7: stloc.s 8
-				IL_00f9: ldloc.s 8
-				IL_00fb: brtrue IL_011b
+				IL_00b1: ldarg.0
+				IL_00b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+				IL_00b7: ldstr "dirname"
+				IL_00bc: ldloc.0
+				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00c2: stloc.3
+				IL_00c3: ldloc.3
+				IL_00c4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00c9: ldc.i4.0
+				IL_00ca: ceq
+				IL_00cc: stloc.s 8
+				IL_00ce: ldloc.s 8
+				IL_00d0: box [System.Runtime]System.Boolean
+				IL_00d5: stloc.s 12
+				IL_00d7: ldloc.s 12
+				IL_00d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00de: stloc.s 8
+				IL_00e0: ldloc.s 8
+				IL_00e2: brtrue IL_0102
 
-				IL_0100: ldloc.3
-				IL_0101: ldloc.0
-				IL_0102: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0107: stloc.s 8
-				IL_0109: ldloc.s 8
-				IL_010b: box [System.Runtime]System.Boolean
-				IL_0110: stloc.s 13
-				IL_0112: ldloc.s 13
-				IL_0114: stloc.s 14
-				IL_0116: br IL_011f
+				IL_00e7: ldloc.3
+				IL_00e8: ldloc.0
+				IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00ee: stloc.s 8
+				IL_00f0: ldloc.s 8
+				IL_00f2: box [System.Runtime]System.Boolean
+				IL_00f7: stloc.s 13
+				IL_00f9: ldloc.s 13
+				IL_00fb: stloc.s 14
+				IL_00fd: br IL_0106
 
-				IL_011b: ldloc.s 12
-				IL_011d: stloc.s 14
+				IL_0102: ldloc.s 12
+				IL_0104: stloc.s 14
 
-				IL_011f: ldloc.s 14
-				IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0126: stloc.s 8
-				IL_0128: ldloc.s 8
-				IL_012a: brfalse IL_0134
+				IL_0106: ldloc.s 14
+				IL_0108: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_010d: stloc.s 8
+				IL_010f: ldloc.s 8
+				IL_0111: brfalse IL_011b
 
-				IL_012f: br IL_013b
+				IL_0116: br IL_0122
 
-				IL_0134: ldloc.3
-				IL_0135: stloc.0
-				IL_0136: br IL_0002
+				IL_011b: ldloc.3
+				IL_011c: stloc.0
+				IL_011d: br IL_0002
 			// end loop
 
-			IL_013b: ldarg.2
-			IL_013c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0141: stloc.s 15
-			IL_0143: ldstr "Could not locate jroc repo root starting from: "
-			IL_0148: ldloc.s 15
-			IL_014a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_014f: stloc.s 15
-			IL_0151: ldloc.s 15
-			IL_0153: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_015d: stloc.s 4
-			IL_015f: ldloc.s 4
-			IL_0161: isinst [System.Runtime]System.Exception
-			IL_0166: dup
-			IL_0167: brtrue IL_0175
+			IL_0122: ldarg.2
+			IL_0123: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0128: stloc.s 15
+			IL_012a: ldstr "Could not locate jroc repo root starting from: "
+			IL_012f: ldloc.s 15
+			IL_0131: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0136: stloc.s 15
+			IL_0138: ldloc.s 15
+			IL_013a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0144: stloc.s 4
+			IL_0146: ldloc.s 4
+			IL_0148: isinst [System.Runtime]System.Exception
+			IL_014d: dup
+			IL_014e: brtrue IL_015c
 
-			IL_016c: pop
-			IL_016d: ldloc.s 4
-			IL_016f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0174: throw
+			IL_0153: pop
+			IL_0154: ldloc.s 4
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_015b: throw
 
-			IL_0175: throw
+			IL_015c: throw
 
-			IL_0176: ldnull
-			IL_0177: ret
+			IL_015d: ldnull
+			IL_015e: ret
 		} // end of method findProjectRoot::__js_call__
 
 	} // end of class findProjectRoot
@@ -1484,7 +1470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3505
+				// Method begins at RVA 0x34a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1512,9 +1498,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2a6c
+			// Method begins at RVA 0x2a30
 			// Header size: 12
-			// Code size: 99 (0x63)
+			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -1523,52 +1509,51 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: stloc.0
-			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0012: stloc.1
-			IL_0013: ldarg.3
-			IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0019: stloc.2
-			IL_001a: ldstr "GeneratorTests."
-			IL_001f: ldloc.2
-			IL_0020: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0025: ldstr ".verified.txt"
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: stloc.2
-			IL_0030: ldloc.0
-			IL_0031: ldc.i4.6
-			IL_0032: newarr [System.Runtime]System.Object
-			IL_0037: dup
-			IL_0038: ldc.i4.0
-			IL_0039: ldloc.1
-			IL_003a: stelem.ref
-			IL_003b: dup
-			IL_003c: ldc.i4.1
-			IL_003d: ldstr "tests"
-			IL_0042: stelem.ref
-			IL_0043: dup
-			IL_0044: ldc.i4.2
-			IL_0045: ldstr "Jroc.Tests"
-			IL_004a: stelem.ref
-			IL_004b: dup
-			IL_004c: ldc.i4.3
-			IL_004d: ldarg.2
-			IL_004e: stelem.ref
-			IL_004f: dup
-			IL_0050: ldc.i4.4
-			IL_0051: ldstr "Snapshots"
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.5
-			IL_0059: ldloc.2
-			IL_005a: stelem.ref
-			IL_005b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0060: stloc.1
-			IL_0061: ldloc.1
-			IL_0062: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_000d: stloc.1
+			IL_000e: ldarg.3
+			IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0014: stloc.2
+			IL_0015: ldstr "GeneratorTests."
+			IL_001a: ldloc.2
+			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0020: ldstr ".verified.txt"
+			IL_0025: call string [System.Runtime]System.String::Concat(string, string)
+			IL_002a: stloc.2
+			IL_002b: ldloc.0
+			IL_002c: ldc.i4.6
+			IL_002d: newarr [System.Runtime]System.Object
+			IL_0032: dup
+			IL_0033: ldc.i4.0
+			IL_0034: ldloc.1
+			IL_0035: stelem.ref
+			IL_0036: dup
+			IL_0037: ldc.i4.1
+			IL_0038: ldstr "tests"
+			IL_003d: stelem.ref
+			IL_003e: dup
+			IL_003f: ldc.i4.2
+			IL_0040: ldstr "Jroc.Tests"
+			IL_0045: stelem.ref
+			IL_0046: dup
+			IL_0047: ldc.i4.3
+			IL_0048: ldarg.2
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.4
+			IL_004c: ldstr "Snapshots"
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.5
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_005b: stloc.1
+			IL_005c: ldloc.1
+			IL_005d: ret
 		} // end of method getGeneratorTestSnapshotPath::__js_call__
 
 	} // end of class getGeneratorTestSnapshotPath
@@ -1584,7 +1569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x350e
+				// Method begins at RVA 0x34ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1611,9 +1596,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2adc
+			// Method begins at RVA 0x2a9c
 			// Header size: 12
-			// Code size: 145 (0x91)
+			// Code size: 140 (0x8c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1624,52 +1609,51 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
-			IL_000b: stloc.1
-			IL_000c: ldc.i4.1
-			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0012: dup
-			IL_0013: ldarg.2
-			IL_0014: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0019: stloc.2
-			IL_001a: ldstr "process"
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0029: ldstr "cwd"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0033: stloc.3
-			IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0039: dup
-			IL_003a: ldstr "detached"
-			IL_003f: ldc.i4.1
-			IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0045: dup
-			IL_0046: ldstr "stdio"
-			IL_004b: ldstr "ignore"
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: dup
-			IL_0056: ldstr "shell"
-			IL_005b: ldc.i4.1
-			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0061: dup
-			IL_0062: ldstr "cwd"
-			IL_0067: ldloc.3
-			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006d: stloc.s 4
-			IL_006f: ldloc.1
-			IL_0070: ldstr "ilspy"
-			IL_0075: ldloc.2
-			IL_0076: ldloc.s 4
-			IL_0078: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawn(string, object, object)
-			IL_007d: stloc.0
-			IL_007e: ldloc.0
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0084: ldstr "unref"
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_008e: pop
-			IL_008f: ldnull
-			IL_0090: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_0006: stloc.1
+			IL_0007: ldc.i4.1
+			IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_000d: dup
+			IL_000e: ldarg.2
+			IL_000f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0014: stloc.2
+			IL_0015: ldstr "process"
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0024: ldstr "cwd"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_002e: stloc.3
+			IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0034: dup
+			IL_0035: ldstr "detached"
+			IL_003a: ldc.i4.1
+			IL_003b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0040: dup
+			IL_0041: ldstr "stdio"
+			IL_0046: ldstr "ignore"
+			IL_004b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0050: dup
+			IL_0051: ldstr "shell"
+			IL_0056: ldc.i4.1
+			IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005c: dup
+			IL_005d: ldstr "cwd"
+			IL_0062: ldloc.3
+			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0068: stloc.s 4
+			IL_006a: ldloc.1
+			IL_006b: ldstr "ilspy"
+			IL_0070: ldloc.2
+			IL_0071: ldloc.s 4
+			IL_0073: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawn(string, object, object)
+			IL_0078: stloc.0
+			IL_0079: ldloc.0
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007f: ldstr "unref"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0089: pop
+			IL_008a: ldnull
+			IL_008b: ret
 		} // end of method openInIlSpy::__js_call__
 
 	} // end of class openInIlSpy
@@ -1689,7 +1673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3520
+					// Method begins at RVA 0x34bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1709,7 +1693,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3529
+					// Method begins at RVA 0x34c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1733,7 +1717,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x353b
+						// Method begins at RVA 0x34da
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1751,7 +1735,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3532
+					// Method begins at RVA 0x34d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1771,7 +1755,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3544
+					// Method begins at RVA 0x34e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1795,7 +1779,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3556
+						// Method begins at RVA 0x34f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1813,7 +1797,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x354d
+					// Method begins at RVA 0x34ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1833,7 +1817,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x355f
+					// Method begins at RVA 0x34fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1853,7 +1837,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3568
+					// Method begins at RVA 0x3507
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1871,7 +1855,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3517
+				// Method begins at RVA 0x34b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1897,9 +1881,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
-			// Method begins at RVA 0x2b7c
+			// Method begins at RVA 0x2b34
 			// Header size: 12
-			// Code size: 2145 (0x861)
+			// Code size: 2125 (0x84d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2039,564 +2023,560 @@
 			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0183: stloc.3
 			IL_0184: ldarg.0
-			IL_0185: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_018a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_018f: stloc.s 19
-			IL_0191: ldloc.s 19
-			IL_0193: ldloc.3
-			IL_0194: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0199: box [System.Runtime]System.Boolean
-			IL_019e: stloc.s 17
-			IL_01a0: ldloc.s 17
-			IL_01a2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01a7: ldc.i4.0
-			IL_01a8: ceq
-			IL_01aa: stloc.s 20
-			IL_01ac: ldloc.s 20
-			IL_01ae: brfalse IL_0230
+			IL_0185: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_018a: stloc.s 19
+			IL_018c: ldloc.s 19
+			IL_018e: ldloc.3
+			IL_018f: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0194: box [System.Runtime]System.Boolean
+			IL_0199: stloc.s 17
+			IL_019b: ldloc.s 17
+			IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01a2: ldc.i4.0
+			IL_01a3: ceq
+			IL_01a5: stloc.s 20
+			IL_01a7: ldloc.s 20
+			IL_01a9: brfalse IL_022b
 
-			IL_01b3: ldstr "console"
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c2: stloc.s 17
-			IL_01c4: ldloc.3
-			IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ca: stloc.s 21
-			IL_01cc: ldstr "Generator test snapshot not found: "
-			IL_01d1: ldloc.s 21
-			IL_01d3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d8: stloc.s 21
-			IL_01da: ldloc.s 17
-			IL_01dc: ldstr "error"
-			IL_01e1: ldloc.s 21
-			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e8: pop
-			IL_01e9: ldstr "console"
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f8: ldstr "error"
-			IL_01fd: ldstr "Check the category and test name before running the helper."
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0207: pop
-			IL_0208: ldstr "process"
-			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0217: ldstr "exit"
-			IL_021c: ldc.r8 1
-			IL_0225: box [System.Runtime]System.Double
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_022f: pop
+			IL_01ae: ldstr "console"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bd: stloc.s 17
+			IL_01bf: ldloc.3
+			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01c5: stloc.s 21
+			IL_01c7: ldstr "Generator test snapshot not found: "
+			IL_01cc: ldloc.s 21
+			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d3: stloc.s 21
+			IL_01d5: ldloc.s 17
+			IL_01d7: ldstr "error"
+			IL_01dc: ldloc.s 21
+			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01e3: pop
+			IL_01e4: ldstr "console"
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f3: ldstr "error"
+			IL_01f8: ldstr "Check the category and test name before running the helper."
+			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0202: pop
+			IL_0203: ldstr "process"
+			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0212: ldstr "exit"
+			IL_0217: ldc.r8 1
+			IL_0220: box [System.Runtime]System.Double
+			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022a: pop
 
-			IL_0230: ldloc.1
-			IL_0231: ldstr "namespace"
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023b: stloc.s 17
-			IL_023d: ldloc.s 17
-			IL_023f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0244: stloc.s 21
-			IL_0246: ldstr "Jroc.Tests."
-			IL_024b: ldloc.s 21
-			IL_024d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0252: ldstr ".GeneratorTests."
-			IL_0257: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025c: ldloc.2
-			IL_025d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0262: stloc.s 21
-			IL_0264: ldloc.s 21
-			IL_0266: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026b: stloc.s 4
-			IL_026d: ldarg.0
-			IL_026e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_0273: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0278: stloc.s 22
-			IL_027a: ldarg.0
-			IL_027b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0280: stloc.s 17
-			IL_0282: ldloc.s 22
-			IL_0284: ldc.i4.4
-			IL_0285: newarr [System.Runtime]System.Object
-			IL_028a: dup
-			IL_028b: ldc.i4.0
-			IL_028c: ldloc.s 17
-			IL_028e: stelem.ref
-			IL_028f: dup
-			IL_0290: ldc.i4.1
-			IL_0291: ldstr "tests"
-			IL_0296: stelem.ref
-			IL_0297: dup
-			IL_0298: ldc.i4.2
-			IL_0299: ldstr "Jroc.Tests"
-			IL_029e: stelem.ref
-			IL_029f: dup
-			IL_02a0: ldc.i4.3
-			IL_02a1: ldstr "Jroc.Tests.csproj"
-			IL_02a6: stelem.ref
-			IL_02a7: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_02ac: stloc.s 5
-			IL_02ae: ldstr "console"
-			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02bd: stloc.s 17
-			IL_02bf: ldloc.s 4
-			IL_02c1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02c6: stloc.s 21
-			IL_02c8: ldstr "Running test: "
-			IL_02cd: ldloc.s 21
-			IL_02cf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02d4: stloc.s 21
-			IL_02d6: ldloc.s 17
-			IL_02d8: ldstr "log"
-			IL_02dd: ldloc.s 21
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02e4: pop
-			IL_02e5: ldarg.0
-			IL_02e6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_02eb: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
-			IL_02f0: stloc.s 23
-			IL_02f2: ldloc.s 4
-			IL_02f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f9: stloc.s 21
-			IL_02fb: ldstr "FullyQualifiedName="
-			IL_0300: ldloc.s 21
-			IL_0302: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0307: stloc.s 21
-			IL_0309: ldc.i4.5
-			IL_030a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_030f: dup
-			IL_0310: ldstr "test"
-			IL_0315: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_031a: dup
-			IL_031b: ldloc.s 5
-			IL_031d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0322: dup
-			IL_0323: ldstr "--filter"
-			IL_0328: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_032d: dup
-			IL_032e: ldloc.s 21
-			IL_0330: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0335: dup
-			IL_0336: ldstr "--no-build"
-			IL_033b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0340: stloc.s 24
-			IL_0342: ldarg.0
-			IL_0343: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0348: stloc.s 17
-			IL_034a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_034f: dup
-			IL_0350: ldstr "stdio"
-			IL_0355: ldstr "inherit"
-			IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_035f: dup
-			IL_0360: ldstr "shell"
-			IL_0365: ldc.i4.1
-			IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_036b: dup
-			IL_036c: ldstr "cwd"
-			IL_0371: ldloc.s 17
-			IL_0373: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0378: stloc.s 25
-			IL_037a: ldloc.s 23
-			IL_037c: ldstr "dotnet"
-			IL_0381: ldloc.s 24
-			IL_0383: ldloc.s 25
-			IL_0385: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_038a: stloc.s 6
-			IL_038c: ldarg.0
-			IL_038d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_0392: ldc.i4.1
-			IL_0393: newarr [System.Runtime]System.Object
-			IL_0398: dup
-			IL_0399: ldc.i4.0
-			IL_039a: ldarg.0
-			IL_039b: stelem.ref
-			IL_039c: ldloc.2
-			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_03a2: stloc.s 7
-			IL_03a4: ldloc.s 6
-			IL_03a6: ldstr "status"
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b0: stloc.s 17
-			IL_03b2: ldloc.s 17
-			IL_03b4: ldc.r8 0.0
-			IL_03bd: box [System.Runtime]System.Double
-			IL_03c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_03c7: stloc.s 20
-			IL_03c9: ldloc.s 20
-			IL_03cb: brfalse IL_0405
+			IL_022b: ldloc.1
+			IL_022c: ldstr "namespace"
+			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0236: stloc.s 17
+			IL_0238: ldloc.s 17
+			IL_023a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_023f: stloc.s 21
+			IL_0241: ldstr "Jroc.Tests."
+			IL_0246: ldloc.s 21
+			IL_0248: call string [System.Runtime]System.String::Concat(string, string)
+			IL_024d: ldstr ".GeneratorTests."
+			IL_0252: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0257: ldloc.2
+			IL_0258: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_025d: stloc.s 21
+			IL_025f: ldloc.s 21
+			IL_0261: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0266: stloc.s 4
+			IL_0268: ldarg.0
+			IL_0269: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_026e: stloc.s 22
+			IL_0270: ldarg.0
+			IL_0271: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0276: stloc.s 17
+			IL_0278: ldloc.s 22
+			IL_027a: ldc.i4.4
+			IL_027b: newarr [System.Runtime]System.Object
+			IL_0280: dup
+			IL_0281: ldc.i4.0
+			IL_0282: ldloc.s 17
+			IL_0284: stelem.ref
+			IL_0285: dup
+			IL_0286: ldc.i4.1
+			IL_0287: ldstr "tests"
+			IL_028c: stelem.ref
+			IL_028d: dup
+			IL_028e: ldc.i4.2
+			IL_028f: ldstr "Jroc.Tests"
+			IL_0294: stelem.ref
+			IL_0295: dup
+			IL_0296: ldc.i4.3
+			IL_0297: ldstr "Jroc.Tests.csproj"
+			IL_029c: stelem.ref
+			IL_029d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_02a2: stloc.s 5
+			IL_02a4: ldstr "console"
+			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b3: stloc.s 17
+			IL_02b5: ldloc.s 4
+			IL_02b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02bc: stloc.s 21
+			IL_02be: ldstr "Running test: "
+			IL_02c3: ldloc.s 21
+			IL_02c5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02ca: stloc.s 21
+			IL_02cc: ldloc.s 17
+			IL_02ce: ldstr "log"
+			IL_02d3: ldloc.s 21
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02da: pop
+			IL_02db: ldarg.0
+			IL_02dc: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_02e1: stloc.s 23
+			IL_02e3: ldloc.s 4
+			IL_02e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02ea: stloc.s 21
+			IL_02ec: ldstr "FullyQualifiedName="
+			IL_02f1: ldloc.s 21
+			IL_02f3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02f8: stloc.s 21
+			IL_02fa: ldc.i4.5
+			IL_02fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0300: dup
+			IL_0301: ldstr "test"
+			IL_0306: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030b: dup
+			IL_030c: ldloc.s 5
+			IL_030e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0313: dup
+			IL_0314: ldstr "--filter"
+			IL_0319: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_031e: dup
+			IL_031f: ldloc.s 21
+			IL_0321: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0326: dup
+			IL_0327: ldstr "--no-build"
+			IL_032c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0331: stloc.s 24
+			IL_0333: ldarg.0
+			IL_0334: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0339: stloc.s 17
+			IL_033b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0340: dup
+			IL_0341: ldstr "stdio"
+			IL_0346: ldstr "inherit"
+			IL_034b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0350: dup
+			IL_0351: ldstr "shell"
+			IL_0356: ldc.i4.1
+			IL_0357: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_035c: dup
+			IL_035d: ldstr "cwd"
+			IL_0362: ldloc.s 17
+			IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0369: stloc.s 25
+			IL_036b: ldloc.s 23
+			IL_036d: ldstr "dotnet"
+			IL_0372: ldloc.s 24
+			IL_0374: ldloc.s 25
+			IL_0376: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_037b: stloc.s 6
+			IL_037d: ldarg.0
+			IL_037e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_0383: ldc.i4.1
+			IL_0384: newarr [System.Runtime]System.Object
+			IL_0389: dup
+			IL_038a: ldc.i4.0
+			IL_038b: ldarg.0
+			IL_038c: stelem.ref
+			IL_038d: ldloc.2
+			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0393: stloc.s 7
+			IL_0395: ldloc.s 6
+			IL_0397: ldstr "status"
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a1: stloc.s 17
+			IL_03a3: ldloc.s 17
+			IL_03a5: ldc.r8 0.0
+			IL_03ae: box [System.Runtime]System.Double
+			IL_03b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03b8: stloc.s 20
+			IL_03ba: ldloc.s 20
+			IL_03bc: brfalse IL_03f6
 
-			IL_03d0: ldarg.0
-			IL_03d1: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_03d6: ldc.i4.1
-			IL_03d7: newarr [System.Runtime]System.Object
-			IL_03dc: dup
-			IL_03dd: ldc.i4.0
-			IL_03de: ldarg.0
-			IL_03df: stelem.ref
-			IL_03e0: stloc.s 18
-			IL_03e2: ldloc.1
-			IL_03e3: ldstr "path"
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ed: stloc.s 17
-			IL_03ef: ldloc.s 18
-			IL_03f1: ldloc.s 17
-			IL_03f3: ldloc.s 7
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03fa: stloc.s 17
-			IL_03fc: ldloc.s 17
-			IL_03fe: stloc.s 8
-			IL_0400: br IL_040d
+			IL_03c1: ldarg.0
+			IL_03c2: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_03c7: ldc.i4.1
+			IL_03c8: newarr [System.Runtime]System.Object
+			IL_03cd: dup
+			IL_03ce: ldc.i4.0
+			IL_03cf: ldarg.0
+			IL_03d0: stelem.ref
+			IL_03d1: stloc.s 18
+			IL_03d3: ldloc.1
+			IL_03d4: ldstr "path"
+			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03de: stloc.s 17
+			IL_03e0: ldloc.s 18
+			IL_03e2: ldloc.s 17
+			IL_03e4: ldloc.s 7
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03eb: stloc.s 17
+			IL_03ed: ldloc.s 17
+			IL_03ef: stloc.s 8
+			IL_03f1: br IL_03fe
 
-			IL_0405: ldc.i4.0
-			IL_0406: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_040b: stloc.s 8
+			IL_03f6: ldc.i4.0
+			IL_03f7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03fc: stloc.s 8
 
-			IL_040d: ldloc.s 8
-			IL_040f: stloc.s 9
-			IL_0411: ldloc.s 9
-			IL_0413: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0418: ldc.i4.0
-			IL_0419: ceq
-			IL_041b: stloc.s 20
-			IL_041d: ldloc.s 20
-			IL_041f: brfalse IL_05a4
+			IL_03fe: ldloc.s 8
+			IL_0400: stloc.s 9
+			IL_0402: ldloc.s 9
+			IL_0404: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0409: ldc.i4.0
+			IL_040a: ceq
+			IL_040c: stloc.s 20
+			IL_040e: ldloc.s 20
+			IL_0410: brfalse IL_0590
 
-			IL_0424: ldstr "console"
-			IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0433: ldstr "log"
-			IL_0438: ldstr "Test did not produce an assembly, retrying with build..."
-			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0442: pop
-			IL_0443: ldarg.0
-			IL_0444: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0449: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
-			IL_044e: stloc.s 23
-			IL_0450: ldloc.s 4
-			IL_0452: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0457: stloc.s 21
-			IL_0459: ldstr "FullyQualifiedName="
-			IL_045e: ldloc.s 21
-			IL_0460: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0465: stloc.s 21
-			IL_0467: ldc.i4.4
-			IL_0468: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_046d: dup
-			IL_046e: ldstr "test"
-			IL_0473: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0478: dup
-			IL_0479: ldloc.s 5
-			IL_047b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0480: dup
-			IL_0481: ldstr "--filter"
-			IL_0486: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_048b: dup
-			IL_048c: ldloc.s 21
-			IL_048e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0493: stloc.s 24
-			IL_0495: ldarg.0
-			IL_0496: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_049b: stloc.s 17
-			IL_049d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04a2: dup
-			IL_04a3: ldstr "stdio"
-			IL_04a8: ldstr "inherit"
-			IL_04ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04b2: dup
-			IL_04b3: ldstr "shell"
-			IL_04b8: ldc.i4.1
-			IL_04b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04be: dup
-			IL_04bf: ldstr "cwd"
-			IL_04c4: ldloc.s 17
-			IL_04c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04cb: stloc.s 25
-			IL_04cd: ldloc.s 23
-			IL_04cf: ldstr "dotnet"
-			IL_04d4: ldloc.s 24
-			IL_04d6: ldloc.s 25
-			IL_04d8: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_04dd: stloc.s 10
-			IL_04df: ldloc.s 10
-			IL_04e1: ldstr "status"
-			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04eb: stloc.s 17
-			IL_04ed: ldloc.s 17
-			IL_04ef: ldc.r8 0.0
-			IL_04f8: box [System.Runtime]System.Double
-			IL_04fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0502: stloc.s 20
-			IL_0504: ldloc.s 20
-			IL_0506: brfalse IL_0574
+			IL_0415: ldstr "console"
+			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0424: ldstr "log"
+			IL_0429: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0433: pop
+			IL_0434: ldarg.0
+			IL_0435: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_043a: stloc.s 23
+			IL_043c: ldloc.s 4
+			IL_043e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0443: stloc.s 21
+			IL_0445: ldstr "FullyQualifiedName="
+			IL_044a: ldloc.s 21
+			IL_044c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0451: stloc.s 21
+			IL_0453: ldc.i4.4
+			IL_0454: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0459: dup
+			IL_045a: ldstr "test"
+			IL_045f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0464: dup
+			IL_0465: ldloc.s 5
+			IL_0467: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_046c: dup
+			IL_046d: ldstr "--filter"
+			IL_0472: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0477: dup
+			IL_0478: ldloc.s 21
+			IL_047a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_047f: stloc.s 24
+			IL_0481: ldarg.0
+			IL_0482: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0487: stloc.s 17
+			IL_0489: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_048e: dup
+			IL_048f: ldstr "stdio"
+			IL_0494: ldstr "inherit"
+			IL_0499: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_049e: dup
+			IL_049f: ldstr "shell"
+			IL_04a4: ldc.i4.1
+			IL_04a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04aa: dup
+			IL_04ab: ldstr "cwd"
+			IL_04b0: ldloc.s 17
+			IL_04b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04b7: stloc.s 25
+			IL_04b9: ldloc.s 23
+			IL_04bb: ldstr "dotnet"
+			IL_04c0: ldloc.s 24
+			IL_04c2: ldloc.s 25
+			IL_04c4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_04c9: stloc.s 10
+			IL_04cb: ldloc.s 10
+			IL_04cd: ldstr "status"
+			IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d7: stloc.s 17
+			IL_04d9: ldloc.s 17
+			IL_04db: ldc.r8 0.0
+			IL_04e4: box [System.Runtime]System.Double
+			IL_04e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_04ee: stloc.s 20
+			IL_04f0: ldloc.s 20
+			IL_04f2: brfalse IL_0560
 
-			IL_050b: ldstr "console"
-			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_051a: stloc.s 17
-			IL_051c: ldloc.s 4
-			IL_051e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0523: stloc.s 21
-			IL_0525: ldstr "Test "
-			IL_052a: ldloc.s 21
-			IL_052c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0531: ldstr " failed or not found."
-			IL_0536: call string [System.Runtime]System.String::Concat(string, string)
-			IL_053b: stloc.s 21
-			IL_053d: ldloc.s 17
-			IL_053f: ldstr "error"
-			IL_0544: ldloc.s 21
-			IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_054b: pop
-			IL_054c: ldstr "process"
-			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_055b: ldstr "exit"
-			IL_0560: ldc.r8 1
-			IL_0569: box [System.Runtime]System.Double
-			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0573: pop
+			IL_04f7: ldstr "console"
+			IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0506: stloc.s 17
+			IL_0508: ldloc.s 4
+			IL_050a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_050f: stloc.s 21
+			IL_0511: ldstr "Test "
+			IL_0516: ldloc.s 21
+			IL_0518: call string [System.Runtime]System.String::Concat(string, string)
+			IL_051d: ldstr " failed or not found."
+			IL_0522: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0527: stloc.s 21
+			IL_0529: ldloc.s 17
+			IL_052b: ldstr "error"
+			IL_0530: ldloc.s 21
+			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0537: pop
+			IL_0538: ldstr "process"
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0542: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0547: ldstr "exit"
+			IL_054c: ldc.r8 1
+			IL_0555: box [System.Runtime]System.Double
+			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_055f: pop
 
-			IL_0574: ldarg.0
-			IL_0575: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_057a: ldc.i4.1
-			IL_057b: newarr [System.Runtime]System.Object
-			IL_0580: dup
-			IL_0581: ldc.i4.0
-			IL_0582: ldarg.0
-			IL_0583: stelem.ref
-			IL_0584: stloc.s 18
-			IL_0586: ldloc.1
-			IL_0587: ldstr "path"
-			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0591: stloc.s 17
-			IL_0593: ldloc.s 18
-			IL_0595: ldloc.s 17
-			IL_0597: ldloc.s 7
-			IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_059e: stloc.s 17
-			IL_05a0: ldloc.s 17
-			IL_05a2: stloc.s 9
+			IL_0560: ldarg.0
+			IL_0561: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_0566: ldc.i4.1
+			IL_0567: newarr [System.Runtime]System.Object
+			IL_056c: dup
+			IL_056d: ldc.i4.0
+			IL_056e: ldarg.0
+			IL_056f: stelem.ref
+			IL_0570: stloc.s 18
+			IL_0572: ldloc.1
+			IL_0573: ldstr "path"
+			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057d: stloc.s 17
+			IL_057f: ldloc.s 18
+			IL_0581: ldloc.s 17
+			IL_0583: ldloc.s 7
+			IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_058a: stloc.s 17
+			IL_058c: ldloc.s 17
+			IL_058e: stloc.s 9
 
-			IL_05a4: ldloc.s 9
-			IL_05a6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05ab: ldc.i4.0
-			IL_05ac: ceq
-			IL_05ae: stloc.s 20
-			IL_05b0: ldloc.s 20
-			IL_05b2: brfalse IL_072a
+			IL_0590: ldloc.s 9
+			IL_0592: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0597: ldc.i4.0
+			IL_0598: ceq
+			IL_059a: stloc.s 20
+			IL_059c: ldloc.s 20
+			IL_059e: brfalse IL_0716
 
-			IL_05b7: ldstr "console"
-			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c6: stloc.s 17
-			IL_05c8: ldloc.1
-			IL_05c9: ldstr "path"
-			IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d3: stloc.s 26
-			IL_05d5: ldloc.s 26
-			IL_05d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05dc: stloc.s 21
-			IL_05de: ldstr "Assembly not found for category '"
-			IL_05e3: ldloc.s 21
-			IL_05e5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05ea: ldstr "' and test '"
-			IL_05ef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05f4: ldloc.2
-			IL_05f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05fa: stloc.s 21
-			IL_05fc: ldloc.s 21
-			IL_05fe: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0603: ldstr "'."
-			IL_0608: call string [System.Runtime]System.String::Concat(string, string)
-			IL_060d: stloc.s 21
-			IL_060f: ldloc.s 17
-			IL_0611: ldstr "error"
-			IL_0616: ldloc.s 21
-			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_061d: pop
-			IL_061e: ldstr "console"
-			IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062d: ldstr "error"
-			IL_0632: ldstr "Looked under:"
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_063c: pop
-			IL_063d: ldarg.0
-			IL_063e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_0643: ldc.i4.1
-			IL_0644: newarr [System.Runtime]System.Object
-			IL_0649: dup
-			IL_064a: ldc.i4.0
-			IL_064b: ldarg.0
-			IL_064c: stelem.ref
-			IL_064d: stloc.s 18
-			IL_064f: ldloc.1
-			IL_0650: ldstr "path"
-			IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_065a: stloc.s 17
-			IL_065c: ldloc.s 18
-			IL_065e: ldloc.s 17
-			IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0665: stloc.s 11
-			IL_0667: ldc.r8 0.0
-			IL_0670: stloc.s 12
-			// loop start (head: IL_0672)
-				IL_0672: ldloc.s 12
-				IL_0674: stloc.s 27
-				IL_0676: ldloc.s 11
-				IL_0678: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_067d: stloc.s 28
-				IL_067f: ldloc.s 27
-				IL_0681: ldloc.s 28
-				IL_0683: clt
-				IL_0685: brfalse IL_06e3
+			IL_05a3: ldstr "console"
+			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b2: stloc.s 17
+			IL_05b4: ldloc.1
+			IL_05b5: ldstr "path"
+			IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05bf: stloc.s 26
+			IL_05c1: ldloc.s 26
+			IL_05c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05c8: stloc.s 21
+			IL_05ca: ldstr "Assembly not found for category '"
+			IL_05cf: ldloc.s 21
+			IL_05d1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05d6: ldstr "' and test '"
+			IL_05db: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05e0: ldloc.2
+			IL_05e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05e6: stloc.s 21
+			IL_05e8: ldloc.s 21
+			IL_05ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05ef: ldstr "'."
+			IL_05f4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05f9: stloc.s 21
+			IL_05fb: ldloc.s 17
+			IL_05fd: ldstr "error"
+			IL_0602: ldloc.s 21
+			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0609: pop
+			IL_060a: ldstr "console"
+			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0619: ldstr "error"
+			IL_061e: ldstr "Looked under:"
+			IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0628: pop
+			IL_0629: ldarg.0
+			IL_062a: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_062f: ldc.i4.1
+			IL_0630: newarr [System.Runtime]System.Object
+			IL_0635: dup
+			IL_0636: ldc.i4.0
+			IL_0637: ldarg.0
+			IL_0638: stelem.ref
+			IL_0639: stloc.s 18
+			IL_063b: ldloc.1
+			IL_063c: ldstr "path"
+			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0646: stloc.s 17
+			IL_0648: ldloc.s 18
+			IL_064a: ldloc.s 17
+			IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0651: stloc.s 11
+			IL_0653: ldc.r8 0.0
+			IL_065c: stloc.s 12
+			// loop start (head: IL_065e)
+				IL_065e: ldloc.s 12
+				IL_0660: stloc.s 27
+				IL_0662: ldloc.s 11
+				IL_0664: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+				IL_0669: stloc.s 28
+				IL_066b: ldloc.s 27
+				IL_066d: ldloc.s 28
+				IL_066f: clt
+				IL_0671: brfalse IL_06cf
 
-				IL_068a: ldstr "console"
-				IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0699: stloc.s 17
-				IL_069b: ldloc.s 11
-				IL_069d: ldloc.s 12
-				IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_06a4: stloc.s 26
-				IL_06a6: ldloc.s 26
-				IL_06a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_06ad: stloc.s 21
-				IL_06af: ldstr "  - "
-				IL_06b4: ldloc.s 21
-				IL_06b6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_06bb: stloc.s 21
-				IL_06bd: ldloc.s 17
-				IL_06bf: ldstr "error"
-				IL_06c4: ldloc.s 21
-				IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06cb: pop
-				IL_06cc: ldloc.s 12
-				IL_06ce: ldc.r8 1
-				IL_06d7: add
-				IL_06d8: stloc.s 28
-				IL_06da: ldloc.s 28
-				IL_06dc: stloc.s 12
-				IL_06de: br IL_0672
+				IL_0676: ldstr "console"
+				IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0685: stloc.s 17
+				IL_0687: ldloc.s 11
+				IL_0689: ldloc.s 12
+				IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0690: stloc.s 26
+				IL_0692: ldloc.s 26
+				IL_0694: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0699: stloc.s 21
+				IL_069b: ldstr "  - "
+				IL_06a0: ldloc.s 21
+				IL_06a2: call string [System.Runtime]System.String::Concat(string, string)
+				IL_06a7: stloc.s 21
+				IL_06a9: ldloc.s 17
+				IL_06ab: ldstr "error"
+				IL_06b0: ldloc.s 21
+				IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_06b7: pop
+				IL_06b8: ldloc.s 12
+				IL_06ba: ldc.r8 1
+				IL_06c3: add
+				IL_06c4: stloc.s 28
+				IL_06c6: ldloc.s 28
+				IL_06c8: stloc.s 12
+				IL_06ca: br IL_065e
 			// end loop
 
-			IL_06e3: ldstr "console"
-			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06f2: ldstr "error"
-			IL_06f7: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0701: pop
-			IL_0702: ldstr "process"
-			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0711: ldstr "exit"
-			IL_0716: ldc.r8 1
-			IL_071f: box [System.Runtime]System.Double
-			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0729: pop
+			IL_06cf: ldstr "console"
+			IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06de: ldstr "error"
+			IL_06e3: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06ed: pop
+			IL_06ee: ldstr "process"
+			IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06fd: ldstr "exit"
+			IL_0702: ldc.r8 1
+			IL_070b: box [System.Runtime]System.Double
+			IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0715: pop
 
-			IL_072a: ldstr "console"
-			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0739: stloc.s 17
-			IL_073b: ldloc.s 9
-			IL_073d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0742: stloc.s 21
-			IL_0744: ldstr "Found assembly: "
-			IL_0749: ldloc.s 21
-			IL_074b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0750: stloc.s 21
-			IL_0752: ldloc.s 17
-			IL_0754: ldstr "log"
-			IL_0759: ldloc.s 21
-			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0760: pop
+			IL_0716: ldstr "console"
+			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0720: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0725: stloc.s 17
+			IL_0727: ldloc.s 9
+			IL_0729: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_072e: stloc.s 21
+			IL_0730: ldstr "Found assembly: "
+			IL_0735: ldloc.s 21
+			IL_0737: call string [System.Runtime]System.String::Concat(string, string)
+			IL_073c: stloc.s 21
+			IL_073e: ldloc.s 17
+			IL_0740: ldstr "log"
+			IL_0745: ldloc.s 21
+			IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_074c: pop
 			.try
 			{
-				IL_0761: nop
-				IL_0762: ldstr "console"
-				IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0771: ldstr "log"
-				IL_0776: ldstr "Opening in ILSpy..."
-				IL_077b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0780: pop
-				IL_0781: ldarg.0
-				IL_0782: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_0787: stloc.s 17
-				IL_0789: ldloc.s 17
-				IL_078b: ldc.i4.1
-				IL_078c: newarr [System.Runtime]System.Object
-				IL_0791: dup
-				IL_0792: ldc.i4.0
-				IL_0793: ldarg.0
-				IL_0794: stelem.ref
-				IL_0795: ldloc.s 9
-				IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_079c: pop
-				IL_079d: leave IL_083c
+				IL_074d: nop
+				IL_074e: ldstr "console"
+				IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_075d: ldstr "log"
+				IL_0762: ldstr "Opening in ILSpy..."
+				IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_076c: pop
+				IL_076d: ldarg.0
+				IL_076e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_0773: stloc.s 17
+				IL_0775: ldloc.s 17
+				IL_0777: ldc.i4.1
+				IL_0778: newarr [System.Runtime]System.Object
+				IL_077d: dup
+				IL_077e: ldc.i4.0
+				IL_077f: ldarg.0
+				IL_0780: stelem.ref
+				IL_0781: ldloc.s 9
+				IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0788: pop
+				IL_0789: leave IL_0828
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_07a2: stloc.s 13
-				IL_07a4: ldloc.s 13
-				IL_07a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_07ab: dup
-				IL_07ac: brtrue IL_07c2
+				IL_078e: stloc.s 13
+				IL_0790: ldloc.s 13
+				IL_0792: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0797: dup
+				IL_0798: brtrue IL_07ae
 
-				IL_07b1: pop
-				IL_07b2: ldloc.s 13
-				IL_07b4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_07b9: dup
-				IL_07ba: brtrue IL_07ce
+				IL_079d: pop
+				IL_079e: ldloc.s 13
+				IL_07a0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_07a5: dup
+				IL_07a6: brtrue IL_07ba
 
-				IL_07bf: pop
-				IL_07c0: rethrow
+				IL_07ab: pop
+				IL_07ac: rethrow
 
-				IL_07c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_07c7: stloc.s 14
-				IL_07c9: br IL_07d0
+				IL_07ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_07b3: stloc.s 14
+				IL_07b5: br IL_07bc
 
-				IL_07ce: stloc.s 14
+				IL_07ba: stloc.s 14
 
-				IL_07d0: ldloc.s 14
-				IL_07d2: stloc.s 15
-				IL_07d4: ldstr "console"
-				IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_07e3: ldstr "error"
-				IL_07e8: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_07f2: pop
-				IL_07f3: ldstr "console"
-				IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0802: ldstr "error"
-				IL_0807: ldloc.s 15
-				IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_080e: pop
-				IL_080f: ldstr "process"
-				IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_081e: ldstr "exit"
-				IL_0823: ldc.r8 1
-				IL_082c: box [System.Runtime]System.Double
-				IL_0831: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0836: pop
-				IL_0837: leave IL_083c
+				IL_07bc: ldloc.s 14
+				IL_07be: stloc.s 15
+				IL_07c0: ldstr "console"
+				IL_07c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_07ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_07cf: ldstr "error"
+				IL_07d4: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_07de: pop
+				IL_07df: ldstr "console"
+				IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_07e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_07ee: ldstr "error"
+				IL_07f3: ldloc.s 15
+				IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_07fa: pop
+				IL_07fb: ldstr "process"
+				IL_0800: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_080a: ldstr "exit"
+				IL_080f: ldc.r8 1
+				IL_0818: box [System.Runtime]System.Double
+				IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0822: pop
+				IL_0823: leave IL_0828
 			} // end handler
 
-			IL_083c: ldstr "console"
-			IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0846: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_084b: ldstr "log"
-			IL_0850: ldstr "Done!"
-			IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_085a: pop
-			IL_085b: ldnull
-			IL_085c: stloc.s 16
-			IL_085e: ldloc.s 16
-			IL_0860: ret
+			IL_0828: ldstr "console"
+			IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0837: ldstr "log"
+			IL_083c: ldstr "Done!"
+			IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0846: pop
+			IL_0847: ldnull
+			IL_0848: stloc.s 16
+			IL_084a: ldloc.s 16
+			IL_084c: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2626,10 +2606,10 @@
 			74 7d 2c 20 e2 80 a6 00 00
 		)
 		// Fields
-		.field public object childProcess
-		.field public object fs
-		.field public object path
-		.field public object os
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule childProcess
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule os
 		.field public object getAssemblyFileBaseName
 		.field public object normalizeCategory
 		.field public object getCandidateCategoryRoots
@@ -2645,7 +2625,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x346c
+			// Method begins at RVA 0x340b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2824,28 +2804,28 @@
 		IL_0191: stloc.s 5
 		IL_0193: ldloc.0
 		IL_0194: ldloc.s 5
-		IL_0196: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+		IL_0196: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
 		IL_019b: ldarg.1
 		IL_019c: ldstr "node:fs"
 		IL_01a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01a6: stloc.s 6
 		IL_01a8: ldloc.0
 		IL_01a9: ldloc.s 6
-		IL_01ab: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+		IL_01ab: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
 		IL_01b0: ldarg.1
 		IL_01b1: ldstr "node:path"
 		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01bb: stloc.s 7
 		IL_01bd: ldloc.0
 		IL_01be: ldloc.s 7
-		IL_01c0: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+		IL_01c0: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
 		IL_01c5: ldarg.1
 		IL_01c6: ldstr "node:os"
 		IL_01cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01d0: stloc.s 8
 		IL_01d2: ldloc.0
 		IL_01d3: ldloc.s 8
-		IL_01d5: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
+		IL_01d5: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
 		IL_01da: nop
 		IL_01db: nop
 		IL_01dc: nop
@@ -2881,7 +2861,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3571
+		// Method begins at RVA 0x3510
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x456f
+				// Method begins at RVA 0x4553
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4578
+				// Method begins at RVA 0x455c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4566
+			// Method begins at RVA 0x454a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4593
+					// Method begins at RVA 0x4577
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x458a
+				// Method begins at RVA 0x456e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x459c
+				// Method begins at RVA 0x4580
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b7
+						// Method begins at RVA 0x459b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c0
+						// Method begins at RVA 0x45a4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c9
+						// Method begins at RVA 0x45ad
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45d2
+						// Method begins at RVA 0x45b6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45db
+						// Method begins at RVA 0x45bf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45e4
+						// Method begins at RVA 0x45c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ae
+					// Method begins at RVA 0x4592
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45a5
+				// Method begins at RVA 0x4589
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x463e
+							// Method begins at RVA 0x4622
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44e0
+						// Method begins at RVA 0x44c4
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4647
+							// Method begins at RVA 0x462b
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4514
+						// Method begins at RVA 0x44f8
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x462c
+								// Method begins at RVA 0x4610
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4623
+							// Method begins at RVA 0x4607
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4635
+							// Method begins at RVA 0x4619
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x461a
+						// Method begins at RVA 0x45fe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,7 +1411,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x407c
+					// Method begins at RVA 0x4060
 					// Header size: 12
 					// Code size: 1111 (0x457)
 					.maxstack 8
@@ -1914,7 +1914,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4608
+						// Method begins at RVA 0x45ec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1934,7 +1934,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4611
+						// Method begins at RVA 0x45f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1957,7 +1957,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ff
+					// Method begins at RVA 0x45e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1983,9 +1983,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e50
+				// Method begins at RVA 0x3e40
 				// Header size: 12
-				// Code size: 526 (0x20e)
+				// Code size: 516 (0x204)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -2092,7 +2092,7 @@
 					IL_00b9: stloc.2
 					IL_00ba: ldnull
 					IL_00bb: stloc.2
-					IL_00bc: leave IL_020c
+					IL_00bc: leave IL_0202
 
 					IL_00c1: leave IL_00c6
 				} // end handler
@@ -2107,114 +2107,112 @@
 				IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 				IL_00e4: stloc.s 10
 				IL_00e6: ldloc.s 10
-				IL_00e8: brfalse IL_0109
+				IL_00e8: brfalse IL_0104
 
 				IL_00ed: ldarg.0
 				IL_00ee: ldc.i4.0
 				IL_00ef: ldelem.ref
 				IL_00f0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_00f5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_00fa: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-				IL_00ff: stloc.s 11
-				IL_0101: ldloc.s 11
-				IL_0103: stloc.3
-				IL_0104: br IL_0120
+				IL_00f5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00fa: stloc.s 11
+				IL_00fc: ldloc.s 11
+				IL_00fe: stloc.3
+				IL_00ff: br IL_0116
 
-				IL_0109: ldarg.0
-				IL_010a: ldc.i4.0
-				IL_010b: ldelem.ref
-				IL_010c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0111: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0116: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-				IL_011b: stloc.s 12
-				IL_011d: ldloc.s 12
-				IL_011f: stloc.3
+				IL_0104: ldarg.0
+				IL_0105: ldc.i4.0
+				IL_0106: ldelem.ref
+				IL_0107: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_010c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_0111: stloc.s 12
+				IL_0113: ldloc.s 12
+				IL_0115: stloc.3
 
-				IL_0120: ldloc.3
-				IL_0121: stloc.s 4
-				IL_0123: ldloc.s 4
-				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_012a: stloc.s 7
-				IL_012c: ldloc.0
-				IL_012d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0132: stloc.s 6
-				IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0139: dup
-				IL_013a: ldstr "method"
-				IL_013f: ldstr "GET"
-				IL_0144: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0149: dup
-				IL_014a: ldstr "headers"
-				IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0154: dup
-				IL_0155: ldstr "Accept-Encoding"
-				IL_015a: ldstr "identity"
-				IL_015f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0164: dup
-				IL_0165: ldstr "User-Agent"
-				IL_016a: ldstr "jroc-docs-script"
-				IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0179: stloc.s 13
-				IL_017b: ldnull
-				IL_017c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_0187: ldc.i4.3
-				IL_0188: newarr [System.Runtime]System.Object
-				IL_018d: dup
-				IL_018e: ldc.i4.0
-				IL_018f: ldarg.0
-				IL_0190: ldc.i4.0
-				IL_0191: ldelem.ref
+				IL_0116: ldloc.3
+				IL_0117: stloc.s 4
+				IL_0119: ldloc.s 4
+				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0120: stloc.s 7
+				IL_0122: ldloc.0
+				IL_0123: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_0128: stloc.s 6
+				IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012f: dup
+				IL_0130: ldstr "method"
+				IL_0135: ldstr "GET"
+				IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013f: dup
+				IL_0140: ldstr "headers"
+				IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_014a: dup
+				IL_014b: ldstr "Accept-Encoding"
+				IL_0150: ldstr "identity"
+				IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_015a: dup
+				IL_015b: ldstr "User-Agent"
+				IL_0160: ldstr "jroc-docs-script"
+				IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016f: stloc.s 13
+				IL_0171: ldnull
+				IL_0172: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_017d: ldc.i4.3
+				IL_017e: newarr [System.Runtime]System.Object
+				IL_0183: dup
+				IL_0184: ldc.i4.0
+				IL_0185: ldarg.0
+				IL_0186: ldc.i4.0
+				IL_0187: ldelem.ref
+				IL_0188: stelem.ref
+				IL_0189: dup
+				IL_018a: ldc.i4.1
+				IL_018b: ldarg.0
+				IL_018c: ldc.i4.1
+				IL_018d: ldelem.ref
+				IL_018e: stelem.ref
+				IL_018f: dup
+				IL_0190: ldc.i4.2
+				IL_0191: ldloc.0
 				IL_0192: stelem.ref
-				IL_0193: dup
-				IL_0194: ldc.i4.1
-				IL_0195: ldarg.0
-				IL_0196: ldc.i4.1
-				IL_0197: ldelem.ref
-				IL_0198: stelem.ref
-				IL_0199: dup
-				IL_019a: ldc.i4.2
-				IL_019b: ldloc.0
-				IL_019c: stelem.ref
-				IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_01a7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-				IL_01ac: ldc.i4.1
-				IL_01ad: conv.r8
-				IL_01ae: ldstr ""
-				IL_01b3: ldc.i4.0
-				IL_01b4: ldc.i4.0
-				IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-				IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-				IL_01bf: stloc.s 14
-				IL_01c1: ldloc.s 7
-				IL_01c3: ldstr "request"
-				IL_01c8: ldloc.s 6
-				IL_01ca: ldloc.s 13
-				IL_01cc: ldloc.s 14
-				IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-				IL_01d3: stloc.s 5
-				IL_01d5: ldloc.s 5
-				IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01dc: stloc.s 6
-				IL_01de: ldloc.0
-				IL_01df: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_01e4: stloc.s 7
-				IL_01e6: ldloc.s 6
-				IL_01e8: ldstr "on"
-				IL_01ed: ldstr "error"
-				IL_01f2: ldloc.s 7
-				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01f9: pop
-				IL_01fa: ldloc.s 5
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0201: ldstr "end"
-				IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_020b: pop
+				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_019d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				IL_01a2: ldc.i4.1
+				IL_01a3: conv.r8
+				IL_01a4: ldstr ""
+				IL_01a9: ldc.i4.0
+				IL_01aa: ldc.i4.0
+				IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+				IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+				IL_01b5: stloc.s 14
+				IL_01b7: ldloc.s 7
+				IL_01b9: ldstr "request"
+				IL_01be: ldloc.s 6
+				IL_01c0: ldloc.s 13
+				IL_01c2: ldloc.s 14
+				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+				IL_01c9: stloc.s 5
+				IL_01cb: ldloc.s 5
+				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01d2: stloc.s 6
+				IL_01d4: ldloc.0
+				IL_01d5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01da: stloc.s 7
+				IL_01dc: ldloc.s 6
+				IL_01de: ldstr "on"
+				IL_01e3: ldstr "error"
+				IL_01e8: ldloc.s 7
+				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01ef: pop
+				IL_01f0: ldloc.s 5
+				IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01f7: ldstr "end"
+				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0201: pop
 
-				IL_020c: ldloc.2
-				IL_020d: ret
+				IL_0202: ldloc.2
+				IL_0203: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2236,7 +2234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45f6
+					// Method begins at RVA 0x45da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2258,7 +2256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45ed
+				// Method begins at RVA 0x45d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2355,7 +2353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4650
+				// Method begins at RVA 0x4634
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2422,7 +2420,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4662
+					// Method begins at RVA 0x4646
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2446,7 +2444,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4674
+						// Method begins at RVA 0x4658
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2464,7 +2462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x466b
+					// Method begins at RVA 0x464f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2482,7 +2480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4659
+				// Method begins at RVA 0x463d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2747,7 +2745,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4686
+					// Method begins at RVA 0x466a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2767,7 +2765,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x468f
+					// Method begins at RVA 0x4673
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2787,7 +2785,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4698
+					// Method begins at RVA 0x467c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2807,7 +2805,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46a1
+					// Method begins at RVA 0x4685
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2831,7 +2829,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46b3
+						// Method begins at RVA 0x4697
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2851,7 +2849,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46bc
+						// Method begins at RVA 0x46a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2875,7 +2873,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46ce
+							// Method begins at RVA 0x46b2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2893,7 +2891,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46c5
+						// Method begins at RVA 0x46a9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2913,7 +2911,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46d7
+						// Method begins at RVA 0x46bb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2931,7 +2929,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46aa
+					// Method begins at RVA 0x468e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2949,7 +2947,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x467d
+				// Method begins at RVA 0x4661
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3354,7 +3352,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46e9
+					// Method begins at RVA 0x46cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3372,7 +3370,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e0
+				// Method begins at RVA 0x46c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3605,7 +3603,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46f2
+				// Method begins at RVA 0x46d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3723,7 +3721,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4704
+					// Method begins at RVA 0x46e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3743,7 +3741,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x470d
+					// Method begins at RVA 0x46f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3763,7 +3761,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4716
+					// Method begins at RVA 0x46fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3787,7 +3785,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4728
+						// Method begins at RVA 0x470c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3807,7 +3805,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4731
+						// Method begins at RVA 0x4715
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3825,7 +3823,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x471f
+					// Method begins at RVA 0x4703
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3845,7 +3843,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x473a
+					// Method begins at RVA 0x471e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3865,7 +3863,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4743
+					// Method begins at RVA 0x4727
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3905,7 +3903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46fb
+				// Method begins at RVA 0x46df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3931,7 +3929,7 @@
 			)
 			// Method begins at RVA 0x326c
 			// Header size: 12
-			// Code size: 3029 (0xbd5)
+			// Code size: 3014 (0xbc6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -5129,208 +5127,205 @@
 			IL_098e: ldc.i4.1
 			IL_098f: ldelem.ref
 			IL_0990: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0995: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_099a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_099f: stloc.s 31
-			IL_09a1: ldstr "process"
-			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09ab: stloc.s 22
-			IL_09ad: ldloc.s 22
-			IL_09af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09b4: stloc.s 22
-			IL_09b6: ldloc.s 22
-			IL_09b8: ldstr "cwd"
-			IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_09c2: stloc.s 22
-			IL_09c4: ldloc.1
-			IL_09c5: ldstr "outFile"
-			IL_09ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09cf: stloc.s 27
-			IL_09d1: ldloc.s 31
-			IL_09d3: ldc.i4.2
-			IL_09d4: newarr [System.Runtime]System.Object
+			IL_0995: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_099a: stloc.s 31
+			IL_099c: ldstr "process"
+			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09a6: stloc.s 22
+			IL_09a8: ldloc.s 22
+			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09af: stloc.s 22
+			IL_09b1: ldloc.s 22
+			IL_09b3: ldstr "cwd"
+			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_09bd: stloc.s 22
+			IL_09bf: ldloc.1
+			IL_09c0: ldstr "outFile"
+			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ca: stloc.s 27
+			IL_09cc: ldloc.s 31
+			IL_09ce: ldc.i4.2
+			IL_09cf: newarr [System.Runtime]System.Object
+			IL_09d4: dup
+			IL_09d5: ldc.i4.0
+			IL_09d6: ldloc.s 22
+			IL_09d8: stelem.ref
 			IL_09d9: dup
-			IL_09da: ldc.i4.0
-			IL_09db: ldloc.s 22
+			IL_09da: ldc.i4.1
+			IL_09db: ldloc.s 27
 			IL_09dd: stelem.ref
-			IL_09de: dup
-			IL_09df: ldc.i4.1
-			IL_09e0: ldloc.s 27
-			IL_09e2: stelem.ref
-			IL_09e3: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_09e8: stloc.s 19
-			IL_09ea: ldarg.0
-			IL_09eb: ldc.i4.1
-			IL_09ec: ldelem.ref
-			IL_09ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09f2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_09f7: ldc.i4.1
-			IL_09f8: newarr [System.Runtime]System.Object
-			IL_09fd: dup
-			IL_09fe: ldc.i4.0
-			IL_09ff: ldarg.0
-			IL_0a00: ldc.i4.1
-			IL_0a01: ldelem.ref
-			IL_0a02: stelem.ref
-			IL_0a03: stloc.s 21
-			IL_0a05: ldloc.s 18
-			IL_0a07: ldstr "html"
-			IL_0a0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a11: stloc.s 27
-			IL_0a13: ldloc.1
-			IL_0a14: ldstr "section"
-			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a1e: stloc.s 22
-			IL_0a20: ldloc.s 22
-			IL_0a22: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a27: stloc.s 26
-			IL_0a29: ldstr "ECMA-262 "
-			IL_0a2e: ldloc.s 26
-			IL_0a30: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a35: stloc.s 26
-			IL_0a37: ldloc.s 21
-			IL_0a39: ldloc.s 27
-			IL_0a3b: ldloc.s 26
-			IL_0a3d: ldloc.s 10
-			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a44: stloc.s 20
-			IL_0a46: ldarg.0
-			IL_0a47: ldc.i4.1
-			IL_0a48: ldelem.ref
-			IL_0a49: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a4e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a53: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0a58: stloc.s 32
-			IL_0a5a: ldloc.s 32
-			IL_0a5c: ldloc.s 19
-			IL_0a5e: ldloc.s 20
-			IL_0a60: ldstr "utf8"
-			IL_0a65: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0a6a: ldstr "console"
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a74: stloc.s 27
-			IL_0a76: ldloc.s 27
-			IL_0a78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a7d: stloc.s 27
-			IL_0a7f: ldarg.0
-			IL_0a80: ldc.i4.1
-			IL_0a81: ldelem.ref
-			IL_0a82: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a87: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0a8c: ldc.i4.1
-			IL_0a8d: newarr [System.Runtime]System.Object
-			IL_0a92: dup
-			IL_0a93: ldc.i4.0
-			IL_0a94: ldarg.0
-			IL_0a95: ldc.i4.1
-			IL_0a96: ldelem.ref
-			IL_0a97: stelem.ref
-			IL_0a98: stloc.s 21
-			IL_0a9a: ldloc.1
-			IL_0a9b: ldstr "section"
-			IL_0aa0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aa5: stloc.s 22
-			IL_0aa7: ldloc.s 22
-			IL_0aa9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aae: stloc.s 26
-			IL_0ab0: ldstr "Extracted section "
-			IL_0ab5: ldloc.s 26
+			IL_09de: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_09e3: stloc.s 19
+			IL_09e5: ldarg.0
+			IL_09e6: ldc.i4.1
+			IL_09e7: ldelem.ref
+			IL_09e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09f2: ldc.i4.1
+			IL_09f3: newarr [System.Runtime]System.Object
+			IL_09f8: dup
+			IL_09f9: ldc.i4.0
+			IL_09fa: ldarg.0
+			IL_09fb: ldc.i4.1
+			IL_09fc: ldelem.ref
+			IL_09fd: stelem.ref
+			IL_09fe: stloc.s 21
+			IL_0a00: ldloc.s 18
+			IL_0a02: ldstr "html"
+			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0c: stloc.s 27
+			IL_0a0e: ldloc.1
+			IL_0a0f: ldstr "section"
+			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a19: stloc.s 22
+			IL_0a1b: ldloc.s 22
+			IL_0a1d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a22: stloc.s 26
+			IL_0a24: ldstr "ECMA-262 "
+			IL_0a29: ldloc.s 26
+			IL_0a2b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a30: stloc.s 26
+			IL_0a32: ldloc.s 21
+			IL_0a34: ldloc.s 27
+			IL_0a36: ldloc.s 26
+			IL_0a38: ldloc.s 10
+			IL_0a3a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a3f: stloc.s 20
+			IL_0a41: ldarg.0
+			IL_0a42: ldc.i4.1
+			IL_0a43: ldelem.ref
+			IL_0a44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a49: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a4e: stloc.s 32
+			IL_0a50: ldloc.s 32
+			IL_0a52: ldloc.s 19
+			IL_0a54: ldloc.s 20
+			IL_0a56: ldstr "utf8"
+			IL_0a5b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0a60: ldstr "console"
+			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a6a: stloc.s 27
+			IL_0a6c: ldloc.s 27
+			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a73: stloc.s 27
+			IL_0a75: ldarg.0
+			IL_0a76: ldc.i4.1
+			IL_0a77: ldelem.ref
+			IL_0a78: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a7d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a82: ldc.i4.1
+			IL_0a83: newarr [System.Runtime]System.Object
+			IL_0a88: dup
+			IL_0a89: ldc.i4.0
+			IL_0a8a: ldarg.0
+			IL_0a8b: ldc.i4.1
+			IL_0a8c: ldelem.ref
+			IL_0a8d: stelem.ref
+			IL_0a8e: stloc.s 21
+			IL_0a90: ldloc.1
+			IL_0a91: ldstr "section"
+			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a9b: stloc.s 22
+			IL_0a9d: ldloc.s 22
+			IL_0a9f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aa4: stloc.s 26
+			IL_0aa6: ldstr "Extracted section "
+			IL_0aab: ldloc.s 26
+			IL_0aad: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ab2: ldstr " (id="
 			IL_0ab7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0abc: ldstr " (id="
-			IL_0ac1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ac6: ldloc.s 9
-			IL_0ac8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0acd: stloc.s 26
-			IL_0acf: ldloc.s 26
+			IL_0abc: ldloc.s 9
+			IL_0abe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ac3: stloc.s 26
+			IL_0ac5: ldloc.s 26
+			IL_0ac7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0acc: ldstr ", tag="
 			IL_0ad1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ad6: ldstr ", tag="
-			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ae0: ldloc.s 18
-			IL_0ae2: ldstr "tagName"
-			IL_0ae7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aec: stloc.s 22
-			IL_0aee: ldloc.s 22
-			IL_0af0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0af5: stloc.s 26
-			IL_0af7: ldloc.s 26
+			IL_0ad6: ldloc.s 18
+			IL_0ad8: ldstr "tagName"
+			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ae2: stloc.s 22
+			IL_0ae4: ldloc.s 22
+			IL_0ae6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aeb: stloc.s 26
+			IL_0aed: ldloc.s 26
+			IL_0aef: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0af4: ldstr ") -> "
 			IL_0af9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0afe: ldstr ") -> "
-			IL_0b03: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b08: ldloc.s 19
-			IL_0b0a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b0f: stloc.s 26
-			IL_0b11: ldloc.s 26
-			IL_0b13: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b18: stloc.s 26
-			IL_0b1a: ldloc.s 21
-			IL_0b1c: ldloc.s 26
-			IL_0b1e: ldloc.s 19
-			IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b25: stloc.s 22
-			IL_0b27: ldloc.s 27
-			IL_0b29: ldstr "log"
-			IL_0b2e: ldloc.s 22
-			IL_0b30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b35: pop
-			IL_0b36: ldstr "console"
-			IL_0b3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b40: stloc.s 22
-			IL_0b42: ldloc.s 22
-			IL_0b44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b49: stloc.s 22
-			IL_0b4b: ldarg.0
-			IL_0b4c: ldc.i4.1
-			IL_0b4d: ldelem.ref
-			IL_0b4e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b53: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b58: stloc.s 27
-			IL_0b5a: ldc.i4.1
-			IL_0b5b: newarr [System.Runtime]System.Object
-			IL_0b60: dup
-			IL_0b61: ldc.i4.0
-			IL_0b62: ldarg.0
-			IL_0b63: ldc.i4.1
-			IL_0b64: ldelem.ref
-			IL_0b65: stelem.ref
-			IL_0b66: stloc.s 21
-			IL_0b68: ldarg.0
-			IL_0b69: ldc.i4.1
-			IL_0b6a: ldelem.ref
-			IL_0b6b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b70: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0b75: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0b7a: stloc.s 32
-			IL_0b7c: ldloc.s 32
-			IL_0b7e: ldloc.s 19
-			IL_0b80: ldstr "utf8"
-			IL_0b85: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0afe: ldloc.s 19
+			IL_0b00: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b05: stloc.s 26
+			IL_0b07: ldloc.s 26
+			IL_0b09: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b0e: stloc.s 26
+			IL_0b10: ldloc.s 21
+			IL_0b12: ldloc.s 26
+			IL_0b14: ldloc.s 19
+			IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b1b: stloc.s 22
+			IL_0b1d: ldloc.s 27
+			IL_0b1f: ldstr "log"
+			IL_0b24: ldloc.s 22
+			IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b2b: pop
+			IL_0b2c: ldstr "console"
+			IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b36: stloc.s 22
+			IL_0b38: ldloc.s 22
+			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b3f: stloc.s 22
+			IL_0b41: ldarg.0
+			IL_0b42: ldc.i4.1
+			IL_0b43: ldelem.ref
+			IL_0b44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b49: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b4e: stloc.s 27
+			IL_0b50: ldc.i4.1
+			IL_0b51: newarr [System.Runtime]System.Object
+			IL_0b56: dup
+			IL_0b57: ldc.i4.0
+			IL_0b58: ldarg.0
+			IL_0b59: ldc.i4.1
+			IL_0b5a: ldelem.ref
+			IL_0b5b: stelem.ref
+			IL_0b5c: stloc.s 21
+			IL_0b5e: ldarg.0
+			IL_0b5f: ldc.i4.1
+			IL_0b60: ldelem.ref
+			IL_0b61: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b66: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b6b: stloc.s 32
+			IL_0b6d: ldloc.s 32
+			IL_0b6f: ldloc.s 19
+			IL_0b71: ldstr "utf8"
+			IL_0b76: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0b7b: stloc.s 28
+			IL_0b7d: ldloc.s 27
+			IL_0b7f: ldloc.s 21
+			IL_0b81: ldloc.s 28
+			IL_0b83: ldloc.s 19
+			IL_0b85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0b8a: stloc.s 28
-			IL_0b8c: ldloc.s 27
-			IL_0b8e: ldloc.s 21
-			IL_0b90: ldloc.s 28
-			IL_0b92: ldloc.s 19
-			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b99: stloc.s 28
-			IL_0b9b: ldloc.s 22
-			IL_0b9d: ldstr "log"
-			IL_0ba2: ldloc.s 28
-			IL_0ba4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0ba9: pop
-			IL_0baa: ldloc.0
-			IL_0bab: ldc.i4.m1
-			IL_0bac: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0bb1: ldloc.0
-			IL_0bb2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bb7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0bbc: ldarg.0
-			IL_0bbd: ldc.i4.1
-			IL_0bbe: newarr [System.Runtime]System.Object
-			IL_0bc3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bc8: pop
-			IL_0bc9: ldloc.0
-			IL_0bca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bcf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bd4: ret
+			IL_0b8c: ldloc.s 22
+			IL_0b8e: ldstr "log"
+			IL_0b93: ldloc.s 28
+			IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b9a: pop
+			IL_0b9b: ldloc.0
+			IL_0b9c: ldc.i4.m1
+			IL_0b9d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0ba2: ldloc.0
+			IL_0ba3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bad: ldarg.0
+			IL_0bae: ldc.i4.1
+			IL_0baf: newarr [System.Runtime]System.Object
+			IL_0bb4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bb9: pop
+			IL_0bba: ldloc.0
+			IL_0bbb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bc0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bc5: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5351,10 +5346,10 @@
 			74 7d 2c 20 e2 80 a6 00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object http
-		.field public object https
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule https
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object NodeUrl
 		.field public object normalize
 		.field public object parseArgs
@@ -5370,7 +5365,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4581
+			// Method begins at RVA 0x4565
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5554,28 +5549,28 @@
 		IL_018e: stloc.s 5
 		IL_0190: ldloc.0
 		IL_0191: ldloc.s 5
-		IL_0193: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+		IL_0193: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
 		IL_0198: ldarg.1
 		IL_0199: ldstr "node:http"
 		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01a3: stloc.s 6
 		IL_01a5: ldloc.0
 		IL_01a6: ldloc.s 6
-		IL_01a8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+		IL_01a8: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
 		IL_01ad: ldarg.1
 		IL_01ae: ldstr "node:https"
 		IL_01b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01b8: stloc.s 7
 		IL_01ba: ldloc.0
 		IL_01bb: ldloc.s 7
-		IL_01bd: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+		IL_01bd: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
 		IL_01c2: ldarg.1
 		IL_01c3: ldstr "path"
 		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01cd: stloc.s 8
 		IL_01cf: ldloc.0
 		IL_01d0: ldloc.s 8
-		IL_01d2: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+		IL_01d2: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
 		IL_01d7: ldarg.1
 		IL_01d8: ldstr "node:url"
 		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -5626,7 +5621,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x474c
+		// Method begins at RVA 0x4730
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x456f
+				// Method begins at RVA 0x4553
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4578
+				// Method begins at RVA 0x455c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -355,7 +355,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4566
+			// Method begins at RVA 0x454a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -470,7 +470,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4593
+					// Method begins at RVA 0x4577
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -488,7 +488,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x458a
+				// Method begins at RVA 0x456e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -633,7 +633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x459c
+				// Method begins at RVA 0x4580
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45b7
+						// Method begins at RVA 0x459b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -681,7 +681,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c0
+						// Method begins at RVA 0x45a4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -701,7 +701,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45c9
+						// Method begins at RVA 0x45ad
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45d2
+						// Method begins at RVA 0x45b6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -741,7 +741,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45db
+						// Method begins at RVA 0x45bf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -761,7 +761,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45e4
+						// Method begins at RVA 0x45c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -779,7 +779,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ae
+					// Method begins at RVA 0x4592
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45a5
+				// Method begins at RVA 0x4589
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1156,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x463e
+							// Method begins at RVA 0x4622
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1181,7 +1181,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44e0
+						// Method begins at RVA 0x44c4
 						// Header size: 12
 						// Code size: 38 (0x26)
 						.maxstack 8
@@ -1223,7 +1223,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4647
+							// Method begins at RVA 0x462b
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1247,7 +1247,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4514
+						// Method begins at RVA 0x44f8
 						// Header size: 12
 						// Code size: 70 (0x46)
 						.maxstack 8
@@ -1326,7 +1326,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x462c
+								// Method begins at RVA 0x4610
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1344,7 +1344,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4623
+							// Method begins at RVA 0x4607
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1364,7 +1364,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4635
+							// Method begins at RVA 0x4619
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1386,7 +1386,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x461a
+						// Method begins at RVA 0x45fe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1411,7 +1411,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x407c
+					// Method begins at RVA 0x4060
 					// Header size: 12
 					// Code size: 1111 (0x457)
 					.maxstack 8
@@ -1914,7 +1914,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4608
+						// Method begins at RVA 0x45ec
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1934,7 +1934,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4611
+						// Method begins at RVA 0x45f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1957,7 +1957,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ff
+					// Method begins at RVA 0x45e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1983,9 +1983,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e50
+				// Method begins at RVA 0x3e40
 				// Header size: 12
-				// Code size: 526 (0x20e)
+				// Code size: 516 (0x204)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope,
@@ -2092,7 +2092,7 @@
 					IL_00b9: stloc.2
 					IL_00ba: ldnull
 					IL_00bb: stloc.2
-					IL_00bc: leave IL_020c
+					IL_00bc: leave IL_0202
 
 					IL_00c1: leave IL_00c6
 				} // end handler
@@ -2107,114 +2107,112 @@
 				IL_00df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 				IL_00e4: stloc.s 10
 				IL_00e6: ldloc.s 10
-				IL_00e8: brfalse IL_0109
+				IL_00e8: brfalse IL_0104
 
 				IL_00ed: ldarg.0
 				IL_00ee: ldc.i4.0
 				IL_00ef: ldelem.ref
 				IL_00f0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_00f5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
-				IL_00fa: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-				IL_00ff: stloc.s 11
-				IL_0101: ldloc.s 11
-				IL_0103: stloc.3
-				IL_0104: br IL_0120
+				IL_00f5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+				IL_00fa: stloc.s 11
+				IL_00fc: ldloc.s 11
+				IL_00fe: stloc.3
+				IL_00ff: br IL_0116
 
-				IL_0109: ldarg.0
-				IL_010a: ldc.i4.0
-				IL_010b: ldelem.ref
-				IL_010c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-				IL_0111: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
-				IL_0116: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-				IL_011b: stloc.s 12
-				IL_011d: ldloc.s 12
-				IL_011f: stloc.3
+				IL_0104: ldarg.0
+				IL_0105: ldc.i4.0
+				IL_0106: ldelem.ref
+				IL_0107: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+				IL_010c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+				IL_0111: stloc.s 12
+				IL_0113: ldloc.s 12
+				IL_0115: stloc.3
 
-				IL_0120: ldloc.3
-				IL_0121: stloc.s 4
-				IL_0123: ldloc.s 4
-				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_012a: stloc.s 7
-				IL_012c: ldloc.0
-				IL_012d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
-				IL_0132: stloc.s 6
-				IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0139: dup
-				IL_013a: ldstr "method"
-				IL_013f: ldstr "GET"
-				IL_0144: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0149: dup
-				IL_014a: ldstr "headers"
-				IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0154: dup
-				IL_0155: ldstr "Accept-Encoding"
-				IL_015a: ldstr "identity"
-				IL_015f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0164: dup
-				IL_0165: ldstr "User-Agent"
-				IL_016a: ldstr "jroc-docs-script"
-				IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0179: stloc.s 13
-				IL_017b: ldnull
-				IL_017c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
-				IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_0187: ldc.i4.3
-				IL_0188: newarr [System.Runtime]System.Object
-				IL_018d: dup
-				IL_018e: ldc.i4.0
-				IL_018f: ldarg.0
-				IL_0190: ldc.i4.0
-				IL_0191: ldelem.ref
+				IL_0116: ldloc.3
+				IL_0117: stloc.s 4
+				IL_0119: ldloc.s 4
+				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0120: stloc.s 7
+				IL_0122: ldloc.0
+				IL_0123: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
+				IL_0128: stloc.s 6
+				IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_012f: dup
+				IL_0130: ldstr "method"
+				IL_0135: ldstr "GET"
+				IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_013f: dup
+				IL_0140: ldstr "headers"
+				IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_014a: dup
+				IL_014b: ldstr "Accept-Encoding"
+				IL_0150: ldstr "identity"
+				IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_015a: dup
+				IL_015b: ldstr "User-Agent"
+				IL_0160: ldstr "jroc-docs-script"
+				IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016f: stloc.s 13
+				IL_0171: ldnull
+				IL_0172: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7::__js_call__(object[], object, object)
+				IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_017d: ldc.i4.3
+				IL_017e: newarr [System.Runtime]System.Object
+				IL_0183: dup
+				IL_0184: ldc.i4.0
+				IL_0185: ldarg.0
+				IL_0186: ldc.i4.0
+				IL_0187: ldelem.ref
+				IL_0188: stelem.ref
+				IL_0189: dup
+				IL_018a: ldc.i4.1
+				IL_018b: ldarg.0
+				IL_018c: ldc.i4.1
+				IL_018d: ldelem.ref
+				IL_018e: stelem.ref
+				IL_018f: dup
+				IL_0190: ldc.i4.2
+				IL_0191: ldloc.0
 				IL_0192: stelem.ref
-				IL_0193: dup
-				IL_0194: ldc.i4.1
-				IL_0195: ldarg.0
-				IL_0196: ldc.i4.1
-				IL_0197: ldelem.ref
-				IL_0198: stelem.ref
-				IL_0199: dup
-				IL_019a: ldc.i4.2
-				IL_019b: ldloc.0
-				IL_019c: stelem.ref
-				IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_01a7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-				IL_01ac: ldc.i4.1
-				IL_01ad: conv.r8
-				IL_01ae: ldstr ""
-				IL_01b3: ldc.i4.0
-				IL_01b4: ldc.i4.0
-				IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-				IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-				IL_01bf: stloc.s 14
-				IL_01c1: ldloc.s 7
-				IL_01c3: ldstr "request"
-				IL_01c8: ldloc.s 6
-				IL_01ca: ldloc.s 13
-				IL_01cc: ldloc.s 14
-				IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-				IL_01d3: stloc.s 5
-				IL_01d5: ldloc.s 5
-				IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01dc: stloc.s 6
-				IL_01de: ldloc.0
-				IL_01df: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-				IL_01e4: stloc.s 7
-				IL_01e6: ldloc.s 6
-				IL_01e8: ldstr "on"
-				IL_01ed: ldstr "error"
-				IL_01f2: ldloc.s 7
-				IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01f9: pop
-				IL_01fa: ldloc.s 5
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0201: ldstr "end"
-				IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_020b: pop
+				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_019d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				IL_01a2: ldc.i4.1
+				IL_01a3: conv.r8
+				IL_01a4: ldstr ""
+				IL_01a9: ldc.i4.0
+				IL_01aa: ldc.i4.0
+				IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+				IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+				IL_01b5: stloc.s 14
+				IL_01b7: ldloc.s 7
+				IL_01b9: ldstr "request"
+				IL_01be: ldloc.s 6
+				IL_01c0: ldloc.s 13
+				IL_01c2: ldloc.s 14
+				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+				IL_01c9: stloc.s 5
+				IL_01cb: ldloc.s 5
+				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01d2: stloc.s 6
+				IL_01d4: ldloc.0
+				IL_01d5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+				IL_01da: stloc.s 7
+				IL_01dc: ldloc.s 6
+				IL_01de: ldstr "on"
+				IL_01e3: ldstr "error"
+				IL_01e8: ldloc.s 7
+				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01ef: pop
+				IL_01f0: ldloc.s 5
+				IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01f7: ldstr "end"
+				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0201: pop
 
-				IL_020c: ldloc.2
-				IL_020d: ret
+				IL_0202: ldloc.2
+				IL_0203: ret
 			} // end of method ArrowFunction_L72C22::__js_call__
 
 		} // end of class ArrowFunction_L72C22
@@ -2236,7 +2234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45f6
+					// Method begins at RVA 0x45da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2258,7 +2256,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45ed
+				// Method begins at RVA 0x45d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2355,7 +2353,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4650
+				// Method begins at RVA 0x4634
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2422,7 +2420,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4662
+					// Method begins at RVA 0x4646
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2446,7 +2444,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4674
+						// Method begins at RVA 0x4658
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2464,7 +2462,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x466b
+					// Method begins at RVA 0x464f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2482,7 +2480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4659
+				// Method begins at RVA 0x463d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2747,7 +2745,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4686
+					// Method begins at RVA 0x466a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2767,7 +2765,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x468f
+					// Method begins at RVA 0x4673
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2787,7 +2785,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4698
+					// Method begins at RVA 0x467c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2807,7 +2805,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46a1
+					// Method begins at RVA 0x4685
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2831,7 +2829,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46b3
+						// Method begins at RVA 0x4697
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2851,7 +2849,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46bc
+						// Method begins at RVA 0x46a0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2875,7 +2873,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46ce
+							// Method begins at RVA 0x46b2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2893,7 +2891,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46c5
+						// Method begins at RVA 0x46a9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2913,7 +2911,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46d7
+						// Method begins at RVA 0x46bb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2931,7 +2929,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46aa
+					// Method begins at RVA 0x468e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2949,7 +2947,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x467d
+				// Method begins at RVA 0x4661
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3354,7 +3352,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46e9
+					// Method begins at RVA 0x46cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3372,7 +3370,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46e0
+				// Method begins at RVA 0x46c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3605,7 +3603,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46f2
+				// Method begins at RVA 0x46d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3723,7 +3721,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4704
+					// Method begins at RVA 0x46e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3743,7 +3741,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x470d
+					// Method begins at RVA 0x46f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3763,7 +3761,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4716
+					// Method begins at RVA 0x46fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3787,7 +3785,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4728
+						// Method begins at RVA 0x470c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3807,7 +3805,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4731
+						// Method begins at RVA 0x4715
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3825,7 +3823,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x471f
+					// Method begins at RVA 0x4703
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3845,7 +3843,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x473a
+					// Method begins at RVA 0x471e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3865,7 +3863,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4743
+					// Method begins at RVA 0x4727
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3905,7 +3903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46fb
+				// Method begins at RVA 0x46df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3931,7 +3929,7 @@
 			)
 			// Method begins at RVA 0x326c
 			// Header size: 12
-			// Code size: 3029 (0xbd5)
+			// Code size: 3014 (0xbc6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -5129,208 +5127,205 @@
 			IL_098e: ldc.i4.1
 			IL_098f: ldelem.ref
 			IL_0990: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0995: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_099a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_099f: stloc.s 31
-			IL_09a1: ldstr "process"
-			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09ab: stloc.s 22
-			IL_09ad: ldloc.s 22
-			IL_09af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09b4: stloc.s 22
-			IL_09b6: ldloc.s 22
-			IL_09b8: ldstr "cwd"
-			IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_09c2: stloc.s 22
-			IL_09c4: ldloc.1
-			IL_09c5: ldstr "outFile"
-			IL_09ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09cf: stloc.s 27
-			IL_09d1: ldloc.s 31
-			IL_09d3: ldc.i4.2
-			IL_09d4: newarr [System.Runtime]System.Object
+			IL_0995: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_099a: stloc.s 31
+			IL_099c: ldstr "process"
+			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09a6: stloc.s 22
+			IL_09a8: ldloc.s 22
+			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09af: stloc.s 22
+			IL_09b1: ldloc.s 22
+			IL_09b3: ldstr "cwd"
+			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_09bd: stloc.s 22
+			IL_09bf: ldloc.1
+			IL_09c0: ldstr "outFile"
+			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ca: stloc.s 27
+			IL_09cc: ldloc.s 31
+			IL_09ce: ldc.i4.2
+			IL_09cf: newarr [System.Runtime]System.Object
+			IL_09d4: dup
+			IL_09d5: ldc.i4.0
+			IL_09d6: ldloc.s 22
+			IL_09d8: stelem.ref
 			IL_09d9: dup
-			IL_09da: ldc.i4.0
-			IL_09db: ldloc.s 22
+			IL_09da: ldc.i4.1
+			IL_09db: ldloc.s 27
 			IL_09dd: stelem.ref
-			IL_09de: dup
-			IL_09df: ldc.i4.1
-			IL_09e0: ldloc.s 27
-			IL_09e2: stelem.ref
-			IL_09e3: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_09e8: stloc.s 19
-			IL_09ea: ldarg.0
-			IL_09eb: ldc.i4.1
-			IL_09ec: ldelem.ref
-			IL_09ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09f2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_09f7: ldc.i4.1
-			IL_09f8: newarr [System.Runtime]System.Object
-			IL_09fd: dup
-			IL_09fe: ldc.i4.0
-			IL_09ff: ldarg.0
-			IL_0a00: ldc.i4.1
-			IL_0a01: ldelem.ref
-			IL_0a02: stelem.ref
-			IL_0a03: stloc.s 21
-			IL_0a05: ldloc.s 18
-			IL_0a07: ldstr "html"
-			IL_0a0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a11: stloc.s 27
-			IL_0a13: ldloc.1
-			IL_0a14: ldstr "section"
-			IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a1e: stloc.s 22
-			IL_0a20: ldloc.s 22
-			IL_0a22: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a27: stloc.s 26
-			IL_0a29: ldstr "ECMA-262 "
-			IL_0a2e: ldloc.s 26
-			IL_0a30: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a35: stloc.s 26
-			IL_0a37: ldloc.s 21
-			IL_0a39: ldloc.s 27
-			IL_0a3b: ldloc.s 26
-			IL_0a3d: ldloc.s 10
-			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a44: stloc.s 20
-			IL_0a46: ldarg.0
-			IL_0a47: ldc.i4.1
-			IL_0a48: ldelem.ref
-			IL_0a49: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a4e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a53: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0a58: stloc.s 32
-			IL_0a5a: ldloc.s 32
-			IL_0a5c: ldloc.s 19
-			IL_0a5e: ldloc.s 20
-			IL_0a60: ldstr "utf8"
-			IL_0a65: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0a6a: ldstr "console"
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a74: stloc.s 27
-			IL_0a76: ldloc.s 27
-			IL_0a78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a7d: stloc.s 27
-			IL_0a7f: ldarg.0
-			IL_0a80: ldc.i4.1
-			IL_0a81: ldelem.ref
-			IL_0a82: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a87: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0a8c: ldc.i4.1
-			IL_0a8d: newarr [System.Runtime]System.Object
-			IL_0a92: dup
-			IL_0a93: ldc.i4.0
-			IL_0a94: ldarg.0
-			IL_0a95: ldc.i4.1
-			IL_0a96: ldelem.ref
-			IL_0a97: stelem.ref
-			IL_0a98: stloc.s 21
-			IL_0a9a: ldloc.1
-			IL_0a9b: ldstr "section"
-			IL_0aa0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aa5: stloc.s 22
-			IL_0aa7: ldloc.s 22
-			IL_0aa9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0aae: stloc.s 26
-			IL_0ab0: ldstr "Extracted section "
-			IL_0ab5: ldloc.s 26
+			IL_09de: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_09e3: stloc.s 19
+			IL_09e5: ldarg.0
+			IL_09e6: ldc.i4.1
+			IL_09e7: ldelem.ref
+			IL_09e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09f2: ldc.i4.1
+			IL_09f3: newarr [System.Runtime]System.Object
+			IL_09f8: dup
+			IL_09f9: ldc.i4.0
+			IL_09fa: ldarg.0
+			IL_09fb: ldc.i4.1
+			IL_09fc: ldelem.ref
+			IL_09fd: stelem.ref
+			IL_09fe: stloc.s 21
+			IL_0a00: ldloc.s 18
+			IL_0a02: ldstr "html"
+			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0c: stloc.s 27
+			IL_0a0e: ldloc.1
+			IL_0a0f: ldstr "section"
+			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a19: stloc.s 22
+			IL_0a1b: ldloc.s 22
+			IL_0a1d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a22: stloc.s 26
+			IL_0a24: ldstr "ECMA-262 "
+			IL_0a29: ldloc.s 26
+			IL_0a2b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a30: stloc.s 26
+			IL_0a32: ldloc.s 21
+			IL_0a34: ldloc.s 27
+			IL_0a36: ldloc.s 26
+			IL_0a38: ldloc.s 10
+			IL_0a3a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a3f: stloc.s 20
+			IL_0a41: ldarg.0
+			IL_0a42: ldc.i4.1
+			IL_0a43: ldelem.ref
+			IL_0a44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a49: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a4e: stloc.s 32
+			IL_0a50: ldloc.s 32
+			IL_0a52: ldloc.s 19
+			IL_0a54: ldloc.s 20
+			IL_0a56: ldstr "utf8"
+			IL_0a5b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0a60: ldstr "console"
+			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a6a: stloc.s 27
+			IL_0a6c: ldloc.s 27
+			IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a73: stloc.s 27
+			IL_0a75: ldarg.0
+			IL_0a76: ldc.i4.1
+			IL_0a77: ldelem.ref
+			IL_0a78: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a7d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a82: ldc.i4.1
+			IL_0a83: newarr [System.Runtime]System.Object
+			IL_0a88: dup
+			IL_0a89: ldc.i4.0
+			IL_0a8a: ldarg.0
+			IL_0a8b: ldc.i4.1
+			IL_0a8c: ldelem.ref
+			IL_0a8d: stelem.ref
+			IL_0a8e: stloc.s 21
+			IL_0a90: ldloc.1
+			IL_0a91: ldstr "section"
+			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a9b: stloc.s 22
+			IL_0a9d: ldloc.s 22
+			IL_0a9f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aa4: stloc.s 26
+			IL_0aa6: ldstr "Extracted section "
+			IL_0aab: ldloc.s 26
+			IL_0aad: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ab2: ldstr " (id="
 			IL_0ab7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0abc: ldstr " (id="
-			IL_0ac1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ac6: ldloc.s 9
-			IL_0ac8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0acd: stloc.s 26
-			IL_0acf: ldloc.s 26
+			IL_0abc: ldloc.s 9
+			IL_0abe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ac3: stloc.s 26
+			IL_0ac5: ldloc.s 26
+			IL_0ac7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0acc: ldstr ", tag="
 			IL_0ad1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ad6: ldstr ", tag="
-			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ae0: ldloc.s 18
-			IL_0ae2: ldstr "tagName"
-			IL_0ae7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aec: stloc.s 22
-			IL_0aee: ldloc.s 22
-			IL_0af0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0af5: stloc.s 26
-			IL_0af7: ldloc.s 26
+			IL_0ad6: ldloc.s 18
+			IL_0ad8: ldstr "tagName"
+			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ae2: stloc.s 22
+			IL_0ae4: ldloc.s 22
+			IL_0ae6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0aeb: stloc.s 26
+			IL_0aed: ldloc.s 26
+			IL_0aef: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0af4: ldstr ") -> "
 			IL_0af9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0afe: ldstr ") -> "
-			IL_0b03: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b08: ldloc.s 19
-			IL_0b0a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b0f: stloc.s 26
-			IL_0b11: ldloc.s 26
-			IL_0b13: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b18: stloc.s 26
-			IL_0b1a: ldloc.s 21
-			IL_0b1c: ldloc.s 26
-			IL_0b1e: ldloc.s 19
-			IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b25: stloc.s 22
-			IL_0b27: ldloc.s 27
-			IL_0b29: ldstr "log"
-			IL_0b2e: ldloc.s 22
-			IL_0b30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b35: pop
-			IL_0b36: ldstr "console"
-			IL_0b3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b40: stloc.s 22
-			IL_0b42: ldloc.s 22
-			IL_0b44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b49: stloc.s 22
-			IL_0b4b: ldarg.0
-			IL_0b4c: ldc.i4.1
-			IL_0b4d: ldelem.ref
-			IL_0b4e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b53: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b58: stloc.s 27
-			IL_0b5a: ldc.i4.1
-			IL_0b5b: newarr [System.Runtime]System.Object
-			IL_0b60: dup
-			IL_0b61: ldc.i4.0
-			IL_0b62: ldarg.0
-			IL_0b63: ldc.i4.1
-			IL_0b64: ldelem.ref
-			IL_0b65: stelem.ref
-			IL_0b66: stloc.s 21
-			IL_0b68: ldarg.0
-			IL_0b69: ldc.i4.1
-			IL_0b6a: ldelem.ref
-			IL_0b6b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b70: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0b75: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0b7a: stloc.s 32
-			IL_0b7c: ldloc.s 32
-			IL_0b7e: ldloc.s 19
-			IL_0b80: ldstr "utf8"
-			IL_0b85: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0afe: ldloc.s 19
+			IL_0b00: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b05: stloc.s 26
+			IL_0b07: ldloc.s 26
+			IL_0b09: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b0e: stloc.s 26
+			IL_0b10: ldloc.s 21
+			IL_0b12: ldloc.s 26
+			IL_0b14: ldloc.s 19
+			IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b1b: stloc.s 22
+			IL_0b1d: ldloc.s 27
+			IL_0b1f: ldstr "log"
+			IL_0b24: ldloc.s 22
+			IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b2b: pop
+			IL_0b2c: ldstr "console"
+			IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b36: stloc.s 22
+			IL_0b38: ldloc.s 22
+			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b3f: stloc.s 22
+			IL_0b41: ldarg.0
+			IL_0b42: ldc.i4.1
+			IL_0b43: ldelem.ref
+			IL_0b44: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b49: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b4e: stloc.s 27
+			IL_0b50: ldc.i4.1
+			IL_0b51: newarr [System.Runtime]System.Object
+			IL_0b56: dup
+			IL_0b57: ldc.i4.0
+			IL_0b58: ldarg.0
+			IL_0b59: ldc.i4.1
+			IL_0b5a: ldelem.ref
+			IL_0b5b: stelem.ref
+			IL_0b5c: stloc.s 21
+			IL_0b5e: ldarg.0
+			IL_0b5f: ldc.i4.1
+			IL_0b60: ldelem.ref
+			IL_0b61: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b66: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b6b: stloc.s 32
+			IL_0b6d: ldloc.s 32
+			IL_0b6f: ldloc.s 19
+			IL_0b71: ldstr "utf8"
+			IL_0b76: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0b7b: stloc.s 28
+			IL_0b7d: ldloc.s 27
+			IL_0b7f: ldloc.s 21
+			IL_0b81: ldloc.s 28
+			IL_0b83: ldloc.s 19
+			IL_0b85: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0b8a: stloc.s 28
-			IL_0b8c: ldloc.s 27
-			IL_0b8e: ldloc.s 21
-			IL_0b90: ldloc.s 28
-			IL_0b92: ldloc.s 19
-			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b99: stloc.s 28
-			IL_0b9b: ldloc.s 22
-			IL_0b9d: ldstr "log"
-			IL_0ba2: ldloc.s 28
-			IL_0ba4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0ba9: pop
-			IL_0baa: ldloc.0
-			IL_0bab: ldc.i4.m1
-			IL_0bac: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0bb1: ldloc.0
-			IL_0bb2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bb7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0bbc: ldarg.0
-			IL_0bbd: ldc.i4.1
-			IL_0bbe: newarr [System.Runtime]System.Object
-			IL_0bc3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bc8: pop
-			IL_0bc9: ldloc.0
-			IL_0bca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bcf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bd4: ret
+			IL_0b8c: ldloc.s 22
+			IL_0b8e: ldstr "log"
+			IL_0b93: ldloc.s 28
+			IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b9a: pop
+			IL_0b9b: ldloc.0
+			IL_0b9c: ldc.i4.m1
+			IL_0b9d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0ba2: ldloc.0
+			IL_0ba3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bad: ldarg.0
+			IL_0bae: ldc.i4.1
+			IL_0baf: newarr [System.Runtime]System.Object
+			IL_0bb4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bb9: pop
+			IL_0bba: ldloc.0
+			IL_0bbb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bc0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bc5: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5351,10 +5346,10 @@
 			74 7d 2c 20 e2 80 a6 00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object http
-		.field public object https
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule https
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object NodeUrl
 		.field public object normalize
 		.field public object parseArgs
@@ -5370,7 +5365,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4581
+			// Method begins at RVA 0x4565
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5554,28 +5549,28 @@
 		IL_018e: stloc.s 5
 		IL_0190: ldloc.0
 		IL_0191: ldloc.s 5
-		IL_0193: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+		IL_0193: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
 		IL_0198: ldarg.1
 		IL_0199: ldstr "node:http"
 		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01a3: stloc.s 6
 		IL_01a5: ldloc.0
 		IL_01a6: ldloc.s 6
-		IL_01a8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
+		IL_01a8: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::http
 		IL_01ad: ldarg.1
 		IL_01ae: ldstr "node:https"
 		IL_01b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01b8: stloc.s 7
 		IL_01ba: ldloc.0
 		IL_01bb: ldloc.s 7
-		IL_01bd: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
+		IL_01bd: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::https
 		IL_01c2: ldarg.1
 		IL_01c3: ldstr "path"
 		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_01cd: stloc.s 8
 		IL_01cf: ldloc.0
 		IL_01d0: ldloc.s 8
-		IL_01d2: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+		IL_01d2: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
 		IL_01d7: ldarg.1
 		IL_01d8: ldstr "node:url"
 		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -5626,7 +5621,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x474c
+		// Method begins at RVA 0x4730
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c0
+				// Method begins at RVA 0x36a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -47,7 +47,7 @@
 			)
 			// Method begins at RVA 0x22a4
 			// Header size: 12
-			// Code size: 32 (0x20)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
@@ -55,17 +55,16 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldarg.2
-			IL_000e: ldstr "utf8"
-			IL_0013: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0018: stloc.1
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_001f: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldarg.2
+			IL_0009: ldstr "utf8"
+			IL_000e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0013: stloc.1
+			IL_0014: ldloc.1
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_001a: ret
 		} // end of method readJson::__js_call__
 
 	} // end of class readJson
@@ -81,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c9
+				// Method begins at RVA 0x36a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22cc
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -158,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d2
+				// Method begins at RVA 0x36b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -182,7 +181,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x2314
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -225,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36db
+				// Method begins at RVA 0x36bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -250,7 +249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2354
+			// Method begins at RVA 0x2350
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -323,7 +322,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e4
+				// Method begins at RVA 0x36c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +349,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x23cc
+			// Method begins at RVA 0x23c8
 			// Header size: 12
 			// Code size: 281 (0x119)
 			.maxstack 8
@@ -494,7 +493,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36f6
+					// Method begins at RVA 0x36d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -519,7 +518,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3670
+				// Method begins at RVA 0x3650
 				// Header size: 12
 				// Code size: 59 (0x3b)
 				.maxstack 8
@@ -571,7 +570,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36ed
+				// Method begins at RVA 0x36cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -598,7 +597,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x24f4
+			// Method begins at RVA 0x24f0
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -696,7 +695,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36ff
+				// Method begins at RVA 0x36df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -720,7 +719,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3711
+					// Method begins at RVA 0x36f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -738,7 +737,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3708
+				// Method begins at RVA 0x36e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -765,7 +764,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x25b0
+			// Method begins at RVA 0x25ac
 			// Header size: 12
 			// Code size: 617 (0x269)
 			.maxstack 10
@@ -1045,7 +1044,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x371a
+				// Method begins at RVA 0x36fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1069,7 +1068,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x372c
+					// Method begins at RVA 0x370c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1093,7 +1092,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x373e
+						// Method begins at RVA 0x371e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1111,7 +1110,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3735
+					// Method begins at RVA 0x3715
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1129,7 +1128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3723
+				// Method begins at RVA 0x3703
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1156,7 +1155,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2844
+			// Method begins at RVA 0x2840
 			// Header size: 12
 			// Code size: 789 (0x315)
 			.maxstack 11
@@ -1526,7 +1525,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3747
+				// Method begins at RVA 0x3727
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1554,7 +1553,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3762
+						// Method begins at RVA 0x3742
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1574,7 +1573,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x376b
+						// Method begins at RVA 0x374b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1594,7 +1593,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3774
+						// Method begins at RVA 0x3754
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1612,7 +1611,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3759
+					// Method begins at RVA 0x3739
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1630,7 +1629,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3750
+				// Method begins at RVA 0x3730
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1657,7 +1656,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2b9c
+			// Method begins at RVA 0x2b98
 			// Header size: 12
 			// Code size: 760 (0x2f8)
 			.maxstack 10
@@ -1999,7 +1998,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x377d
+				// Method begins at RVA 0x375d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2027,7 +2026,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3798
+						// Method begins at RVA 0x3778
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2047,7 +2046,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37a1
+						// Method begins at RVA 0x3781
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2067,7 +2066,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37aa
+						// Method begins at RVA 0x378a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2091,7 +2090,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x37bc
+							// Method begins at RVA 0x379c
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2109,7 +2108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37b3
+						// Method begins at RVA 0x3793
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2127,7 +2126,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x378f
+					// Method begins at RVA 0x376f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2145,7 +2144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3786
+				// Method begins at RVA 0x3766
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2172,7 +2171,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2ebc
+			// Method begins at RVA 0x2eb8
 			// Header size: 12
 			// Code size: 1054 (0x41e)
 			.maxstack 11
@@ -2624,7 +2623,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37c5
+				// Method begins at RVA 0x37a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2644,7 +2643,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37ce
+				// Method begins at RVA 0x37ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2668,7 +2667,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x331c
+			// Method begins at RVA 0x3318
 			// Header size: 12
 			// Code size: 286 (0x11e)
 			.maxstack 10
@@ -2826,7 +2825,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37d7
+				// Method begins at RVA 0x37b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2852,9 +2851,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x3458
+			// Method begins at RVA 0x3454
 			// Header size: 12
-			// Code size: 521 (0x209)
+			// Code size: 496 (0x1f0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2874,213 +2873,208 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: stloc.s 7
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::__dirname
-			IL_0013: stloc.s 8
-			IL_0015: ldloc.s 7
-			IL_0017: ldc.i4.2
-			IL_0018: newarr [System.Runtime]System.Object
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_0006: stloc.s 7
+			IL_0008: ldarg.0
+			IL_0009: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::__dirname
+			IL_000e: stloc.s 8
+			IL_0010: ldloc.s 7
+			IL_0012: ldc.i4.2
+			IL_0013: newarr [System.Runtime]System.Object
+			IL_0018: dup
+			IL_0019: ldc.i4.0
+			IL_001a: ldloc.s 8
+			IL_001c: stelem.ref
 			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldloc.s 8
-			IL_0021: stelem.ref
-			IL_0022: dup
-			IL_0023: ldc.i4.1
-			IL_0024: ldstr ".."
-			IL_0029: stelem.ref
-			IL_002a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_002f: stloc.0
-			IL_0030: ldarg.0
-			IL_0031: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_0036: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_003b: stloc.s 7
-			IL_003d: ldloc.s 7
-			IL_003f: ldc.i4.4
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldloc.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldstr "docs"
-			IL_0050: stelem.ref
-			IL_0051: dup
-			IL_0052: ldc.i4.2
-			IL_0053: ldstr "nodejs"
-			IL_0058: stelem.ref
-			IL_0059: dup
-			IL_005a: ldc.i4.3
-			IL_005b: ldstr "NodeSupport.json"
-			IL_0060: stelem.ref
-			IL_0061: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0066: stloc.1
-			IL_0067: ldarg.0
-			IL_0068: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_006d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0072: stloc.s 7
-			IL_0074: ldloc.s 7
-			IL_0076: ldc.i4.4
-			IL_0077: newarr [System.Runtime]System.Object
-			IL_007c: dup
-			IL_007d: ldc.i4.0
-			IL_007e: ldloc.0
-			IL_007f: stelem.ref
-			IL_0080: dup
-			IL_0081: ldc.i4.1
-			IL_0082: ldstr "docs"
-			IL_0087: stelem.ref
-			IL_0088: dup
-			IL_0089: ldc.i4.2
-			IL_008a: ldstr "nodejs"
-			IL_008f: stelem.ref
-			IL_0090: dup
-			IL_0091: ldc.i4.3
-			IL_0092: ldstr "NodeSupport.md"
-			IL_0097: stelem.ref
-			IL_0098: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_009d: stloc.2
-			IL_009e: ldarg.0
-			IL_009f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::readJson
-			IL_00a4: ldc.i4.1
-			IL_00a5: newarr [System.Runtime]System.Object
-			IL_00aa: dup
-			IL_00ab: ldc.i4.0
-			IL_00ac: ldarg.0
-			IL_00ad: stelem.ref
-			IL_00ae: ldloc.1
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00b4: stloc.3
-			IL_00b5: ldc.i4.0
-			IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00bb: stloc.s 4
-			IL_00bd: ldarg.0
-			IL_00be: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderHeader
-			IL_00c3: ldc.i4.1
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: ldloc.3
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d3: stloc.s 8
-			IL_00d5: ldloc.s 4
-			IL_00d7: ldloc.s 8
-			IL_00d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00de: pop
-			IL_00df: ldarg.0
-			IL_00e0: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderModules
-			IL_00e5: ldc.i4.1
-			IL_00e6: newarr [System.Runtime]System.Object
-			IL_00eb: dup
-			IL_00ec: ldc.i4.0
-			IL_00ed: ldarg.0
-			IL_00ee: stelem.ref
-			IL_00ef: ldloc.3
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00f5: stloc.s 8
-			IL_00f7: ldloc.s 4
-			IL_00f9: ldloc.s 8
-			IL_00fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0100: pop
-			IL_0101: ldarg.0
-			IL_0102: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderGlobals
-			IL_0107: ldc.i4.1
-			IL_0108: newarr [System.Runtime]System.Object
-			IL_010d: dup
-			IL_010e: ldc.i4.0
-			IL_010f: ldarg.0
-			IL_0110: stelem.ref
-			IL_0111: ldloc.3
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0117: stloc.s 8
-			IL_0119: ldloc.s 4
-			IL_011b: ldloc.s 8
-			IL_011d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0122: pop
-			IL_0123: ldarg.0
-			IL_0124: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderLimitations
-			IL_0129: ldc.i4.1
-			IL_012a: newarr [System.Runtime]System.Object
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldarg.0
-			IL_0132: stelem.ref
-			IL_0133: ldloc.3
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0139: stloc.s 5
-			IL_013b: ldloc.s 5
-			IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0142: stloc.s 9
-			IL_0144: ldloc.s 9
-			IL_0146: brfalse IL_0155
+			IL_001e: ldc.i4.1
+			IL_001f: ldstr ".."
+			IL_0024: stelem.ref
+			IL_0025: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_002a: stloc.0
+			IL_002b: ldarg.0
+			IL_002c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_0031: stloc.s 7
+			IL_0033: ldloc.s 7
+			IL_0035: ldc.i4.4
+			IL_0036: newarr [System.Runtime]System.Object
+			IL_003b: dup
+			IL_003c: ldc.i4.0
+			IL_003d: ldloc.0
+			IL_003e: stelem.ref
+			IL_003f: dup
+			IL_0040: ldc.i4.1
+			IL_0041: ldstr "docs"
+			IL_0046: stelem.ref
+			IL_0047: dup
+			IL_0048: ldc.i4.2
+			IL_0049: ldstr "nodejs"
+			IL_004e: stelem.ref
+			IL_004f: dup
+			IL_0050: ldc.i4.3
+			IL_0051: ldstr "NodeSupport.json"
+			IL_0056: stelem.ref
+			IL_0057: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_005c: stloc.1
+			IL_005d: ldarg.0
+			IL_005e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_0063: stloc.s 7
+			IL_0065: ldloc.s 7
+			IL_0067: ldc.i4.4
+			IL_0068: newarr [System.Runtime]System.Object
+			IL_006d: dup
+			IL_006e: ldc.i4.0
+			IL_006f: ldloc.0
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.1
+			IL_0073: ldstr "docs"
+			IL_0078: stelem.ref
+			IL_0079: dup
+			IL_007a: ldc.i4.2
+			IL_007b: ldstr "nodejs"
+			IL_0080: stelem.ref
+			IL_0081: dup
+			IL_0082: ldc.i4.3
+			IL_0083: ldstr "NodeSupport.md"
+			IL_0088: stelem.ref
+			IL_0089: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_008e: stloc.2
+			IL_008f: ldarg.0
+			IL_0090: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::readJson
+			IL_0095: ldc.i4.1
+			IL_0096: newarr [System.Runtime]System.Object
+			IL_009b: dup
+			IL_009c: ldc.i4.0
+			IL_009d: ldarg.0
+			IL_009e: stelem.ref
+			IL_009f: ldloc.1
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a5: stloc.3
+			IL_00a6: ldc.i4.0
+			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00ac: stloc.s 4
+			IL_00ae: ldarg.0
+			IL_00af: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderHeader
+			IL_00b4: ldc.i4.1
+			IL_00b5: newarr [System.Runtime]System.Object
+			IL_00ba: dup
+			IL_00bb: ldc.i4.0
+			IL_00bc: ldarg.0
+			IL_00bd: stelem.ref
+			IL_00be: ldloc.3
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00c4: stloc.s 8
+			IL_00c6: ldloc.s 4
+			IL_00c8: ldloc.s 8
+			IL_00ca: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00cf: pop
+			IL_00d0: ldarg.0
+			IL_00d1: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderModules
+			IL_00d6: ldc.i4.1
+			IL_00d7: newarr [System.Runtime]System.Object
+			IL_00dc: dup
+			IL_00dd: ldc.i4.0
+			IL_00de: ldarg.0
+			IL_00df: stelem.ref
+			IL_00e0: ldloc.3
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00e6: stloc.s 8
+			IL_00e8: ldloc.s 4
+			IL_00ea: ldloc.s 8
+			IL_00ec: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00f1: pop
+			IL_00f2: ldarg.0
+			IL_00f3: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderGlobals
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldarg.0
+			IL_0101: stelem.ref
+			IL_0102: ldloc.3
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0108: stloc.s 8
+			IL_010a: ldloc.s 4
+			IL_010c: ldloc.s 8
+			IL_010e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0113: pop
+			IL_0114: ldarg.0
+			IL_0115: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderLimitations
+			IL_011a: ldc.i4.1
+			IL_011b: newarr [System.Runtime]System.Object
+			IL_0120: dup
+			IL_0121: ldc.i4.0
+			IL_0122: ldarg.0
+			IL_0123: stelem.ref
+			IL_0124: ldloc.3
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_012a: stloc.s 5
+			IL_012c: ldloc.s 5
+			IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0133: stloc.s 9
+			IL_0135: ldloc.s 9
+			IL_0137: brfalse IL_0146
 
-			IL_014b: ldloc.s 4
-			IL_014d: ldloc.s 5
-			IL_014f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0154: pop
+			IL_013c: ldloc.s 4
+			IL_013e: ldloc.s 5
+			IL_0140: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0145: pop
 
-			IL_0155: ldloc.s 4
-			IL_0157: ldc.i4.1
-			IL_0158: newarr [System.Runtime]System.Object
-			IL_015d: dup
-			IL_015e: ldc.i4.0
-			IL_015f: ldstr "\n\n"
-			IL_0164: stelem.ref
-			IL_0165: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_016a: stloc.s 10
-			IL_016c: ldloc.s 10
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0173: stloc.s 8
-			IL_0175: ldstr "\\r?\\n"
-			IL_017a: ldstr "g"
-			IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0184: stloc.s 11
-			IL_0186: ldloc.s 8
-			IL_0188: ldstr "replace"
-			IL_018d: ldloc.s 11
-			IL_018f: ldstr "\n"
-			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0199: stloc.s 6
-			IL_019b: ldarg.0
-			IL_019c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_01a1: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_01a6: stloc.s 12
-			IL_01a8: ldloc.s 12
-			IL_01aa: ldloc.2
-			IL_01ab: ldloc.s 6
-			IL_01ad: ldstr "utf8"
-			IL_01b2: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_01b7: ldstr "console"
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c6: stloc.s 8
-			IL_01c8: ldarg.0
-			IL_01c9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_01ce: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_01d3: ldstr "relative"
-			IL_01d8: ldloc.0
-			IL_01d9: ldloc.2
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01df: stloc.s 13
-			IL_01e1: ldloc.s 13
-			IL_01e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01e8: stloc.s 10
-			IL_01ea: ldstr "Wrote "
-			IL_01ef: ldloc.s 10
-			IL_01f1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f6: stloc.s 10
-			IL_01f8: ldloc.s 8
-			IL_01fa: ldstr "log"
-			IL_01ff: ldloc.s 10
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0206: pop
-			IL_0207: ldnull
-			IL_0208: ret
+			IL_0146: ldloc.s 4
+			IL_0148: ldc.i4.1
+			IL_0149: newarr [System.Runtime]System.Object
+			IL_014e: dup
+			IL_014f: ldc.i4.0
+			IL_0150: ldstr "\n\n"
+			IL_0155: stelem.ref
+			IL_0156: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_015b: stloc.s 10
+			IL_015d: ldloc.s 10
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0164: stloc.s 8
+			IL_0166: ldstr "\\r?\\n"
+			IL_016b: ldstr "g"
+			IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0175: stloc.s 11
+			IL_0177: ldloc.s 8
+			IL_0179: ldstr "replace"
+			IL_017e: ldloc.s 11
+			IL_0180: ldstr "\n"
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_018a: stloc.s 6
+			IL_018c: ldarg.0
+			IL_018d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_0192: stloc.s 12
+			IL_0194: ldloc.s 12
+			IL_0196: ldloc.2
+			IL_0197: ldloc.s 6
+			IL_0199: ldstr "utf8"
+			IL_019e: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_01a3: ldstr "console"
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b2: stloc.s 8
+			IL_01b4: ldarg.0
+			IL_01b5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_01ba: ldstr "relative"
+			IL_01bf: ldloc.0
+			IL_01c0: ldloc.2
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01c6: stloc.s 13
+			IL_01c8: ldloc.s 13
+			IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01cf: stloc.s 10
+			IL_01d1: ldstr "Wrote "
+			IL_01d6: ldloc.s 10
+			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01dd: stloc.s 10
+			IL_01df: ldloc.s 8
+			IL_01e1: ldstr "log"
+			IL_01e6: ldloc.s 10
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ed: pop
+			IL_01ee: ldnull
+			IL_01ef: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -3104,8 +3098,8 @@
 		)
 		// Fields
 		.field public object __dirname
-		.field public object fs
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object readJson
 		.field public object asArray
 		.field public object fmtCode
@@ -3123,7 +3117,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x36b7
+			// Method begins at RVA 0x3697
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3345,14 +3339,14 @@
 		IL_020f: stloc.s 4
 		IL_0211: ldloc.0
 		IL_0212: ldloc.s 4
-		IL_0214: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+		IL_0214: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
 		IL_0219: ldarg.1
 		IL_021a: ldstr "path"
 		IL_021f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0224: stloc.s 5
 		IL_0226: ldloc.0
 		IL_0227: ldloc.s 5
-		IL_0229: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+		IL_0229: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
 		IL_022e: nop
 		IL_022f: nop
 		IL_0230: nop
@@ -3381,7 +3375,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x37e0
+		// Method begins at RVA 0x37c0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a59
+					// Method begins at RVA 0x2a51
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2760
+				// Method begins at RVA 0x2758
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -103,7 +103,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a62
+					// Method begins at RVA 0x2a5a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -128,7 +128,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2794
+				// Method begins at RVA 0x278c
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -177,7 +177,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a6b
+					// Method begins at RVA 0x2a63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -202,7 +202,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x27c8
+				// Method begins at RVA 0x27c0
 				// Header size: 12
 				// Code size: 116 (0x74)
 				.maxstack 8
@@ -269,7 +269,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a74
+					// Method begins at RVA 0x2a6c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -294,7 +294,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2848
+				// Method begins at RVA 0x2840
 				// Header size: 12
 				// Code size: 265 (0x109)
 				.maxstack 8
@@ -420,7 +420,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a50
+				// Method begins at RVA 0x2a48
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -448,7 +448,7 @@
 			)
 			// Method begins at RVA 0x2244
 			// Header size: 12
-			// Code size: 804 (0x324)
+			// Code size: 799 (0x31f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope,
@@ -465,265 +465,264 @@
 			IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_000c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
-			IL_0011: stloc.1
-			IL_0012: ldc.i4.1
-			IL_0013: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0018: dup
-			IL_0019: ldstr "emit-stdio"
-			IL_001e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0023: stloc.2
-			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0029: dup
-			IL_002a: ldstr "silent"
-			IL_002f: ldc.i4.1
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0035: stloc.3
-			IL_0036: ldloc.1
-			IL_0037: ldstr "./Require_ChildProcess_Fork_Silent_Child"
-			IL_003c: ldloc.2
-			IL_003d: ldloc.3
-			IL_003e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
-			IL_0043: stloc.s 4
-			IL_0045: ldloc.0
-			IL_0046: ldloc.s 4
-			IL_0048: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_004d: ldstr "console"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005c: stloc.s 4
-			IL_005e: ldloc.0
-			IL_005f: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0064: ldstr "stdout"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006e: stloc.s 5
-			IL_0070: ldloc.s 5
-			IL_0072: ldc.i4.0
-			IL_0073: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_007d: stloc.s 6
-			IL_007f: ldloc.s 6
-			IL_0081: box [System.Runtime]System.Boolean
-			IL_0086: stloc.s 7
-			IL_0088: ldloc.s 4
-			IL_008a: ldstr "log"
-			IL_008f: ldstr "silent true stdout piped:"
-			IL_0094: ldloc.s 7
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_009b: pop
-			IL_009c: ldstr "console"
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: stloc.s 4
-			IL_00ad: ldloc.0
-			IL_00ae: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_00b3: ldstr "stderr"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.s 5
-			IL_00c1: ldc.i4.0
-			IL_00c2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00cc: stloc.s 6
-			IL_00ce: ldloc.s 6
-			IL_00d0: box [System.Runtime]System.Boolean
-			IL_00d5: stloc.s 7
-			IL_00d7: ldloc.s 4
-			IL_00d9: ldstr "log"
-			IL_00de: ldstr "silent true stderr piped:"
-			IL_00e3: ldloc.s 7
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ea: pop
-			IL_00eb: ldstr "console"
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fa: stloc.s 4
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0102: ldstr "connected"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010c: stloc.s 5
-			IL_010e: ldloc.s 4
-			IL_0110: ldstr "log"
-			IL_0115: ldstr "silent true connected initially:"
-			IL_011a: ldloc.s 5
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0121: pop
-			IL_0122: ldloc.0
-			IL_0123: ldstr ""
-			IL_0128: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
-			IL_012d: ldloc.0
-			IL_012e: ldstr ""
-			IL_0133: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-			IL_0138: ldloc.0
-			IL_0139: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_013e: ldstr "stdout"
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0148: stloc.s 5
-			IL_014a: ldloc.s 5
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0151: ldstr "setEncoding"
-			IL_0156: ldstr "utf8"
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0160: pop
-			IL_0161: ldloc.0
-			IL_0162: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_0167: ldstr "stdout"
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0171: stloc.s 5
-			IL_0173: ldloc.s 5
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017a: stloc.s 5
-			IL_017c: ldnull
-			IL_017d: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29::__js_call__(object[], object, object)
-			IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0188: ldc.i4.2
-			IL_0189: newarr [System.Runtime]System.Object
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldarg.0
-			IL_0191: stelem.ref
-			IL_0192: dup
-			IL_0193: ldc.i4.1
-			IL_0194: ldloc.0
-			IL_0195: stelem.ref
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01a0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_01a5: ldc.i4.1
-			IL_01a6: conv.r8
-			IL_01a7: ldstr ""
-			IL_01ac: ldc.i4.0
-			IL_01ad: ldc.i4.0
-			IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_01b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_01b8: stloc.s 8
-			IL_01ba: ldloc.s 5
-			IL_01bc: ldstr "on"
-			IL_01c1: ldstr "data"
-			IL_01c6: ldloc.s 8
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01cd: pop
-			IL_01ce: ldloc.0
-			IL_01cf: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01d4: ldstr "stderr"
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01de: stloc.s 5
-			IL_01e0: ldloc.s 5
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e7: ldstr "setEncoding"
-			IL_01ec: ldstr "utf8"
-			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01f6: pop
-			IL_01f7: ldloc.0
-			IL_01f8: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01fd: ldstr "stderr"
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0207: stloc.s 5
-			IL_0209: ldloc.s 5
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0210: stloc.s 5
-			IL_0212: ldnull
-			IL_0213: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29::__js_call__(object[], object, object)
-			IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_021e: ldc.i4.2
-			IL_021f: newarr [System.Runtime]System.Object
-			IL_0224: dup
-			IL_0225: ldc.i4.0
-			IL_0226: ldarg.0
-			IL_0227: stelem.ref
-			IL_0228: dup
-			IL_0229: ldc.i4.1
-			IL_022a: ldloc.0
-			IL_022b: stelem.ref
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0236: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_023b: ldc.i4.1
-			IL_023c: conv.r8
-			IL_023d: ldstr ""
-			IL_0242: ldc.i4.0
-			IL_0243: ldc.i4.0
-			IL_0244: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_0249: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_024e: stloc.s 8
-			IL_0250: ldloc.s 5
-			IL_0252: ldstr "on"
-			IL_0257: ldstr "data"
-			IL_025c: ldloc.s 8
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0263: pop
-			IL_0264: ldloc.0
-			IL_0265: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026f: stloc.s 5
-			IL_0271: ldnull
-			IL_0272: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25::__js_call__(object[], object, object)
-			IL_0278: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_027d: ldc.i4.2
-			IL_027e: newarr [System.Runtime]System.Object
-			IL_0283: dup
-			IL_0284: ldc.i4.0
-			IL_0285: ldarg.0
-			IL_0286: stelem.ref
-			IL_0287: dup
-			IL_0288: ldc.i4.1
-			IL_0289: ldloc.0
-			IL_028a: stelem.ref
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0295: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_029a: ldc.i4.1
-			IL_029b: conv.r8
-			IL_029c: ldstr ""
-			IL_02a1: ldc.i4.0
-			IL_02a2: ldc.i4.0
-			IL_02a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_02ad: stloc.s 8
-			IL_02af: ldloc.s 5
-			IL_02b1: ldstr "on"
-			IL_02b6: ldstr "message"
-			IL_02bb: ldloc.s 8
-			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02c2: pop
-			IL_02c3: ldloc.0
-			IL_02c4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ce: stloc.s 5
-			IL_02d0: ldnull
-			IL_02d1: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23::__js_call__(object[], object, object)
-			IL_02d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_02dc: ldc.i4.2
-			IL_02dd: newarr [System.Runtime]System.Object
-			IL_02e2: dup
-			IL_02e3: ldc.i4.0
-			IL_02e4: ldarg.0
-			IL_02e5: stelem.ref
-			IL_02e6: dup
-			IL_02e7: ldc.i4.1
-			IL_02e8: ldloc.0
-			IL_02e9: stelem.ref
-			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02f4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_02f9: ldc.i4.1
-			IL_02fa: conv.r8
-			IL_02fb: ldstr ""
-			IL_0300: ldc.i4.0
-			IL_0301: ldc.i4.0
-			IL_0302: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_0307: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_030c: stloc.s 8
-			IL_030e: ldloc.s 5
-			IL_0310: ldstr "on"
-			IL_0315: ldstr "close"
-			IL_031a: ldloc.s 8
-			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0321: pop
-			IL_0322: ldnull
-			IL_0323: ret
+			IL_0007: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
+			IL_000c: stloc.1
+			IL_000d: ldc.i4.1
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0013: dup
+			IL_0014: ldstr "emit-stdio"
+			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_001e: stloc.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "silent"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: stloc.3
+			IL_0031: ldloc.1
+			IL_0032: ldstr "./Require_ChildProcess_Fork_Silent_Child"
+			IL_0037: ldloc.2
+			IL_0038: ldloc.3
+			IL_0039: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
+			IL_003e: stloc.s 4
+			IL_0040: ldloc.0
+			IL_0041: ldloc.s 4
+			IL_0043: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0048: ldstr "console"
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.0
+			IL_005a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_005f: ldstr "stdout"
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0069: stloc.s 5
+			IL_006b: ldloc.s 5
+			IL_006d: ldc.i4.0
+			IL_006e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0078: stloc.s 6
+			IL_007a: ldloc.s 6
+			IL_007c: box [System.Runtime]System.Boolean
+			IL_0081: stloc.s 7
+			IL_0083: ldloc.s 4
+			IL_0085: ldstr "log"
+			IL_008a: ldstr "silent true stdout piped:"
+			IL_008f: ldloc.s 7
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0096: pop
+			IL_0097: ldstr "console"
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a6: stloc.s 4
+			IL_00a8: ldloc.0
+			IL_00a9: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_00ae: ldstr "stderr"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b8: stloc.s 5
+			IL_00ba: ldloc.s 5
+			IL_00bc: ldc.i4.0
+			IL_00bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00c7: stloc.s 6
+			IL_00c9: ldloc.s 6
+			IL_00cb: box [System.Runtime]System.Boolean
+			IL_00d0: stloc.s 7
+			IL_00d2: ldloc.s 4
+			IL_00d4: ldstr "log"
+			IL_00d9: ldstr "silent true stderr piped:"
+			IL_00de: ldloc.s 7
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00e5: pop
+			IL_00e6: ldstr "console"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f5: stloc.s 4
+			IL_00f7: ldloc.0
+			IL_00f8: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_00fd: ldstr "connected"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0107: stloc.s 5
+			IL_0109: ldloc.s 4
+			IL_010b: ldstr "log"
+			IL_0110: ldstr "silent true connected initially:"
+			IL_0115: ldloc.s 5
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_011c: pop
+			IL_011d: ldloc.0
+			IL_011e: ldstr ""
+			IL_0123: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
+			IL_0128: ldloc.0
+			IL_0129: ldstr ""
+			IL_012e: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+			IL_0133: ldloc.0
+			IL_0134: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0139: ldstr "stdout"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0143: stloc.s 5
+			IL_0145: ldloc.s 5
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014c: ldstr "setEncoding"
+			IL_0151: ldstr "utf8"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_015b: pop
+			IL_015c: ldloc.0
+			IL_015d: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0162: ldstr "stdout"
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016c: stloc.s 5
+			IL_016e: ldloc.s 5
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0175: stloc.s 5
+			IL_0177: ldnull
+			IL_0178: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29::__js_call__(object[], object, object)
+			IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0183: ldc.i4.2
+			IL_0184: newarr [System.Runtime]System.Object
+			IL_0189: dup
+			IL_018a: ldc.i4.0
+			IL_018b: ldarg.0
+			IL_018c: stelem.ref
+			IL_018d: dup
+			IL_018e: ldc.i4.1
+			IL_018f: ldloc.0
+			IL_0190: stelem.ref
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_019b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_01a0: ldc.i4.1
+			IL_01a1: conv.r8
+			IL_01a2: ldstr ""
+			IL_01a7: ldc.i4.0
+			IL_01a8: ldc.i4.0
+			IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_01b3: stloc.s 8
+			IL_01b5: ldloc.s 5
+			IL_01b7: ldstr "on"
+			IL_01bc: ldstr "data"
+			IL_01c1: ldloc.s 8
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01c8: pop
+			IL_01c9: ldloc.0
+			IL_01ca: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_01cf: ldstr "stderr"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d9: stloc.s 5
+			IL_01db: ldloc.s 5
+			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e2: ldstr "setEncoding"
+			IL_01e7: ldstr "utf8"
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f1: pop
+			IL_01f2: ldloc.0
+			IL_01f3: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_01f8: ldstr "stderr"
+			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0202: stloc.s 5
+			IL_0204: ldloc.s 5
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020b: stloc.s 5
+			IL_020d: ldnull
+			IL_020e: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29::__js_call__(object[], object, object)
+			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0219: ldc.i4.2
+			IL_021a: newarr [System.Runtime]System.Object
+			IL_021f: dup
+			IL_0220: ldc.i4.0
+			IL_0221: ldarg.0
+			IL_0222: stelem.ref
+			IL_0223: dup
+			IL_0224: ldc.i4.1
+			IL_0225: ldloc.0
+			IL_0226: stelem.ref
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0231: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_0236: ldc.i4.1
+			IL_0237: conv.r8
+			IL_0238: ldstr ""
+			IL_023d: ldc.i4.0
+			IL_023e: ldc.i4.0
+			IL_023f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_0244: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_0249: stloc.s 8
+			IL_024b: ldloc.s 5
+			IL_024d: ldstr "on"
+			IL_0252: ldstr "data"
+			IL_0257: ldloc.s 8
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_025e: pop
+			IL_025f: ldloc.0
+			IL_0260: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_026a: stloc.s 5
+			IL_026c: ldnull
+			IL_026d: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25::__js_call__(object[], object, object)
+			IL_0273: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0278: ldc.i4.2
+			IL_0279: newarr [System.Runtime]System.Object
+			IL_027e: dup
+			IL_027f: ldc.i4.0
+			IL_0280: ldarg.0
+			IL_0281: stelem.ref
+			IL_0282: dup
+			IL_0283: ldc.i4.1
+			IL_0284: ldloc.0
+			IL_0285: stelem.ref
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0290: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_0295: ldc.i4.1
+			IL_0296: conv.r8
+			IL_0297: ldstr ""
+			IL_029c: ldc.i4.0
+			IL_029d: ldc.i4.0
+			IL_029e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_02a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_02a8: stloc.s 8
+			IL_02aa: ldloc.s 5
+			IL_02ac: ldstr "on"
+			IL_02b1: ldstr "message"
+			IL_02b6: ldloc.s 8
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02bd: pop
+			IL_02be: ldloc.0
+			IL_02bf: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c9: stloc.s 5
+			IL_02cb: ldnull
+			IL_02cc: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23::__js_call__(object[], object, object)
+			IL_02d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_02d7: ldc.i4.2
+			IL_02d8: newarr [System.Runtime]System.Object
+			IL_02dd: dup
+			IL_02de: ldc.i4.0
+			IL_02df: ldarg.0
+			IL_02e0: stelem.ref
+			IL_02e1: dup
+			IL_02e2: ldc.i4.1
+			IL_02e3: ldloc.0
+			IL_02e4: stelem.ref
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_02ef: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_02f4: ldc.i4.1
+			IL_02f5: conv.r8
+			IL_02f6: ldstr ""
+			IL_02fb: ldc.i4.0
+			IL_02fc: ldc.i4.0
+			IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_0302: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_0307: stloc.s 8
+			IL_0309: ldloc.s 5
+			IL_030b: ldstr "on"
+			IL_0310: ldstr "close"
+			IL_0315: ldloc.s 8
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_031c: pop
+			IL_031d: ldnull
+			IL_031e: ret
 		} // end of method runSilentTrue::__js_call__
 
 	} // end of class runSilentTrue
@@ -750,7 +749,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a86
+					// Method begins at RVA 0x2a7e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -775,7 +774,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2960
+				// Method begins at RVA 0x2958
 				// Header size: 12
 				// Code size: 116 (0x74)
 				.maxstack 8
@@ -842,7 +841,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a8f
+					// Method begins at RVA 0x2a87
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -866,7 +865,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29e0
+				// Method begins at RVA 0x29d8
 				// Header size: 1
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -899,7 +898,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a7d
+				// Method begins at RVA 0x2a75
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -925,9 +924,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2570
 			// Header size: 12
-			// Code size: 478 (0x1de)
+			// Code size: 473 (0x1d9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope,
@@ -945,157 +944,156 @@
 			IL_0000: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
-			IL_000c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
-			IL_0011: stloc.1
-			IL_0012: ldc.i4.1
-			IL_0013: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0018: dup
-			IL_0019: ldstr "quiet"
-			IL_001e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0023: stloc.2
-			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0029: dup
-			IL_002a: ldstr "silent"
-			IL_002f: ldc.i4.0
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0035: stloc.3
-			IL_0036: ldloc.1
-			IL_0037: ldstr "./Require_ChildProcess_Fork_Silent_Child"
-			IL_003c: ldloc.2
-			IL_003d: ldloc.3
-			IL_003e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
-			IL_0043: stloc.s 4
-			IL_0045: ldloc.0
-			IL_0046: ldloc.s 4
-			IL_0048: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_004d: ldstr "console"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005c: stloc.s 4
-			IL_005e: ldloc.0
-			IL_005f: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0064: ldstr "stdout"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006e: stloc.s 5
-			IL_0070: ldloc.s 5
-			IL_0072: ldc.i4.0
-			IL_0073: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_007d: stloc.s 6
-			IL_007f: ldloc.s 6
-			IL_0081: box [System.Runtime]System.Boolean
-			IL_0086: stloc.s 7
-			IL_0088: ldloc.s 4
-			IL_008a: ldstr "log"
-			IL_008f: ldstr "silent false stdout null:"
-			IL_0094: ldloc.s 7
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_009b: pop
-			IL_009c: ldstr "console"
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: stloc.s 4
-			IL_00ad: ldloc.0
-			IL_00ae: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_00b3: ldstr "stderr"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.s 5
-			IL_00c1: ldc.i4.0
-			IL_00c2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00cc: stloc.s 6
-			IL_00ce: ldloc.s 6
-			IL_00d0: box [System.Runtime]System.Boolean
-			IL_00d5: stloc.s 7
-			IL_00d7: ldloc.s 4
-			IL_00d9: ldstr "log"
-			IL_00de: ldstr "silent false stderr null:"
-			IL_00e3: ldloc.s 7
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ea: pop
-			IL_00eb: ldstr "console"
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fa: stloc.s 4
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0102: ldstr "connected"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010c: stloc.s 5
-			IL_010e: ldloc.s 4
-			IL_0110: ldstr "log"
-			IL_0115: ldstr "silent false connected initially:"
-			IL_011a: ldloc.s 5
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0121: pop
-			IL_0122: ldloc.0
-			IL_0123: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012d: stloc.s 5
-			IL_012f: ldnull
-			IL_0130: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L45C25::__js_call__(object[], object, object)
-			IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_013b: ldc.i4.2
-			IL_013c: newarr [System.Runtime]System.Object
-			IL_0141: dup
-			IL_0142: ldc.i4.0
-			IL_0143: ldarg.0
-			IL_0144: stelem.ref
-			IL_0145: dup
-			IL_0146: ldc.i4.1
-			IL_0147: ldloc.0
-			IL_0148: stelem.ref
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0153: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_0158: ldc.i4.1
-			IL_0159: conv.r8
-			IL_015a: ldstr ""
-			IL_015f: ldc.i4.0
-			IL_0160: ldc.i4.0
-			IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_016b: stloc.s 8
-			IL_016d: ldloc.s 5
-			IL_016f: ldstr "on"
-			IL_0174: ldstr "message"
-			IL_0179: ldloc.s 8
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0180: pop
-			IL_0181: ldloc.0
-			IL_0182: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 5
-			IL_018e: ldnull
-			IL_018f: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L50C23::__js_call__(object, object)
-			IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_019a: ldc.i4.1
-			IL_019b: newarr [System.Runtime]System.Object
-			IL_01a0: dup
-			IL_01a1: ldc.i4.0
-			IL_01a2: ldarg.0
-			IL_01a3: stelem.ref
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01ae: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_01b3: ldc.i4.1
-			IL_01b4: conv.r8
-			IL_01b5: ldstr ""
-			IL_01ba: ldc.i4.0
-			IL_01bb: ldc.i4.0
-			IL_01bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-			IL_01c6: stloc.s 9
-			IL_01c8: ldloc.s 5
-			IL_01ca: ldstr "on"
-			IL_01cf: ldstr "close"
-			IL_01d4: ldloc.s 9
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01db: pop
-			IL_01dc: ldnull
-			IL_01dd: ret
+			IL_0007: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
+			IL_000c: stloc.1
+			IL_000d: ldc.i4.1
+			IL_000e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0013: dup
+			IL_0014: ldstr "quiet"
+			IL_0019: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_001e: stloc.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "silent"
+			IL_002a: ldc.i4.0
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: stloc.3
+			IL_0031: ldloc.1
+			IL_0032: ldstr "./Require_ChildProcess_Fork_Silent_Child"
+			IL_0037: ldloc.2
+			IL_0038: ldloc.3
+			IL_0039: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
+			IL_003e: stloc.s 4
+			IL_0040: ldloc.0
+			IL_0041: ldloc.s 4
+			IL_0043: stfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0048: ldstr "console"
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0057: stloc.s 4
+			IL_0059: ldloc.0
+			IL_005a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_005f: ldstr "stdout"
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0069: stloc.s 5
+			IL_006b: ldloc.s 5
+			IL_006d: ldc.i4.0
+			IL_006e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0078: stloc.s 6
+			IL_007a: ldloc.s 6
+			IL_007c: box [System.Runtime]System.Boolean
+			IL_0081: stloc.s 7
+			IL_0083: ldloc.s 4
+			IL_0085: ldstr "log"
+			IL_008a: ldstr "silent false stdout null:"
+			IL_008f: ldloc.s 7
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0096: pop
+			IL_0097: ldstr "console"
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a6: stloc.s 4
+			IL_00a8: ldloc.0
+			IL_00a9: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_00ae: ldstr "stderr"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b8: stloc.s 5
+			IL_00ba: ldloc.s 5
+			IL_00bc: ldc.i4.0
+			IL_00bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00c7: stloc.s 6
+			IL_00c9: ldloc.s 6
+			IL_00cb: box [System.Runtime]System.Boolean
+			IL_00d0: stloc.s 7
+			IL_00d2: ldloc.s 4
+			IL_00d4: ldstr "log"
+			IL_00d9: ldstr "silent false stderr null:"
+			IL_00de: ldloc.s 7
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00e5: pop
+			IL_00e6: ldstr "console"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f5: stloc.s 4
+			IL_00f7: ldloc.0
+			IL_00f8: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_00fd: ldstr "connected"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0107: stloc.s 5
+			IL_0109: ldloc.s 4
+			IL_010b: ldstr "log"
+			IL_0110: ldstr "silent false connected initially:"
+			IL_0115: ldloc.s 5
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_011c: pop
+			IL_011d: ldloc.0
+			IL_011e: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0128: stloc.s 5
+			IL_012a: ldnull
+			IL_012b: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L45C25::__js_call__(object[], object, object)
+			IL_0131: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0136: ldc.i4.2
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldarg.0
+			IL_013f: stelem.ref
+			IL_0140: dup
+			IL_0141: ldc.i4.1
+			IL_0142: ldloc.0
+			IL_0143: stelem.ref
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_014e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_0153: ldc.i4.1
+			IL_0154: conv.r8
+			IL_0155: ldstr ""
+			IL_015a: ldc.i4.0
+			IL_015b: ldc.i4.0
+			IL_015c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_0166: stloc.s 8
+			IL_0168: ldloc.s 5
+			IL_016a: ldstr "on"
+			IL_016f: ldstr "message"
+			IL_0174: ldloc.s 8
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_017b: pop
+			IL_017c: ldloc.0
+			IL_017d: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0187: stloc.s 5
+			IL_0189: ldnull
+			IL_018a: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/ArrowFunction_L50C23::__js_call__(object, object)
+			IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0195: ldc.i4.1
+			IL_0196: newarr [System.Runtime]System.Object
+			IL_019b: dup
+			IL_019c: ldc.i4.0
+			IL_019d: ldarg.0
+			IL_019e: stelem.ref
+			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01a9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_01ae: ldc.i4.1
+			IL_01af: conv.r8
+			IL_01b0: ldstr ""
+			IL_01b5: ldc.i4.0
+			IL_01b6: ldc.i4.0
+			IL_01b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_01bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+			IL_01c1: stloc.s 9
+			IL_01c3: ldloc.s 5
+			IL_01c5: ldstr "on"
+			IL_01ca: ldstr "close"
+			IL_01cf: ldloc.s 9
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01d6: pop
+			IL_01d7: ldnull
+			IL_01d8: ret
 		} // end of method runSilentFalse::__js_call__
 
 	} // end of class runSilentFalse
@@ -1120,7 +1118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a47
+				// Method begins at RVA 0x2a3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1135,7 +1133,7 @@
 
 
 		// Fields
-		.field public object childProcess
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule childProcess
 		.field public object runSilentTrue
 		.field public object runSilentFalse
 
@@ -1143,7 +1141,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a3e
+			// Method begins at RVA 0x2a36
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1214,7 +1212,7 @@
 		IL_0063: stloc.3
 		IL_0064: ldloc.0
 		IL_0065: ldloc.3
-		IL_0066: stfld object Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
+		IL_0066: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Require_ChildProcess_Fork_Silent/Scope::childProcess
 		IL_006b: ldc.i4.0
 		IL_006c: brfalse IL_007d
 
@@ -1257,7 +1255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ab3
+					// Method begins at RVA 0x2aab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1278,7 +1276,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aaa
+				// Method begins at RVA 0x2aa2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1302,7 +1300,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a04
+			// Method begins at RVA 0x29fc
 			// Header size: 12
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -1341,7 +1339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa1
+				// Method begins at RVA 0x2a99
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1359,7 +1357,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a98
+			// Method begins at RVA 0x2a90
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1511,7 +1509,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2abc
+		// Method begins at RVA 0x2ab4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f1f
+					// Method begins at RVA 0x3ebf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f28
+					// Method begins at RVA 0x3ec8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f16
+				// Method begins at RVA 0x3eb6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2860
+			// Method begins at RVA 0x2854
 			// Header size: 12
 			// Code size: 284 (0x11c)
 			.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f31
+				// Method begins at RVA 0x3ed1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -243,24 +243,23 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2998
+			// Method begins at RVA 0x298c
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 33 (0x21)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: ldstr "createHash"
-			IL_0010: ldc.r8 123
-			IL_0019: box [System.Runtime]System.Double
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: ldstr "createHash"
+			IL_000b: ldc.r8 123
+			IL_0014: box [System.Runtime]System.Double
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: ret
 		} // end of method ArrowFunction_L16C28::__js_call__
 
 	} // end of class ArrowFunction_L16C28
@@ -276,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f3a
+				// Method begins at RVA 0x3eda
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,9 +301,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29cc
+			// Method begins at RVA 0x29bc
 			// Header size: 12
-			// Code size: 26 (0x1a)
+			// Code size: 21 (0x15)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -312,15 +311,14 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "sha3"
-			IL_0012: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
-			IL_0017: stloc.1
-			IL_0018: ldloc.1
-			IL_0019: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "sha3"
+			IL_000d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: ret
 		} // end of method ArrowFunction_L17C35::__js_call__
 
 	} // end of class ArrowFunction_L17C35
@@ -336,7 +334,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f43
+				// Method begins at RVA 0x3ee3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -362,25 +360,24 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29f4
+			// Method begins at RVA 0x29e0
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 38 (0x26)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: ldstr "createHmac"
-			IL_0010: ldc.r8 123
-			IL_0019: box [System.Runtime]System.Double
-			IL_001e: ldstr "key"
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: ldstr "createHmac"
+			IL_000b: ldc.r8 123
+			IL_0014: box [System.Runtime]System.Double
+			IL_0019: ldstr "key"
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ret
 		} // end of method ArrowFunction_L18C33::__js_call__
 
 	} // end of class ArrowFunction_L18C33
@@ -396,7 +393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f4c
+				// Method begins at RVA 0x3eec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -422,9 +419,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a2c
+			// Method begins at RVA 0x2a14
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -432,16 +429,15 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "sha3"
-			IL_0012: ldstr "key"
-			IL_0017: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.1
-			IL_001e: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "sha3"
+			IL_000d: ldstr "key"
+			IL_0012: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: ret
 		} // end of method ArrowFunction_L19C40::__js_call__
 
 	} // end of class ArrowFunction_L19C40
@@ -457,7 +453,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f55
+				// Method begins at RVA 0x3ef5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -483,9 +479,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a58
+			// Method begins at RVA 0x2a3c
 			// Header size: 12
-			// Code size: 32 (0x20)
+			// Code size: 27 (0x1b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -493,17 +489,16 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "sha256"
-			IL_0012: ldc.i4.0
-			IL_0013: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0018: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-			IL_001d: stloc.1
-			IL_001e: ldloc.1
-			IL_001f: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "sha256"
+			IL_000d: ldc.i4.0
+			IL_000e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0013: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: ret
 		} // end of method ArrowFunction_L20C27::__js_call__
 
 	} // end of class ArrowFunction_L20C27
@@ -519,7 +514,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f5e
+				// Method begins at RVA 0x3efe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -545,9 +540,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a84
+			// Method begins at RVA 0x2a64
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -555,17 +550,16 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "sha256"
-			IL_0012: ldc.r8 123
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-			IL_0025: stloc.1
-			IL_0026: ldloc.1
-			IL_0027: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "sha256"
+			IL_000d: ldc.r8 123
+			IL_0016: box [System.Runtime]System.Double
+			IL_001b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+			IL_0020: stloc.1
+			IL_0021: ldloc.1
+			IL_0022: ret
 		} // end of method ArrowFunction_L21C29::__js_call__
 
 	} // end of class ArrowFunction_L21C29
@@ -581,7 +575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f67
+				// Method begins at RVA 0x3f07
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -607,43 +601,42 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2ab8
+			// Method begins at RVA 0x2a94
 			// Header size: 12
-			// Code size: 85 (0x55)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0010: ldstr "pbkdf2Sync"
-			IL_0015: ldc.i4.4
-			IL_0016: newarr [System.Runtime]System.Object
-			IL_001b: dup
-			IL_001c: ldc.i4.0
-			IL_001d: ldstr "password"
-			IL_0022: stelem.ref
-			IL_0023: dup
-			IL_0024: ldc.i4.1
-			IL_0025: ldstr "salt"
-			IL_002a: stelem.ref
-			IL_002b: dup
-			IL_002c: ldc.i4.2
-			IL_002d: ldc.r8 1
-			IL_0036: box [System.Runtime]System.Double
-			IL_003b: stelem.ref
-			IL_003c: dup
-			IL_003d: ldc.i4.3
-			IL_003e: ldc.r8 16
-			IL_0047: box [System.Runtime]System.Double
-			IL_004c: stelem.ref
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0052: stloc.0
-			IL_0053: ldloc.0
-			IL_0054: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: ldstr "pbkdf2Sync"
+			IL_0010: ldc.i4.4
+			IL_0011: newarr [System.Runtime]System.Object
+			IL_0016: dup
+			IL_0017: ldc.i4.0
+			IL_0018: ldstr "password"
+			IL_001d: stelem.ref
+			IL_001e: dup
+			IL_001f: ldc.i4.1
+			IL_0020: ldstr "salt"
+			IL_0025: stelem.ref
+			IL_0026: dup
+			IL_0027: ldc.i4.2
+			IL_0028: ldc.r8 1
+			IL_0031: box [System.Runtime]System.Double
+			IL_0036: stelem.ref
+			IL_0037: dup
+			IL_0038: ldc.i4.3
+			IL_0039: ldc.r8 16
+			IL_0042: box [System.Runtime]System.Double
+			IL_0047: stelem.ref
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_004d: stloc.0
+			IL_004e: ldloc.0
+			IL_004f: ret
 		} // end of method ArrowFunction_L22C35::__js_call__
 
 	} // end of class ArrowFunction_L22C35
@@ -659,7 +652,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f70
+				// Method begins at RVA 0x3f10
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -685,9 +678,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b1c
+			// Method begins at RVA 0x2af0
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -695,19 +688,18 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "password"
-			IL_0012: ldstr "salt"
-			IL_0017: ldc.r8 1
-			IL_0020: ldc.r8 16
-			IL_0029: ldstr "sha3"
-			IL_002e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "password"
+			IL_000d: ldstr "salt"
+			IL_0012: ldc.r8 1
+			IL_001b: ldc.r8 16
+			IL_0024: ldstr "sha3"
+			IL_0029: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: ret
 		} // end of method ArrowFunction_L23C39::__js_call__
 
 	} // end of class ArrowFunction_L23C39
@@ -723,7 +715,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f79
+				// Method begins at RVA 0x3f19
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -749,9 +741,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b60
+			// Method begins at RVA 0x2b30
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 58 (0x3a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -759,20 +751,19 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldc.r8 123
-			IL_0016: box [System.Runtime]System.Double
-			IL_001b: ldstr "salt"
-			IL_0020: ldc.r8 1
-			IL_0029: ldc.r8 16
-			IL_0032: ldstr "sha256"
-			IL_0037: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_003c: stloc.1
-			IL_003d: ldloc.1
-			IL_003e: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldc.r8 123
+			IL_0011: box [System.Runtime]System.Double
+			IL_0016: ldstr "salt"
+			IL_001b: ldc.r8 1
+			IL_0024: ldc.r8 16
+			IL_002d: ldstr "sha256"
+			IL_0032: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_0037: stloc.1
+			IL_0038: ldloc.1
+			IL_0039: ret
 		} // end of method ArrowFunction_L24C36::__js_call__
 
 	} // end of class ArrowFunction_L24C36
@@ -788,7 +779,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f82
+				// Method begins at RVA 0x3f22
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -814,9 +805,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2bac
+			// Method begins at RVA 0x2b78
 			// Header size: 12
-			// Code size: 55 (0x37)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -824,20 +815,19 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "password"
-			IL_0012: ldc.i4.0
-			IL_0013: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0018: ldc.r8 1
-			IL_0021: ldc.r8 16
-			IL_002a: ldstr "sha256"
-			IL_002f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_0034: stloc.1
-			IL_0035: ldloc.1
-			IL_0036: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "password"
+			IL_000d: ldc.i4.0
+			IL_000e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0013: ldc.r8 1
+			IL_001c: ldc.r8 16
+			IL_0025: ldstr "sha256"
+			IL_002a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_002f: stloc.1
+			IL_0030: ldloc.1
+			IL_0031: ret
 		} // end of method ArrowFunction_L25C30::__js_call__
 
 	} // end of class ArrowFunction_L25C30
@@ -853,7 +843,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f8b
+				// Method begins at RVA 0x3f2b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -879,45 +869,44 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2bf0
+			// Method begins at RVA 0x2bb8
 			// Header size: 12
-			// Code size: 79 (0x4f)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: ldstr "pbkdf2Sync"
-			IL_0010: ldc.i4.5
-			IL_0011: newarr [System.Runtime]System.Object
-			IL_0016: dup
-			IL_0017: ldc.i4.0
-			IL_0018: ldstr "password"
-			IL_001d: stelem.ref
-			IL_001e: dup
-			IL_001f: ldc.i4.1
-			IL_0020: ldstr "salt"
-			IL_0025: stelem.ref
-			IL_0026: dup
-			IL_0027: ldc.i4.2
-			IL_0028: ldstr "1"
-			IL_002d: stelem.ref
-			IL_002e: dup
-			IL_002f: ldc.i4.3
-			IL_0030: ldc.r8 16
-			IL_0039: box [System.Runtime]System.Double
-			IL_003e: stelem.ref
-			IL_003f: dup
-			IL_0040: ldc.i4.4
-			IL_0041: ldstr "sha256"
-			IL_0046: stelem.ref
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_004c: stloc.0
-			IL_004d: ldloc.0
-			IL_004e: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: ldstr "pbkdf2Sync"
+			IL_000b: ldc.i4.5
+			IL_000c: newarr [System.Runtime]System.Object
+			IL_0011: dup
+			IL_0012: ldc.i4.0
+			IL_0013: ldstr "password"
+			IL_0018: stelem.ref
+			IL_0019: dup
+			IL_001a: ldc.i4.1
+			IL_001b: ldstr "salt"
+			IL_0020: stelem.ref
+			IL_0021: dup
+			IL_0022: ldc.i4.2
+			IL_0023: ldstr "1"
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.3
+			IL_002b: ldc.r8 16
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: stelem.ref
+			IL_003a: dup
+			IL_003b: ldc.i4.4
+			IL_003c: ldstr "sha256"
+			IL_0041: stelem.ref
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0047: stloc.0
+			IL_0048: ldloc.0
+			IL_0049: ret
 		} // end of method ArrowFunction_L26C36::__js_call__
 
 	} // end of class ArrowFunction_L26C36
@@ -933,7 +922,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f94
+				// Method begins at RVA 0x3f34
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -959,9 +948,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c4c
+			// Method begins at RVA 0x2c10
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -969,19 +958,18 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "password"
-			IL_0012: ldstr "salt"
-			IL_0017: ldc.r8 1.5
-			IL_0020: ldc.r8 16
-			IL_0029: ldstr "sha256"
-			IL_002e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "password"
+			IL_000d: ldstr "salt"
+			IL_0012: ldc.r8 1.5
+			IL_001b: ldc.r8 16
+			IL_0024: ldstr "sha256"
+			IL_0029: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: ret
 		} // end of method ArrowFunction_L27C37::__js_call__
 
 	} // end of class ArrowFunction_L27C37
@@ -997,7 +985,70 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f9d
+				// Method begins at RVA 0x3f3d
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Require_Crypto_ErrorPaths/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 24 00 00 02
+			)
+			// Method begins at RVA 0x2c50
+			// Header size: 12
+			// Code size: 49 (0x31)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "password"
+			IL_000d: ldstr "salt"
+			IL_0012: ldc.r8 0.0
+			IL_001b: ldc.r8 16
+			IL_0024: ldstr "sha256"
+			IL_0029: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: ret
+		} // end of method ArrowFunction_L28C36::__js_call__
+
+	} // end of class ArrowFunction_L28C36
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L29C33
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3f46
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1025,7 +1076,7 @@
 			)
 			// Method begins at RVA 0x2c90
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -1033,24 +1084,23 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "password"
-			IL_0012: ldstr "salt"
-			IL_0017: ldc.r8 0.0
-			IL_0020: ldc.r8 16
-			IL_0029: ldstr "sha256"
-			IL_002e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ret
-		} // end of method ArrowFunction_L28C36::__js_call__
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "password"
+			IL_000d: ldstr "salt"
+			IL_0012: ldc.r8 1
+			IL_001b: ldc.r8 8.5
+			IL_0024: ldstr "sha256"
+			IL_0029: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: ret
+		} // end of method ArrowFunction_L29C33::__js_call__
 
-	} // end of class ArrowFunction_L28C36
+	} // end of class ArrowFunction_L29C33
 
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L29C33
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L30C36
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -1061,7 +1111,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fa6
+				// Method begins at RVA 0x3f4f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1087,34 +1137,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2cd4
+			// Method begins at RVA 0x2cd0
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
-				[1] object
+				[1] float64,
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldstr "password"
-			IL_0012: ldstr "salt"
-			IL_0017: ldc.r8 1
-			IL_0020: ldc.r8 8.5
-			IL_0029: ldstr "sha256"
-			IL_002e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ret
-		} // end of method ArrowFunction_L29C33::__js_call__
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldc.r8 1
+			IL_0010: neg
+			IL_0011: stloc.1
+			IL_0012: ldloc.1
+			IL_0013: box [System.Runtime]System.Double
+			IL_0018: stloc.2
+			IL_0019: ldloc.0
+			IL_001a: ldstr "password"
+			IL_001f: ldstr "salt"
+			IL_0024: ldc.r8 1
+			IL_002d: ldloc.1
+			IL_002e: ldstr "sha256"
+			IL_0033: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+			IL_0038: stloc.3
+			IL_0039: ldloc.3
+			IL_003a: ret
+		} // end of method ArrowFunction_L30C36::__js_call__
 
-	} // end of class ArrowFunction_L29C33
+	} // end of class ArrowFunction_L30C36
 
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L30C36
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L31C30
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -1125,7 +1182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3faf
+				// Method begins at RVA 0x3f58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1153,93 +1210,20 @@
 			)
 			// Method begins at RVA 0x2d18
 			// Header size: 12
-			// Code size: 64 (0x40)
-			.maxstack 8
-			.locals init (
-				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
-				[1] float64,
-				[2] object,
-				[3] object
-			)
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldc.r8 1
-			IL_0015: neg
-			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: box [System.Runtime]System.Double
-			IL_001d: stloc.2
-			IL_001e: ldloc.0
-			IL_001f: ldstr "password"
-			IL_0024: ldstr "salt"
-			IL_0029: ldc.r8 1
-			IL_0032: ldloc.1
-			IL_0033: ldstr "sha256"
-			IL_0038: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-			IL_003d: stloc.3
-			IL_003e: ldloc.3
-			IL_003f: ret
-		} // end of method ArrowFunction_L30C36::__js_call__
-
-	} // end of class ArrowFunction_L30C36
-
-	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L31C30
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x3fb8
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Require_Crypto_ErrorPaths/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 24 00 00 02
-			)
-			// Method begins at RVA 0x2d64
-			// Header size: 12
-			// Code size: 29 (0x1d)
+			// Code size: 24 (0x18)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: ldstr "randomBytes"
-			IL_0010: ldstr "4"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001a: stloc.0
-			IL_001b: ldloc.0
-			IL_001c: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: ldstr "randomBytes"
+			IL_000b: ldstr "4"
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: ret
 		} // end of method ArrowFunction_L31C30::__js_call__
 
 	} // end of class ArrowFunction_L31C30
@@ -1255,7 +1239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fc1
+				// Method begins at RVA 0x3f61
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1281,9 +1265,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d90
+			// Method begins at RVA 0x2d3c
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 35 (0x23)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
@@ -1293,21 +1277,20 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_000b: stloc.0
-			IL_000c: ldc.r8 1
-			IL_0015: neg
-			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: box [System.Runtime]System.Double
-			IL_001d: stloc.2
-			IL_001e: ldloc.0
-			IL_001f: ldloc.1
-			IL_0020: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::randomBytes(float64)
-			IL_0025: stloc.3
-			IL_0026: ldloc.3
-			IL_0027: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_0006: stloc.0
+			IL_0007: ldc.r8 1
+			IL_0010: neg
+			IL_0011: stloc.1
+			IL_0012: ldloc.1
+			IL_0013: box [System.Runtime]System.Double
+			IL_0018: stloc.2
+			IL_0019: ldloc.0
+			IL_001a: ldloc.1
+			IL_001b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::randomBytes(float64)
+			IL_0020: stloc.3
+			IL_0021: ldloc.3
+			IL_0022: ret
 		} // end of method ArrowFunction_L32C34::__js_call__
 
 	} // end of class ArrowFunction_L32C34
@@ -1323,7 +1306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fca
+				// Method begins at RVA 0x3f6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1349,7 +1332,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2dc4
+			// Method begins at RVA 0x2d6c
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -1381,7 +1364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fd3
+				// Method begins at RVA 0x3f73
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1407,7 +1390,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2df0
+			// Method begins at RVA 0x2d98
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1453,7 +1436,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fe5
+					// Method begins at RVA 0x3f85
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1473,7 +1456,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fee
+					// Method begins at RVA 0x3f8e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1497,7 +1480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fdc
+				// Method begins at RVA 0x3f7c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1523,7 +1506,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e24
+			// Method begins at RVA 0x2dcc
 			// Header size: 12
 			// Code size: 573 (0x23d)
 			.maxstack 8
@@ -1795,7 +1778,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4000
+					// Method begins at RVA 0x3fa0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1819,7 +1802,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a54
+				// Method begins at RVA 0x39f4
 				// Header size: 12
 				// Code size: 48 (0x30)
 				.maxstack 8
@@ -1859,7 +1842,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4009
+					// Method begins at RVA 0x3fa9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1883,7 +1866,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a90
+				// Method begins at RVA 0x3a30
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 10
@@ -1953,7 +1936,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4012
+					// Method begins at RVA 0x3fb2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1977,7 +1960,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b1c
+				// Method begins at RVA 0x3abc
 				// Header size: 12
 				// Code size: 122 (0x7a)
 				.maxstack 10
@@ -2046,7 +2029,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x401b
+					// Method begins at RVA 0x3fbb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2070,7 +2053,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ba4
+				// Method begins at RVA 0x3b44
 				// Header size: 12
 				// Code size: 116 (0x74)
 				.maxstack 10
@@ -2137,7 +2120,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4024
+					// Method begins at RVA 0x3fc4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2161,7 +2144,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c24
+				// Method begins at RVA 0x3bc4
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 10
@@ -2231,7 +2214,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x402d
+					// Method begins at RVA 0x3fcd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2255,7 +2238,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cb0
+				// Method begins at RVA 0x3c50
 				// Header size: 12
 				// Code size: 127 (0x7f)
 				.maxstack 10
@@ -2325,7 +2308,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4036
+					// Method begins at RVA 0x3fd6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2349,7 +2332,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3d3c
+				// Method begins at RVA 0x3cdc
 				// Header size: 12
 				// Code size: 136 (0x88)
 				.maxstack 10
@@ -2420,7 +2403,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x403f
+					// Method begins at RVA 0x3fdf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2444,7 +2427,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3dd0
+				// Method begins at RVA 0x3d70
 				// Header size: 12
 				// Code size: 147 (0x93)
 				.maxstack 10
@@ -2518,7 +2501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4048
+					// Method begins at RVA 0x3fe8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2542,7 +2525,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e70
+				// Method begins at RVA 0x3e10
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2592,7 +2575,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4051
+					// Method begins at RVA 0x3ff1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2616,7 +2599,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ec0
+				// Method begins at RVA 0x3e60
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2694,7 +2677,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ff7
+				// Method begins at RVA 0x3f97
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2718,9 +2701,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3070
+			// Method begins at RVA 0x3018
 			// Header size: 12
-			// Code size: 2483 (0x9b3)
+			// Code size: 2478 (0x9ae)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope,
@@ -2818,1148 +2801,1147 @@
 
 			IL_00ae: ldloc.0
 			IL_00af: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00b4: switch (IL_00e9, IL_01d0, IL_0291, IL_0352, IL_0413, IL_04d4, IL_0595, IL_0656, IL_0717, IL_07f4, IL_08be, IL_0981)
+			IL_00b4: switch (IL_00e9, IL_01cb, IL_028c, IL_034d, IL_040e, IL_04cf, IL_0590, IL_0651, IL_0712, IL_07ef, IL_08b9, IL_097c)
 
 			IL_00e9: ldarg.0
 			IL_00ea: ldc.i4.1
 			IL_00eb: ldelem.ref
 			IL_00ec: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_00f1: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_00f6: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_00fb: stloc.1
-			IL_00fc: ldloc.1
-			IL_00fd: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
-			IL_0102: stloc.2
-			IL_0103: ldloc.2
-			IL_0104: ldstr "subtle"
-			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010e: stloc.2
-			IL_010f: ldloc.0
-			IL_0110: ldloc.2
-			IL_0111: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_0116: ldarg.0
-			IL_0117: ldc.i4.1
-			IL_0118: ldelem.ref
-			IL_0119: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_011e: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_0123: ldc.i4.1
-			IL_0124: newarr [System.Runtime]System.Object
-			IL_0129: dup
-			IL_012a: ldc.i4.0
-			IL_012b: ldarg.0
-			IL_012c: ldc.i4.1
-			IL_012d: ldelem.ref
-			IL_012e: stelem.ref
-			IL_012f: stloc.3
-			IL_0130: ldc.i4.2
-			IL_0131: newarr [System.Runtime]System.Object
-			IL_0136: dup
-			IL_0137: ldc.i4.0
-			IL_0138: ldarg.0
-			IL_0139: ldc.i4.1
-			IL_013a: ldelem.ref
-			IL_013b: stelem.ref
-			IL_013c: dup
-			IL_013d: ldc.i4.1
-			IL_013e: ldloc.0
-			IL_013f: stelem.ref
-			IL_0140: stloc.s 4
-			IL_0142: ldnull
-			IL_0143: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
-			IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_014e: ldloc.s 4
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_015a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_015f: ldc.i4.0
-			IL_0160: conv.r8
-			IL_0161: ldstr ""
-			IL_0166: ldc.i4.0
-			IL_0167: ldc.i4.0
-			IL_0168: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0172: stloc.s 5
-			IL_0174: ldloc.3
-			IL_0175: ldstr "subtle digest unsupported"
-			IL_017a: ldloc.s 5
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0181: stloc.2
-			IL_0182: ldloc.0
-			IL_0183: ldc.i4.1
-			IL_0184: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0189: ldloc.0
-			IL_018a: ldloc.2
-			IL_018b: ldarg.0
-			IL_018c: ldc.i4.1
-			IL_018d: ldloc.0
-			IL_018e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0193: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0198: ldloc.0
-			IL_0199: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_019e: dup
-			IL_019f: ldc.i4.0
-			IL_01a0: ldloc.1
-			IL_01a1: stelem.ref
-			IL_01a2: dup
-			IL_01a3: ldc.i4.1
-			IL_01a4: ldloc.2
-			IL_01a5: stelem.ref
-			IL_01a6: dup
-			IL_01a7: ldc.i4.2
-			IL_01a8: ldloc.3
+			IL_00f1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+			IL_00f6: stloc.1
+			IL_00f7: ldloc.1
+			IL_00f8: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
+			IL_00fd: stloc.2
+			IL_00fe: ldloc.2
+			IL_00ff: ldstr "subtle"
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0109: stloc.2
+			IL_010a: ldloc.0
+			IL_010b: ldloc.2
+			IL_010c: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_0111: ldarg.0
+			IL_0112: ldc.i4.1
+			IL_0113: ldelem.ref
+			IL_0114: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0119: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_011e: ldc.i4.1
+			IL_011f: newarr [System.Runtime]System.Object
+			IL_0124: dup
+			IL_0125: ldc.i4.0
+			IL_0126: ldarg.0
+			IL_0127: ldc.i4.1
+			IL_0128: ldelem.ref
+			IL_0129: stelem.ref
+			IL_012a: stloc.3
+			IL_012b: ldc.i4.2
+			IL_012c: newarr [System.Runtime]System.Object
+			IL_0131: dup
+			IL_0132: ldc.i4.0
+			IL_0133: ldarg.0
+			IL_0134: ldc.i4.1
+			IL_0135: ldelem.ref
+			IL_0136: stelem.ref
+			IL_0137: dup
+			IL_0138: ldc.i4.1
+			IL_0139: ldloc.0
+			IL_013a: stelem.ref
+			IL_013b: stloc.s 4
+			IL_013d: ldnull
+			IL_013e: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
+			IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0149: ldloc.s 4
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0155: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_015a: ldc.i4.0
+			IL_015b: conv.r8
+			IL_015c: ldstr ""
+			IL_0161: ldc.i4.0
+			IL_0162: ldc.i4.0
+			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0168: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_016d: stloc.s 5
+			IL_016f: ldloc.3
+			IL_0170: ldstr "subtle digest unsupported"
+			IL_0175: ldloc.s 5
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_017c: stloc.2
+			IL_017d: ldloc.0
+			IL_017e: ldc.i4.1
+			IL_017f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0184: ldloc.0
+			IL_0185: ldloc.2
+			IL_0186: ldarg.0
+			IL_0187: ldc.i4.1
+			IL_0188: ldloc.0
+			IL_0189: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_018e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0193: ldloc.0
+			IL_0194: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0199: dup
+			IL_019a: ldc.i4.0
+			IL_019b: ldloc.1
+			IL_019c: stelem.ref
+			IL_019d: dup
+			IL_019e: ldc.i4.1
+			IL_019f: ldloc.2
+			IL_01a0: stelem.ref
+			IL_01a1: dup
+			IL_01a2: ldc.i4.2
+			IL_01a3: ldloc.3
+			IL_01a4: stelem.ref
+			IL_01a5: dup
+			IL_01a6: ldc.i4.3
+			IL_01a7: ldloc.s 4
 			IL_01a9: stelem.ref
 			IL_01aa: dup
-			IL_01ab: ldc.i4.3
-			IL_01ac: ldloc.s 4
+			IL_01ab: ldc.i4.4
+			IL_01ac: ldloc.s 5
 			IL_01ae: stelem.ref
 			IL_01af: dup
-			IL_01b0: ldc.i4.4
-			IL_01b1: ldloc.s 5
+			IL_01b0: ldc.i4.5
+			IL_01b1: ldloc.s 6
 			IL_01b3: stelem.ref
 			IL_01b4: dup
-			IL_01b5: ldc.i4.5
-			IL_01b6: ldloc.s 6
+			IL_01b5: ldc.i4.6
+			IL_01b6: ldloc.s 7
 			IL_01b8: stelem.ref
 			IL_01b9: dup
-			IL_01ba: ldc.i4.6
-			IL_01bb: ldloc.s 7
+			IL_01ba: ldc.i4.7
+			IL_01bb: ldloc.s 8
 			IL_01bd: stelem.ref
-			IL_01be: dup
-			IL_01bf: ldc.i4.7
-			IL_01c0: ldloc.s 8
-			IL_01c2: stelem.ref
-			IL_01c3: pop
-			IL_01c4: ldloc.0
-			IL_01c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01cf: ret
+			IL_01be: pop
+			IL_01bf: ldloc.0
+			IL_01c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ca: ret
 
-			IL_01d0: ldloc.0
-			IL_01d1: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
-			IL_01d6: pop
-			IL_01d7: ldarg.0
-			IL_01d8: ldc.i4.1
-			IL_01d9: ldelem.ref
-			IL_01da: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_01df: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_01e4: ldc.i4.1
-			IL_01e5: newarr [System.Runtime]System.Object
-			IL_01ea: dup
-			IL_01eb: ldc.i4.0
-			IL_01ec: ldarg.0
-			IL_01ed: ldc.i4.1
-			IL_01ee: ldelem.ref
-			IL_01ef: stelem.ref
-			IL_01f0: stloc.3
-			IL_01f1: ldc.i4.2
-			IL_01f2: newarr [System.Runtime]System.Object
-			IL_01f7: dup
-			IL_01f8: ldc.i4.0
-			IL_01f9: ldarg.0
-			IL_01fa: ldc.i4.1
-			IL_01fb: ldelem.ref
-			IL_01fc: stelem.ref
-			IL_01fd: dup
-			IL_01fe: ldc.i4.1
-			IL_01ff: ldloc.0
-			IL_0200: stelem.ref
-			IL_0201: stloc.s 4
-			IL_0203: ldnull
-			IL_0204: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
-			IL_020a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_020f: ldloc.s 4
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_021b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_0220: ldc.i4.0
-			IL_0221: conv.r8
-			IL_0222: ldstr ""
-			IL_0227: ldc.i4.0
-			IL_0228: ldc.i4.0
-			IL_0229: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0233: stloc.s 5
-			IL_0235: ldloc.3
-			IL_0236: ldstr "subtle import format"
-			IL_023b: ldloc.s 5
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0242: stloc.2
-			IL_0243: ldloc.0
-			IL_0244: ldc.i4.2
-			IL_0245: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_024a: ldloc.0
-			IL_024b: ldloc.2
-			IL_024c: ldarg.0
-			IL_024d: ldc.i4.2
-			IL_024e: ldloc.0
-			IL_024f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0254: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0259: ldloc.0
-			IL_025a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_025f: dup
-			IL_0260: ldc.i4.0
-			IL_0261: ldloc.1
-			IL_0262: stelem.ref
-			IL_0263: dup
-			IL_0264: ldc.i4.1
-			IL_0265: ldloc.2
-			IL_0266: stelem.ref
-			IL_0267: dup
-			IL_0268: ldc.i4.2
-			IL_0269: ldloc.3
+			IL_01cb: ldloc.0
+			IL_01cc: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
+			IL_01d1: pop
+			IL_01d2: ldarg.0
+			IL_01d3: ldc.i4.1
+			IL_01d4: ldelem.ref
+			IL_01d5: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_01da: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_01df: ldc.i4.1
+			IL_01e0: newarr [System.Runtime]System.Object
+			IL_01e5: dup
+			IL_01e6: ldc.i4.0
+			IL_01e7: ldarg.0
+			IL_01e8: ldc.i4.1
+			IL_01e9: ldelem.ref
+			IL_01ea: stelem.ref
+			IL_01eb: stloc.3
+			IL_01ec: ldc.i4.2
+			IL_01ed: newarr [System.Runtime]System.Object
+			IL_01f2: dup
+			IL_01f3: ldc.i4.0
+			IL_01f4: ldarg.0
+			IL_01f5: ldc.i4.1
+			IL_01f6: ldelem.ref
+			IL_01f7: stelem.ref
+			IL_01f8: dup
+			IL_01f9: ldc.i4.1
+			IL_01fa: ldloc.0
+			IL_01fb: stelem.ref
+			IL_01fc: stloc.s 4
+			IL_01fe: ldnull
+			IL_01ff: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
+			IL_0205: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_020a: ldloc.s 4
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0216: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_021b: ldc.i4.0
+			IL_021c: conv.r8
+			IL_021d: ldstr ""
+			IL_0222: ldc.i4.0
+			IL_0223: ldc.i4.0
+			IL_0224: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0229: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_022e: stloc.s 5
+			IL_0230: ldloc.3
+			IL_0231: ldstr "subtle import format"
+			IL_0236: ldloc.s 5
+			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_023d: stloc.2
+			IL_023e: ldloc.0
+			IL_023f: ldc.i4.2
+			IL_0240: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0245: ldloc.0
+			IL_0246: ldloc.2
+			IL_0247: ldarg.0
+			IL_0248: ldc.i4.2
+			IL_0249: ldloc.0
+			IL_024a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0254: ldloc.0
+			IL_0255: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_025a: dup
+			IL_025b: ldc.i4.0
+			IL_025c: ldloc.1
+			IL_025d: stelem.ref
+			IL_025e: dup
+			IL_025f: ldc.i4.1
+			IL_0260: ldloc.2
+			IL_0261: stelem.ref
+			IL_0262: dup
+			IL_0263: ldc.i4.2
+			IL_0264: ldloc.3
+			IL_0265: stelem.ref
+			IL_0266: dup
+			IL_0267: ldc.i4.3
+			IL_0268: ldloc.s 4
 			IL_026a: stelem.ref
 			IL_026b: dup
-			IL_026c: ldc.i4.3
-			IL_026d: ldloc.s 4
+			IL_026c: ldc.i4.4
+			IL_026d: ldloc.s 5
 			IL_026f: stelem.ref
 			IL_0270: dup
-			IL_0271: ldc.i4.4
-			IL_0272: ldloc.s 5
+			IL_0271: ldc.i4.5
+			IL_0272: ldloc.s 6
 			IL_0274: stelem.ref
 			IL_0275: dup
-			IL_0276: ldc.i4.5
-			IL_0277: ldloc.s 6
+			IL_0276: ldc.i4.6
+			IL_0277: ldloc.s 7
 			IL_0279: stelem.ref
 			IL_027a: dup
-			IL_027b: ldc.i4.6
-			IL_027c: ldloc.s 7
+			IL_027b: ldc.i4.7
+			IL_027c: ldloc.s 8
 			IL_027e: stelem.ref
-			IL_027f: dup
-			IL_0280: ldc.i4.7
-			IL_0281: ldloc.s 8
-			IL_0283: stelem.ref
-			IL_0284: pop
-			IL_0285: ldloc.0
-			IL_0286: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_028b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0290: ret
+			IL_027f: pop
+			IL_0280: ldloc.0
+			IL_0281: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0286: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_028b: ret
 
-			IL_0291: ldloc.0
-			IL_0292: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
-			IL_0297: pop
-			IL_0298: ldarg.0
-			IL_0299: ldc.i4.1
-			IL_029a: ldelem.ref
-			IL_029b: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_02a0: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_02a5: ldc.i4.1
-			IL_02a6: newarr [System.Runtime]System.Object
-			IL_02ab: dup
-			IL_02ac: ldc.i4.0
-			IL_02ad: ldarg.0
-			IL_02ae: ldc.i4.1
-			IL_02af: ldelem.ref
-			IL_02b0: stelem.ref
-			IL_02b1: stloc.3
-			IL_02b2: ldc.i4.2
-			IL_02b3: newarr [System.Runtime]System.Object
-			IL_02b8: dup
-			IL_02b9: ldc.i4.0
-			IL_02ba: ldarg.0
-			IL_02bb: ldc.i4.1
-			IL_02bc: ldelem.ref
-			IL_02bd: stelem.ref
-			IL_02be: dup
-			IL_02bf: ldc.i4.1
-			IL_02c0: ldloc.0
-			IL_02c1: stelem.ref
-			IL_02c2: stloc.s 4
-			IL_02c4: ldnull
-			IL_02c5: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
-			IL_02cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_02d0: ldloc.s 4
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02dc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_02e1: ldc.i4.0
-			IL_02e2: conv.r8
-			IL_02e3: ldstr ""
-			IL_02e8: ldc.i4.0
-			IL_02e9: ldc.i4.0
-			IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_02ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_02f4: stloc.s 5
-			IL_02f6: ldloc.3
-			IL_02f7: ldstr "subtle import key data"
-			IL_02fc: ldloc.s 5
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0303: stloc.2
-			IL_0304: ldloc.0
-			IL_0305: ldc.i4.3
-			IL_0306: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_030b: ldloc.0
-			IL_030c: ldloc.2
-			IL_030d: ldarg.0
-			IL_030e: ldc.i4.3
-			IL_030f: ldloc.0
-			IL_0310: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0315: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_031a: ldloc.0
-			IL_031b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0320: dup
-			IL_0321: ldc.i4.0
-			IL_0322: ldloc.1
-			IL_0323: stelem.ref
-			IL_0324: dup
-			IL_0325: ldc.i4.1
-			IL_0326: ldloc.2
-			IL_0327: stelem.ref
-			IL_0328: dup
-			IL_0329: ldc.i4.2
-			IL_032a: ldloc.3
+			IL_028c: ldloc.0
+			IL_028d: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
+			IL_0292: pop
+			IL_0293: ldarg.0
+			IL_0294: ldc.i4.1
+			IL_0295: ldelem.ref
+			IL_0296: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_029b: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_02a0: ldc.i4.1
+			IL_02a1: newarr [System.Runtime]System.Object
+			IL_02a6: dup
+			IL_02a7: ldc.i4.0
+			IL_02a8: ldarg.0
+			IL_02a9: ldc.i4.1
+			IL_02aa: ldelem.ref
+			IL_02ab: stelem.ref
+			IL_02ac: stloc.3
+			IL_02ad: ldc.i4.2
+			IL_02ae: newarr [System.Runtime]System.Object
+			IL_02b3: dup
+			IL_02b4: ldc.i4.0
+			IL_02b5: ldarg.0
+			IL_02b6: ldc.i4.1
+			IL_02b7: ldelem.ref
+			IL_02b8: stelem.ref
+			IL_02b9: dup
+			IL_02ba: ldc.i4.1
+			IL_02bb: ldloc.0
+			IL_02bc: stelem.ref
+			IL_02bd: stloc.s 4
+			IL_02bf: ldnull
+			IL_02c0: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
+			IL_02c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_02cb: ldloc.s 4
+			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_02d7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_02dc: ldc.i4.0
+			IL_02dd: conv.r8
+			IL_02de: ldstr ""
+			IL_02e3: ldc.i4.0
+			IL_02e4: ldc.i4.0
+			IL_02e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_02ef: stloc.s 5
+			IL_02f1: ldloc.3
+			IL_02f2: ldstr "subtle import key data"
+			IL_02f7: ldloc.s 5
+			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02fe: stloc.2
+			IL_02ff: ldloc.0
+			IL_0300: ldc.i4.3
+			IL_0301: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0306: ldloc.0
+			IL_0307: ldloc.2
+			IL_0308: ldarg.0
+			IL_0309: ldc.i4.3
+			IL_030a: ldloc.0
+			IL_030b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0310: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0315: ldloc.0
+			IL_0316: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_031b: dup
+			IL_031c: ldc.i4.0
+			IL_031d: ldloc.1
+			IL_031e: stelem.ref
+			IL_031f: dup
+			IL_0320: ldc.i4.1
+			IL_0321: ldloc.2
+			IL_0322: stelem.ref
+			IL_0323: dup
+			IL_0324: ldc.i4.2
+			IL_0325: ldloc.3
+			IL_0326: stelem.ref
+			IL_0327: dup
+			IL_0328: ldc.i4.3
+			IL_0329: ldloc.s 4
 			IL_032b: stelem.ref
 			IL_032c: dup
-			IL_032d: ldc.i4.3
-			IL_032e: ldloc.s 4
+			IL_032d: ldc.i4.4
+			IL_032e: ldloc.s 5
 			IL_0330: stelem.ref
 			IL_0331: dup
-			IL_0332: ldc.i4.4
-			IL_0333: ldloc.s 5
+			IL_0332: ldc.i4.5
+			IL_0333: ldloc.s 6
 			IL_0335: stelem.ref
 			IL_0336: dup
-			IL_0337: ldc.i4.5
-			IL_0338: ldloc.s 6
+			IL_0337: ldc.i4.6
+			IL_0338: ldloc.s 7
 			IL_033a: stelem.ref
 			IL_033b: dup
-			IL_033c: ldc.i4.6
-			IL_033d: ldloc.s 7
+			IL_033c: ldc.i4.7
+			IL_033d: ldloc.s 8
 			IL_033f: stelem.ref
-			IL_0340: dup
-			IL_0341: ldc.i4.7
-			IL_0342: ldloc.s 8
-			IL_0344: stelem.ref
-			IL_0345: pop
-			IL_0346: ldloc.0
-			IL_0347: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_034c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0351: ret
+			IL_0340: pop
+			IL_0341: ldloc.0
+			IL_0342: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0347: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_034c: ret
 
-			IL_0352: ldloc.0
-			IL_0353: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
-			IL_0358: pop
-			IL_0359: ldarg.0
-			IL_035a: ldc.i4.1
-			IL_035b: ldelem.ref
-			IL_035c: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0361: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_0366: ldc.i4.1
-			IL_0367: newarr [System.Runtime]System.Object
-			IL_036c: dup
-			IL_036d: ldc.i4.0
-			IL_036e: ldarg.0
-			IL_036f: ldc.i4.1
-			IL_0370: ldelem.ref
-			IL_0371: stelem.ref
-			IL_0372: stloc.3
-			IL_0373: ldc.i4.2
-			IL_0374: newarr [System.Runtime]System.Object
-			IL_0379: dup
-			IL_037a: ldc.i4.0
-			IL_037b: ldarg.0
-			IL_037c: ldc.i4.1
-			IL_037d: ldelem.ref
-			IL_037e: stelem.ref
-			IL_037f: dup
-			IL_0380: ldc.i4.1
-			IL_0381: ldloc.0
-			IL_0382: stelem.ref
-			IL_0383: stloc.s 4
-			IL_0385: ldnull
-			IL_0386: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
-			IL_038c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0391: ldloc.s 4
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_039d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_03a2: ldc.i4.0
-			IL_03a3: conv.r8
-			IL_03a4: ldstr ""
-			IL_03a9: ldc.i4.0
-			IL_03aa: ldc.i4.0
-			IL_03ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_03b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_03b5: stloc.s 5
-			IL_03b7: ldloc.3
-			IL_03b8: ldstr "subtle import empty usages"
-			IL_03bd: ldloc.s 5
-			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03c4: stloc.2
-			IL_03c5: ldloc.0
-			IL_03c6: ldc.i4.4
-			IL_03c7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03cc: ldloc.0
-			IL_03cd: ldloc.2
-			IL_03ce: ldarg.0
-			IL_03cf: ldc.i4.4
-			IL_03d0: ldloc.0
-			IL_03d1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03db: ldloc.0
-			IL_03dc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03e1: dup
-			IL_03e2: ldc.i4.0
-			IL_03e3: ldloc.1
-			IL_03e4: stelem.ref
-			IL_03e5: dup
-			IL_03e6: ldc.i4.1
-			IL_03e7: ldloc.2
-			IL_03e8: stelem.ref
-			IL_03e9: dup
-			IL_03ea: ldc.i4.2
-			IL_03eb: ldloc.3
+			IL_034d: ldloc.0
+			IL_034e: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
+			IL_0353: pop
+			IL_0354: ldarg.0
+			IL_0355: ldc.i4.1
+			IL_0356: ldelem.ref
+			IL_0357: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_035c: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0361: ldc.i4.1
+			IL_0362: newarr [System.Runtime]System.Object
+			IL_0367: dup
+			IL_0368: ldc.i4.0
+			IL_0369: ldarg.0
+			IL_036a: ldc.i4.1
+			IL_036b: ldelem.ref
+			IL_036c: stelem.ref
+			IL_036d: stloc.3
+			IL_036e: ldc.i4.2
+			IL_036f: newarr [System.Runtime]System.Object
+			IL_0374: dup
+			IL_0375: ldc.i4.0
+			IL_0376: ldarg.0
+			IL_0377: ldc.i4.1
+			IL_0378: ldelem.ref
+			IL_0379: stelem.ref
+			IL_037a: dup
+			IL_037b: ldc.i4.1
+			IL_037c: ldloc.0
+			IL_037d: stelem.ref
+			IL_037e: stloc.s 4
+			IL_0380: ldnull
+			IL_0381: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
+			IL_0387: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_038c: ldloc.s 4
+			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0398: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_039d: ldc.i4.0
+			IL_039e: conv.r8
+			IL_039f: ldstr ""
+			IL_03a4: ldc.i4.0
+			IL_03a5: ldc.i4.0
+			IL_03a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_03ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_03b0: stloc.s 5
+			IL_03b2: ldloc.3
+			IL_03b3: ldstr "subtle import empty usages"
+			IL_03b8: ldloc.s 5
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03bf: stloc.2
+			IL_03c0: ldloc.0
+			IL_03c1: ldc.i4.4
+			IL_03c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03c7: ldloc.0
+			IL_03c8: ldloc.2
+			IL_03c9: ldarg.0
+			IL_03ca: ldc.i4.4
+			IL_03cb: ldloc.0
+			IL_03cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03d6: ldloc.0
+			IL_03d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03dc: dup
+			IL_03dd: ldc.i4.0
+			IL_03de: ldloc.1
+			IL_03df: stelem.ref
+			IL_03e0: dup
+			IL_03e1: ldc.i4.1
+			IL_03e2: ldloc.2
+			IL_03e3: stelem.ref
+			IL_03e4: dup
+			IL_03e5: ldc.i4.2
+			IL_03e6: ldloc.3
+			IL_03e7: stelem.ref
+			IL_03e8: dup
+			IL_03e9: ldc.i4.3
+			IL_03ea: ldloc.s 4
 			IL_03ec: stelem.ref
 			IL_03ed: dup
-			IL_03ee: ldc.i4.3
-			IL_03ef: ldloc.s 4
+			IL_03ee: ldc.i4.4
+			IL_03ef: ldloc.s 5
 			IL_03f1: stelem.ref
 			IL_03f2: dup
-			IL_03f3: ldc.i4.4
-			IL_03f4: ldloc.s 5
+			IL_03f3: ldc.i4.5
+			IL_03f4: ldloc.s 6
 			IL_03f6: stelem.ref
 			IL_03f7: dup
-			IL_03f8: ldc.i4.5
-			IL_03f9: ldloc.s 6
+			IL_03f8: ldc.i4.6
+			IL_03f9: ldloc.s 7
 			IL_03fb: stelem.ref
 			IL_03fc: dup
-			IL_03fd: ldc.i4.6
-			IL_03fe: ldloc.s 7
+			IL_03fd: ldc.i4.7
+			IL_03fe: ldloc.s 8
 			IL_0400: stelem.ref
-			IL_0401: dup
-			IL_0402: ldc.i4.7
-			IL_0403: ldloc.s 8
-			IL_0405: stelem.ref
-			IL_0406: pop
-			IL_0407: ldloc.0
-			IL_0408: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_040d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0412: ret
+			IL_0401: pop
+			IL_0402: ldloc.0
+			IL_0403: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0408: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_040d: ret
 
-			IL_0413: ldloc.0
-			IL_0414: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
-			IL_0419: pop
-			IL_041a: ldarg.0
-			IL_041b: ldc.i4.1
-			IL_041c: ldelem.ref
-			IL_041d: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0422: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_0427: ldc.i4.1
-			IL_0428: newarr [System.Runtime]System.Object
-			IL_042d: dup
-			IL_042e: ldc.i4.0
-			IL_042f: ldarg.0
-			IL_0430: ldc.i4.1
-			IL_0431: ldelem.ref
-			IL_0432: stelem.ref
-			IL_0433: stloc.3
-			IL_0434: ldc.i4.2
-			IL_0435: newarr [System.Runtime]System.Object
-			IL_043a: dup
-			IL_043b: ldc.i4.0
-			IL_043c: ldarg.0
-			IL_043d: ldc.i4.1
-			IL_043e: ldelem.ref
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.1
-			IL_0442: ldloc.0
-			IL_0443: stelem.ref
-			IL_0444: stloc.s 4
-			IL_0446: ldnull
-			IL_0447: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
-			IL_044d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0452: ldloc.s 4
-			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_045e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_0463: ldc.i4.0
-			IL_0464: conv.r8
-			IL_0465: ldstr ""
-			IL_046a: ldc.i4.0
-			IL_046b: ldc.i4.0
-			IL_046c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0471: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0476: stloc.s 5
-			IL_0478: ldloc.3
-			IL_0479: ldstr "subtle import invalid usage enum"
-			IL_047e: ldloc.s 5
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0485: stloc.2
-			IL_0486: ldloc.0
-			IL_0487: ldc.i4.5
-			IL_0488: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_048d: ldloc.0
-			IL_048e: ldloc.2
-			IL_048f: ldarg.0
-			IL_0490: ldc.i4.5
-			IL_0491: ldloc.0
-			IL_0492: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0497: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_049c: ldloc.0
-			IL_049d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04a2: dup
-			IL_04a3: ldc.i4.0
-			IL_04a4: ldloc.1
-			IL_04a5: stelem.ref
-			IL_04a6: dup
-			IL_04a7: ldc.i4.1
-			IL_04a8: ldloc.2
-			IL_04a9: stelem.ref
-			IL_04aa: dup
-			IL_04ab: ldc.i4.2
-			IL_04ac: ldloc.3
+			IL_040e: ldloc.0
+			IL_040f: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
+			IL_0414: pop
+			IL_0415: ldarg.0
+			IL_0416: ldc.i4.1
+			IL_0417: ldelem.ref
+			IL_0418: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_041d: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0422: ldc.i4.1
+			IL_0423: newarr [System.Runtime]System.Object
+			IL_0428: dup
+			IL_0429: ldc.i4.0
+			IL_042a: ldarg.0
+			IL_042b: ldc.i4.1
+			IL_042c: ldelem.ref
+			IL_042d: stelem.ref
+			IL_042e: stloc.3
+			IL_042f: ldc.i4.2
+			IL_0430: newarr [System.Runtime]System.Object
+			IL_0435: dup
+			IL_0436: ldc.i4.0
+			IL_0437: ldarg.0
+			IL_0438: ldc.i4.1
+			IL_0439: ldelem.ref
+			IL_043a: stelem.ref
+			IL_043b: dup
+			IL_043c: ldc.i4.1
+			IL_043d: ldloc.0
+			IL_043e: stelem.ref
+			IL_043f: stloc.s 4
+			IL_0441: ldnull
+			IL_0442: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
+			IL_0448: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_044d: ldloc.s 4
+			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0459: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_045e: ldc.i4.0
+			IL_045f: conv.r8
+			IL_0460: ldstr ""
+			IL_0465: ldc.i4.0
+			IL_0466: ldc.i4.0
+			IL_0467: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_046c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0471: stloc.s 5
+			IL_0473: ldloc.3
+			IL_0474: ldstr "subtle import invalid usage enum"
+			IL_0479: ldloc.s 5
+			IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0480: stloc.2
+			IL_0481: ldloc.0
+			IL_0482: ldc.i4.5
+			IL_0483: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0488: ldloc.0
+			IL_0489: ldloc.2
+			IL_048a: ldarg.0
+			IL_048b: ldc.i4.5
+			IL_048c: ldloc.0
+			IL_048d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0492: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0497: ldloc.0
+			IL_0498: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_049d: dup
+			IL_049e: ldc.i4.0
+			IL_049f: ldloc.1
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.1
+			IL_04a3: ldloc.2
+			IL_04a4: stelem.ref
+			IL_04a5: dup
+			IL_04a6: ldc.i4.2
+			IL_04a7: ldloc.3
+			IL_04a8: stelem.ref
+			IL_04a9: dup
+			IL_04aa: ldc.i4.3
+			IL_04ab: ldloc.s 4
 			IL_04ad: stelem.ref
 			IL_04ae: dup
-			IL_04af: ldc.i4.3
-			IL_04b0: ldloc.s 4
+			IL_04af: ldc.i4.4
+			IL_04b0: ldloc.s 5
 			IL_04b2: stelem.ref
 			IL_04b3: dup
-			IL_04b4: ldc.i4.4
-			IL_04b5: ldloc.s 5
+			IL_04b4: ldc.i4.5
+			IL_04b5: ldloc.s 6
 			IL_04b7: stelem.ref
 			IL_04b8: dup
-			IL_04b9: ldc.i4.5
-			IL_04ba: ldloc.s 6
+			IL_04b9: ldc.i4.6
+			IL_04ba: ldloc.s 7
 			IL_04bc: stelem.ref
 			IL_04bd: dup
-			IL_04be: ldc.i4.6
-			IL_04bf: ldloc.s 7
+			IL_04be: ldc.i4.7
+			IL_04bf: ldloc.s 8
 			IL_04c1: stelem.ref
-			IL_04c2: dup
-			IL_04c3: ldc.i4.7
-			IL_04c4: ldloc.s 8
-			IL_04c6: stelem.ref
-			IL_04c7: pop
-			IL_04c8: ldloc.0
-			IL_04c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04d3: ret
+			IL_04c2: pop
+			IL_04c3: ldloc.0
+			IL_04c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04ce: ret
 
-			IL_04d4: ldloc.0
-			IL_04d5: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
-			IL_04da: pop
-			IL_04db: ldarg.0
-			IL_04dc: ldc.i4.1
-			IL_04dd: ldelem.ref
-			IL_04de: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_04e3: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_04e8: ldc.i4.1
-			IL_04e9: newarr [System.Runtime]System.Object
-			IL_04ee: dup
-			IL_04ef: ldc.i4.0
-			IL_04f0: ldarg.0
-			IL_04f1: ldc.i4.1
-			IL_04f2: ldelem.ref
-			IL_04f3: stelem.ref
-			IL_04f4: stloc.3
-			IL_04f5: ldc.i4.2
-			IL_04f6: newarr [System.Runtime]System.Object
-			IL_04fb: dup
-			IL_04fc: ldc.i4.0
-			IL_04fd: ldarg.0
-			IL_04fe: ldc.i4.1
-			IL_04ff: ldelem.ref
-			IL_0500: stelem.ref
-			IL_0501: dup
-			IL_0502: ldc.i4.1
-			IL_0503: ldloc.0
-			IL_0504: stelem.ref
-			IL_0505: stloc.s 4
-			IL_0507: ldnull
-			IL_0508: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
-			IL_050e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0513: ldloc.s 4
-			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_051f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_0524: ldc.i4.0
-			IL_0525: conv.r8
-			IL_0526: ldstr ""
-			IL_052b: ldc.i4.0
-			IL_052c: ldc.i4.0
-			IL_052d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0532: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0537: stloc.s 5
-			IL_0539: ldloc.3
-			IL_053a: ldstr "subtle import unsupported usage"
-			IL_053f: ldloc.s 5
-			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0546: stloc.2
-			IL_0547: ldloc.0
-			IL_0548: ldc.i4.6
-			IL_0549: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_054e: ldloc.0
-			IL_054f: ldloc.2
-			IL_0550: ldarg.0
-			IL_0551: ldc.i4.6
-			IL_0552: ldloc.0
-			IL_0553: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0558: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_055d: ldloc.0
-			IL_055e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0563: dup
-			IL_0564: ldc.i4.0
-			IL_0565: ldloc.1
-			IL_0566: stelem.ref
-			IL_0567: dup
-			IL_0568: ldc.i4.1
-			IL_0569: ldloc.2
-			IL_056a: stelem.ref
-			IL_056b: dup
-			IL_056c: ldc.i4.2
-			IL_056d: ldloc.3
+			IL_04cf: ldloc.0
+			IL_04d0: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
+			IL_04d5: pop
+			IL_04d6: ldarg.0
+			IL_04d7: ldc.i4.1
+			IL_04d8: ldelem.ref
+			IL_04d9: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_04de: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_04e3: ldc.i4.1
+			IL_04e4: newarr [System.Runtime]System.Object
+			IL_04e9: dup
+			IL_04ea: ldc.i4.0
+			IL_04eb: ldarg.0
+			IL_04ec: ldc.i4.1
+			IL_04ed: ldelem.ref
+			IL_04ee: stelem.ref
+			IL_04ef: stloc.3
+			IL_04f0: ldc.i4.2
+			IL_04f1: newarr [System.Runtime]System.Object
+			IL_04f6: dup
+			IL_04f7: ldc.i4.0
+			IL_04f8: ldarg.0
+			IL_04f9: ldc.i4.1
+			IL_04fa: ldelem.ref
+			IL_04fb: stelem.ref
+			IL_04fc: dup
+			IL_04fd: ldc.i4.1
+			IL_04fe: ldloc.0
+			IL_04ff: stelem.ref
+			IL_0500: stloc.s 4
+			IL_0502: ldnull
+			IL_0503: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
+			IL_0509: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_050e: ldloc.s 4
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_051a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_051f: ldc.i4.0
+			IL_0520: conv.r8
+			IL_0521: ldstr ""
+			IL_0526: ldc.i4.0
+			IL_0527: ldc.i4.0
+			IL_0528: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_052d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0532: stloc.s 5
+			IL_0534: ldloc.3
+			IL_0535: ldstr "subtle import unsupported usage"
+			IL_053a: ldloc.s 5
+			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0541: stloc.2
+			IL_0542: ldloc.0
+			IL_0543: ldc.i4.6
+			IL_0544: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0549: ldloc.0
+			IL_054a: ldloc.2
+			IL_054b: ldarg.0
+			IL_054c: ldc.i4.6
+			IL_054d: ldloc.0
+			IL_054e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0553: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0558: ldloc.0
+			IL_0559: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_055e: dup
+			IL_055f: ldc.i4.0
+			IL_0560: ldloc.1
+			IL_0561: stelem.ref
+			IL_0562: dup
+			IL_0563: ldc.i4.1
+			IL_0564: ldloc.2
+			IL_0565: stelem.ref
+			IL_0566: dup
+			IL_0567: ldc.i4.2
+			IL_0568: ldloc.3
+			IL_0569: stelem.ref
+			IL_056a: dup
+			IL_056b: ldc.i4.3
+			IL_056c: ldloc.s 4
 			IL_056e: stelem.ref
 			IL_056f: dup
-			IL_0570: ldc.i4.3
-			IL_0571: ldloc.s 4
+			IL_0570: ldc.i4.4
+			IL_0571: ldloc.s 5
 			IL_0573: stelem.ref
 			IL_0574: dup
-			IL_0575: ldc.i4.4
-			IL_0576: ldloc.s 5
+			IL_0575: ldc.i4.5
+			IL_0576: ldloc.s 6
 			IL_0578: stelem.ref
 			IL_0579: dup
-			IL_057a: ldc.i4.5
-			IL_057b: ldloc.s 6
+			IL_057a: ldc.i4.6
+			IL_057b: ldloc.s 7
 			IL_057d: stelem.ref
 			IL_057e: dup
-			IL_057f: ldc.i4.6
-			IL_0580: ldloc.s 7
+			IL_057f: ldc.i4.7
+			IL_0580: ldloc.s 8
 			IL_0582: stelem.ref
-			IL_0583: dup
-			IL_0584: ldc.i4.7
-			IL_0585: ldloc.s 8
-			IL_0587: stelem.ref
-			IL_0588: pop
-			IL_0589: ldloc.0
-			IL_058a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_058f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0594: ret
+			IL_0583: pop
+			IL_0584: ldloc.0
+			IL_0585: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_058a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_058f: ret
 
-			IL_0595: ldloc.0
-			IL_0596: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
-			IL_059b: pop
-			IL_059c: ldarg.0
-			IL_059d: ldc.i4.1
-			IL_059e: ldelem.ref
-			IL_059f: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_05a4: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_05a9: ldc.i4.1
-			IL_05aa: newarr [System.Runtime]System.Object
-			IL_05af: dup
-			IL_05b0: ldc.i4.0
-			IL_05b1: ldarg.0
-			IL_05b2: ldc.i4.1
-			IL_05b3: ldelem.ref
-			IL_05b4: stelem.ref
-			IL_05b5: stloc.3
-			IL_05b6: ldc.i4.2
-			IL_05b7: newarr [System.Runtime]System.Object
-			IL_05bc: dup
-			IL_05bd: ldc.i4.0
-			IL_05be: ldarg.0
-			IL_05bf: ldc.i4.1
-			IL_05c0: ldelem.ref
-			IL_05c1: stelem.ref
-			IL_05c2: dup
-			IL_05c3: ldc.i4.1
-			IL_05c4: ldloc.0
-			IL_05c5: stelem.ref
-			IL_05c6: stloc.s 4
-			IL_05c8: ldnull
-			IL_05c9: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
-			IL_05cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_05d4: ldloc.s 4
-			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_05e0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_05e5: ldc.i4.0
-			IL_05e6: conv.r8
-			IL_05e7: ldstr ""
-			IL_05ec: ldc.i4.0
-			IL_05ed: ldc.i4.0
-			IL_05ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_05f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_05f8: stloc.s 5
-			IL_05fa: ldloc.3
-			IL_05fb: ldstr "subtle import zero key"
-			IL_0600: ldloc.s 5
-			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0607: stloc.2
-			IL_0608: ldloc.0
-			IL_0609: ldc.i4.7
-			IL_060a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_060f: ldloc.0
-			IL_0610: ldloc.2
-			IL_0611: ldarg.0
-			IL_0612: ldc.i4.7
-			IL_0613: ldloc.0
-			IL_0614: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0619: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_061e: ldloc.0
-			IL_061f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0624: dup
-			IL_0625: ldc.i4.0
-			IL_0626: ldloc.1
-			IL_0627: stelem.ref
-			IL_0628: dup
-			IL_0629: ldc.i4.1
-			IL_062a: ldloc.2
-			IL_062b: stelem.ref
-			IL_062c: dup
-			IL_062d: ldc.i4.2
-			IL_062e: ldloc.3
+			IL_0590: ldloc.0
+			IL_0591: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
+			IL_0596: pop
+			IL_0597: ldarg.0
+			IL_0598: ldc.i4.1
+			IL_0599: ldelem.ref
+			IL_059a: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_059f: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_05a4: ldc.i4.1
+			IL_05a5: newarr [System.Runtime]System.Object
+			IL_05aa: dup
+			IL_05ab: ldc.i4.0
+			IL_05ac: ldarg.0
+			IL_05ad: ldc.i4.1
+			IL_05ae: ldelem.ref
+			IL_05af: stelem.ref
+			IL_05b0: stloc.3
+			IL_05b1: ldc.i4.2
+			IL_05b2: newarr [System.Runtime]System.Object
+			IL_05b7: dup
+			IL_05b8: ldc.i4.0
+			IL_05b9: ldarg.0
+			IL_05ba: ldc.i4.1
+			IL_05bb: ldelem.ref
+			IL_05bc: stelem.ref
+			IL_05bd: dup
+			IL_05be: ldc.i4.1
+			IL_05bf: ldloc.0
+			IL_05c0: stelem.ref
+			IL_05c1: stloc.s 4
+			IL_05c3: ldnull
+			IL_05c4: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
+			IL_05ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_05cf: ldloc.s 4
+			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_05db: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_05e0: ldc.i4.0
+			IL_05e1: conv.r8
+			IL_05e2: ldstr ""
+			IL_05e7: ldc.i4.0
+			IL_05e8: ldc.i4.0
+			IL_05e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_05ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_05f3: stloc.s 5
+			IL_05f5: ldloc.3
+			IL_05f6: ldstr "subtle import zero key"
+			IL_05fb: ldloc.s 5
+			IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0602: stloc.2
+			IL_0603: ldloc.0
+			IL_0604: ldc.i4.7
+			IL_0605: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_060a: ldloc.0
+			IL_060b: ldloc.2
+			IL_060c: ldarg.0
+			IL_060d: ldc.i4.7
+			IL_060e: ldloc.0
+			IL_060f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0614: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0619: ldloc.0
+			IL_061a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_061f: dup
+			IL_0620: ldc.i4.0
+			IL_0621: ldloc.1
+			IL_0622: stelem.ref
+			IL_0623: dup
+			IL_0624: ldc.i4.1
+			IL_0625: ldloc.2
+			IL_0626: stelem.ref
+			IL_0627: dup
+			IL_0628: ldc.i4.2
+			IL_0629: ldloc.3
+			IL_062a: stelem.ref
+			IL_062b: dup
+			IL_062c: ldc.i4.3
+			IL_062d: ldloc.s 4
 			IL_062f: stelem.ref
 			IL_0630: dup
-			IL_0631: ldc.i4.3
-			IL_0632: ldloc.s 4
+			IL_0631: ldc.i4.4
+			IL_0632: ldloc.s 5
 			IL_0634: stelem.ref
 			IL_0635: dup
-			IL_0636: ldc.i4.4
-			IL_0637: ldloc.s 5
+			IL_0636: ldc.i4.5
+			IL_0637: ldloc.s 6
 			IL_0639: stelem.ref
 			IL_063a: dup
-			IL_063b: ldc.i4.5
-			IL_063c: ldloc.s 6
+			IL_063b: ldc.i4.6
+			IL_063c: ldloc.s 7
 			IL_063e: stelem.ref
 			IL_063f: dup
-			IL_0640: ldc.i4.6
-			IL_0641: ldloc.s 7
+			IL_0640: ldc.i4.7
+			IL_0641: ldloc.s 8
 			IL_0643: stelem.ref
-			IL_0644: dup
-			IL_0645: ldc.i4.7
-			IL_0646: ldloc.s 8
-			IL_0648: stelem.ref
-			IL_0649: pop
-			IL_064a: ldloc.0
-			IL_064b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0650: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0655: ret
+			IL_0644: pop
+			IL_0645: ldloc.0
+			IL_0646: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_064b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0650: ret
 
-			IL_0656: ldloc.0
-			IL_0657: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
-			IL_065c: pop
-			IL_065d: ldarg.0
-			IL_065e: ldc.i4.1
-			IL_065f: ldelem.ref
-			IL_0660: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_0665: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_066a: ldc.i4.1
-			IL_066b: newarr [System.Runtime]System.Object
-			IL_0670: dup
-			IL_0671: ldc.i4.0
-			IL_0672: ldarg.0
-			IL_0673: ldc.i4.1
-			IL_0674: ldelem.ref
-			IL_0675: stelem.ref
-			IL_0676: stloc.3
-			IL_0677: ldc.i4.2
-			IL_0678: newarr [System.Runtime]System.Object
-			IL_067d: dup
-			IL_067e: ldc.i4.0
-			IL_067f: ldarg.0
-			IL_0680: ldc.i4.1
-			IL_0681: ldelem.ref
-			IL_0682: stelem.ref
-			IL_0683: dup
-			IL_0684: ldc.i4.1
-			IL_0685: ldloc.0
-			IL_0686: stelem.ref
-			IL_0687: stloc.s 4
-			IL_0689: ldnull
-			IL_068a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
-			IL_0690: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0695: ldloc.s 4
-			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_06a1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_06a6: ldc.i4.0
-			IL_06a7: conv.r8
-			IL_06a8: ldstr ""
-			IL_06ad: ldc.i4.0
-			IL_06ae: ldc.i4.0
-			IL_06af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_06b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_06b9: stloc.s 5
-			IL_06bb: ldloc.3
-			IL_06bc: ldstr "subtle import length mismatch"
-			IL_06c1: ldloc.s 5
-			IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06c8: stloc.2
-			IL_06c9: ldloc.0
-			IL_06ca: ldc.i4.8
-			IL_06cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06d0: ldloc.0
-			IL_06d1: ldloc.2
-			IL_06d2: ldarg.0
-			IL_06d3: ldc.i4.8
-			IL_06d4: ldloc.0
-			IL_06d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_06df: ldloc.0
-			IL_06e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06e5: dup
-			IL_06e6: ldc.i4.0
-			IL_06e7: ldloc.1
-			IL_06e8: stelem.ref
-			IL_06e9: dup
-			IL_06ea: ldc.i4.1
-			IL_06eb: ldloc.2
-			IL_06ec: stelem.ref
-			IL_06ed: dup
-			IL_06ee: ldc.i4.2
-			IL_06ef: ldloc.3
+			IL_0651: ldloc.0
+			IL_0652: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
+			IL_0657: pop
+			IL_0658: ldarg.0
+			IL_0659: ldc.i4.1
+			IL_065a: ldelem.ref
+			IL_065b: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0660: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0665: ldc.i4.1
+			IL_0666: newarr [System.Runtime]System.Object
+			IL_066b: dup
+			IL_066c: ldc.i4.0
+			IL_066d: ldarg.0
+			IL_066e: ldc.i4.1
+			IL_066f: ldelem.ref
+			IL_0670: stelem.ref
+			IL_0671: stloc.3
+			IL_0672: ldc.i4.2
+			IL_0673: newarr [System.Runtime]System.Object
+			IL_0678: dup
+			IL_0679: ldc.i4.0
+			IL_067a: ldarg.0
+			IL_067b: ldc.i4.1
+			IL_067c: ldelem.ref
+			IL_067d: stelem.ref
+			IL_067e: dup
+			IL_067f: ldc.i4.1
+			IL_0680: ldloc.0
+			IL_0681: stelem.ref
+			IL_0682: stloc.s 4
+			IL_0684: ldnull
+			IL_0685: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
+			IL_068b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0690: ldloc.s 4
+			IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_069c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_06a1: ldc.i4.0
+			IL_06a2: conv.r8
+			IL_06a3: ldstr ""
+			IL_06a8: ldc.i4.0
+			IL_06a9: ldc.i4.0
+			IL_06aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_06af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_06b4: stloc.s 5
+			IL_06b6: ldloc.3
+			IL_06b7: ldstr "subtle import length mismatch"
+			IL_06bc: ldloc.s 5
+			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06c3: stloc.2
+			IL_06c4: ldloc.0
+			IL_06c5: ldc.i4.8
+			IL_06c6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06cb: ldloc.0
+			IL_06cc: ldloc.2
+			IL_06cd: ldarg.0
+			IL_06ce: ldc.i4.8
+			IL_06cf: ldloc.0
+			IL_06d0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_06da: ldloc.0
+			IL_06db: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06e0: dup
+			IL_06e1: ldc.i4.0
+			IL_06e2: ldloc.1
+			IL_06e3: stelem.ref
+			IL_06e4: dup
+			IL_06e5: ldc.i4.1
+			IL_06e6: ldloc.2
+			IL_06e7: stelem.ref
+			IL_06e8: dup
+			IL_06e9: ldc.i4.2
+			IL_06ea: ldloc.3
+			IL_06eb: stelem.ref
+			IL_06ec: dup
+			IL_06ed: ldc.i4.3
+			IL_06ee: ldloc.s 4
 			IL_06f0: stelem.ref
 			IL_06f1: dup
-			IL_06f2: ldc.i4.3
-			IL_06f3: ldloc.s 4
+			IL_06f2: ldc.i4.4
+			IL_06f3: ldloc.s 5
 			IL_06f5: stelem.ref
 			IL_06f6: dup
-			IL_06f7: ldc.i4.4
-			IL_06f8: ldloc.s 5
+			IL_06f7: ldc.i4.5
+			IL_06f8: ldloc.s 6
 			IL_06fa: stelem.ref
 			IL_06fb: dup
-			IL_06fc: ldc.i4.5
-			IL_06fd: ldloc.s 6
+			IL_06fc: ldc.i4.6
+			IL_06fd: ldloc.s 7
 			IL_06ff: stelem.ref
 			IL_0700: dup
-			IL_0701: ldc.i4.6
-			IL_0702: ldloc.s 7
+			IL_0701: ldc.i4.7
+			IL_0702: ldloc.s 8
 			IL_0704: stelem.ref
-			IL_0705: dup
-			IL_0706: ldc.i4.7
-			IL_0707: ldloc.s 8
-			IL_0709: stelem.ref
-			IL_070a: pop
-			IL_070b: ldloc.0
-			IL_070c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0711: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0716: ret
+			IL_0705: pop
+			IL_0706: ldloc.0
+			IL_0707: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_070c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0711: ret
 
-			IL_0717: ldloc.0
-			IL_0718: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
-			IL_071d: pop
-			IL_071e: ldloc.0
-			IL_071f: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0729: stloc.2
-			IL_072a: ldstr "key"
-			IL_072f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0734: stloc.s 6
-			IL_0736: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_073b: dup
-			IL_073c: ldstr "name"
-			IL_0741: ldstr "HMAC"
-			IL_0746: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_074b: dup
-			IL_074c: ldstr "hash"
-			IL_0751: ldstr "SHA-256"
-			IL_0756: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_075b: stloc.s 7
-			IL_075d: ldc.i4.1
-			IL_075e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0763: dup
-			IL_0764: ldstr "verify"
-			IL_0769: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_076e: stloc.s 8
-			IL_0770: ldc.i4.5
-			IL_0771: newarr [System.Runtime]System.Object
-			IL_0776: dup
-			IL_0777: ldc.i4.0
-			IL_0778: ldstr "raw"
+			IL_0712: ldloc.0
+			IL_0713: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
+			IL_0718: pop
+			IL_0719: ldloc.0
+			IL_071a: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0724: stloc.2
+			IL_0725: ldstr "key"
+			IL_072a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_072f: stloc.s 6
+			IL_0731: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0736: dup
+			IL_0737: ldstr "name"
+			IL_073c: ldstr "HMAC"
+			IL_0741: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0746: dup
+			IL_0747: ldstr "hash"
+			IL_074c: ldstr "SHA-256"
+			IL_0751: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0756: stloc.s 7
+			IL_0758: ldc.i4.1
+			IL_0759: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_075e: dup
+			IL_075f: ldstr "verify"
+			IL_0764: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0769: stloc.s 8
+			IL_076b: ldc.i4.5
+			IL_076c: newarr [System.Runtime]System.Object
+			IL_0771: dup
+			IL_0772: ldc.i4.0
+			IL_0773: ldstr "raw"
+			IL_0778: stelem.ref
+			IL_0779: dup
+			IL_077a: ldc.i4.1
+			IL_077b: ldloc.s 6
 			IL_077d: stelem.ref
 			IL_077e: dup
-			IL_077f: ldc.i4.1
-			IL_0780: ldloc.s 6
+			IL_077f: ldc.i4.2
+			IL_0780: ldloc.s 7
 			IL_0782: stelem.ref
 			IL_0783: dup
-			IL_0784: ldc.i4.2
-			IL_0785: ldloc.s 7
-			IL_0787: stelem.ref
-			IL_0788: dup
-			IL_0789: ldc.i4.3
-			IL_078a: ldc.i4.0
-			IL_078b: box [System.Runtime]System.Boolean
+			IL_0784: ldc.i4.3
+			IL_0785: ldc.i4.0
+			IL_0786: box [System.Runtime]System.Boolean
+			IL_078b: stelem.ref
+			IL_078c: dup
+			IL_078d: ldc.i4.4
+			IL_078e: ldloc.s 8
 			IL_0790: stelem.ref
-			IL_0791: dup
-			IL_0792: ldc.i4.4
-			IL_0793: ldloc.s 8
-			IL_0795: stelem.ref
-			IL_0796: stloc.3
-			IL_0797: ldloc.2
-			IL_0798: ldstr "importKey"
-			IL_079d: ldloc.3
-			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_07a3: stloc.2
-			IL_07a4: ldloc.0
-			IL_07a5: ldc.i4.s 9
-			IL_07a7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0791: stloc.3
+			IL_0792: ldloc.2
+			IL_0793: ldstr "importKey"
+			IL_0798: ldloc.3
+			IL_0799: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_079e: stloc.2
+			IL_079f: ldloc.0
+			IL_07a0: ldc.i4.s 9
+			IL_07a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07a7: ldloc.0
+			IL_07a8: ldloc.2
+			IL_07a9: ldarg.0
+			IL_07aa: ldc.i4.s 9
 			IL_07ac: ldloc.0
-			IL_07ad: ldloc.2
-			IL_07ae: ldarg.0
-			IL_07af: ldc.i4.s 9
-			IL_07b1: ldloc.0
-			IL_07b2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_07bc: ldloc.0
-			IL_07bd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07c2: dup
-			IL_07c3: ldc.i4.0
-			IL_07c4: ldloc.1
-			IL_07c5: stelem.ref
-			IL_07c6: dup
-			IL_07c7: ldc.i4.1
-			IL_07c8: ldloc.2
-			IL_07c9: stelem.ref
-			IL_07ca: dup
-			IL_07cb: ldc.i4.2
-			IL_07cc: ldloc.3
+			IL_07ad: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07b7: ldloc.0
+			IL_07b8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07bd: dup
+			IL_07be: ldc.i4.0
+			IL_07bf: ldloc.1
+			IL_07c0: stelem.ref
+			IL_07c1: dup
+			IL_07c2: ldc.i4.1
+			IL_07c3: ldloc.2
+			IL_07c4: stelem.ref
+			IL_07c5: dup
+			IL_07c6: ldc.i4.2
+			IL_07c7: ldloc.3
+			IL_07c8: stelem.ref
+			IL_07c9: dup
+			IL_07ca: ldc.i4.3
+			IL_07cb: ldloc.s 4
 			IL_07cd: stelem.ref
 			IL_07ce: dup
-			IL_07cf: ldc.i4.3
-			IL_07d0: ldloc.s 4
+			IL_07cf: ldc.i4.4
+			IL_07d0: ldloc.s 5
 			IL_07d2: stelem.ref
 			IL_07d3: dup
-			IL_07d4: ldc.i4.4
-			IL_07d5: ldloc.s 5
+			IL_07d4: ldc.i4.5
+			IL_07d5: ldloc.s 6
 			IL_07d7: stelem.ref
 			IL_07d8: dup
-			IL_07d9: ldc.i4.5
-			IL_07da: ldloc.s 6
+			IL_07d9: ldc.i4.6
+			IL_07da: ldloc.s 7
 			IL_07dc: stelem.ref
 			IL_07dd: dup
-			IL_07de: ldc.i4.6
-			IL_07df: ldloc.s 7
+			IL_07de: ldc.i4.7
+			IL_07df: ldloc.s 8
 			IL_07e1: stelem.ref
-			IL_07e2: dup
-			IL_07e3: ldc.i4.7
-			IL_07e4: ldloc.s 8
-			IL_07e6: stelem.ref
-			IL_07e7: pop
-			IL_07e8: ldloc.0
-			IL_07e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07ee: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07f3: ret
+			IL_07e2: pop
+			IL_07e3: ldloc.0
+			IL_07e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07ee: ret
 
-			IL_07f4: ldloc.0
-			IL_07f5: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
-			IL_07fa: stloc.2
-			IL_07fb: ldloc.0
-			IL_07fc: ldloc.2
-			IL_07fd: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-			IL_0802: ldarg.0
-			IL_0803: ldc.i4.1
-			IL_0804: ldelem.ref
-			IL_0805: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_080a: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_080f: ldc.i4.1
-			IL_0810: newarr [System.Runtime]System.Object
-			IL_0815: dup
-			IL_0816: ldc.i4.0
-			IL_0817: ldarg.0
-			IL_0818: ldc.i4.1
-			IL_0819: ldelem.ref
-			IL_081a: stelem.ref
-			IL_081b: stloc.3
-			IL_081c: ldc.i4.2
-			IL_081d: newarr [System.Runtime]System.Object
-			IL_0822: dup
-			IL_0823: ldc.i4.0
-			IL_0824: ldarg.0
-			IL_0825: ldc.i4.1
-			IL_0826: ldelem.ref
-			IL_0827: stelem.ref
-			IL_0828: dup
-			IL_0829: ldc.i4.1
-			IL_082a: ldloc.0
-			IL_082b: stelem.ref
-			IL_082c: stloc.s 4
-			IL_082e: ldnull
-			IL_082f: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
-			IL_0835: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_083a: ldloc.s 4
-			IL_083c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0846: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_084b: ldc.i4.0
-			IL_084c: conv.r8
-			IL_084d: ldstr ""
-			IL_0852: ldc.i4.0
-			IL_0853: ldc.i4.0
-			IL_0854: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0859: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_085e: stloc.s 5
-			IL_0860: ldloc.3
-			IL_0861: ldstr "subtle sign algorithm"
-			IL_0866: ldloc.s 5
-			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_086d: stloc.2
-			IL_086e: ldloc.0
-			IL_086f: ldc.i4.s 10
-			IL_0871: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07ef: ldloc.0
+			IL_07f0: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
+			IL_07f5: stloc.2
+			IL_07f6: ldloc.0
+			IL_07f7: ldloc.2
+			IL_07f8: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+			IL_07fd: ldarg.0
+			IL_07fe: ldc.i4.1
+			IL_07ff: ldelem.ref
+			IL_0800: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0805: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_080a: ldc.i4.1
+			IL_080b: newarr [System.Runtime]System.Object
+			IL_0810: dup
+			IL_0811: ldc.i4.0
+			IL_0812: ldarg.0
+			IL_0813: ldc.i4.1
+			IL_0814: ldelem.ref
+			IL_0815: stelem.ref
+			IL_0816: stloc.3
+			IL_0817: ldc.i4.2
+			IL_0818: newarr [System.Runtime]System.Object
+			IL_081d: dup
+			IL_081e: ldc.i4.0
+			IL_081f: ldarg.0
+			IL_0820: ldc.i4.1
+			IL_0821: ldelem.ref
+			IL_0822: stelem.ref
+			IL_0823: dup
+			IL_0824: ldc.i4.1
+			IL_0825: ldloc.0
+			IL_0826: stelem.ref
+			IL_0827: stloc.s 4
+			IL_0829: ldnull
+			IL_082a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
+			IL_0830: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0835: ldloc.s 4
+			IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_083c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0841: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0846: ldc.i4.0
+			IL_0847: conv.r8
+			IL_0848: ldstr ""
+			IL_084d: ldc.i4.0
+			IL_084e: ldc.i4.0
+			IL_084f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0854: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0859: stloc.s 5
+			IL_085b: ldloc.3
+			IL_085c: ldstr "subtle sign algorithm"
+			IL_0861: ldloc.s 5
+			IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0868: stloc.2
+			IL_0869: ldloc.0
+			IL_086a: ldc.i4.s 10
+			IL_086c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0871: ldloc.0
+			IL_0872: ldloc.2
+			IL_0873: ldarg.0
+			IL_0874: ldc.i4.s 10
 			IL_0876: ldloc.0
-			IL_0877: ldloc.2
-			IL_0878: ldarg.0
-			IL_0879: ldc.i4.s 10
-			IL_087b: ldloc.0
-			IL_087c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0881: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0886: ldloc.0
-			IL_0887: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_088c: dup
-			IL_088d: ldc.i4.0
-			IL_088e: ldloc.1
-			IL_088f: stelem.ref
-			IL_0890: dup
-			IL_0891: ldc.i4.1
-			IL_0892: ldloc.2
-			IL_0893: stelem.ref
-			IL_0894: dup
-			IL_0895: ldc.i4.2
-			IL_0896: ldloc.3
+			IL_0877: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_087c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0881: ldloc.0
+			IL_0882: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0887: dup
+			IL_0888: ldc.i4.0
+			IL_0889: ldloc.1
+			IL_088a: stelem.ref
+			IL_088b: dup
+			IL_088c: ldc.i4.1
+			IL_088d: ldloc.2
+			IL_088e: stelem.ref
+			IL_088f: dup
+			IL_0890: ldc.i4.2
+			IL_0891: ldloc.3
+			IL_0892: stelem.ref
+			IL_0893: dup
+			IL_0894: ldc.i4.3
+			IL_0895: ldloc.s 4
 			IL_0897: stelem.ref
 			IL_0898: dup
-			IL_0899: ldc.i4.3
-			IL_089a: ldloc.s 4
+			IL_0899: ldc.i4.4
+			IL_089a: ldloc.s 5
 			IL_089c: stelem.ref
 			IL_089d: dup
-			IL_089e: ldc.i4.4
-			IL_089f: ldloc.s 5
+			IL_089e: ldc.i4.5
+			IL_089f: ldloc.s 6
 			IL_08a1: stelem.ref
 			IL_08a2: dup
-			IL_08a3: ldc.i4.5
-			IL_08a4: ldloc.s 6
+			IL_08a3: ldc.i4.6
+			IL_08a4: ldloc.s 7
 			IL_08a6: stelem.ref
 			IL_08a7: dup
-			IL_08a8: ldc.i4.6
-			IL_08a9: ldloc.s 7
+			IL_08a8: ldc.i4.7
+			IL_08a9: ldloc.s 8
 			IL_08ab: stelem.ref
-			IL_08ac: dup
-			IL_08ad: ldc.i4.7
-			IL_08ae: ldloc.s 8
-			IL_08b0: stelem.ref
-			IL_08b1: pop
-			IL_08b2: ldloc.0
-			IL_08b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08b8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08bd: ret
+			IL_08ac: pop
+			IL_08ad: ldloc.0
+			IL_08ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08b3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08b8: ret
 
-			IL_08be: ldloc.0
-			IL_08bf: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
-			IL_08c4: pop
-			IL_08c5: ldarg.0
-			IL_08c6: ldc.i4.1
-			IL_08c7: ldelem.ref
-			IL_08c8: castclass Modules.Require_Crypto_ErrorPaths/Scope
-			IL_08cd: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
-			IL_08d2: ldc.i4.1
-			IL_08d3: newarr [System.Runtime]System.Object
-			IL_08d8: dup
-			IL_08d9: ldc.i4.0
-			IL_08da: ldarg.0
-			IL_08db: ldc.i4.1
-			IL_08dc: ldelem.ref
-			IL_08dd: stelem.ref
-			IL_08de: stloc.3
-			IL_08df: ldc.i4.2
-			IL_08e0: newarr [System.Runtime]System.Object
-			IL_08e5: dup
-			IL_08e6: ldc.i4.0
-			IL_08e7: ldarg.0
-			IL_08e8: ldc.i4.1
-			IL_08e9: ldelem.ref
-			IL_08ea: stelem.ref
-			IL_08eb: dup
-			IL_08ec: ldc.i4.1
-			IL_08ed: ldloc.0
-			IL_08ee: stelem.ref
-			IL_08ef: stloc.s 4
-			IL_08f1: ldnull
-			IL_08f2: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
-			IL_08f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_08fd: ldloc.s 4
-			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0904: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0909: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_090e: ldc.i4.0
-			IL_090f: conv.r8
-			IL_0910: ldstr ""
-			IL_0915: ldc.i4.0
-			IL_0916: ldc.i4.0
-			IL_0917: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_091c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0921: stloc.s 5
-			IL_0923: ldloc.3
-			IL_0924: ldstr "subtle sign usage"
-			IL_0929: ldloc.s 5
-			IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0930: stloc.2
-			IL_0931: ldloc.0
-			IL_0932: ldc.i4.s 11
-			IL_0934: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08b9: ldloc.0
+			IL_08ba: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
+			IL_08bf: pop
+			IL_08c0: ldarg.0
+			IL_08c1: ldc.i4.1
+			IL_08c2: ldelem.ref
+			IL_08c3: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_08c8: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_08cd: ldc.i4.1
+			IL_08ce: newarr [System.Runtime]System.Object
+			IL_08d3: dup
+			IL_08d4: ldc.i4.0
+			IL_08d5: ldarg.0
+			IL_08d6: ldc.i4.1
+			IL_08d7: ldelem.ref
+			IL_08d8: stelem.ref
+			IL_08d9: stloc.3
+			IL_08da: ldc.i4.2
+			IL_08db: newarr [System.Runtime]System.Object
+			IL_08e0: dup
+			IL_08e1: ldc.i4.0
+			IL_08e2: ldarg.0
+			IL_08e3: ldc.i4.1
+			IL_08e4: ldelem.ref
+			IL_08e5: stelem.ref
+			IL_08e6: dup
+			IL_08e7: ldc.i4.1
+			IL_08e8: ldloc.0
+			IL_08e9: stelem.ref
+			IL_08ea: stloc.s 4
+			IL_08ec: ldnull
+			IL_08ed: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
+			IL_08f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_08f8: ldloc.s 4
+			IL_08fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0904: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0909: ldc.i4.0
+			IL_090a: conv.r8
+			IL_090b: ldstr ""
+			IL_0910: ldc.i4.0
+			IL_0911: ldc.i4.0
+			IL_0912: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0917: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_091c: stloc.s 5
+			IL_091e: ldloc.3
+			IL_091f: ldstr "subtle sign usage"
+			IL_0924: ldloc.s 5
+			IL_0926: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_092b: stloc.2
+			IL_092c: ldloc.0
+			IL_092d: ldc.i4.s 11
+			IL_092f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0934: ldloc.0
+			IL_0935: ldloc.2
+			IL_0936: ldarg.0
+			IL_0937: ldc.i4.s 11
 			IL_0939: ldloc.0
-			IL_093a: ldloc.2
-			IL_093b: ldarg.0
-			IL_093c: ldc.i4.s 11
-			IL_093e: ldloc.0
-			IL_093f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0944: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0949: ldloc.0
-			IL_094a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_094f: dup
-			IL_0950: ldc.i4.0
-			IL_0951: ldloc.1
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.1
-			IL_0955: ldloc.2
-			IL_0956: stelem.ref
-			IL_0957: dup
-			IL_0958: ldc.i4.2
-			IL_0959: ldloc.3
+			IL_093a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_093f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0944: ldloc.0
+			IL_0945: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_094a: dup
+			IL_094b: ldc.i4.0
+			IL_094c: ldloc.1
+			IL_094d: stelem.ref
+			IL_094e: dup
+			IL_094f: ldc.i4.1
+			IL_0950: ldloc.2
+			IL_0951: stelem.ref
+			IL_0952: dup
+			IL_0953: ldc.i4.2
+			IL_0954: ldloc.3
+			IL_0955: stelem.ref
+			IL_0956: dup
+			IL_0957: ldc.i4.3
+			IL_0958: ldloc.s 4
 			IL_095a: stelem.ref
 			IL_095b: dup
-			IL_095c: ldc.i4.3
-			IL_095d: ldloc.s 4
+			IL_095c: ldc.i4.4
+			IL_095d: ldloc.s 5
 			IL_095f: stelem.ref
 			IL_0960: dup
-			IL_0961: ldc.i4.4
-			IL_0962: ldloc.s 5
+			IL_0961: ldc.i4.5
+			IL_0962: ldloc.s 6
 			IL_0964: stelem.ref
 			IL_0965: dup
-			IL_0966: ldc.i4.5
-			IL_0967: ldloc.s 6
+			IL_0966: ldc.i4.6
+			IL_0967: ldloc.s 7
 			IL_0969: stelem.ref
 			IL_096a: dup
-			IL_096b: ldc.i4.6
-			IL_096c: ldloc.s 7
+			IL_096b: ldc.i4.7
+			IL_096c: ldloc.s 8
 			IL_096e: stelem.ref
-			IL_096f: dup
-			IL_0970: ldc.i4.7
-			IL_0971: ldloc.s 8
-			IL_0973: stelem.ref
-			IL_0974: pop
-			IL_0975: ldloc.0
-			IL_0976: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_097b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0980: ret
+			IL_096f: pop
+			IL_0970: ldloc.0
+			IL_0971: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0976: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_097b: ret
 
-			IL_0981: ldloc.0
-			IL_0982: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
-			IL_0987: pop
-			IL_0988: ldloc.0
-			IL_0989: ldc.i4.m1
-			IL_098a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_098f: ldloc.0
-			IL_0990: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0995: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_099a: ldarg.0
-			IL_099b: ldc.i4.1
-			IL_099c: newarr [System.Runtime]System.Object
-			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09a6: pop
-			IL_09a7: ldloc.0
-			IL_09a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09ad: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09b2: ret
+			IL_097c: ldloc.0
+			IL_097d: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
+			IL_0982: pop
+			IL_0983: ldloc.0
+			IL_0984: ldc.i4.m1
+			IL_0985: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_098a: ldloc.0
+			IL_098b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0990: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0995: ldarg.0
+			IL_0996: ldc.i4.1
+			IL_0997: newarr [System.Runtime]System.Object
+			IL_099c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_09a1: pop
+			IL_09a2: ldloc.0
+			IL_09a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09ad: ret
 		} // end of method runWebCryptoErrors::__js_call__
 
 	} // end of class runWebCryptoErrors
@@ -3975,7 +3957,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x405a
+				// Method begins at RVA 0x3ffa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3998,7 +3980,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3a2f
+			// Method begins at RVA 0x39d2
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -4032,7 +4014,7 @@
 			6f 72 73 7d 00 00
 		)
 		// Fields
-		.field public object crypto
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule crypto
 		.field public object logError
 		.field public object hash
 		.field public object hmac
@@ -4043,7 +4025,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3f0d
+			// Method begins at RVA 0x3ead
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4069,7 +4051,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2049 (0x801)
+		// Code size: 2039 (0x7f7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
@@ -4138,7 +4120,7 @@
 		IL_008b: stloc.s 4
 		IL_008d: ldloc.0
 		IL_008e: ldloc.s 4
-		IL_0090: stfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0090: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
 		IL_0095: nop
 		IL_0096: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_009b: stloc.s 5
@@ -4634,145 +4616,143 @@
 		IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_064b: pop
 		IL_064c: ldloc.0
-		IL_064d: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_0652: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-		IL_0657: stloc.s 4
-		IL_0659: ldloc.s 4
-		IL_065b: ldstr "sha256"
-		IL_0660: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
-		IL_0665: stloc.s 7
-		IL_0667: ldloc.0
-		IL_0668: ldloc.s 7
-		IL_066a: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_066f: ldloc.0
-		IL_0670: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_067a: ldstr "update"
-		IL_067f: ldstr "abc"
-		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0689: pop
-		IL_068a: ldstr "console"
-		IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0699: stloc.s 7
-		IL_069b: ldloc.0
-		IL_069c: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a6: ldstr "digest"
-		IL_06ab: ldstr "hex"
-		IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b5: stloc.s 8
-		IL_06b7: ldloc.s 7
-		IL_06b9: ldstr "log"
-		IL_06be: ldstr "digest first:"
-		IL_06c3: ldloc.s 8
-		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06ca: pop
-		IL_06cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06d0: stloc.s 5
-		IL_06d2: ldloc.0
-		IL_06d3: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_06d8: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_06de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_06e3: ldc.i4.1
-		IL_06e4: newarr [System.Runtime]System.Object
-		IL_06e9: dup
-		IL_06ea: ldc.i4.0
-		IL_06eb: ldloc.0
-		IL_06ec: stelem.ref
-		IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_06f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_06f7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_06fc: ldc.i4.0
-		IL_06fd: conv.r8
-		IL_06fe: ldstr ""
-		IL_0703: ldc.i4.0
-		IL_0704: ldc.i4.0
-		IL_0705: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_070a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_070f: stloc.s 6
-		IL_0711: ldloc.1
-		IL_0712: ldloc.s 5
-		IL_0714: ldstr "digest twice"
-		IL_0719: ldloc.s 6
-		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0720: pop
-		IL_0721: ldloc.0
-		IL_0722: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_0727: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-		IL_072c: stloc.s 4
-		IL_072e: ldloc.s 4
-		IL_0730: ldstr "sha256"
-		IL_0735: ldstr "key"
-		IL_073a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_073f: stloc.s 8
-		IL_0741: ldloc.0
-		IL_0742: ldloc.s 8
-		IL_0744: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-		IL_0749: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_074e: stloc.s 5
-		IL_0750: ldloc.0
-		IL_0751: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0756: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_075c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0761: ldc.i4.1
-		IL_0762: newarr [System.Runtime]System.Object
-		IL_0767: dup
-		IL_0768: ldc.i4.0
-		IL_0769: ldloc.0
-		IL_076a: stelem.ref
-		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0775: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_077a: ldc.i4.0
-		IL_077b: conv.r8
-		IL_077c: ldstr ""
-		IL_0781: ldc.i4.0
-		IL_0782: ldc.i4.0
-		IL_0783: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0788: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_078d: stloc.s 6
-		IL_078f: ldloc.1
-		IL_0790: ldloc.s 5
-		IL_0792: ldstr "hmac update type"
-		IL_0797: ldloc.s 6
-		IL_0799: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_079e: pop
-		IL_079f: nop
-		IL_07a0: nop
-		IL_07a1: ldloc.2
-		IL_07a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_07a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_07ac: stloc.s 8
-		IL_07ae: ldloc.s 8
-		IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07b5: stloc.s 8
-		IL_07b7: ldnull
-		IL_07b8: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27::__js_call__(object)
-		IL_07be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_07c3: ldc.i4.1
-		IL_07c4: newarr [System.Runtime]System.Object
-		IL_07c9: dup
-		IL_07ca: ldc.i4.0
-		IL_07cb: ldloc.0
-		IL_07cc: stelem.ref
-		IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_07d7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_07dc: ldc.i4.0
-		IL_07dd: conv.r8
-		IL_07de: ldstr ""
-		IL_07e3: ldc.i4.0
-		IL_07e4: ldc.i4.0
-		IL_07e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_07ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_07ef: stloc.s 6
-		IL_07f1: ldloc.s 8
-		IL_07f3: ldstr "then"
-		IL_07f8: ldloc.s 6
-		IL_07fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07ff: pop
-		IL_0800: ret
+		IL_064d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0652: stloc.s 4
+		IL_0654: ldloc.s 4
+		IL_0656: ldstr "sha256"
+		IL_065b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
+		IL_0660: stloc.s 7
+		IL_0662: ldloc.0
+		IL_0663: ldloc.s 7
+		IL_0665: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_066a: ldloc.0
+		IL_066b: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_0670: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0675: ldstr "update"
+		IL_067a: ldstr "abc"
+		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0684: pop
+		IL_0685: ldstr "console"
+		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0694: stloc.s 7
+		IL_0696: ldloc.0
+		IL_0697: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06a1: ldstr "digest"
+		IL_06a6: ldstr "hex"
+		IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06b0: stloc.s 8
+		IL_06b2: ldloc.s 7
+		IL_06b4: ldstr "log"
+		IL_06b9: ldstr "digest first:"
+		IL_06be: ldloc.s 8
+		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06c5: pop
+		IL_06c6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06cb: stloc.s 5
+		IL_06cd: ldloc.0
+		IL_06ce: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_06d3: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_06d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_06de: ldc.i4.1
+		IL_06df: newarr [System.Runtime]System.Object
+		IL_06e4: dup
+		IL_06e5: ldc.i4.0
+		IL_06e6: ldloc.0
+		IL_06e7: stelem.ref
+		IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_06f2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_06f7: ldc.i4.0
+		IL_06f8: conv.r8
+		IL_06f9: ldstr ""
+		IL_06fe: ldc.i4.0
+		IL_06ff: ldc.i4.0
+		IL_0700: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0705: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_070a: stloc.s 6
+		IL_070c: ldloc.1
+		IL_070d: ldloc.s 5
+		IL_070f: ldstr "digest twice"
+		IL_0714: ldloc.s 6
+		IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_071b: pop
+		IL_071c: ldloc.0
+		IL_071d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0722: stloc.s 4
+		IL_0724: ldloc.s 4
+		IL_0726: ldstr "sha256"
+		IL_072b: ldstr "key"
+		IL_0730: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_0735: stloc.s 8
+		IL_0737: ldloc.0
+		IL_0738: ldloc.s 8
+		IL_073a: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
+		IL_073f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0744: stloc.s 5
+		IL_0746: ldloc.0
+		IL_0747: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_074c: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0752: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0757: ldc.i4.1
+		IL_0758: newarr [System.Runtime]System.Object
+		IL_075d: dup
+		IL_075e: ldc.i4.0
+		IL_075f: ldloc.0
+		IL_0760: stelem.ref
+		IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_076b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0770: ldc.i4.0
+		IL_0771: conv.r8
+		IL_0772: ldstr ""
+		IL_0777: ldc.i4.0
+		IL_0778: ldc.i4.0
+		IL_0779: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_077e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0783: stloc.s 6
+		IL_0785: ldloc.1
+		IL_0786: ldloc.s 5
+		IL_0788: ldstr "hmac update type"
+		IL_078d: ldloc.s 6
+		IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0794: pop
+		IL_0795: nop
+		IL_0796: nop
+		IL_0797: ldloc.2
+		IL_0798: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_079d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_07a2: stloc.s 8
+		IL_07a4: ldloc.s 8
+		IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07ab: stloc.s 8
+		IL_07ad: ldnull
+		IL_07ae: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27::__js_call__(object)
+		IL_07b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_07b9: ldc.i4.1
+		IL_07ba: newarr [System.Runtime]System.Object
+		IL_07bf: dup
+		IL_07c0: ldc.i4.0
+		IL_07c1: ldloc.0
+		IL_07c2: stelem.ref
+		IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_07cd: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_07d2: ldc.i4.0
+		IL_07d3: conv.r8
+		IL_07d4: ldstr ""
+		IL_07d9: ldc.i4.0
+		IL_07da: ldc.i4.0
+		IL_07db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_07e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_07e5: stloc.s 6
+		IL_07e7: ldloc.s 8
+		IL_07e9: ldstr "then"
+		IL_07ee: ldloc.s 6
+		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07f5: pop
+		IL_07f6: ret
 	} // end of method Require_Crypto_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Crypto_ErrorPaths
@@ -4784,7 +4764,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4063
+		// Method begins at RVA 0x4003
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d29
+				// Method begins at RVA 0x2d24
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,7 +95,7 @@
 			)
 			// Method begins at RVA 0x20fc
 			// Header size: 12
-			// Code size: 3062 (0xbf6)
+			// Code size: 3057 (0xbf1)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Require_Crypto_WebCrypto_Subtle/run/Scope,
@@ -236,1227 +236,1226 @@
 
 			IL_00ed: ldloc.0
 			IL_00ee: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00f3: switch (IL_011c, IL_01f2, IL_034d, IL_0461, IL_0575, IL_06f0, IL_08ff, IL_0a42, IL_0baf)
+			IL_00f3: switch (IL_011c, IL_01ed, IL_0348, IL_045c, IL_0570, IL_06eb, IL_08fa, IL_0a3d, IL_0baa)
 
 			IL_011c: ldarg.0
 			IL_011d: ldc.i4.1
 			IL_011e: ldelem.ref
 			IL_011f: castclass Modules.Require_Crypto_WebCrypto_Subtle/Scope
-			IL_0124: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
-			IL_0129: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule
-			IL_012e: stloc.s 8
-			IL_0130: ldloc.s 8
-			IL_0132: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
-			IL_0137: stloc.s 9
-			IL_0139: ldloc.s 9
-			IL_013b: ldstr "subtle"
-			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0145: stloc.1
-			IL_0146: ldloc.1
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014c: stloc.s 9
-			IL_014e: ldstr "abc"
-			IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0158: stloc.s 10
-			IL_015a: ldloc.s 9
-			IL_015c: ldstr "digest"
-			IL_0161: ldstr "SHA-256"
-			IL_0166: ldloc.s 10
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_016d: stloc.s 9
-			IL_016f: ldloc.0
-			IL_0170: ldc.i4.1
-			IL_0171: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0124: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
+			IL_0129: stloc.s 8
+			IL_012b: ldloc.s 8
+			IL_012d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
+			IL_0132: stloc.s 9
+			IL_0134: ldloc.s 9
+			IL_0136: ldstr "subtle"
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0140: stloc.1
+			IL_0141: ldloc.1
+			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0147: stloc.s 9
+			IL_0149: ldstr "abc"
+			IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0153: stloc.s 10
+			IL_0155: ldloc.s 9
+			IL_0157: ldstr "digest"
+			IL_015c: ldstr "SHA-256"
+			IL_0161: ldloc.s 10
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0168: stloc.s 9
+			IL_016a: ldloc.0
+			IL_016b: ldc.i4.1
+			IL_016c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0171: ldloc.0
+			IL_0172: ldloc.s 9
+			IL_0174: ldarg.0
+			IL_0175: ldc.i4.1
 			IL_0176: ldloc.0
-			IL_0177: ldloc.s 9
-			IL_0179: ldarg.0
-			IL_017a: ldc.i4.1
-			IL_017b: ldloc.0
-			IL_017c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0181: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0186: ldloc.0
-			IL_0187: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_018c: dup
-			IL_018d: ldc.i4.0
-			IL_018e: ldloc.1
-			IL_018f: stelem.ref
-			IL_0190: dup
-			IL_0191: ldc.i4.1
-			IL_0192: ldloc.2
-			IL_0193: stelem.ref
-			IL_0194: dup
-			IL_0195: ldc.i4.2
-			IL_0196: ldloc.3
+			IL_0177: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0181: ldloc.0
+			IL_0182: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0187: dup
+			IL_0188: ldc.i4.0
+			IL_0189: ldloc.1
+			IL_018a: stelem.ref
+			IL_018b: dup
+			IL_018c: ldc.i4.1
+			IL_018d: ldloc.2
+			IL_018e: stelem.ref
+			IL_018f: dup
+			IL_0190: ldc.i4.2
+			IL_0191: ldloc.3
+			IL_0192: stelem.ref
+			IL_0193: dup
+			IL_0194: ldc.i4.3
+			IL_0195: ldloc.s 4
 			IL_0197: stelem.ref
 			IL_0198: dup
-			IL_0199: ldc.i4.3
-			IL_019a: ldloc.s 4
+			IL_0199: ldc.i4.4
+			IL_019a: ldloc.s 5
 			IL_019c: stelem.ref
 			IL_019d: dup
-			IL_019e: ldc.i4.4
-			IL_019f: ldloc.s 5
+			IL_019e: ldc.i4.5
+			IL_019f: ldloc.s 6
 			IL_01a1: stelem.ref
 			IL_01a2: dup
-			IL_01a3: ldc.i4.5
-			IL_01a4: ldloc.s 6
+			IL_01a3: ldc.i4.6
+			IL_01a4: ldloc.s 7
 			IL_01a6: stelem.ref
 			IL_01a7: dup
-			IL_01a8: ldc.i4.6
-			IL_01a9: ldloc.s 7
+			IL_01a8: ldc.i4.7
+			IL_01a9: ldloc.s 8
 			IL_01ab: stelem.ref
 			IL_01ac: dup
-			IL_01ad: ldc.i4.7
-			IL_01ae: ldloc.s 8
+			IL_01ad: ldc.i4.8
+			IL_01ae: ldloc.s 9
 			IL_01b0: stelem.ref
 			IL_01b1: dup
-			IL_01b2: ldc.i4.8
-			IL_01b3: ldloc.s 9
-			IL_01b5: stelem.ref
-			IL_01b6: dup
-			IL_01b7: ldc.i4.s 9
-			IL_01b9: ldloc.s 10
-			IL_01bb: stelem.ref
-			IL_01bc: dup
-			IL_01bd: ldc.i4.s 10
-			IL_01bf: ldloc.s 11
-			IL_01c1: stelem.ref
-			IL_01c2: dup
-			IL_01c3: ldc.i4.s 11
-			IL_01c5: ldloc.s 12
-			IL_01c7: stelem.ref
-			IL_01c8: dup
-			IL_01c9: ldc.i4.s 12
-			IL_01cb: ldloc.s 13
-			IL_01cd: stelem.ref
-			IL_01ce: dup
-			IL_01cf: ldc.i4.s 13
-			IL_01d1: ldloc.s 14
-			IL_01d3: stelem.ref
-			IL_01d4: dup
-			IL_01d5: ldc.i4.s 14
-			IL_01d7: ldloc.s 15
-			IL_01d9: stelem.ref
-			IL_01da: dup
-			IL_01db: ldc.i4.s 15
-			IL_01dd: ldloc.s 16
-			IL_01df: box [System.Runtime]System.Double
-			IL_01e4: stelem.ref
-			IL_01e5: pop
-			IL_01e6: ldloc.0
-			IL_01e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ec: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f1: ret
+			IL_01b2: ldc.i4.s 9
+			IL_01b4: ldloc.s 10
+			IL_01b6: stelem.ref
+			IL_01b7: dup
+			IL_01b8: ldc.i4.s 10
+			IL_01ba: ldloc.s 11
+			IL_01bc: stelem.ref
+			IL_01bd: dup
+			IL_01be: ldc.i4.s 11
+			IL_01c0: ldloc.s 12
+			IL_01c2: stelem.ref
+			IL_01c3: dup
+			IL_01c4: ldc.i4.s 12
+			IL_01c6: ldloc.s 13
+			IL_01c8: stelem.ref
+			IL_01c9: dup
+			IL_01ca: ldc.i4.s 13
+			IL_01cc: ldloc.s 14
+			IL_01ce: stelem.ref
+			IL_01cf: dup
+			IL_01d0: ldc.i4.s 14
+			IL_01d2: ldloc.s 15
+			IL_01d4: stelem.ref
+			IL_01d5: dup
+			IL_01d6: ldc.i4.s 15
+			IL_01d8: ldloc.s 16
+			IL_01da: box [System.Runtime]System.Double
+			IL_01df: stelem.ref
+			IL_01e0: pop
+			IL_01e1: ldloc.0
+			IL_01e2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ec: ret
 
-			IL_01f2: ldloc.0
-			IL_01f3: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited1
-			IL_01f8: stloc.2
-			IL_01f9: ldloc.2
-			IL_01fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_01ff: stloc.3
-			IL_0200: ldstr "console"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_020a: stloc.s 9
-			IL_020c: ldloc.s 9
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0213: stloc.s 9
-			IL_0215: ldloc.2
-			IL_0216: ldstr "byteLength"
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0220: stloc.s 11
-			IL_0222: ldloc.s 9
-			IL_0224: ldstr "log"
-			IL_0229: ldstr "digest byteLength:"
-			IL_022e: ldloc.s 11
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0235: pop
-			IL_0236: ldstr "console"
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0240: stloc.s 11
-			IL_0242: ldloc.s 11
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0249: stloc.s 11
-			IL_024b: ldloc.3
-			IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0251: stloc.s 12
-			IL_0253: ldloc.s 12
-			IL_0255: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_025a: stloc.s 10
-			IL_025c: ldloc.s 10
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0263: stloc.s 9
-			IL_0265: ldloc.s 9
-			IL_0267: ldstr "toString"
-			IL_026c: ldstr "hex"
-			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0276: stloc.s 9
-			IL_0278: ldloc.s 11
-			IL_027a: ldstr "log"
-			IL_027f: ldstr "digest hex:"
-			IL_0284: ldloc.s 9
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_028b: pop
-			IL_028c: ldstr "console"
-			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0296: stloc.s 9
-			IL_0298: ldloc.s 9
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_029f: stloc.s 9
-			IL_02a1: ldloc.1
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a7: stloc.s 11
-			IL_02a9: ldstr "abc"
-			IL_02ae: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_02b3: stloc.s 10
-			IL_02b5: ldloc.s 11
-			IL_02b7: ldstr "digest"
-			IL_02bc: ldstr "SHA-1"
-			IL_02c1: ldloc.s 10
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02c8: stloc.s 11
-			IL_02ca: ldloc.0
-			IL_02cb: ldc.i4.2
-			IL_02cc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ed: ldloc.0
+			IL_01ee: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited1
+			IL_01f3: stloc.2
+			IL_01f4: ldloc.2
+			IL_01f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_01fa: stloc.3
+			IL_01fb: ldstr "console"
+			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0205: stloc.s 9
+			IL_0207: ldloc.s 9
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020e: stloc.s 9
+			IL_0210: ldloc.2
+			IL_0211: ldstr "byteLength"
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021b: stloc.s 11
+			IL_021d: ldloc.s 9
+			IL_021f: ldstr "log"
+			IL_0224: ldstr "digest byteLength:"
+			IL_0229: ldloc.s 11
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0230: pop
+			IL_0231: ldstr "console"
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_023b: stloc.s 11
+			IL_023d: ldloc.s 11
+			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0244: stloc.s 11
+			IL_0246: ldloc.3
+			IL_0247: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_024c: stloc.s 12
+			IL_024e: ldloc.s 12
+			IL_0250: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0255: stloc.s 10
+			IL_0257: ldloc.s 10
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025e: stloc.s 9
+			IL_0260: ldloc.s 9
+			IL_0262: ldstr "toString"
+			IL_0267: ldstr "hex"
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0271: stloc.s 9
+			IL_0273: ldloc.s 11
+			IL_0275: ldstr "log"
+			IL_027a: ldstr "digest hex:"
+			IL_027f: ldloc.s 9
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0286: pop
+			IL_0287: ldstr "console"
+			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0291: stloc.s 9
+			IL_0293: ldloc.s 9
+			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_029a: stloc.s 9
+			IL_029c: ldloc.1
+			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a2: stloc.s 11
+			IL_02a4: ldstr "abc"
+			IL_02a9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_02ae: stloc.s 10
+			IL_02b0: ldloc.s 11
+			IL_02b2: ldstr "digest"
+			IL_02b7: ldstr "SHA-1"
+			IL_02bc: ldloc.s 10
+			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02c3: stloc.s 11
+			IL_02c5: ldloc.0
+			IL_02c6: ldc.i4.2
+			IL_02c7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02cc: ldloc.0
+			IL_02cd: ldloc.s 11
+			IL_02cf: ldarg.0
+			IL_02d0: ldc.i4.2
 			IL_02d1: ldloc.0
-			IL_02d2: ldloc.s 11
-			IL_02d4: ldarg.0
-			IL_02d5: ldc.i4.2
-			IL_02d6: ldloc.0
-			IL_02d7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02e1: ldloc.0
-			IL_02e2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02e7: dup
-			IL_02e8: ldc.i4.0
-			IL_02e9: ldloc.1
-			IL_02ea: stelem.ref
-			IL_02eb: dup
-			IL_02ec: ldc.i4.1
-			IL_02ed: ldloc.2
-			IL_02ee: stelem.ref
-			IL_02ef: dup
-			IL_02f0: ldc.i4.2
-			IL_02f1: ldloc.3
+			IL_02d2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02dc: ldloc.0
+			IL_02dd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02e2: dup
+			IL_02e3: ldc.i4.0
+			IL_02e4: ldloc.1
+			IL_02e5: stelem.ref
+			IL_02e6: dup
+			IL_02e7: ldc.i4.1
+			IL_02e8: ldloc.2
+			IL_02e9: stelem.ref
+			IL_02ea: dup
+			IL_02eb: ldc.i4.2
+			IL_02ec: ldloc.3
+			IL_02ed: stelem.ref
+			IL_02ee: dup
+			IL_02ef: ldc.i4.3
+			IL_02f0: ldloc.s 4
 			IL_02f2: stelem.ref
 			IL_02f3: dup
-			IL_02f4: ldc.i4.3
-			IL_02f5: ldloc.s 4
+			IL_02f4: ldc.i4.4
+			IL_02f5: ldloc.s 5
 			IL_02f7: stelem.ref
 			IL_02f8: dup
-			IL_02f9: ldc.i4.4
-			IL_02fa: ldloc.s 5
+			IL_02f9: ldc.i4.5
+			IL_02fa: ldloc.s 6
 			IL_02fc: stelem.ref
 			IL_02fd: dup
-			IL_02fe: ldc.i4.5
-			IL_02ff: ldloc.s 6
+			IL_02fe: ldc.i4.6
+			IL_02ff: ldloc.s 7
 			IL_0301: stelem.ref
 			IL_0302: dup
-			IL_0303: ldc.i4.6
-			IL_0304: ldloc.s 7
+			IL_0303: ldc.i4.7
+			IL_0304: ldloc.s 8
 			IL_0306: stelem.ref
 			IL_0307: dup
-			IL_0308: ldc.i4.7
-			IL_0309: ldloc.s 8
+			IL_0308: ldc.i4.8
+			IL_0309: ldloc.s 9
 			IL_030b: stelem.ref
 			IL_030c: dup
-			IL_030d: ldc.i4.8
-			IL_030e: ldloc.s 9
-			IL_0310: stelem.ref
-			IL_0311: dup
-			IL_0312: ldc.i4.s 9
-			IL_0314: ldloc.s 10
-			IL_0316: stelem.ref
-			IL_0317: dup
-			IL_0318: ldc.i4.s 10
-			IL_031a: ldloc.s 11
-			IL_031c: stelem.ref
-			IL_031d: dup
-			IL_031e: ldc.i4.s 11
-			IL_0320: ldloc.s 12
-			IL_0322: stelem.ref
-			IL_0323: dup
-			IL_0324: ldc.i4.s 12
-			IL_0326: ldloc.s 13
-			IL_0328: stelem.ref
-			IL_0329: dup
-			IL_032a: ldc.i4.s 13
-			IL_032c: ldloc.s 14
-			IL_032e: stelem.ref
-			IL_032f: dup
-			IL_0330: ldc.i4.s 14
-			IL_0332: ldloc.s 15
-			IL_0334: stelem.ref
-			IL_0335: dup
-			IL_0336: ldc.i4.s 15
-			IL_0338: ldloc.s 16
-			IL_033a: box [System.Runtime]System.Double
-			IL_033f: stelem.ref
-			IL_0340: pop
-			IL_0341: ldloc.0
-			IL_0342: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0347: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_034c: ret
+			IL_030d: ldc.i4.s 9
+			IL_030f: ldloc.s 10
+			IL_0311: stelem.ref
+			IL_0312: dup
+			IL_0313: ldc.i4.s 10
+			IL_0315: ldloc.s 11
+			IL_0317: stelem.ref
+			IL_0318: dup
+			IL_0319: ldc.i4.s 11
+			IL_031b: ldloc.s 12
+			IL_031d: stelem.ref
+			IL_031e: dup
+			IL_031f: ldc.i4.s 12
+			IL_0321: ldloc.s 13
+			IL_0323: stelem.ref
+			IL_0324: dup
+			IL_0325: ldc.i4.s 13
+			IL_0327: ldloc.s 14
+			IL_0329: stelem.ref
+			IL_032a: dup
+			IL_032b: ldc.i4.s 14
+			IL_032d: ldloc.s 15
+			IL_032f: stelem.ref
+			IL_0330: dup
+			IL_0331: ldc.i4.s 15
+			IL_0333: ldloc.s 16
+			IL_0335: box [System.Runtime]System.Double
+			IL_033a: stelem.ref
+			IL_033b: pop
+			IL_033c: ldloc.0
+			IL_033d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0342: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0347: ret
 
-			IL_034d: ldloc.0
-			IL_034e: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
-			IL_0353: stloc.s 11
-			IL_0355: ldloc.s 11
-			IL_0357: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_035c: stloc.s 13
-			IL_035e: ldloc.s 13
-			IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0365: stloc.s 12
-			IL_0367: ldloc.s 12
-			IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_036e: stloc.s 10
-			IL_0370: ldloc.s 10
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0377: stloc.s 11
-			IL_0379: ldloc.s 11
-			IL_037b: ldstr "toString"
-			IL_0380: ldstr "hex"
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_038a: stloc.s 11
-			IL_038c: ldloc.s 9
-			IL_038e: ldstr "log"
-			IL_0393: ldstr "digest sha1 hex:"
-			IL_0398: ldloc.s 11
-			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_039f: pop
-			IL_03a0: ldstr "console"
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03aa: stloc.s 11
-			IL_03ac: ldloc.s 11
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b3: stloc.s 11
-			IL_03b5: ldloc.1
-			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03bb: stloc.s 9
-			IL_03bd: ldstr "abc"
-			IL_03c2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_03c7: stloc.s 10
-			IL_03c9: ldloc.s 9
-			IL_03cb: ldstr "digest"
-			IL_03d0: ldstr "SHA-384"
-			IL_03d5: ldloc.s 10
-			IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03dc: stloc.s 9
-			IL_03de: ldloc.0
-			IL_03df: ldc.i4.3
-			IL_03e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0348: ldloc.0
+			IL_0349: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
+			IL_034e: stloc.s 11
+			IL_0350: ldloc.s 11
+			IL_0352: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0357: stloc.s 13
+			IL_0359: ldloc.s 13
+			IL_035b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0360: stloc.s 12
+			IL_0362: ldloc.s 12
+			IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0369: stloc.s 10
+			IL_036b: ldloc.s 10
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0372: stloc.s 11
+			IL_0374: ldloc.s 11
+			IL_0376: ldstr "toString"
+			IL_037b: ldstr "hex"
+			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0385: stloc.s 11
+			IL_0387: ldloc.s 9
+			IL_0389: ldstr "log"
+			IL_038e: ldstr "digest sha1 hex:"
+			IL_0393: ldloc.s 11
+			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_039a: pop
+			IL_039b: ldstr "console"
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03a5: stloc.s 11
+			IL_03a7: ldloc.s 11
+			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ae: stloc.s 11
+			IL_03b0: ldloc.1
+			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b6: stloc.s 9
+			IL_03b8: ldstr "abc"
+			IL_03bd: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_03c2: stloc.s 10
+			IL_03c4: ldloc.s 9
+			IL_03c6: ldstr "digest"
+			IL_03cb: ldstr "SHA-384"
+			IL_03d0: ldloc.s 10
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_03d7: stloc.s 9
+			IL_03d9: ldloc.0
+			IL_03da: ldc.i4.3
+			IL_03db: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03e0: ldloc.0
+			IL_03e1: ldloc.s 9
+			IL_03e3: ldarg.0
+			IL_03e4: ldc.i4.3
 			IL_03e5: ldloc.0
-			IL_03e6: ldloc.s 9
-			IL_03e8: ldarg.0
-			IL_03e9: ldc.i4.3
-			IL_03ea: ldloc.0
-			IL_03eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03f5: ldloc.0
-			IL_03f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03fb: dup
-			IL_03fc: ldc.i4.0
-			IL_03fd: ldloc.1
-			IL_03fe: stelem.ref
-			IL_03ff: dup
-			IL_0400: ldc.i4.1
-			IL_0401: ldloc.2
-			IL_0402: stelem.ref
-			IL_0403: dup
-			IL_0404: ldc.i4.2
-			IL_0405: ldloc.3
+			IL_03e6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03f0: ldloc.0
+			IL_03f1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03f6: dup
+			IL_03f7: ldc.i4.0
+			IL_03f8: ldloc.1
+			IL_03f9: stelem.ref
+			IL_03fa: dup
+			IL_03fb: ldc.i4.1
+			IL_03fc: ldloc.2
+			IL_03fd: stelem.ref
+			IL_03fe: dup
+			IL_03ff: ldc.i4.2
+			IL_0400: ldloc.3
+			IL_0401: stelem.ref
+			IL_0402: dup
+			IL_0403: ldc.i4.3
+			IL_0404: ldloc.s 4
 			IL_0406: stelem.ref
 			IL_0407: dup
-			IL_0408: ldc.i4.3
-			IL_0409: ldloc.s 4
+			IL_0408: ldc.i4.4
+			IL_0409: ldloc.s 5
 			IL_040b: stelem.ref
 			IL_040c: dup
-			IL_040d: ldc.i4.4
-			IL_040e: ldloc.s 5
+			IL_040d: ldc.i4.5
+			IL_040e: ldloc.s 6
 			IL_0410: stelem.ref
 			IL_0411: dup
-			IL_0412: ldc.i4.5
-			IL_0413: ldloc.s 6
+			IL_0412: ldc.i4.6
+			IL_0413: ldloc.s 7
 			IL_0415: stelem.ref
 			IL_0416: dup
-			IL_0417: ldc.i4.6
-			IL_0418: ldloc.s 7
+			IL_0417: ldc.i4.7
+			IL_0418: ldloc.s 8
 			IL_041a: stelem.ref
 			IL_041b: dup
-			IL_041c: ldc.i4.7
-			IL_041d: ldloc.s 8
+			IL_041c: ldc.i4.8
+			IL_041d: ldloc.s 9
 			IL_041f: stelem.ref
 			IL_0420: dup
-			IL_0421: ldc.i4.8
-			IL_0422: ldloc.s 9
-			IL_0424: stelem.ref
-			IL_0425: dup
-			IL_0426: ldc.i4.s 9
-			IL_0428: ldloc.s 10
-			IL_042a: stelem.ref
-			IL_042b: dup
-			IL_042c: ldc.i4.s 10
-			IL_042e: ldloc.s 11
-			IL_0430: stelem.ref
-			IL_0431: dup
-			IL_0432: ldc.i4.s 11
-			IL_0434: ldloc.s 12
-			IL_0436: stelem.ref
-			IL_0437: dup
-			IL_0438: ldc.i4.s 12
-			IL_043a: ldloc.s 13
-			IL_043c: stelem.ref
-			IL_043d: dup
-			IL_043e: ldc.i4.s 13
-			IL_0440: ldloc.s 14
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.s 14
-			IL_0446: ldloc.s 15
-			IL_0448: stelem.ref
-			IL_0449: dup
-			IL_044a: ldc.i4.s 15
-			IL_044c: ldloc.s 16
-			IL_044e: box [System.Runtime]System.Double
-			IL_0453: stelem.ref
-			IL_0454: pop
-			IL_0455: ldloc.0
-			IL_0456: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_045b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0460: ret
+			IL_0421: ldc.i4.s 9
+			IL_0423: ldloc.s 10
+			IL_0425: stelem.ref
+			IL_0426: dup
+			IL_0427: ldc.i4.s 10
+			IL_0429: ldloc.s 11
+			IL_042b: stelem.ref
+			IL_042c: dup
+			IL_042d: ldc.i4.s 11
+			IL_042f: ldloc.s 12
+			IL_0431: stelem.ref
+			IL_0432: dup
+			IL_0433: ldc.i4.s 12
+			IL_0435: ldloc.s 13
+			IL_0437: stelem.ref
+			IL_0438: dup
+			IL_0439: ldc.i4.s 13
+			IL_043b: ldloc.s 14
+			IL_043d: stelem.ref
+			IL_043e: dup
+			IL_043f: ldc.i4.s 14
+			IL_0441: ldloc.s 15
+			IL_0443: stelem.ref
+			IL_0444: dup
+			IL_0445: ldc.i4.s 15
+			IL_0447: ldloc.s 16
+			IL_0449: box [System.Runtime]System.Double
+			IL_044e: stelem.ref
+			IL_044f: pop
+			IL_0450: ldloc.0
+			IL_0451: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0456: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_045b: ret
 
-			IL_0461: ldloc.0
-			IL_0462: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
-			IL_0467: stloc.s 9
-			IL_0469: ldloc.s 9
-			IL_046b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0470: stloc.s 13
-			IL_0472: ldloc.s 13
-			IL_0474: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0479: stloc.s 12
-			IL_047b: ldloc.s 12
-			IL_047d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0482: stloc.s 10
-			IL_0484: ldloc.s 10
-			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_048b: stloc.s 9
-			IL_048d: ldloc.s 9
-			IL_048f: ldstr "toString"
-			IL_0494: ldstr "hex"
-			IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_049e: stloc.s 9
-			IL_04a0: ldloc.s 11
-			IL_04a2: ldstr "log"
-			IL_04a7: ldstr "digest sha384 hex:"
-			IL_04ac: ldloc.s 9
-			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04b3: pop
-			IL_04b4: ldstr "console"
-			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04be: stloc.s 9
-			IL_04c0: ldloc.s 9
-			IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04c7: stloc.s 9
-			IL_04c9: ldloc.1
-			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04cf: stloc.s 11
-			IL_04d1: ldstr "abc"
-			IL_04d6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_04db: stloc.s 10
-			IL_04dd: ldloc.s 11
-			IL_04df: ldstr "digest"
-			IL_04e4: ldstr "SHA-512"
-			IL_04e9: ldloc.s 10
-			IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04f0: stloc.s 11
-			IL_04f2: ldloc.0
-			IL_04f3: ldc.i4.4
-			IL_04f4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_045c: ldloc.0
+			IL_045d: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
+			IL_0462: stloc.s 9
+			IL_0464: ldloc.s 9
+			IL_0466: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_046b: stloc.s 13
+			IL_046d: ldloc.s 13
+			IL_046f: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0474: stloc.s 12
+			IL_0476: ldloc.s 12
+			IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_047d: stloc.s 10
+			IL_047f: ldloc.s 10
+			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0486: stloc.s 9
+			IL_0488: ldloc.s 9
+			IL_048a: ldstr "toString"
+			IL_048f: ldstr "hex"
+			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0499: stloc.s 9
+			IL_049b: ldloc.s 11
+			IL_049d: ldstr "log"
+			IL_04a2: ldstr "digest sha384 hex:"
+			IL_04a7: ldloc.s 9
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04ae: pop
+			IL_04af: ldstr "console"
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04b9: stloc.s 9
+			IL_04bb: ldloc.s 9
+			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04c2: stloc.s 9
+			IL_04c4: ldloc.1
+			IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ca: stloc.s 11
+			IL_04cc: ldstr "abc"
+			IL_04d1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_04d6: stloc.s 10
+			IL_04d8: ldloc.s 11
+			IL_04da: ldstr "digest"
+			IL_04df: ldstr "SHA-512"
+			IL_04e4: ldloc.s 10
+			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04eb: stloc.s 11
+			IL_04ed: ldloc.0
+			IL_04ee: ldc.i4.4
+			IL_04ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04f4: ldloc.0
+			IL_04f5: ldloc.s 11
+			IL_04f7: ldarg.0
+			IL_04f8: ldc.i4.4
 			IL_04f9: ldloc.0
-			IL_04fa: ldloc.s 11
-			IL_04fc: ldarg.0
-			IL_04fd: ldc.i4.4
-			IL_04fe: ldloc.0
-			IL_04ff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0504: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0509: ldloc.0
-			IL_050a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_050f: dup
-			IL_0510: ldc.i4.0
-			IL_0511: ldloc.1
-			IL_0512: stelem.ref
-			IL_0513: dup
-			IL_0514: ldc.i4.1
-			IL_0515: ldloc.2
-			IL_0516: stelem.ref
-			IL_0517: dup
-			IL_0518: ldc.i4.2
-			IL_0519: ldloc.3
+			IL_04fa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0504: ldloc.0
+			IL_0505: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_050a: dup
+			IL_050b: ldc.i4.0
+			IL_050c: ldloc.1
+			IL_050d: stelem.ref
+			IL_050e: dup
+			IL_050f: ldc.i4.1
+			IL_0510: ldloc.2
+			IL_0511: stelem.ref
+			IL_0512: dup
+			IL_0513: ldc.i4.2
+			IL_0514: ldloc.3
+			IL_0515: stelem.ref
+			IL_0516: dup
+			IL_0517: ldc.i4.3
+			IL_0518: ldloc.s 4
 			IL_051a: stelem.ref
 			IL_051b: dup
-			IL_051c: ldc.i4.3
-			IL_051d: ldloc.s 4
+			IL_051c: ldc.i4.4
+			IL_051d: ldloc.s 5
 			IL_051f: stelem.ref
 			IL_0520: dup
-			IL_0521: ldc.i4.4
-			IL_0522: ldloc.s 5
+			IL_0521: ldc.i4.5
+			IL_0522: ldloc.s 6
 			IL_0524: stelem.ref
 			IL_0525: dup
-			IL_0526: ldc.i4.5
-			IL_0527: ldloc.s 6
+			IL_0526: ldc.i4.6
+			IL_0527: ldloc.s 7
 			IL_0529: stelem.ref
 			IL_052a: dup
-			IL_052b: ldc.i4.6
-			IL_052c: ldloc.s 7
+			IL_052b: ldc.i4.7
+			IL_052c: ldloc.s 8
 			IL_052e: stelem.ref
 			IL_052f: dup
-			IL_0530: ldc.i4.7
-			IL_0531: ldloc.s 8
+			IL_0530: ldc.i4.8
+			IL_0531: ldloc.s 9
 			IL_0533: stelem.ref
 			IL_0534: dup
-			IL_0535: ldc.i4.8
-			IL_0536: ldloc.s 9
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.s 9
-			IL_053c: ldloc.s 10
-			IL_053e: stelem.ref
-			IL_053f: dup
-			IL_0540: ldc.i4.s 10
-			IL_0542: ldloc.s 11
-			IL_0544: stelem.ref
-			IL_0545: dup
-			IL_0546: ldc.i4.s 11
-			IL_0548: ldloc.s 12
-			IL_054a: stelem.ref
-			IL_054b: dup
-			IL_054c: ldc.i4.s 12
-			IL_054e: ldloc.s 13
-			IL_0550: stelem.ref
-			IL_0551: dup
-			IL_0552: ldc.i4.s 13
-			IL_0554: ldloc.s 14
-			IL_0556: stelem.ref
-			IL_0557: dup
-			IL_0558: ldc.i4.s 14
-			IL_055a: ldloc.s 15
-			IL_055c: stelem.ref
-			IL_055d: dup
-			IL_055e: ldc.i4.s 15
-			IL_0560: ldloc.s 16
-			IL_0562: box [System.Runtime]System.Double
-			IL_0567: stelem.ref
-			IL_0568: pop
-			IL_0569: ldloc.0
-			IL_056a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_056f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0574: ret
+			IL_0535: ldc.i4.s 9
+			IL_0537: ldloc.s 10
+			IL_0539: stelem.ref
+			IL_053a: dup
+			IL_053b: ldc.i4.s 10
+			IL_053d: ldloc.s 11
+			IL_053f: stelem.ref
+			IL_0540: dup
+			IL_0541: ldc.i4.s 11
+			IL_0543: ldloc.s 12
+			IL_0545: stelem.ref
+			IL_0546: dup
+			IL_0547: ldc.i4.s 12
+			IL_0549: ldloc.s 13
+			IL_054b: stelem.ref
+			IL_054c: dup
+			IL_054d: ldc.i4.s 13
+			IL_054f: ldloc.s 14
+			IL_0551: stelem.ref
+			IL_0552: dup
+			IL_0553: ldc.i4.s 14
+			IL_0555: ldloc.s 15
+			IL_0557: stelem.ref
+			IL_0558: dup
+			IL_0559: ldc.i4.s 15
+			IL_055b: ldloc.s 16
+			IL_055d: box [System.Runtime]System.Double
+			IL_0562: stelem.ref
+			IL_0563: pop
+			IL_0564: ldloc.0
+			IL_0565: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_056a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_056f: ret
 
-			IL_0575: ldloc.0
-			IL_0576: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
-			IL_057b: stloc.s 11
-			IL_057d: ldloc.s 11
-			IL_057f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0584: stloc.s 13
-			IL_0586: ldloc.s 13
-			IL_0588: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_058d: stloc.s 12
-			IL_058f: ldloc.s 12
-			IL_0591: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0596: stloc.s 10
-			IL_0598: ldloc.s 10
-			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_059f: stloc.s 11
-			IL_05a1: ldloc.s 11
-			IL_05a3: ldstr "toString"
-			IL_05a8: ldstr "hex"
-			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05b2: stloc.s 11
-			IL_05b4: ldloc.s 9
-			IL_05b6: ldstr "log"
-			IL_05bb: ldstr "digest sha512 hex:"
-			IL_05c0: ldloc.s 11
-			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05c7: pop
-			IL_05c8: ldloc.1
-			IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ce: stloc.s 11
-			IL_05d0: ldstr "key"
-			IL_05d5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_05da: stloc.s 10
-			IL_05dc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05e1: dup
-			IL_05e2: ldstr "name"
-			IL_05e7: ldstr "HMAC"
-			IL_05ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05f1: dup
-			IL_05f2: ldstr "hash"
-			IL_05f7: ldstr "SHA-256"
-			IL_05fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0601: dup
-			IL_0602: ldstr "length"
-			IL_0607: ldc.r8 24
-			IL_0610: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0615: stloc.s 14
-			IL_0617: ldc.i4.2
-			IL_0618: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_061d: dup
-			IL_061e: ldstr "sign"
-			IL_0623: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0628: dup
-			IL_0629: ldstr "verify"
-			IL_062e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0633: stloc.s 12
-			IL_0635: ldc.i4.5
-			IL_0636: newarr [System.Runtime]System.Object
-			IL_063b: dup
-			IL_063c: ldc.i4.0
-			IL_063d: ldstr "raw"
+			IL_0570: ldloc.0
+			IL_0571: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
+			IL_0576: stloc.s 11
+			IL_0578: ldloc.s 11
+			IL_057a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_057f: stloc.s 13
+			IL_0581: ldloc.s 13
+			IL_0583: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0588: stloc.s 12
+			IL_058a: ldloc.s 12
+			IL_058c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0591: stloc.s 10
+			IL_0593: ldloc.s 10
+			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_059a: stloc.s 11
+			IL_059c: ldloc.s 11
+			IL_059e: ldstr "toString"
+			IL_05a3: ldstr "hex"
+			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05ad: stloc.s 11
+			IL_05af: ldloc.s 9
+			IL_05b1: ldstr "log"
+			IL_05b6: ldstr "digest sha512 hex:"
+			IL_05bb: ldloc.s 11
+			IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05c2: pop
+			IL_05c3: ldloc.1
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05c9: stloc.s 11
+			IL_05cb: ldstr "key"
+			IL_05d0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_05d5: stloc.s 10
+			IL_05d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05dc: dup
+			IL_05dd: ldstr "name"
+			IL_05e2: ldstr "HMAC"
+			IL_05e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ec: dup
+			IL_05ed: ldstr "hash"
+			IL_05f2: ldstr "SHA-256"
+			IL_05f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05fc: dup
+			IL_05fd: ldstr "length"
+			IL_0602: ldc.r8 24
+			IL_060b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0610: stloc.s 14
+			IL_0612: ldc.i4.2
+			IL_0613: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0618: dup
+			IL_0619: ldstr "sign"
+			IL_061e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0623: dup
+			IL_0624: ldstr "verify"
+			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_062e: stloc.s 12
+			IL_0630: ldc.i4.5
+			IL_0631: newarr [System.Runtime]System.Object
+			IL_0636: dup
+			IL_0637: ldc.i4.0
+			IL_0638: ldstr "raw"
+			IL_063d: stelem.ref
+			IL_063e: dup
+			IL_063f: ldc.i4.1
+			IL_0640: ldloc.s 10
 			IL_0642: stelem.ref
 			IL_0643: dup
-			IL_0644: ldc.i4.1
-			IL_0645: ldloc.s 10
+			IL_0644: ldc.i4.2
+			IL_0645: ldloc.s 14
 			IL_0647: stelem.ref
 			IL_0648: dup
-			IL_0649: ldc.i4.2
-			IL_064a: ldloc.s 14
-			IL_064c: stelem.ref
-			IL_064d: dup
-			IL_064e: ldc.i4.3
-			IL_064f: ldc.i4.0
-			IL_0650: box [System.Runtime]System.Boolean
+			IL_0649: ldc.i4.3
+			IL_064a: ldc.i4.0
+			IL_064b: box [System.Runtime]System.Boolean
+			IL_0650: stelem.ref
+			IL_0651: dup
+			IL_0652: ldc.i4.4
+			IL_0653: ldloc.s 12
 			IL_0655: stelem.ref
-			IL_0656: dup
-			IL_0657: ldc.i4.4
-			IL_0658: ldloc.s 12
-			IL_065a: stelem.ref
-			IL_065b: stloc.s 15
-			IL_065d: ldloc.s 11
-			IL_065f: ldstr "importKey"
-			IL_0664: ldloc.s 15
-			IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_066b: stloc.s 11
-			IL_066d: ldloc.0
-			IL_066e: ldc.i4.5
-			IL_066f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0656: stloc.s 15
+			IL_0658: ldloc.s 11
+			IL_065a: ldstr "importKey"
+			IL_065f: ldloc.s 15
+			IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0666: stloc.s 11
+			IL_0668: ldloc.0
+			IL_0669: ldc.i4.5
+			IL_066a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_066f: ldloc.0
+			IL_0670: ldloc.s 11
+			IL_0672: ldarg.0
+			IL_0673: ldc.i4.5
 			IL_0674: ldloc.0
-			IL_0675: ldloc.s 11
-			IL_0677: ldarg.0
-			IL_0678: ldc.i4.5
-			IL_0679: ldloc.0
-			IL_067a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_067f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0684: ldloc.0
-			IL_0685: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_068a: dup
-			IL_068b: ldc.i4.0
-			IL_068c: ldloc.1
-			IL_068d: stelem.ref
-			IL_068e: dup
-			IL_068f: ldc.i4.1
-			IL_0690: ldloc.2
-			IL_0691: stelem.ref
-			IL_0692: dup
-			IL_0693: ldc.i4.2
-			IL_0694: ldloc.3
+			IL_0675: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_067a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_067f: ldloc.0
+			IL_0680: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0685: dup
+			IL_0686: ldc.i4.0
+			IL_0687: ldloc.1
+			IL_0688: stelem.ref
+			IL_0689: dup
+			IL_068a: ldc.i4.1
+			IL_068b: ldloc.2
+			IL_068c: stelem.ref
+			IL_068d: dup
+			IL_068e: ldc.i4.2
+			IL_068f: ldloc.3
+			IL_0690: stelem.ref
+			IL_0691: dup
+			IL_0692: ldc.i4.3
+			IL_0693: ldloc.s 4
 			IL_0695: stelem.ref
 			IL_0696: dup
-			IL_0697: ldc.i4.3
-			IL_0698: ldloc.s 4
+			IL_0697: ldc.i4.4
+			IL_0698: ldloc.s 5
 			IL_069a: stelem.ref
 			IL_069b: dup
-			IL_069c: ldc.i4.4
-			IL_069d: ldloc.s 5
+			IL_069c: ldc.i4.5
+			IL_069d: ldloc.s 6
 			IL_069f: stelem.ref
 			IL_06a0: dup
-			IL_06a1: ldc.i4.5
-			IL_06a2: ldloc.s 6
+			IL_06a1: ldc.i4.6
+			IL_06a2: ldloc.s 7
 			IL_06a4: stelem.ref
 			IL_06a5: dup
-			IL_06a6: ldc.i4.6
-			IL_06a7: ldloc.s 7
+			IL_06a6: ldc.i4.7
+			IL_06a7: ldloc.s 8
 			IL_06a9: stelem.ref
 			IL_06aa: dup
-			IL_06ab: ldc.i4.7
-			IL_06ac: ldloc.s 8
+			IL_06ab: ldc.i4.8
+			IL_06ac: ldloc.s 9
 			IL_06ae: stelem.ref
 			IL_06af: dup
-			IL_06b0: ldc.i4.8
-			IL_06b1: ldloc.s 9
-			IL_06b3: stelem.ref
-			IL_06b4: dup
-			IL_06b5: ldc.i4.s 9
-			IL_06b7: ldloc.s 10
-			IL_06b9: stelem.ref
-			IL_06ba: dup
-			IL_06bb: ldc.i4.s 10
-			IL_06bd: ldloc.s 11
-			IL_06bf: stelem.ref
-			IL_06c0: dup
-			IL_06c1: ldc.i4.s 11
-			IL_06c3: ldloc.s 12
-			IL_06c5: stelem.ref
-			IL_06c6: dup
-			IL_06c7: ldc.i4.s 12
-			IL_06c9: ldloc.s 13
-			IL_06cb: stelem.ref
-			IL_06cc: dup
-			IL_06cd: ldc.i4.s 13
-			IL_06cf: ldloc.s 14
-			IL_06d1: stelem.ref
-			IL_06d2: dup
-			IL_06d3: ldc.i4.s 14
-			IL_06d5: ldloc.s 15
-			IL_06d7: stelem.ref
-			IL_06d8: dup
-			IL_06d9: ldc.i4.s 15
-			IL_06db: ldloc.s 16
-			IL_06dd: box [System.Runtime]System.Double
-			IL_06e2: stelem.ref
-			IL_06e3: pop
-			IL_06e4: ldloc.0
-			IL_06e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06ea: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06ef: ret
+			IL_06b0: ldc.i4.s 9
+			IL_06b2: ldloc.s 10
+			IL_06b4: stelem.ref
+			IL_06b5: dup
+			IL_06b6: ldc.i4.s 10
+			IL_06b8: ldloc.s 11
+			IL_06ba: stelem.ref
+			IL_06bb: dup
+			IL_06bc: ldc.i4.s 11
+			IL_06be: ldloc.s 12
+			IL_06c0: stelem.ref
+			IL_06c1: dup
+			IL_06c2: ldc.i4.s 12
+			IL_06c4: ldloc.s 13
+			IL_06c6: stelem.ref
+			IL_06c7: dup
+			IL_06c8: ldc.i4.s 13
+			IL_06ca: ldloc.s 14
+			IL_06cc: stelem.ref
+			IL_06cd: dup
+			IL_06ce: ldc.i4.s 14
+			IL_06d0: ldloc.s 15
+			IL_06d2: stelem.ref
+			IL_06d3: dup
+			IL_06d4: ldc.i4.s 15
+			IL_06d6: ldloc.s 16
+			IL_06d8: box [System.Runtime]System.Double
+			IL_06dd: stelem.ref
+			IL_06de: pop
+			IL_06df: ldloc.0
+			IL_06e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06e5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06ea: ret
 
-			IL_06f0: ldloc.0
-			IL_06f1: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
-			IL_06f6: stloc.s 4
-			IL_06f8: ldstr "console"
-			IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0702: stloc.s 11
-			IL_0704: ldloc.s 11
-			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_070b: stloc.s 11
-			IL_070d: ldloc.s 4
-			IL_070f: ldstr "type"
-			IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0719: stloc.s 9
-			IL_071b: ldloc.s 11
-			IL_071d: ldstr "log"
-			IL_0722: ldstr "key type:"
-			IL_0727: ldloc.s 9
-			IL_0729: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_072e: pop
-			IL_072f: ldstr "console"
-			IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0739: stloc.s 9
-			IL_073b: ldloc.s 9
-			IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0742: stloc.s 9
-			IL_0744: ldloc.s 4
-			IL_0746: ldstr "algorithm"
-			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0750: stloc.s 11
-			IL_0752: ldloc.s 11
-			IL_0754: ldstr "name"
-			IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_075e: stloc.s 11
-			IL_0760: ldloc.s 9
-			IL_0762: ldstr "log"
-			IL_0767: ldstr "key algorithm:"
-			IL_076c: ldloc.s 11
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0773: pop
-			IL_0774: ldstr "console"
-			IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_077e: stloc.s 11
-			IL_0780: ldloc.s 11
-			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0787: stloc.s 11
-			IL_0789: ldloc.s 4
-			IL_078b: ldstr "algorithm"
-			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0795: stloc.s 9
-			IL_0797: ldloc.s 9
-			IL_0799: ldstr "hash"
-			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a3: stloc.s 9
-			IL_07a5: ldloc.s 9
-			IL_07a7: ldstr "name"
-			IL_07ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07b1: stloc.s 9
-			IL_07b3: ldloc.s 11
-			IL_07b5: ldstr "log"
-			IL_07ba: ldstr "key hash:"
-			IL_07bf: ldloc.s 9
-			IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_07c6: pop
-			IL_07c7: ldstr "console"
-			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07d1: stloc.s 9
-			IL_07d3: ldloc.s 9
-			IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07da: stloc.s 9
-			IL_07dc: ldloc.s 4
-			IL_07de: ldstr "extractable"
-			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07e8: stloc.s 11
-			IL_07ea: ldloc.s 9
-			IL_07ec: ldstr "log"
-			IL_07f1: ldstr "key extractable:"
-			IL_07f6: ldloc.s 11
-			IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_07fd: pop
-			IL_07fe: ldstr "console"
-			IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0808: stloc.s 11
-			IL_080a: ldloc.s 11
-			IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0811: stloc.s 11
-			IL_0813: ldloc.s 4
-			IL_0815: ldstr "usages"
-			IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_081f: stloc.s 9
-			IL_0821: ldloc.s 9
-			IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0828: stloc.s 9
-			IL_082a: ldloc.s 9
-			IL_082c: ldstr "join"
-			IL_0831: ldstr ","
-			IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_083b: stloc.s 9
-			IL_083d: ldloc.s 11
-			IL_083f: ldstr "log"
-			IL_0844: ldstr "key usages:"
-			IL_0849: ldloc.s 9
-			IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0850: pop
-			IL_0851: ldloc.1
-			IL_0852: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0857: stloc.s 9
-			IL_0859: ldstr "abc"
-			IL_085e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0863: stloc.s 10
-			IL_0865: ldloc.s 9
-			IL_0867: ldstr "sign"
-			IL_086c: ldstr "HMAC"
-			IL_0871: ldloc.s 4
-			IL_0873: ldloc.s 10
-			IL_0875: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_087a: stloc.s 9
-			IL_087c: ldloc.0
-			IL_087d: ldc.i4.6
-			IL_087e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06eb: ldloc.0
+			IL_06ec: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
+			IL_06f1: stloc.s 4
+			IL_06f3: ldstr "console"
+			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06fd: stloc.s 11
+			IL_06ff: ldloc.s 11
+			IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0706: stloc.s 11
+			IL_0708: ldloc.s 4
+			IL_070a: ldstr "type"
+			IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0714: stloc.s 9
+			IL_0716: ldloc.s 11
+			IL_0718: ldstr "log"
+			IL_071d: ldstr "key type:"
+			IL_0722: ldloc.s 9
+			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0729: pop
+			IL_072a: ldstr "console"
+			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0734: stloc.s 9
+			IL_0736: ldloc.s 9
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_073d: stloc.s 9
+			IL_073f: ldloc.s 4
+			IL_0741: ldstr "algorithm"
+			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_074b: stloc.s 11
+			IL_074d: ldloc.s 11
+			IL_074f: ldstr "name"
+			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0759: stloc.s 11
+			IL_075b: ldloc.s 9
+			IL_075d: ldstr "log"
+			IL_0762: ldstr "key algorithm:"
+			IL_0767: ldloc.s 11
+			IL_0769: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_076e: pop
+			IL_076f: ldstr "console"
+			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0779: stloc.s 11
+			IL_077b: ldloc.s 11
+			IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0782: stloc.s 11
+			IL_0784: ldloc.s 4
+			IL_0786: ldstr "algorithm"
+			IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0790: stloc.s 9
+			IL_0792: ldloc.s 9
+			IL_0794: ldstr "hash"
+			IL_0799: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079e: stloc.s 9
+			IL_07a0: ldloc.s 9
+			IL_07a2: ldstr "name"
+			IL_07a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07ac: stloc.s 9
+			IL_07ae: ldloc.s 11
+			IL_07b0: ldstr "log"
+			IL_07b5: ldstr "key hash:"
+			IL_07ba: ldloc.s 9
+			IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_07c1: pop
+			IL_07c2: ldstr "console"
+			IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07cc: stloc.s 9
+			IL_07ce: ldloc.s 9
+			IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07d5: stloc.s 9
+			IL_07d7: ldloc.s 4
+			IL_07d9: ldstr "extractable"
+			IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07e3: stloc.s 11
+			IL_07e5: ldloc.s 9
+			IL_07e7: ldstr "log"
+			IL_07ec: ldstr "key extractable:"
+			IL_07f1: ldloc.s 11
+			IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_07f8: pop
+			IL_07f9: ldstr "console"
+			IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0803: stloc.s 11
+			IL_0805: ldloc.s 11
+			IL_0807: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_080c: stloc.s 11
+			IL_080e: ldloc.s 4
+			IL_0810: ldstr "usages"
+			IL_0815: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_081a: stloc.s 9
+			IL_081c: ldloc.s 9
+			IL_081e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0823: stloc.s 9
+			IL_0825: ldloc.s 9
+			IL_0827: ldstr "join"
+			IL_082c: ldstr ","
+			IL_0831: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0836: stloc.s 9
+			IL_0838: ldloc.s 11
+			IL_083a: ldstr "log"
+			IL_083f: ldstr "key usages:"
+			IL_0844: ldloc.s 9
+			IL_0846: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_084b: pop
+			IL_084c: ldloc.1
+			IL_084d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0852: stloc.s 9
+			IL_0854: ldstr "abc"
+			IL_0859: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_085e: stloc.s 10
+			IL_0860: ldloc.s 9
+			IL_0862: ldstr "sign"
+			IL_0867: ldstr "HMAC"
+			IL_086c: ldloc.s 4
+			IL_086e: ldloc.s 10
+			IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0875: stloc.s 9
+			IL_0877: ldloc.0
+			IL_0878: ldc.i4.6
+			IL_0879: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_087e: ldloc.0
+			IL_087f: ldloc.s 9
+			IL_0881: ldarg.0
+			IL_0882: ldc.i4.6
 			IL_0883: ldloc.0
-			IL_0884: ldloc.s 9
-			IL_0886: ldarg.0
-			IL_0887: ldc.i4.6
-			IL_0888: ldloc.0
-			IL_0889: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_088e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0893: ldloc.0
-			IL_0894: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0899: dup
-			IL_089a: ldc.i4.0
-			IL_089b: ldloc.1
-			IL_089c: stelem.ref
-			IL_089d: dup
-			IL_089e: ldc.i4.1
-			IL_089f: ldloc.2
-			IL_08a0: stelem.ref
-			IL_08a1: dup
-			IL_08a2: ldc.i4.2
-			IL_08a3: ldloc.3
+			IL_0884: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0889: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_088e: ldloc.0
+			IL_088f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0894: dup
+			IL_0895: ldc.i4.0
+			IL_0896: ldloc.1
+			IL_0897: stelem.ref
+			IL_0898: dup
+			IL_0899: ldc.i4.1
+			IL_089a: ldloc.2
+			IL_089b: stelem.ref
+			IL_089c: dup
+			IL_089d: ldc.i4.2
+			IL_089e: ldloc.3
+			IL_089f: stelem.ref
+			IL_08a0: dup
+			IL_08a1: ldc.i4.3
+			IL_08a2: ldloc.s 4
 			IL_08a4: stelem.ref
 			IL_08a5: dup
-			IL_08a6: ldc.i4.3
-			IL_08a7: ldloc.s 4
+			IL_08a6: ldc.i4.4
+			IL_08a7: ldloc.s 5
 			IL_08a9: stelem.ref
 			IL_08aa: dup
-			IL_08ab: ldc.i4.4
-			IL_08ac: ldloc.s 5
+			IL_08ab: ldc.i4.5
+			IL_08ac: ldloc.s 6
 			IL_08ae: stelem.ref
 			IL_08af: dup
-			IL_08b0: ldc.i4.5
-			IL_08b1: ldloc.s 6
+			IL_08b0: ldc.i4.6
+			IL_08b1: ldloc.s 7
 			IL_08b3: stelem.ref
 			IL_08b4: dup
-			IL_08b5: ldc.i4.6
-			IL_08b6: ldloc.s 7
+			IL_08b5: ldc.i4.7
+			IL_08b6: ldloc.s 8
 			IL_08b8: stelem.ref
 			IL_08b9: dup
-			IL_08ba: ldc.i4.7
-			IL_08bb: ldloc.s 8
+			IL_08ba: ldc.i4.8
+			IL_08bb: ldloc.s 9
 			IL_08bd: stelem.ref
 			IL_08be: dup
-			IL_08bf: ldc.i4.8
-			IL_08c0: ldloc.s 9
-			IL_08c2: stelem.ref
-			IL_08c3: dup
-			IL_08c4: ldc.i4.s 9
-			IL_08c6: ldloc.s 10
-			IL_08c8: stelem.ref
-			IL_08c9: dup
-			IL_08ca: ldc.i4.s 10
-			IL_08cc: ldloc.s 11
-			IL_08ce: stelem.ref
-			IL_08cf: dup
-			IL_08d0: ldc.i4.s 11
-			IL_08d2: ldloc.s 12
-			IL_08d4: stelem.ref
-			IL_08d5: dup
-			IL_08d6: ldc.i4.s 12
-			IL_08d8: ldloc.s 13
-			IL_08da: stelem.ref
-			IL_08db: dup
-			IL_08dc: ldc.i4.s 13
-			IL_08de: ldloc.s 14
-			IL_08e0: stelem.ref
-			IL_08e1: dup
-			IL_08e2: ldc.i4.s 14
-			IL_08e4: ldloc.s 15
-			IL_08e6: stelem.ref
-			IL_08e7: dup
-			IL_08e8: ldc.i4.s 15
-			IL_08ea: ldloc.s 16
-			IL_08ec: box [System.Runtime]System.Double
-			IL_08f1: stelem.ref
-			IL_08f2: pop
-			IL_08f3: ldloc.0
-			IL_08f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08fe: ret
+			IL_08bf: ldc.i4.s 9
+			IL_08c1: ldloc.s 10
+			IL_08c3: stelem.ref
+			IL_08c4: dup
+			IL_08c5: ldc.i4.s 10
+			IL_08c7: ldloc.s 11
+			IL_08c9: stelem.ref
+			IL_08ca: dup
+			IL_08cb: ldc.i4.s 11
+			IL_08cd: ldloc.s 12
+			IL_08cf: stelem.ref
+			IL_08d0: dup
+			IL_08d1: ldc.i4.s 12
+			IL_08d3: ldloc.s 13
+			IL_08d5: stelem.ref
+			IL_08d6: dup
+			IL_08d7: ldc.i4.s 13
+			IL_08d9: ldloc.s 14
+			IL_08db: stelem.ref
+			IL_08dc: dup
+			IL_08dd: ldc.i4.s 14
+			IL_08df: ldloc.s 15
+			IL_08e1: stelem.ref
+			IL_08e2: dup
+			IL_08e3: ldc.i4.s 15
+			IL_08e5: ldloc.s 16
+			IL_08e7: box [System.Runtime]System.Double
+			IL_08ec: stelem.ref
+			IL_08ed: pop
+			IL_08ee: ldloc.0
+			IL_08ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08f9: ret
 
-			IL_08ff: ldloc.0
-			IL_0900: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
-			IL_0905: stloc.s 5
-			IL_0907: ldloc.s 5
-			IL_0909: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_090e: stloc.s 6
-			IL_0910: ldstr "console"
-			IL_0915: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_091a: stloc.s 9
-			IL_091c: ldloc.s 9
-			IL_091e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0923: stloc.s 9
-			IL_0925: ldloc.s 6
-			IL_0927: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_092c: stloc.s 12
-			IL_092e: ldloc.s 12
-			IL_0930: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0935: stloc.s 10
-			IL_0937: ldloc.s 10
-			IL_0939: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_093e: stloc.s 11
-			IL_0940: ldloc.s 11
-			IL_0942: ldstr "toString"
-			IL_0947: ldstr "hex"
-			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0951: stloc.s 11
-			IL_0953: ldloc.s 9
-			IL_0955: ldstr "log"
-			IL_095a: ldstr "signature hex:"
-			IL_095f: ldloc.s 11
-			IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0966: pop
-			IL_0967: ldstr "console"
-			IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0971: stloc.s 11
-			IL_0973: ldloc.s 11
-			IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_097a: stloc.s 11
-			IL_097c: ldloc.1
-			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0982: stloc.s 9
-			IL_0984: ldstr "abc"
-			IL_0989: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_098e: stloc.s 10
-			IL_0990: ldc.i4.4
-			IL_0991: newarr [System.Runtime]System.Object
-			IL_0996: dup
-			IL_0997: ldc.i4.0
-			IL_0998: ldstr "HMAC"
+			IL_08fa: ldloc.0
+			IL_08fb: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
+			IL_0900: stloc.s 5
+			IL_0902: ldloc.s 5
+			IL_0904: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0909: stloc.s 6
+			IL_090b: ldstr "console"
+			IL_0910: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0915: stloc.s 9
+			IL_0917: ldloc.s 9
+			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_091e: stloc.s 9
+			IL_0920: ldloc.s 6
+			IL_0922: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0927: stloc.s 12
+			IL_0929: ldloc.s 12
+			IL_092b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0930: stloc.s 10
+			IL_0932: ldloc.s 10
+			IL_0934: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0939: stloc.s 11
+			IL_093b: ldloc.s 11
+			IL_093d: ldstr "toString"
+			IL_0942: ldstr "hex"
+			IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_094c: stloc.s 11
+			IL_094e: ldloc.s 9
+			IL_0950: ldstr "log"
+			IL_0955: ldstr "signature hex:"
+			IL_095a: ldloc.s 11
+			IL_095c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0961: pop
+			IL_0962: ldstr "console"
+			IL_0967: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_096c: stloc.s 11
+			IL_096e: ldloc.s 11
+			IL_0970: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0975: stloc.s 11
+			IL_0977: ldloc.1
+			IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_097d: stloc.s 9
+			IL_097f: ldstr "abc"
+			IL_0984: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0989: stloc.s 10
+			IL_098b: ldc.i4.4
+			IL_098c: newarr [System.Runtime]System.Object
+			IL_0991: dup
+			IL_0992: ldc.i4.0
+			IL_0993: ldstr "HMAC"
+			IL_0998: stelem.ref
+			IL_0999: dup
+			IL_099a: ldc.i4.1
+			IL_099b: ldloc.s 4
 			IL_099d: stelem.ref
 			IL_099e: dup
-			IL_099f: ldc.i4.1
-			IL_09a0: ldloc.s 4
+			IL_099f: ldc.i4.2
+			IL_09a0: ldloc.s 5
 			IL_09a2: stelem.ref
 			IL_09a3: dup
-			IL_09a4: ldc.i4.2
-			IL_09a5: ldloc.s 5
+			IL_09a4: ldc.i4.3
+			IL_09a5: ldloc.s 10
 			IL_09a7: stelem.ref
-			IL_09a8: dup
-			IL_09a9: ldc.i4.3
-			IL_09aa: ldloc.s 10
-			IL_09ac: stelem.ref
-			IL_09ad: stloc.s 15
-			IL_09af: ldloc.s 9
-			IL_09b1: ldstr "verify"
-			IL_09b6: ldloc.s 15
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_09bd: stloc.s 9
-			IL_09bf: ldloc.0
-			IL_09c0: ldc.i4.7
-			IL_09c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09a8: stloc.s 15
+			IL_09aa: ldloc.s 9
+			IL_09ac: ldstr "verify"
+			IL_09b1: ldloc.s 15
+			IL_09b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_09b8: stloc.s 9
+			IL_09ba: ldloc.0
+			IL_09bb: ldc.i4.7
+			IL_09bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09c1: ldloc.0
+			IL_09c2: ldloc.s 9
+			IL_09c4: ldarg.0
+			IL_09c5: ldc.i4.7
 			IL_09c6: ldloc.0
-			IL_09c7: ldloc.s 9
-			IL_09c9: ldarg.0
-			IL_09ca: ldc.i4.7
-			IL_09cb: ldloc.0
-			IL_09cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_09d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_09d6: ldloc.0
-			IL_09d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_09dc: dup
-			IL_09dd: ldc.i4.0
-			IL_09de: ldloc.1
-			IL_09df: stelem.ref
-			IL_09e0: dup
-			IL_09e1: ldc.i4.1
-			IL_09e2: ldloc.2
-			IL_09e3: stelem.ref
-			IL_09e4: dup
-			IL_09e5: ldc.i4.2
-			IL_09e6: ldloc.3
+			IL_09c7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_09cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_09d1: ldloc.0
+			IL_09d2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_09d7: dup
+			IL_09d8: ldc.i4.0
+			IL_09d9: ldloc.1
+			IL_09da: stelem.ref
+			IL_09db: dup
+			IL_09dc: ldc.i4.1
+			IL_09dd: ldloc.2
+			IL_09de: stelem.ref
+			IL_09df: dup
+			IL_09e0: ldc.i4.2
+			IL_09e1: ldloc.3
+			IL_09e2: stelem.ref
+			IL_09e3: dup
+			IL_09e4: ldc.i4.3
+			IL_09e5: ldloc.s 4
 			IL_09e7: stelem.ref
 			IL_09e8: dup
-			IL_09e9: ldc.i4.3
-			IL_09ea: ldloc.s 4
+			IL_09e9: ldc.i4.4
+			IL_09ea: ldloc.s 5
 			IL_09ec: stelem.ref
 			IL_09ed: dup
-			IL_09ee: ldc.i4.4
-			IL_09ef: ldloc.s 5
+			IL_09ee: ldc.i4.5
+			IL_09ef: ldloc.s 6
 			IL_09f1: stelem.ref
 			IL_09f2: dup
-			IL_09f3: ldc.i4.5
-			IL_09f4: ldloc.s 6
+			IL_09f3: ldc.i4.6
+			IL_09f4: ldloc.s 7
 			IL_09f6: stelem.ref
 			IL_09f7: dup
-			IL_09f8: ldc.i4.6
-			IL_09f9: ldloc.s 7
+			IL_09f8: ldc.i4.7
+			IL_09f9: ldloc.s 8
 			IL_09fb: stelem.ref
 			IL_09fc: dup
-			IL_09fd: ldc.i4.7
-			IL_09fe: ldloc.s 8
+			IL_09fd: ldc.i4.8
+			IL_09fe: ldloc.s 9
 			IL_0a00: stelem.ref
 			IL_0a01: dup
-			IL_0a02: ldc.i4.8
-			IL_0a03: ldloc.s 9
-			IL_0a05: stelem.ref
-			IL_0a06: dup
-			IL_0a07: ldc.i4.s 9
-			IL_0a09: ldloc.s 10
-			IL_0a0b: stelem.ref
-			IL_0a0c: dup
-			IL_0a0d: ldc.i4.s 10
-			IL_0a0f: ldloc.s 11
-			IL_0a11: stelem.ref
-			IL_0a12: dup
-			IL_0a13: ldc.i4.s 11
-			IL_0a15: ldloc.s 12
-			IL_0a17: stelem.ref
-			IL_0a18: dup
-			IL_0a19: ldc.i4.s 12
-			IL_0a1b: ldloc.s 13
-			IL_0a1d: stelem.ref
-			IL_0a1e: dup
-			IL_0a1f: ldc.i4.s 13
-			IL_0a21: ldloc.s 14
-			IL_0a23: stelem.ref
-			IL_0a24: dup
-			IL_0a25: ldc.i4.s 14
-			IL_0a27: ldloc.s 15
-			IL_0a29: stelem.ref
-			IL_0a2a: dup
-			IL_0a2b: ldc.i4.s 15
-			IL_0a2d: ldloc.s 16
-			IL_0a2f: box [System.Runtime]System.Double
-			IL_0a34: stelem.ref
-			IL_0a35: pop
-			IL_0a36: ldloc.0
-			IL_0a37: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a3c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a41: ret
+			IL_0a02: ldc.i4.s 9
+			IL_0a04: ldloc.s 10
+			IL_0a06: stelem.ref
+			IL_0a07: dup
+			IL_0a08: ldc.i4.s 10
+			IL_0a0a: ldloc.s 11
+			IL_0a0c: stelem.ref
+			IL_0a0d: dup
+			IL_0a0e: ldc.i4.s 11
+			IL_0a10: ldloc.s 12
+			IL_0a12: stelem.ref
+			IL_0a13: dup
+			IL_0a14: ldc.i4.s 12
+			IL_0a16: ldloc.s 13
+			IL_0a18: stelem.ref
+			IL_0a19: dup
+			IL_0a1a: ldc.i4.s 13
+			IL_0a1c: ldloc.s 14
+			IL_0a1e: stelem.ref
+			IL_0a1f: dup
+			IL_0a20: ldc.i4.s 14
+			IL_0a22: ldloc.s 15
+			IL_0a24: stelem.ref
+			IL_0a25: dup
+			IL_0a26: ldc.i4.s 15
+			IL_0a28: ldloc.s 16
+			IL_0a2a: box [System.Runtime]System.Double
+			IL_0a2f: stelem.ref
+			IL_0a30: pop
+			IL_0a31: ldloc.0
+			IL_0a32: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a37: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a3c: ret
 
-			IL_0a42: ldloc.0
-			IL_0a43: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
-			IL_0a48: stloc.s 9
-			IL_0a4a: ldloc.s 11
-			IL_0a4c: ldstr "log"
-			IL_0a51: ldstr "verify true:"
-			IL_0a56: ldloc.s 9
-			IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0a5d: pop
-			IL_0a5e: ldloc.s 6
-			IL_0a60: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0a65: stloc.s 12
-			IL_0a67: ldloc.s 12
-			IL_0a69: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0a6e: stloc.s 7
-			IL_0a70: ldloc.s 7
-			IL_0a72: ldc.r8 0.0
-			IL_0a7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a80: stloc.s 9
-			IL_0a82: ldloc.s 9
-			IL_0a84: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0a89: stloc.s 16
-			IL_0a8b: ldloc.s 16
-			IL_0a8d: conv.i4
-			IL_0a8e: ldc.r8 255
-			IL_0a97: conv.i4
-			IL_0a98: xor
-			IL_0a99: conv.r8
-			IL_0a9a: stloc.s 16
-			IL_0a9c: ldloc.s 16
-			IL_0a9e: conv.i4
-			IL_0a9f: ldc.r8 255
-			IL_0aa8: conv.i4
-			IL_0aa9: and
-			IL_0aaa: conv.r8
-			IL_0aab: stloc.s 16
-			IL_0aad: ldloc.s 7
-			IL_0aaf: ldc.r8 0.0
-			IL_0ab8: ldloc.s 16
-			IL_0aba: ldc.i4.1
-			IL_0abb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0ac0: ldstr "console"
-			IL_0ac5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0aca: stloc.s 9
-			IL_0acc: ldloc.s 9
-			IL_0ace: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ad3: stloc.s 9
-			IL_0ad5: ldloc.1
-			IL_0ad6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0adb: stloc.s 11
-			IL_0add: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0ae2: dup
-			IL_0ae3: ldstr "name"
-			IL_0ae8: ldstr "HMAC"
-			IL_0aed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0af2: stloc.s 14
-			IL_0af4: ldstr "abc"
-			IL_0af9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0afe: stloc.s 10
-			IL_0b00: ldc.i4.4
-			IL_0b01: newarr [System.Runtime]System.Object
+			IL_0a3d: ldloc.0
+			IL_0a3e: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
+			IL_0a43: stloc.s 9
+			IL_0a45: ldloc.s 11
+			IL_0a47: ldstr "log"
+			IL_0a4c: ldstr "verify true:"
+			IL_0a51: ldloc.s 9
+			IL_0a53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0a58: pop
+			IL_0a59: ldloc.s 6
+			IL_0a5b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0a60: stloc.s 12
+			IL_0a62: ldloc.s 12
+			IL_0a64: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0a69: stloc.s 7
+			IL_0a6b: ldloc.s 7
+			IL_0a6d: ldc.r8 0.0
+			IL_0a76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a7b: stloc.s 9
+			IL_0a7d: ldloc.s 9
+			IL_0a7f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0a84: stloc.s 16
+			IL_0a86: ldloc.s 16
+			IL_0a88: conv.i4
+			IL_0a89: ldc.r8 255
+			IL_0a92: conv.i4
+			IL_0a93: xor
+			IL_0a94: conv.r8
+			IL_0a95: stloc.s 16
+			IL_0a97: ldloc.s 16
+			IL_0a99: conv.i4
+			IL_0a9a: ldc.r8 255
+			IL_0aa3: conv.i4
+			IL_0aa4: and
+			IL_0aa5: conv.r8
+			IL_0aa6: stloc.s 16
+			IL_0aa8: ldloc.s 7
+			IL_0aaa: ldc.r8 0.0
+			IL_0ab3: ldloc.s 16
+			IL_0ab5: ldc.i4.1
+			IL_0ab6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0abb: ldstr "console"
+			IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ac5: stloc.s 9
+			IL_0ac7: ldloc.s 9
+			IL_0ac9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ace: stloc.s 9
+			IL_0ad0: ldloc.1
+			IL_0ad1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ad6: stloc.s 11
+			IL_0ad8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0add: dup
+			IL_0ade: ldstr "name"
+			IL_0ae3: ldstr "HMAC"
+			IL_0ae8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0aed: stloc.s 14
+			IL_0aef: ldstr "abc"
+			IL_0af4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0af9: stloc.s 10
+			IL_0afb: ldc.i4.4
+			IL_0afc: newarr [System.Runtime]System.Object
+			IL_0b01: dup
+			IL_0b02: ldc.i4.0
+			IL_0b03: ldloc.s 14
+			IL_0b05: stelem.ref
 			IL_0b06: dup
-			IL_0b07: ldc.i4.0
-			IL_0b08: ldloc.s 14
+			IL_0b07: ldc.i4.1
+			IL_0b08: ldloc.s 4
 			IL_0b0a: stelem.ref
 			IL_0b0b: dup
-			IL_0b0c: ldc.i4.1
-			IL_0b0d: ldloc.s 4
+			IL_0b0c: ldc.i4.2
+			IL_0b0d: ldloc.s 7
 			IL_0b0f: stelem.ref
 			IL_0b10: dup
-			IL_0b11: ldc.i4.2
-			IL_0b12: ldloc.s 7
+			IL_0b11: ldc.i4.3
+			IL_0b12: ldloc.s 10
 			IL_0b14: stelem.ref
-			IL_0b15: dup
-			IL_0b16: ldc.i4.3
-			IL_0b17: ldloc.s 10
-			IL_0b19: stelem.ref
-			IL_0b1a: stloc.s 15
-			IL_0b1c: ldloc.s 11
-			IL_0b1e: ldstr "verify"
-			IL_0b23: ldloc.s 15
-			IL_0b25: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0b2a: stloc.s 11
-			IL_0b2c: ldloc.0
-			IL_0b2d: ldc.i4.8
-			IL_0b2e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b15: stloc.s 15
+			IL_0b17: ldloc.s 11
+			IL_0b19: ldstr "verify"
+			IL_0b1e: ldloc.s 15
+			IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0b25: stloc.s 11
+			IL_0b27: ldloc.0
+			IL_0b28: ldc.i4.8
+			IL_0b29: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b2e: ldloc.0
+			IL_0b2f: ldloc.s 11
+			IL_0b31: ldarg.0
+			IL_0b32: ldc.i4.8
 			IL_0b33: ldloc.0
-			IL_0b34: ldloc.s 11
-			IL_0b36: ldarg.0
-			IL_0b37: ldc.i4.8
-			IL_0b38: ldloc.0
-			IL_0b39: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0b3e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0b43: ldloc.0
-			IL_0b44: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0b49: dup
-			IL_0b4a: ldc.i4.0
-			IL_0b4b: ldloc.1
-			IL_0b4c: stelem.ref
-			IL_0b4d: dup
-			IL_0b4e: ldc.i4.1
-			IL_0b4f: ldloc.2
-			IL_0b50: stelem.ref
-			IL_0b51: dup
-			IL_0b52: ldc.i4.2
-			IL_0b53: ldloc.3
+			IL_0b34: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0b39: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0b3e: ldloc.0
+			IL_0b3f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0b44: dup
+			IL_0b45: ldc.i4.0
+			IL_0b46: ldloc.1
+			IL_0b47: stelem.ref
+			IL_0b48: dup
+			IL_0b49: ldc.i4.1
+			IL_0b4a: ldloc.2
+			IL_0b4b: stelem.ref
+			IL_0b4c: dup
+			IL_0b4d: ldc.i4.2
+			IL_0b4e: ldloc.3
+			IL_0b4f: stelem.ref
+			IL_0b50: dup
+			IL_0b51: ldc.i4.3
+			IL_0b52: ldloc.s 4
 			IL_0b54: stelem.ref
 			IL_0b55: dup
-			IL_0b56: ldc.i4.3
-			IL_0b57: ldloc.s 4
+			IL_0b56: ldc.i4.4
+			IL_0b57: ldloc.s 5
 			IL_0b59: stelem.ref
 			IL_0b5a: dup
-			IL_0b5b: ldc.i4.4
-			IL_0b5c: ldloc.s 5
+			IL_0b5b: ldc.i4.5
+			IL_0b5c: ldloc.s 6
 			IL_0b5e: stelem.ref
 			IL_0b5f: dup
-			IL_0b60: ldc.i4.5
-			IL_0b61: ldloc.s 6
+			IL_0b60: ldc.i4.6
+			IL_0b61: ldloc.s 7
 			IL_0b63: stelem.ref
 			IL_0b64: dup
-			IL_0b65: ldc.i4.6
-			IL_0b66: ldloc.s 7
+			IL_0b65: ldc.i4.7
+			IL_0b66: ldloc.s 8
 			IL_0b68: stelem.ref
 			IL_0b69: dup
-			IL_0b6a: ldc.i4.7
-			IL_0b6b: ldloc.s 8
+			IL_0b6a: ldc.i4.8
+			IL_0b6b: ldloc.s 9
 			IL_0b6d: stelem.ref
 			IL_0b6e: dup
-			IL_0b6f: ldc.i4.8
-			IL_0b70: ldloc.s 9
-			IL_0b72: stelem.ref
-			IL_0b73: dup
-			IL_0b74: ldc.i4.s 9
-			IL_0b76: ldloc.s 10
-			IL_0b78: stelem.ref
-			IL_0b79: dup
-			IL_0b7a: ldc.i4.s 10
-			IL_0b7c: ldloc.s 11
-			IL_0b7e: stelem.ref
-			IL_0b7f: dup
-			IL_0b80: ldc.i4.s 11
-			IL_0b82: ldloc.s 12
-			IL_0b84: stelem.ref
-			IL_0b85: dup
-			IL_0b86: ldc.i4.s 12
-			IL_0b88: ldloc.s 13
-			IL_0b8a: stelem.ref
-			IL_0b8b: dup
-			IL_0b8c: ldc.i4.s 13
-			IL_0b8e: ldloc.s 14
-			IL_0b90: stelem.ref
-			IL_0b91: dup
-			IL_0b92: ldc.i4.s 14
-			IL_0b94: ldloc.s 15
-			IL_0b96: stelem.ref
-			IL_0b97: dup
-			IL_0b98: ldc.i4.s 15
-			IL_0b9a: ldloc.s 16
-			IL_0b9c: box [System.Runtime]System.Double
-			IL_0ba1: stelem.ref
-			IL_0ba2: pop
-			IL_0ba3: ldloc.0
-			IL_0ba4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bae: ret
+			IL_0b6f: ldc.i4.s 9
+			IL_0b71: ldloc.s 10
+			IL_0b73: stelem.ref
+			IL_0b74: dup
+			IL_0b75: ldc.i4.s 10
+			IL_0b77: ldloc.s 11
+			IL_0b79: stelem.ref
+			IL_0b7a: dup
+			IL_0b7b: ldc.i4.s 11
+			IL_0b7d: ldloc.s 12
+			IL_0b7f: stelem.ref
+			IL_0b80: dup
+			IL_0b81: ldc.i4.s 12
+			IL_0b83: ldloc.s 13
+			IL_0b85: stelem.ref
+			IL_0b86: dup
+			IL_0b87: ldc.i4.s 13
+			IL_0b89: ldloc.s 14
+			IL_0b8b: stelem.ref
+			IL_0b8c: dup
+			IL_0b8d: ldc.i4.s 14
+			IL_0b8f: ldloc.s 15
+			IL_0b91: stelem.ref
+			IL_0b92: dup
+			IL_0b93: ldc.i4.s 15
+			IL_0b95: ldloc.s 16
+			IL_0b97: box [System.Runtime]System.Double
+			IL_0b9c: stelem.ref
+			IL_0b9d: pop
+			IL_0b9e: ldloc.0
+			IL_0b9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ba9: ret
 
-			IL_0baf: ldloc.0
-			IL_0bb0: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
-			IL_0bb5: stloc.s 11
-			IL_0bb7: ldloc.s 9
-			IL_0bb9: ldstr "log"
-			IL_0bbe: ldstr "verify false:"
-			IL_0bc3: ldloc.s 11
-			IL_0bc5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0bca: pop
-			IL_0bcb: ldloc.0
-			IL_0bcc: ldc.i4.m1
-			IL_0bcd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0bd2: ldloc.0
-			IL_0bd3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bd8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0bdd: ldarg.0
-			IL_0bde: ldc.i4.1
-			IL_0bdf: newarr [System.Runtime]System.Object
-			IL_0be4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0be9: pop
-			IL_0bea: ldloc.0
-			IL_0beb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bf0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bf5: ret
+			IL_0baa: ldloc.0
+			IL_0bab: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
+			IL_0bb0: stloc.s 11
+			IL_0bb2: ldloc.s 9
+			IL_0bb4: ldstr "log"
+			IL_0bb9: ldstr "verify false:"
+			IL_0bbe: ldloc.s 11
+			IL_0bc0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0bc5: pop
+			IL_0bc6: ldloc.0
+			IL_0bc7: ldc.i4.m1
+			IL_0bc8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0bcd: ldloc.0
+			IL_0bce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bd3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bd8: ldarg.0
+			IL_0bd9: ldc.i4.1
+			IL_0bda: newarr [System.Runtime]System.Object
+			IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0be4: pop
+			IL_0be5: ldloc.0
+			IL_0be6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0beb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bf0: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -1472,7 +1471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d32
+				// Method begins at RVA 0x2d2d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1495,7 +1494,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cfe
+			// Method begins at RVA 0x2cf9
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -1522,14 +1521,14 @@
 			75 6e 7d 00 00
 		)
 		// Fields
-		.field public object crypto
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule crypto
 		.field public object run
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d20
+			// Method begins at RVA 0x2d1b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1590,7 +1589,7 @@
 		IL_003b: stloc.2
 		IL_003c: ldloc.0
 		IL_003d: ldloc.2
-		IL_003e: stfld object Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
+		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
 		IL_0043: nop
 		IL_0044: ldloc.1
 		IL_0045: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -1636,7 +1635,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d3b
+		// Method begins at RVA 0x2d36
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3186
+				// Method begins at RVA 0x3166
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a1
+						// Method begins at RVA 0x3181
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3198
+					// Method begins at RVA 0x3178
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318f
+				// Method begins at RVA 0x316f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,9 +116,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21dc
+			// Method begins at RVA 0x21d8
 			// Header size: 12
-			// Code size: 1353 (0x549)
+			// Code size: 1348 (0x544)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope,
@@ -254,7 +254,7 @@
 
 			IL_00e7: ldloc.0
 			IL_00e8: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00ed: switch (IL_0106, IL_0354, IL_042e, IL_028f, IL_0422)
+			IL_00ed: switch (IL_0106, IL_034f, IL_0429, IL_028a, IL_041d)
 
 			IL_0106: ldarg.0
 			IL_0107: ldc.i4.1
@@ -273,429 +273,428 @@
 			IL_0128: ldc.i4.1
 			IL_0129: ldelem.ref
 			IL_012a: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_012f: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_0134: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule
-			IL_0139: stloc.s 12
-			IL_013b: ldloc.s 12
-			IL_013d: ldloc.1
-			IL_013e: ldstr "tick"
-			IL_0143: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::on(object, object)
-			IL_0148: stloc.2
-			IL_0149: ldloc.1
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014f: stloc.s 10
-			IL_0151: ldloc.s 10
-			IL_0153: ldstr "emit"
-			IL_0158: ldstr "tick"
-			IL_015d: ldc.r8 1
-			IL_0166: box [System.Runtime]System.Double
-			IL_016b: ldc.r8 2
-			IL_0174: box [System.Runtime]System.Double
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_017e: pop
-			IL_017f: ldloc.1
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0185: stloc.s 10
-			IL_0187: ldloc.s 10
-			IL_0189: ldstr "emit"
-			IL_018e: ldstr "tick"
-			IL_0193: ldc.r8 3
-			IL_019c: box [System.Runtime]System.Double
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01a6: pop
-			IL_01a7: ldc.r8 0.0
-			IL_01b0: stloc.3
-			IL_01b1: ldloc.2
-			IL_01b2: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetAsyncIterator(object)
-			IL_01b7: stloc.s 4
-			IL_01b9: ldc.i4.0
-			IL_01ba: stloc.s 5
-			IL_01bc: ldc.i4.0
-			IL_01bd: stloc.s 6
-			IL_01bf: ldloc.0
-			IL_01c0: ldc.i4.0
-			IL_01c1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01c6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01cb: ldloc.0
-			IL_01cc: ldc.i4.0
-			IL_01cd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01d2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_01d7: ldloc.0
-			IL_01d8: ldc.i4.0
-			IL_01d9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_01de: ldloc.0
-			IL_01df: ldc.i4.0
-			IL_01e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_012f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_0134: stloc.s 12
+			IL_0136: ldloc.s 12
+			IL_0138: ldloc.1
+			IL_0139: ldstr "tick"
+			IL_013e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::on(object, object)
+			IL_0143: stloc.2
+			IL_0144: ldloc.1
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014a: stloc.s 10
+			IL_014c: ldloc.s 10
+			IL_014e: ldstr "emit"
+			IL_0153: ldstr "tick"
+			IL_0158: ldc.r8 1
+			IL_0161: box [System.Runtime]System.Double
+			IL_0166: ldc.r8 2
+			IL_016f: box [System.Runtime]System.Double
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0179: pop
+			IL_017a: ldloc.1
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0180: stloc.s 10
+			IL_0182: ldloc.s 10
+			IL_0184: ldstr "emit"
+			IL_0189: ldstr "tick"
+			IL_018e: ldc.r8 3
+			IL_0197: box [System.Runtime]System.Double
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01a1: pop
+			IL_01a2: ldc.r8 0.0
+			IL_01ab: stloc.3
+			IL_01ac: ldloc.2
+			IL_01ad: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetAsyncIterator(object)
+			IL_01b2: stloc.s 4
+			IL_01b4: ldc.i4.0
+			IL_01b5: stloc.s 5
+			IL_01b7: ldc.i4.0
+			IL_01b8: stloc.s 6
+			IL_01ba: ldloc.0
+			IL_01bb: ldc.i4.0
+			IL_01bc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01c1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_01c6: ldloc.0
+			IL_01c7: ldc.i4.0
+			IL_01c8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01cd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_01d2: ldloc.0
+			IL_01d3: ldc.i4.0
+			IL_01d4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_01d9: ldloc.0
+			IL_01da: ldc.i4.0
+			IL_01db: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_01e5: ldloc.s 4
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorNext(object)
-			IL_01ec: stloc.s 10
-			IL_01ee: ldloc.0
-			IL_01ef: ldc.i4.3
-			IL_01f0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01e0: ldloc.s 4
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorNext(object)
+			IL_01e7: stloc.s 10
+			IL_01e9: ldloc.0
+			IL_01ea: ldc.i4.3
+			IL_01eb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01f0: ldloc.0
+			IL_01f1: ldloc.s 10
+			IL_01f3: ldarg.0
+			IL_01f4: ldc.i4.1
 			IL_01f5: ldloc.0
-			IL_01f6: ldloc.s 10
-			IL_01f8: ldarg.0
-			IL_01f9: ldc.i4.1
-			IL_01fa: ldloc.0
-			IL_01fb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0200: ldc.i4.1
-			IL_0201: ldstr "_pendingException"
-			IL_0206: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_020b: ldloc.0
-			IL_020c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0211: dup
-			IL_0212: ldc.i4.0
-			IL_0213: ldloc.1
-			IL_0214: stelem.ref
-			IL_0215: dup
-			IL_0216: ldc.i4.1
-			IL_0217: ldloc.2
-			IL_0218: stelem.ref
-			IL_0219: dup
-			IL_021a: ldc.i4.2
-			IL_021b: ldloc.3
-			IL_021c: box [System.Runtime]System.Double
+			IL_01f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01fb: ldc.i4.1
+			IL_01fc: ldstr "_pendingException"
+			IL_0201: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0206: ldloc.0
+			IL_0207: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_020c: dup
+			IL_020d: ldc.i4.0
+			IL_020e: ldloc.1
+			IL_020f: stelem.ref
+			IL_0210: dup
+			IL_0211: ldc.i4.1
+			IL_0212: ldloc.2
+			IL_0213: stelem.ref
+			IL_0214: dup
+			IL_0215: ldc.i4.2
+			IL_0216: ldloc.3
+			IL_0217: box [System.Runtime]System.Double
+			IL_021c: stelem.ref
+			IL_021d: dup
+			IL_021e: ldc.i4.3
+			IL_021f: ldloc.s 4
 			IL_0221: stelem.ref
 			IL_0222: dup
-			IL_0223: ldc.i4.3
-			IL_0224: ldloc.s 4
-			IL_0226: stelem.ref
-			IL_0227: dup
-			IL_0228: ldc.i4.4
-			IL_0229: ldloc.s 5
-			IL_022b: box [System.Runtime]System.Boolean
-			IL_0230: stelem.ref
-			IL_0231: dup
-			IL_0232: ldc.i4.5
-			IL_0233: ldloc.s 6
-			IL_0235: box [System.Runtime]System.Boolean
+			IL_0223: ldc.i4.4
+			IL_0224: ldloc.s 5
+			IL_0226: box [System.Runtime]System.Boolean
+			IL_022b: stelem.ref
+			IL_022c: dup
+			IL_022d: ldc.i4.5
+			IL_022e: ldloc.s 6
+			IL_0230: box [System.Runtime]System.Boolean
+			IL_0235: stelem.ref
+			IL_0236: dup
+			IL_0237: ldc.i4.6
+			IL_0238: ldloc.s 7
 			IL_023a: stelem.ref
 			IL_023b: dup
-			IL_023c: ldc.i4.6
-			IL_023d: ldloc.s 7
-			IL_023f: stelem.ref
-			IL_0240: dup
-			IL_0241: ldc.i4.7
-			IL_0242: ldloc.s 8
-			IL_0244: box [System.Runtime]System.Boolean
-			IL_0249: stelem.ref
-			IL_024a: dup
-			IL_024b: ldc.i4.8
-			IL_024c: ldloc.s 9
-			IL_024e: box [System.Runtime]System.Boolean
-			IL_0253: stelem.ref
-			IL_0254: dup
-			IL_0255: ldc.i4.s 9
-			IL_0257: ldloc.s 10
-			IL_0259: stelem.ref
-			IL_025a: dup
-			IL_025b: ldc.i4.s 10
-			IL_025d: ldloc.s 11
-			IL_025f: stelem.ref
-			IL_0260: dup
-			IL_0261: ldc.i4.s 11
-			IL_0263: ldloc.s 12
-			IL_0265: stelem.ref
-			IL_0266: dup
-			IL_0267: ldc.i4.s 12
-			IL_0269: ldloc.s 13
-			IL_026b: box [System.Runtime]System.Boolean
-			IL_0270: stelem.ref
-			IL_0271: dup
-			IL_0272: ldc.i4.s 13
-			IL_0274: ldloc.s 14
-			IL_0276: stelem.ref
-			IL_0277: dup
-			IL_0278: ldc.i4.s 14
-			IL_027a: ldloc.s 15
-			IL_027c: box [System.Runtime]System.Double
-			IL_0281: stelem.ref
-			IL_0282: pop
-			IL_0283: ldloc.0
-			IL_0284: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0289: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_028e: ret
+			IL_023c: ldc.i4.7
+			IL_023d: ldloc.s 8
+			IL_023f: box [System.Runtime]System.Boolean
+			IL_0244: stelem.ref
+			IL_0245: dup
+			IL_0246: ldc.i4.8
+			IL_0247: ldloc.s 9
+			IL_0249: box [System.Runtime]System.Boolean
+			IL_024e: stelem.ref
+			IL_024f: dup
+			IL_0250: ldc.i4.s 9
+			IL_0252: ldloc.s 10
+			IL_0254: stelem.ref
+			IL_0255: dup
+			IL_0256: ldc.i4.s 10
+			IL_0258: ldloc.s 11
+			IL_025a: stelem.ref
+			IL_025b: dup
+			IL_025c: ldc.i4.s 11
+			IL_025e: ldloc.s 12
+			IL_0260: stelem.ref
+			IL_0261: dup
+			IL_0262: ldc.i4.s 12
+			IL_0264: ldloc.s 13
+			IL_0266: box [System.Runtime]System.Boolean
+			IL_026b: stelem.ref
+			IL_026c: dup
+			IL_026d: ldc.i4.s 13
+			IL_026f: ldloc.s 14
+			IL_0271: stelem.ref
+			IL_0272: dup
+			IL_0273: ldc.i4.s 14
+			IL_0275: ldloc.s 15
+			IL_0277: box [System.Runtime]System.Double
+			IL_027c: stelem.ref
+			IL_027d: pop
+			IL_027e: ldloc.0
+			IL_027f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0284: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0289: ret
 
-			IL_028f: ldloc.0
-			IL_0290: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited1
-			IL_0295: stloc.s 10
-			IL_0297: ldloc.s 10
-			IL_0299: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-			IL_029e: stloc.s 13
-			IL_02a0: ldloc.s 13
-			IL_02a2: brtrue IL_034c
+			IL_028a: ldloc.0
+			IL_028b: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited1
+			IL_0290: stloc.s 10
+			IL_0292: ldloc.s 10
+			IL_0294: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+			IL_0299: stloc.s 13
+			IL_029b: ldloc.s 13
+			IL_029d: brtrue IL_0347
 
-			IL_02a7: ldloc.s 10
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-			IL_02ae: stloc.s 10
-			IL_02b0: ldloc.s 10
-			IL_02b2: stloc.s 7
-			IL_02b4: ldstr "console"
-			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02be: stloc.s 10
-			IL_02c0: ldloc.s 10
-			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c7: stloc.s 10
-			IL_02c9: ldloc.s 7
-			IL_02cb: ldstr "length"
-			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d5: stloc.s 14
-			IL_02d7: ldloc.s 10
-			IL_02d9: ldstr "log"
-			IL_02de: ldloc.s 14
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02e5: pop
-			IL_02e6: ldstr "console"
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f0: stloc.s 14
-			IL_02f2: ldloc.s 14
-			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02f9: stloc.s 14
-			IL_02fb: ldloc.s 7
-			IL_02fd: ldc.r8 0.0
-			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_030b: stloc.s 10
-			IL_030d: ldloc.s 14
-			IL_030f: ldstr "log"
-			IL_0314: ldloc.s 10
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_031b: pop
-			IL_031c: ldloc.3
-			IL_031d: ldc.r8 1
-			IL_0326: add
-			IL_0327: stloc.3
-			IL_0328: ldloc.3
-			IL_0329: stloc.s 15
-			IL_032b: ldloc.s 15
-			IL_032d: ldc.r8 2
-			IL_0336: ceq
-			IL_0338: brfalse IL_0342
+			IL_02a2: ldloc.s 10
+			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+			IL_02a9: stloc.s 10
+			IL_02ab: ldloc.s 10
+			IL_02ad: stloc.s 7
+			IL_02af: ldstr "console"
+			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02b9: stloc.s 10
+			IL_02bb: ldloc.s 10
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c2: stloc.s 10
+			IL_02c4: ldloc.s 7
+			IL_02c6: ldstr "length"
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d0: stloc.s 14
+			IL_02d2: ldloc.s 10
+			IL_02d4: ldstr "log"
+			IL_02d9: ldloc.s 14
+			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02e0: pop
+			IL_02e1: ldstr "console"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02eb: stloc.s 14
+			IL_02ed: ldloc.s 14
+			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f4: stloc.s 14
+			IL_02f6: ldloc.s 7
+			IL_02f8: ldc.r8 0.0
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0306: stloc.s 10
+			IL_0308: ldloc.s 14
+			IL_030a: ldstr "log"
+			IL_030f: ldloc.s 10
+			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0316: pop
+			IL_0317: ldloc.3
+			IL_0318: ldc.r8 1
+			IL_0321: add
+			IL_0322: stloc.3
+			IL_0323: ldloc.3
+			IL_0324: stloc.s 15
+			IL_0326: ldloc.s 15
+			IL_0328: ldc.r8 2
+			IL_0331: ceq
+			IL_0333: brfalse IL_033d
 
-			IL_033d: br IL_0347
+			IL_0338: br IL_0342
 
-			IL_0342: br IL_01e5
+			IL_033d: br IL_01e0
 
-			IL_0347: br IL_0367
+			IL_0342: br IL_0362
 
-			IL_034c: ldc.i4.1
-			IL_034d: stloc.s 5
-			IL_034f: br IL_0367
+			IL_0347: ldc.i4.1
+			IL_0348: stloc.s 5
+			IL_034a: br IL_0362
 
-			IL_0354: ldloc.0
-			IL_0355: ldc.i4.1
-			IL_0356: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_035b: ldloc.0
-			IL_035c: ldc.i4.0
-			IL_035d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0362: br IL_0367
+			IL_034f: ldloc.0
+			IL_0350: ldc.i4.1
+			IL_0351: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0356: ldloc.0
+			IL_0357: ldc.i4.0
+			IL_0358: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_035d: br IL_0362
 
-			IL_0367: ldloc.s 5
-			IL_0369: brtrue IL_0429
+			IL_0362: ldloc.s 5
+			IL_0364: brtrue IL_0424
 
-			IL_036e: ldloc.s 6
-			IL_0370: brtrue IL_0429
+			IL_0369: ldloc.s 6
+			IL_036b: brtrue IL_0424
 
-			IL_0375: ldc.i4.1
-			IL_0376: stloc.s 6
-			IL_0378: ldloc.s 4
-			IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorClose(object)
-			IL_037f: stloc.s 10
-			IL_0381: ldloc.0
-			IL_0382: ldc.i4.4
-			IL_0383: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0370: ldc.i4.1
+			IL_0371: stloc.s 6
+			IL_0373: ldloc.s 4
+			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorClose(object)
+			IL_037a: stloc.s 10
+			IL_037c: ldloc.0
+			IL_037d: ldc.i4.4
+			IL_037e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0383: ldloc.0
+			IL_0384: ldloc.s 10
+			IL_0386: ldarg.0
+			IL_0387: ldc.i4.2
 			IL_0388: ldloc.0
-			IL_0389: ldloc.s 10
-			IL_038b: ldarg.0
-			IL_038c: ldc.i4.2
-			IL_038d: ldloc.0
-			IL_038e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0393: ldc.i4.2
-			IL_0394: ldstr "_pendingException"
-			IL_0399: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_039e: ldloc.0
-			IL_039f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03a4: dup
-			IL_03a5: ldc.i4.0
-			IL_03a6: ldloc.1
-			IL_03a7: stelem.ref
-			IL_03a8: dup
-			IL_03a9: ldc.i4.1
-			IL_03aa: ldloc.2
-			IL_03ab: stelem.ref
-			IL_03ac: dup
-			IL_03ad: ldc.i4.2
-			IL_03ae: ldloc.3
-			IL_03af: box [System.Runtime]System.Double
+			IL_0389: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_038e: ldc.i4.2
+			IL_038f: ldstr "_pendingException"
+			IL_0394: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0399: ldloc.0
+			IL_039a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_039f: dup
+			IL_03a0: ldc.i4.0
+			IL_03a1: ldloc.1
+			IL_03a2: stelem.ref
+			IL_03a3: dup
+			IL_03a4: ldc.i4.1
+			IL_03a5: ldloc.2
+			IL_03a6: stelem.ref
+			IL_03a7: dup
+			IL_03a8: ldc.i4.2
+			IL_03a9: ldloc.3
+			IL_03aa: box [System.Runtime]System.Double
+			IL_03af: stelem.ref
+			IL_03b0: dup
+			IL_03b1: ldc.i4.3
+			IL_03b2: ldloc.s 4
 			IL_03b4: stelem.ref
 			IL_03b5: dup
-			IL_03b6: ldc.i4.3
-			IL_03b7: ldloc.s 4
-			IL_03b9: stelem.ref
-			IL_03ba: dup
-			IL_03bb: ldc.i4.4
-			IL_03bc: ldloc.s 5
-			IL_03be: box [System.Runtime]System.Boolean
-			IL_03c3: stelem.ref
-			IL_03c4: dup
-			IL_03c5: ldc.i4.5
-			IL_03c6: ldloc.s 6
-			IL_03c8: box [System.Runtime]System.Boolean
+			IL_03b6: ldc.i4.4
+			IL_03b7: ldloc.s 5
+			IL_03b9: box [System.Runtime]System.Boolean
+			IL_03be: stelem.ref
+			IL_03bf: dup
+			IL_03c0: ldc.i4.5
+			IL_03c1: ldloc.s 6
+			IL_03c3: box [System.Runtime]System.Boolean
+			IL_03c8: stelem.ref
+			IL_03c9: dup
+			IL_03ca: ldc.i4.6
+			IL_03cb: ldloc.s 7
 			IL_03cd: stelem.ref
 			IL_03ce: dup
-			IL_03cf: ldc.i4.6
-			IL_03d0: ldloc.s 7
-			IL_03d2: stelem.ref
-			IL_03d3: dup
-			IL_03d4: ldc.i4.7
-			IL_03d5: ldloc.s 8
-			IL_03d7: box [System.Runtime]System.Boolean
-			IL_03dc: stelem.ref
-			IL_03dd: dup
-			IL_03de: ldc.i4.8
-			IL_03df: ldloc.s 9
-			IL_03e1: box [System.Runtime]System.Boolean
-			IL_03e6: stelem.ref
-			IL_03e7: dup
-			IL_03e8: ldc.i4.s 9
-			IL_03ea: ldloc.s 10
-			IL_03ec: stelem.ref
-			IL_03ed: dup
-			IL_03ee: ldc.i4.s 10
-			IL_03f0: ldloc.s 11
-			IL_03f2: stelem.ref
-			IL_03f3: dup
-			IL_03f4: ldc.i4.s 11
-			IL_03f6: ldloc.s 12
-			IL_03f8: stelem.ref
-			IL_03f9: dup
-			IL_03fa: ldc.i4.s 12
-			IL_03fc: ldloc.s 13
-			IL_03fe: box [System.Runtime]System.Boolean
-			IL_0403: stelem.ref
-			IL_0404: dup
-			IL_0405: ldc.i4.s 13
-			IL_0407: ldloc.s 14
-			IL_0409: stelem.ref
-			IL_040a: dup
-			IL_040b: ldc.i4.s 14
-			IL_040d: ldloc.s 15
-			IL_040f: box [System.Runtime]System.Double
-			IL_0414: stelem.ref
-			IL_0415: pop
-			IL_0416: ldloc.0
-			IL_0417: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_041c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0421: ret
+			IL_03cf: ldc.i4.7
+			IL_03d0: ldloc.s 8
+			IL_03d2: box [System.Runtime]System.Boolean
+			IL_03d7: stelem.ref
+			IL_03d8: dup
+			IL_03d9: ldc.i4.8
+			IL_03da: ldloc.s 9
+			IL_03dc: box [System.Runtime]System.Boolean
+			IL_03e1: stelem.ref
+			IL_03e2: dup
+			IL_03e3: ldc.i4.s 9
+			IL_03e5: ldloc.s 10
+			IL_03e7: stelem.ref
+			IL_03e8: dup
+			IL_03e9: ldc.i4.s 10
+			IL_03eb: ldloc.s 11
+			IL_03ed: stelem.ref
+			IL_03ee: dup
+			IL_03ef: ldc.i4.s 11
+			IL_03f1: ldloc.s 12
+			IL_03f3: stelem.ref
+			IL_03f4: dup
+			IL_03f5: ldc.i4.s 12
+			IL_03f7: ldloc.s 13
+			IL_03f9: box [System.Runtime]System.Boolean
+			IL_03fe: stelem.ref
+			IL_03ff: dup
+			IL_0400: ldc.i4.s 13
+			IL_0402: ldloc.s 14
+			IL_0404: stelem.ref
+			IL_0405: dup
+			IL_0406: ldc.i4.s 14
+			IL_0408: ldloc.s 15
+			IL_040a: box [System.Runtime]System.Double
+			IL_040f: stelem.ref
+			IL_0410: pop
+			IL_0411: ldloc.0
+			IL_0412: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0417: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_041c: ret
 
-			IL_0422: ldloc.0
-			IL_0423: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited2
-			IL_0428: pop
+			IL_041d: ldloc.0
+			IL_041e: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnBreak/Scope::_awaited2
+			IL_0423: pop
 
-			IL_0429: br IL_0441
+			IL_0424: br IL_043c
 
-			IL_042e: ldloc.0
-			IL_042f: ldc.i4.1
-			IL_0430: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0435: ldloc.0
-			IL_0436: ldc.i4.0
-			IL_0437: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_043c: br IL_0441
+			IL_0429: ldloc.0
+			IL_042a: ldc.i4.1
+			IL_042b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0430: ldloc.0
+			IL_0431: ldc.i4.0
+			IL_0432: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0437: br IL_043c
 
-			IL_0441: ldloc.0
-			IL_0442: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0447: stloc.s 8
-			IL_0449: ldloc.s 8
-			IL_044b: brfalse IL_0488
+			IL_043c: ldloc.0
+			IL_043d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0442: stloc.s 8
+			IL_0444: ldloc.s 8
+			IL_0446: brfalse IL_0483
 
-			IL_0450: ldloc.0
-			IL_0451: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0456: stloc.s 10
-			IL_0458: ldloc.0
-			IL_0459: ldc.i4.m1
-			IL_045a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_045f: ldloc.0
-			IL_0460: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0465: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_046a: ldarg.0
-			IL_046b: ldc.i4.1
-			IL_046c: newarr [System.Runtime]System.Object
-			IL_0471: dup
-			IL_0472: ldc.i4.0
-			IL_0473: ldloc.s 10
-			IL_0475: stelem.ref
-			IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_047b: pop
-			IL_047c: ldloc.0
-			IL_047d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0482: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0487: ret
+			IL_044b: ldloc.0
+			IL_044c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0451: stloc.s 10
+			IL_0453: ldloc.0
+			IL_0454: ldc.i4.m1
+			IL_0455: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_045a: ldloc.0
+			IL_045b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0460: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0465: ldarg.0
+			IL_0466: ldc.i4.1
+			IL_0467: newarr [System.Runtime]System.Object
+			IL_046c: dup
+			IL_046d: ldc.i4.0
+			IL_046e: ldloc.s 10
+			IL_0470: stelem.ref
+			IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0476: pop
+			IL_0477: ldloc.0
+			IL_0478: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_047d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0482: ret
 
-			IL_0488: ldloc.0
-			IL_0489: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_048e: stloc.s 9
-			IL_0490: ldloc.s 9
-			IL_0492: brfalse IL_04cf
+			IL_0483: ldloc.0
+			IL_0484: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0489: stloc.s 9
+			IL_048b: ldloc.s 9
+			IL_048d: brfalse IL_04ca
 
-			IL_0497: ldloc.0
-			IL_0498: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_049d: stloc.s 10
-			IL_049f: ldloc.0
-			IL_04a0: ldc.i4.m1
-			IL_04a1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04a6: ldloc.0
-			IL_04a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_04b1: ldarg.0
-			IL_04b2: ldc.i4.1
-			IL_04b3: newarr [System.Runtime]System.Object
-			IL_04b8: dup
-			IL_04b9: ldc.i4.0
-			IL_04ba: ldloc.s 10
-			IL_04bc: stelem.ref
-			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_04c2: pop
-			IL_04c3: ldloc.0
-			IL_04c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04c9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04ce: ret
+			IL_0492: ldloc.0
+			IL_0493: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0498: stloc.s 10
+			IL_049a: ldloc.0
+			IL_049b: ldc.i4.m1
+			IL_049c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04a1: ldloc.0
+			IL_04a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04ac: ldarg.0
+			IL_04ad: ldc.i4.1
+			IL_04ae: newarr [System.Runtime]System.Object
+			IL_04b3: dup
+			IL_04b4: ldc.i4.0
+			IL_04b5: ldloc.s 10
+			IL_04b7: stelem.ref
+			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04bd: pop
+			IL_04be: ldloc.0
+			IL_04bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c9: ret
 
-			IL_04cf: ldloc.1
-			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04d5: stloc.s 10
-			IL_04d7: ldloc.s 10
-			IL_04d9: ldstr "emit"
-			IL_04de: ldstr "tick"
-			IL_04e3: ldc.r8 99
-			IL_04ec: box [System.Runtime]System.Double
-			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04f6: pop
-			IL_04f7: ldstr "console"
-			IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0501: stloc.s 10
-			IL_0503: ldloc.s 10
-			IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_050a: stloc.s 10
-			IL_050c: ldloc.s 10
-			IL_050e: ldstr "log"
-			IL_0513: ldstr "break-done"
-			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_051d: pop
-			IL_051e: ldloc.0
-			IL_051f: ldc.i4.m1
-			IL_0520: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0525: ldloc.0
-			IL_0526: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_052b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0530: ldarg.0
-			IL_0531: ldc.i4.1
-			IL_0532: newarr [System.Runtime]System.Object
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_053c: pop
-			IL_053d: ldloc.0
-			IL_053e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0543: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0548: ret
+			IL_04ca: ldloc.1
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04d0: stloc.s 10
+			IL_04d2: ldloc.s 10
+			IL_04d4: ldstr "emit"
+			IL_04d9: ldstr "tick"
+			IL_04de: ldc.r8 99
+			IL_04e7: box [System.Runtime]System.Double
+			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04f1: pop
+			IL_04f2: ldstr "console"
+			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04fc: stloc.s 10
+			IL_04fe: ldloc.s 10
+			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0505: stloc.s 10
+			IL_0507: ldloc.s 10
+			IL_0509: ldstr "log"
+			IL_050e: ldstr "break-done"
+			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0518: pop
+			IL_0519: ldloc.0
+			IL_051a: ldc.i4.m1
+			IL_051b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0520: ldloc.0
+			IL_0521: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0526: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_052b: ldarg.0
+			IL_052c: ldc.i4.1
+			IL_052d: newarr [System.Runtime]System.Object
+			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0537: pop
+			IL_0538: ldloc.0
+			IL_0539: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_053e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0543: ret
 		} // end of method runOnBreak::__js_call__
 
 	} // end of class runOnBreak
@@ -728,7 +727,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31bc
+						// Method begins at RVA 0x319c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -752,7 +751,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x31ce
+							// Method begins at RVA 0x31ae
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -770,7 +769,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31c5
+						// Method begins at RVA 0x31a5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -790,7 +789,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31d7
+						// Method begins at RVA 0x31b7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -814,7 +813,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b3
+					// Method begins at RVA 0x3193
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -838,7 +837,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d98
+				// Method begins at RVA 0x2d78
 				// Header size: 12
 				// Code size: 985 (0x3d9)
 				.maxstack 8
@@ -1297,7 +1296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31aa
+				// Method begins at RVA 0x318a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1321,9 +1320,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2734
+			// Method begins at RVA 0x2728
 			// Header size: 12
-			// Code size: 499 (0x1f3)
+			// Code size: 494 (0x1ee)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope,
@@ -1413,7 +1412,7 @@
 
 			IL_009a: ldloc.0
 			IL_009b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00a0: switch (IL_00ad, IL_01c1)
+			IL_00a0: switch (IL_00ad, IL_01bc)
 
 			IL_00ad: ldarg.0
 			IL_00ae: ldc.i4.1
@@ -1432,135 +1431,134 @@
 			IL_00cd: ldc.i4.1
 			IL_00ce: ldelem.ref
 			IL_00cf: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00d4: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00d9: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule
-			IL_00de: stloc.s 5
-			IL_00e0: ldloc.s 5
-			IL_00e2: ldloc.1
-			IL_00e3: ldstr "data"
-			IL_00e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::on(object, object)
-			IL_00ed: stloc.3
-			IL_00ee: ldloc.0
-			IL_00ef: ldloc.3
-			IL_00f0: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
-			IL_00f5: ldc.i4.2
-			IL_00f6: newarr [System.Runtime]System.Object
-			IL_00fb: dup
-			IL_00fc: ldc.i4.0
-			IL_00fd: ldarg.0
-			IL_00fe: ldc.i4.1
-			IL_00ff: ldelem.ref
-			IL_0100: stelem.ref
-			IL_0101: dup
-			IL_0102: ldc.i4.1
-			IL_0103: ldloc.0
-			IL_0104: stelem.ref
-			IL_0105: stloc.s 4
-			IL_0107: ldnull
-			IL_0108: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17::__js_call__(object[], object)
-			IL_010e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0113: ldloc.s 4
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_011f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_0124: ldc.i4.0
-			IL_0125: conv.r8
-			IL_0126: ldstr ""
-			IL_012b: ldc.i4.0
-			IL_012c: ldc.i4.0
-			IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0137: stloc.s 6
-			IL_0139: ldc.i4.0
-			IL_013a: newarr [System.Runtime]System.Object
-			IL_013f: stloc.s 4
-			IL_0141: ldc.i4.1
-			IL_0142: newarr [System.Runtime]System.Object
-			IL_0147: dup
-			IL_0148: ldc.i4.0
-			IL_0149: ldarg.0
-			IL_014a: ldc.i4.1
-			IL_014b: ldelem.ref
-			IL_014c: stelem.ref
-			IL_014d: stloc.s 7
-			IL_014f: ldloc.s 6
-			IL_0151: ldloc.s 7
-			IL_0153: ldloc.s 4
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_015a: stloc.2
-			IL_015b: ldloc.1
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0161: stloc.3
-			IL_0162: ldloc.3
-			IL_0163: ldstr "emit"
-			IL_0168: ldstr "error"
-			IL_016d: ldstr "E1"
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0177: pop
-			IL_0178: ldloc.0
-			IL_0179: ldc.i4.1
-			IL_017a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_017f: ldloc.0
-			IL_0180: ldloc.2
-			IL_0181: ldarg.0
-			IL_0182: ldc.i4.1
-			IL_0183: ldloc.0
-			IL_0184: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0189: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_018e: ldloc.0
-			IL_018f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0194: dup
-			IL_0195: ldc.i4.0
-			IL_0196: ldloc.1
-			IL_0197: stelem.ref
-			IL_0198: dup
-			IL_0199: ldc.i4.1
-			IL_019a: ldloc.2
-			IL_019b: stelem.ref
-			IL_019c: dup
-			IL_019d: ldc.i4.2
-			IL_019e: ldloc.3
+			IL_00d4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00d9: stloc.s 5
+			IL_00db: ldloc.s 5
+			IL_00dd: ldloc.1
+			IL_00de: ldstr "data"
+			IL_00e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::on(object, object)
+			IL_00e8: stloc.3
+			IL_00e9: ldloc.0
+			IL_00ea: ldloc.3
+			IL_00eb: stfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::iterator
+			IL_00f0: ldc.i4.2
+			IL_00f1: newarr [System.Runtime]System.Object
+			IL_00f6: dup
+			IL_00f7: ldc.i4.0
+			IL_00f8: ldarg.0
+			IL_00f9: ldc.i4.1
+			IL_00fa: ldelem.ref
+			IL_00fb: stelem.ref
+			IL_00fc: dup
+			IL_00fd: ldc.i4.1
+			IL_00fe: ldloc.0
+			IL_00ff: stelem.ref
+			IL_0100: stloc.s 4
+			IL_0102: ldnull
+			IL_0103: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/ArrowFunction_L31C17::__js_call__(object[], object)
+			IL_0109: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_010e: ldloc.s 4
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_011a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_011f: ldc.i4.0
+			IL_0120: conv.r8
+			IL_0121: ldstr ""
+			IL_0126: ldc.i4.0
+			IL_0127: ldc.i4.0
+			IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0132: stloc.s 6
+			IL_0134: ldc.i4.0
+			IL_0135: newarr [System.Runtime]System.Object
+			IL_013a: stloc.s 4
+			IL_013c: ldc.i4.1
+			IL_013d: newarr [System.Runtime]System.Object
+			IL_0142: dup
+			IL_0143: ldc.i4.0
+			IL_0144: ldarg.0
+			IL_0145: ldc.i4.1
+			IL_0146: ldelem.ref
+			IL_0147: stelem.ref
+			IL_0148: stloc.s 7
+			IL_014a: ldloc.s 6
+			IL_014c: ldloc.s 7
+			IL_014e: ldloc.s 4
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0155: stloc.2
+			IL_0156: ldloc.1
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015c: stloc.3
+			IL_015d: ldloc.3
+			IL_015e: ldstr "emit"
+			IL_0163: ldstr "error"
+			IL_0168: ldstr "E1"
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0172: pop
+			IL_0173: ldloc.0
+			IL_0174: ldc.i4.1
+			IL_0175: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_017a: ldloc.0
+			IL_017b: ldloc.2
+			IL_017c: ldarg.0
+			IL_017d: ldc.i4.1
+			IL_017e: ldloc.0
+			IL_017f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0184: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0189: ldloc.0
+			IL_018a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_018f: dup
+			IL_0190: ldc.i4.0
+			IL_0191: ldloc.1
+			IL_0192: stelem.ref
+			IL_0193: dup
+			IL_0194: ldc.i4.1
+			IL_0195: ldloc.2
+			IL_0196: stelem.ref
+			IL_0197: dup
+			IL_0198: ldc.i4.2
+			IL_0199: ldloc.3
+			IL_019a: stelem.ref
+			IL_019b: dup
+			IL_019c: ldc.i4.3
+			IL_019d: ldloc.s 4
 			IL_019f: stelem.ref
 			IL_01a0: dup
-			IL_01a1: ldc.i4.3
-			IL_01a2: ldloc.s 4
+			IL_01a1: ldc.i4.4
+			IL_01a2: ldloc.s 5
 			IL_01a4: stelem.ref
 			IL_01a5: dup
-			IL_01a6: ldc.i4.4
-			IL_01a7: ldloc.s 5
+			IL_01a6: ldc.i4.5
+			IL_01a7: ldloc.s 6
 			IL_01a9: stelem.ref
 			IL_01aa: dup
-			IL_01ab: ldc.i4.5
-			IL_01ac: ldloc.s 6
+			IL_01ab: ldc.i4.6
+			IL_01ac: ldloc.s 7
 			IL_01ae: stelem.ref
-			IL_01af: dup
-			IL_01b0: ldc.i4.6
-			IL_01b1: ldloc.s 7
-			IL_01b3: stelem.ref
-			IL_01b4: pop
-			IL_01b5: ldloc.0
-			IL_01b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01c0: ret
+			IL_01af: pop
+			IL_01b0: ldloc.0
+			IL_01b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01bb: ret
 
-			IL_01c1: ldloc.0
-			IL_01c2: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::_awaited1
-			IL_01c7: pop
-			IL_01c8: ldloc.0
-			IL_01c9: ldc.i4.m1
-			IL_01ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01cf: ldloc.0
-			IL_01d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01da: ldarg.0
-			IL_01db: ldc.i4.1
-			IL_01dc: newarr [System.Runtime]System.Object
-			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01e6: pop
-			IL_01e7: ldloc.0
-			IL_01e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f2: ret
+			IL_01bc: ldloc.0
+			IL_01bd: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/Scope::_awaited1
+			IL_01c2: pop
+			IL_01c3: ldloc.0
+			IL_01c4: ldc.i4.m1
+			IL_01c5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ca: ldloc.0
+			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01d5: ldarg.0
+			IL_01d6: ldc.i4.1
+			IL_01d7: newarr [System.Runtime]System.Object
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01e1: pop
+			IL_01e2: ldloc.0
+			IL_01e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ed: ret
 		} // end of method runOnErrorReject::__js_call__
 
 	} // end of class runOnErrorReject
@@ -1586,7 +1584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e0
+				// Method begins at RVA 0x31c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1610,9 +1608,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2934
+			// Method begins at RVA 0x2924
 			// Header size: 12
-			// Code size: 553 (0x229)
+			// Code size: 548 (0x224)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope,
@@ -1700,7 +1698,7 @@
 
 			IL_0090: ldloc.0
 			IL_0091: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0096: switch (IL_00a3, IL_015c)
+			IL_0096: switch (IL_00a3, IL_0157)
 
 			IL_00a3: ldarg.0
 			IL_00a4: ldc.i4.1
@@ -1719,134 +1717,133 @@
 			IL_00c5: ldc.i4.1
 			IL_00c6: ldelem.ref
 			IL_00c7: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00cc: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00d1: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule
-			IL_00d6: stloc.s 6
-			IL_00d8: ldloc.s 6
-			IL_00da: ldloc.1
-			IL_00db: ldstr "ready"
-			IL_00e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::once(object, object)
-			IL_00e5: stloc.2
-			IL_00e6: ldloc.1
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ec: stloc.s 4
-			IL_00ee: ldloc.s 4
-			IL_00f0: ldstr "emit"
-			IL_00f5: ldstr "ready"
-			IL_00fa: ldstr "ok"
-			IL_00ff: ldc.r8 42
-			IL_0108: box [System.Runtime]System.Double
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0112: pop
-			IL_0113: ldloc.0
-			IL_0114: ldc.i4.1
-			IL_0115: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_011a: ldloc.0
-			IL_011b: ldloc.2
-			IL_011c: ldarg.0
-			IL_011d: ldc.i4.1
-			IL_011e: ldloc.0
-			IL_011f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0124: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0129: ldloc.0
-			IL_012a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_012f: dup
-			IL_0130: ldc.i4.0
-			IL_0131: ldloc.1
-			IL_0132: stelem.ref
-			IL_0133: dup
-			IL_0134: ldc.i4.1
-			IL_0135: ldloc.2
-			IL_0136: stelem.ref
-			IL_0137: dup
-			IL_0138: ldc.i4.2
-			IL_0139: ldloc.3
+			IL_00cc: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00d1: stloc.s 6
+			IL_00d3: ldloc.s 6
+			IL_00d5: ldloc.1
+			IL_00d6: ldstr "ready"
+			IL_00db: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::once(object, object)
+			IL_00e0: stloc.2
+			IL_00e1: ldloc.1
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e7: stloc.s 4
+			IL_00e9: ldloc.s 4
+			IL_00eb: ldstr "emit"
+			IL_00f0: ldstr "ready"
+			IL_00f5: ldstr "ok"
+			IL_00fa: ldc.r8 42
+			IL_0103: box [System.Runtime]System.Double
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_010d: pop
+			IL_010e: ldloc.0
+			IL_010f: ldc.i4.1
+			IL_0110: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0115: ldloc.0
+			IL_0116: ldloc.2
+			IL_0117: ldarg.0
+			IL_0118: ldc.i4.1
+			IL_0119: ldloc.0
+			IL_011a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0124: ldloc.0
+			IL_0125: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_012a: dup
+			IL_012b: ldc.i4.0
+			IL_012c: ldloc.1
+			IL_012d: stelem.ref
+			IL_012e: dup
+			IL_012f: ldc.i4.1
+			IL_0130: ldloc.2
+			IL_0131: stelem.ref
+			IL_0132: dup
+			IL_0133: ldc.i4.2
+			IL_0134: ldloc.3
+			IL_0135: stelem.ref
+			IL_0136: dup
+			IL_0137: ldc.i4.3
+			IL_0138: ldloc.s 4
 			IL_013a: stelem.ref
 			IL_013b: dup
-			IL_013c: ldc.i4.3
-			IL_013d: ldloc.s 4
+			IL_013c: ldc.i4.4
+			IL_013d: ldloc.s 5
 			IL_013f: stelem.ref
 			IL_0140: dup
-			IL_0141: ldc.i4.4
-			IL_0142: ldloc.s 5
+			IL_0141: ldc.i4.5
+			IL_0142: ldloc.s 6
 			IL_0144: stelem.ref
 			IL_0145: dup
-			IL_0146: ldc.i4.5
-			IL_0147: ldloc.s 6
+			IL_0146: ldc.i4.6
+			IL_0147: ldloc.s 7
 			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.6
-			IL_014c: ldloc.s 7
-			IL_014e: stelem.ref
-			IL_014f: pop
-			IL_0150: ldloc.0
-			IL_0151: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0156: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_015b: ret
+			IL_014a: pop
+			IL_014b: ldloc.0
+			IL_014c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0151: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0156: ret
 
-			IL_015c: ldloc.0
-			IL_015d: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope::_awaited1
-			IL_0162: stloc.3
-			IL_0163: ldstr "console"
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016d: stloc.s 4
-			IL_016f: ldloc.s 4
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0176: stloc.s 4
-			IL_0178: ldloc.3
-			IL_0179: ldstr "length"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: stloc.s 7
-			IL_0185: ldloc.s 4
-			IL_0187: ldstr "log"
-			IL_018c: ldloc.s 7
-			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0193: pop
-			IL_0194: ldstr "console"
-			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019e: stloc.s 7
-			IL_01a0: ldloc.s 7
-			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a7: stloc.s 7
-			IL_01a9: ldloc.3
-			IL_01aa: ldc.r8 0.0
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01b8: stloc.s 4
-			IL_01ba: ldloc.s 7
-			IL_01bc: ldstr "log"
-			IL_01c1: ldloc.s 4
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01c8: pop
-			IL_01c9: ldstr "console"
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01d3: stloc.s 4
-			IL_01d5: ldloc.s 4
-			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01dc: stloc.s 4
-			IL_01de: ldloc.3
-			IL_01df: ldc.r8 1
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01ed: stloc.s 7
-			IL_01ef: ldloc.s 4
-			IL_01f1: ldstr "log"
-			IL_01f6: ldloc.s 7
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01fd: pop
-			IL_01fe: ldloc.0
-			IL_01ff: ldc.i4.m1
-			IL_0200: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0205: ldloc.0
-			IL_0206: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_020b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0210: ldarg.0
-			IL_0211: ldc.i4.1
-			IL_0212: newarr [System.Runtime]System.Object
-			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_021c: pop
-			IL_021d: ldloc.0
-			IL_021e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0223: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0228: ret
+			IL_0157: ldloc.0
+			IL_0158: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceResolve/Scope::_awaited1
+			IL_015d: stloc.3
+			IL_015e: ldstr "console"
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0168: stloc.s 4
+			IL_016a: ldloc.s 4
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0171: stloc.s 4
+			IL_0173: ldloc.3
+			IL_0174: ldstr "length"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017e: stloc.s 7
+			IL_0180: ldloc.s 4
+			IL_0182: ldstr "log"
+			IL_0187: ldloc.s 7
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_018e: pop
+			IL_018f: ldstr "console"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0199: stloc.s 7
+			IL_019b: ldloc.s 7
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a2: stloc.s 7
+			IL_01a4: ldloc.3
+			IL_01a5: ldc.r8 0.0
+			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01b3: stloc.s 4
+			IL_01b5: ldloc.s 7
+			IL_01b7: ldstr "log"
+			IL_01bc: ldloc.s 4
+			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01c3: pop
+			IL_01c4: ldstr "console"
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ce: stloc.s 4
+			IL_01d0: ldloc.s 4
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d7: stloc.s 4
+			IL_01d9: ldloc.3
+			IL_01da: ldc.r8 1
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01e8: stloc.s 7
+			IL_01ea: ldloc.s 4
+			IL_01ec: ldstr "log"
+			IL_01f1: ldloc.s 7
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f8: pop
+			IL_01f9: ldloc.0
+			IL_01fa: ldc.i4.m1
+			IL_01fb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0200: ldloc.0
+			IL_0201: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0206: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_020b: ldarg.0
+			IL_020c: ldc.i4.1
+			IL_020d: newarr [System.Runtime]System.Object
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0217: pop
+			IL_0218: ldloc.0
+			IL_0219: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0223: ret
 		} // end of method runOnceResolve::__js_call__
 
 	} // end of class runOnceResolve
@@ -1875,7 +1872,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31f2
+					// Method begins at RVA 0x31d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1895,7 +1892,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31fb
+					// Method begins at RVA 0x31db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1919,7 +1916,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e9
+				// Method begins at RVA 0x31c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1943,9 +1940,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b6c
+			// Method begins at RVA 0x2b54
 			// Header size: 12
-			// Code size: 507 (0x1fb)
+			// Code size: 502 (0x1f6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope,
@@ -2028,7 +2025,7 @@
 
 			IL_008b: ldloc.0
 			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0091: switch (IL_00a2, IL_018d, IL_015a)
+			IL_0091: switch (IL_00a2, IL_0188, IL_0155)
 
 			IL_00a2: ldarg.0
 			IL_00a3: ldc.i4.1
@@ -2047,124 +2044,123 @@
 			IL_00c4: ldc.i4.1
 			IL_00c5: ldelem.ref
 			IL_00c6: castclass Modules.Events_AsyncHelpers_On_Once/Scope
-			IL_00cb: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-			IL_00d0: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule
-			IL_00d5: stloc.s 6
-			IL_00d7: ldloc.s 6
-			IL_00d9: ldloc.1
-			IL_00da: ldstr "ready"
-			IL_00df: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::once(object, object)
-			IL_00e4: stloc.2
-			IL_00e5: ldloc.1
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00eb: stloc.s 4
-			IL_00ed: ldloc.s 4
-			IL_00ef: ldstr "emit"
-			IL_00f4: ldstr "error"
-			IL_00f9: ldstr "boom"
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0103: pop
-			IL_0104: ldloc.0
-			IL_0105: ldc.i4.0
-			IL_0106: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_010b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0110: ldloc.0
-			IL_0111: ldc.i4.2
-			IL_0112: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0117: ldloc.0
-			IL_0118: ldloc.2
-			IL_0119: ldarg.0
-			IL_011a: ldc.i4.1
-			IL_011b: ldloc.0
-			IL_011c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0121: ldc.i4.1
-			IL_0122: ldstr "_pendingException"
-			IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_012c: ldloc.0
-			IL_012d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0132: dup
-			IL_0133: ldc.i4.0
-			IL_0134: ldloc.1
-			IL_0135: stelem.ref
-			IL_0136: dup
-			IL_0137: ldc.i4.1
-			IL_0138: ldloc.2
-			IL_0139: stelem.ref
-			IL_013a: dup
-			IL_013b: ldc.i4.2
-			IL_013c: ldloc.3
+			IL_00cb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule Modules.Events_AsyncHelpers_On_Once/Scope::events
+			IL_00d0: stloc.s 6
+			IL_00d2: ldloc.s 6
+			IL_00d4: ldloc.1
+			IL_00d5: ldstr "ready"
+			IL_00da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::once(object, object)
+			IL_00df: stloc.2
+			IL_00e0: ldloc.1
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e6: stloc.s 4
+			IL_00e8: ldloc.s 4
+			IL_00ea: ldstr "emit"
+			IL_00ef: ldstr "error"
+			IL_00f4: ldstr "boom"
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00fe: pop
+			IL_00ff: ldloc.0
+			IL_0100: ldc.i4.0
+			IL_0101: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0106: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_010b: ldloc.0
+			IL_010c: ldc.i4.2
+			IL_010d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0112: ldloc.0
+			IL_0113: ldloc.2
+			IL_0114: ldarg.0
+			IL_0115: ldc.i4.1
+			IL_0116: ldloc.0
+			IL_0117: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_011c: ldc.i4.1
+			IL_011d: ldstr "_pendingException"
+			IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0127: ldloc.0
+			IL_0128: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_012d: dup
+			IL_012e: ldc.i4.0
+			IL_012f: ldloc.1
+			IL_0130: stelem.ref
+			IL_0131: dup
+			IL_0132: ldc.i4.1
+			IL_0133: ldloc.2
+			IL_0134: stelem.ref
+			IL_0135: dup
+			IL_0136: ldc.i4.2
+			IL_0137: ldloc.3
+			IL_0138: stelem.ref
+			IL_0139: dup
+			IL_013a: ldc.i4.3
+			IL_013b: ldloc.s 4
 			IL_013d: stelem.ref
 			IL_013e: dup
-			IL_013f: ldc.i4.3
-			IL_0140: ldloc.s 4
+			IL_013f: ldc.i4.4
+			IL_0140: ldloc.s 5
 			IL_0142: stelem.ref
 			IL_0143: dup
-			IL_0144: ldc.i4.4
-			IL_0145: ldloc.s 5
+			IL_0144: ldc.i4.5
+			IL_0145: ldloc.s 6
 			IL_0147: stelem.ref
-			IL_0148: dup
-			IL_0149: ldc.i4.5
-			IL_014a: ldloc.s 6
-			IL_014c: stelem.ref
-			IL_014d: pop
-			IL_014e: ldloc.0
-			IL_014f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0154: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0159: ret
+			IL_0148: pop
+			IL_0149: ldloc.0
+			IL_014a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_014f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0154: ret
 
-			IL_015a: ldloc.0
-			IL_015b: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
-			IL_0160: pop
-			IL_0161: ldstr "console"
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016b: stloc.s 4
-			IL_016d: ldloc.s 4
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0174: stloc.s 4
-			IL_0176: ldloc.s 4
-			IL_0178: ldstr "log"
-			IL_017d: ldstr "NO_REJECT"
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0187: pop
-			IL_0188: br IL_01d0
+			IL_0155: ldloc.0
+			IL_0156: ldfld object Modules.Events_AsyncHelpers_On_Once/runOnceReject/Scope::_awaited1
+			IL_015b: pop
+			IL_015c: ldstr "console"
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0166: stloc.s 4
+			IL_0168: ldloc.s 4
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 4
+			IL_0171: ldloc.s 4
+			IL_0173: ldstr "log"
+			IL_0178: ldstr "NO_REJECT"
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0182: pop
+			IL_0183: br IL_01cb
 
-			IL_018d: ldloc.0
-			IL_018e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0193: stloc.s 4
-			IL_0195: ldloc.0
-			IL_0196: ldc.i4.0
-			IL_0197: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_019c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_01a1: ldloc.s 4
-			IL_01a3: stloc.3
-			IL_01a4: ldstr "console"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ae: stloc.s 4
-			IL_01b0: ldloc.s 4
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b7: stloc.s 4
-			IL_01b9: ldloc.s 4
-			IL_01bb: ldstr "log"
-			IL_01c0: ldstr "once-reject"
-			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01ca: pop
-			IL_01cb: br IL_01d0
+			IL_0188: ldloc.0
+			IL_0189: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_018e: stloc.s 4
+			IL_0190: ldloc.0
+			IL_0191: ldc.i4.0
+			IL_0192: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0197: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_019c: ldloc.s 4
+			IL_019e: stloc.3
+			IL_019f: ldstr "console"
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01a9: stloc.s 4
+			IL_01ab: ldloc.s 4
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b2: stloc.s 4
+			IL_01b4: ldloc.s 4
+			IL_01b6: ldstr "log"
+			IL_01bb: ldstr "once-reject"
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01c5: pop
+			IL_01c6: br IL_01cb
 
-			IL_01d0: ldloc.0
-			IL_01d1: ldc.i4.m1
-			IL_01d2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d7: ldloc.0
-			IL_01d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_01e2: ldarg.0
-			IL_01e3: ldc.i4.1
-			IL_01e4: newarr [System.Runtime]System.Object
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01ee: pop
-			IL_01ef: ldloc.0
-			IL_01f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01fa: ret
+			IL_01cb: ldloc.0
+			IL_01cc: ldc.i4.m1
+			IL_01cd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01d2: ldloc.0
+			IL_01d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01dd: ldarg.0
+			IL_01de: ldc.i4.1
+			IL_01df: newarr [System.Runtime]System.Object
+			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01e9: pop
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01f0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01f5: ret
 		} // end of method runOnceReject::__js_call__
 
 	} // end of class runOnceReject
@@ -2180,7 +2176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3204
+				// Method begins at RVA 0x31e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2203,7 +2199,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d73
+			// Method begins at RVA 0x2d56
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -2239,7 +2235,7 @@
 			65 63 74 7d 00 00
 		)
 		// Fields
-		.field public object events
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule events
 		.field public object EventEmitter
 		.field public object runOnBreak
 		.field public object runOnErrorReject
@@ -2250,7 +2246,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x317d
+			// Method begins at RVA 0x315d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2276,7 +2272,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 384 (0x180)
+		// Code size: 379 (0x17b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_AsyncHelpers_On_Once/Scope,
@@ -2362,72 +2358,71 @@
 		IL_00b7: stloc.s 5
 		IL_00b9: ldloc.0
 		IL_00ba: ldloc.s 5
-		IL_00bc: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
+		IL_00bc: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule Modules.Events_AsyncHelpers_On_Once/Scope::events
 		IL_00c1: ldloc.0
-		IL_00c2: ldfld object Modules.Events_AsyncHelpers_On_Once/Scope::events
-		IL_00c7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule
-		IL_00cc: stloc.s 5
-		IL_00ce: ldloc.s 5
-		IL_00d0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::get_EventEmitter()
-		IL_00d5: stloc.s 6
-		IL_00d7: ldloc.0
-		IL_00d8: ldloc.s 6
-		IL_00da: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-		IL_00df: nop
-		IL_00e0: nop
-		IL_00e1: nop
-		IL_00e2: nop
-		IL_00e3: ldloc.1
-		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_00ee: stloc.s 6
-		IL_00f0: ldloc.s 6
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f7: ldstr "then"
-		IL_00fc: ldloc.2
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0102: stloc.s 6
-		IL_0104: ldloc.s 6
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010b: ldstr "then"
-		IL_0110: ldloc.3
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0116: stloc.s 6
-		IL_0118: ldloc.s 6
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011f: ldstr "then"
-		IL_0124: ldloc.s 4
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012b: stloc.s 6
-		IL_012d: ldloc.s 6
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0134: stloc.s 6
-		IL_0136: ldnull
-		IL_0137: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
-		IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0142: ldc.i4.1
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: dup
-		IL_0149: ldc.i4.0
-		IL_014a: ldloc.0
-		IL_014b: stelem.ref
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0156: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_015b: ldc.i4.0
-		IL_015c: conv.r8
-		IL_015d: ldstr ""
-		IL_0162: ldc.i4.0
-		IL_0163: ldc.i4.0
-		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_016e: stloc.s 7
-		IL_0170: ldloc.s 6
-		IL_0172: ldstr "then"
-		IL_0177: ldloc.s 7
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017e: pop
-		IL_017f: ret
+		IL_00c2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule Modules.Events_AsyncHelpers_On_Once/Scope::events
+		IL_00c7: stloc.s 5
+		IL_00c9: ldloc.s 5
+		IL_00cb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule::get_EventEmitter()
+		IL_00d0: stloc.s 6
+		IL_00d2: ldloc.0
+		IL_00d3: ldloc.s 6
+		IL_00d5: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
+		IL_00da: nop
+		IL_00db: nop
+		IL_00dc: nop
+		IL_00dd: nop
+		IL_00de: ldloc.1
+		IL_00df: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_00e9: stloc.s 6
+		IL_00eb: ldloc.s 6
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f2: ldstr "then"
+		IL_00f7: ldloc.2
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fd: stloc.s 6
+		IL_00ff: ldloc.s 6
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0106: ldstr "then"
+		IL_010b: ldloc.3
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0111: stloc.s 6
+		IL_0113: ldloc.s 6
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011a: ldstr "then"
+		IL_011f: ldloc.s 4
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0126: stloc.s 6
+		IL_0128: ldloc.s 6
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012f: stloc.s 6
+		IL_0131: ldnull
+		IL_0132: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
+		IL_0138: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_013d: ldc.i4.1
+		IL_013e: newarr [System.Runtime]System.Object
+		IL_0143: dup
+		IL_0144: ldc.i4.0
+		IL_0145: ldloc.0
+		IL_0146: stelem.ref
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0151: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0156: ldc.i4.0
+		IL_0157: conv.r8
+		IL_0158: ldstr ""
+		IL_015d: ldc.i4.0
+		IL_015e: ldc.i4.0
+		IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0169: stloc.s 7
+		IL_016b: ldloc.s 6
+		IL_016d: ldstr "then"
+		IL_0172: ldloc.s 7
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0179: pop
+		IL_017a: ret
 	} // end of method Events_AsyncHelpers_On_Once::__js_module_init__
 
 } // end of class Modules.Events_AsyncHelpers_On_Once
@@ -2439,7 +2434,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x320d
+		// Method begins at RVA 0x31ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad1
+					// Method begins at RVA 0x2a8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ada
+					// Method begins at RVA 0x2a94
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae3
+					// Method begins at RVA 0x2a9d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -117,7 +117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac8
+				// Method begins at RVA 0x2a82
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -143,7 +143,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 2499 (0x9c3)
+			// Code size: 2429 (0x97d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope,
@@ -299,7 +299,7 @@
 
 			IL_00ff: ldloc.0
 			IL_0100: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0105: switch (IL_012e, IL_087d, IL_08f7, IL_07fe, IL_03d4, IL_04c4, IL_05ab, IL_0696, IL_07a6)
+			IL_0105: switch (IL_012e, IL_0841, IL_08b1, IL_07c2, IL_03b1, IL_049c, IL_057e, IL_0664, IL_076f)
 
 			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0133: stloc.s 8
@@ -334,948 +334,934 @@
 			IL_0192: ldc.i4.1
 			IL_0193: ldelem.ref
 			IL_0194: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0199: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_019e: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_01a3: stloc.s 12
-			IL_01a5: ldarg.0
-			IL_01a6: ldc.i4.1
-			IL_01a7: ldelem.ref
-			IL_01a8: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_01ad: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_01b2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule
-			IL_01b7: stloc.s 13
-			IL_01b9: ldloc.s 13
-			IL_01bb: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01c0: stloc.s 8
-			IL_01c2: ldloc.1
-			IL_01c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c8: stloc.s 9
-			IL_01ca: ldstr "jroc-fs-append-"
-			IL_01cf: ldloc.s 9
+			IL_0199: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Append_Rename_Unlink/Scope::path
+			IL_019e: stloc.s 12
+			IL_01a0: ldarg.0
+			IL_01a1: ldc.i4.1
+			IL_01a2: ldelem.ref
+			IL_01a3: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_01a8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_01ad: stloc.s 13
+			IL_01af: ldloc.s 13
+			IL_01b1: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01b6: stloc.s 8
+			IL_01b8: ldloc.1
+			IL_01b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01be: stloc.s 9
+			IL_01c0: ldstr "jroc-fs-append-"
+			IL_01c5: ldloc.s 9
+			IL_01c7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01cc: ldstr ".txt"
 			IL_01d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d6: ldstr ".txt"
-			IL_01db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e0: stloc.s 9
-			IL_01e2: ldloc.s 12
-			IL_01e4: ldc.i4.2
-			IL_01e5: newarr [System.Runtime]System.Object
-			IL_01ea: dup
-			IL_01eb: ldc.i4.0
-			IL_01ec: ldloc.s 8
-			IL_01ee: stelem.ref
-			IL_01ef: dup
-			IL_01f0: ldc.i4.1
-			IL_01f1: ldloc.s 9
-			IL_01f3: stelem.ref
-			IL_01f4: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_01f9: stloc.2
-			IL_01fa: ldarg.0
-			IL_01fb: ldc.i4.1
-			IL_01fc: ldelem.ref
-			IL_01fd: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0202: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
-			IL_0207: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_020c: stloc.s 12
-			IL_020e: ldarg.0
-			IL_020f: ldc.i4.1
-			IL_0210: ldelem.ref
-			IL_0211: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0216: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
-			IL_021b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule
-			IL_0220: stloc.s 13
-			IL_0222: ldloc.s 13
-			IL_0224: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_0229: stloc.s 8
-			IL_022b: ldloc.1
-			IL_022c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0231: stloc.s 9
-			IL_0233: ldstr "jroc-fs-append-"
-			IL_0238: ldloc.s 9
-			IL_023a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_023f: ldstr "-renamed.txt"
-			IL_0244: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0249: stloc.s 9
-			IL_024b: ldloc.s 12
-			IL_024d: ldc.i4.2
-			IL_024e: newarr [System.Runtime]System.Object
-			IL_0253: dup
-			IL_0254: ldc.i4.0
-			IL_0255: ldloc.s 8
-			IL_0257: stelem.ref
-			IL_0258: dup
-			IL_0259: ldc.i4.1
-			IL_025a: ldloc.s 9
-			IL_025c: stelem.ref
-			IL_025d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0262: stloc.3
-			IL_0263: ldloc.0
-			IL_0264: ldc.i4.0
-			IL_0265: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_026a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_026f: ldloc.0
-			IL_0270: ldc.i4.0
-			IL_0271: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0276: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_027b: ldloc.0
-			IL_027c: ldc.i4.0
-			IL_027d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0282: ldloc.0
-			IL_0283: ldc.i4.0
-			IL_0284: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0289: ldarg.0
-			IL_028a: ldc.i4.1
-			IL_028b: ldelem.ref
-			IL_028c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0291: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0296: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_029b: stloc.s 14
-			IL_029d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02a2: dup
-			IL_02a3: ldstr "force"
-			IL_02a8: ldc.i4.1
-			IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02ae: stloc.s 15
-			IL_02b0: ldloc.s 14
-			IL_02b2: ldloc.2
-			IL_02b3: ldloc.s 15
-			IL_02b5: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_02ba: ldarg.0
+			IL_01d6: stloc.s 9
+			IL_01d8: ldloc.s 12
+			IL_01da: ldc.i4.2
+			IL_01db: newarr [System.Runtime]System.Object
+			IL_01e0: dup
+			IL_01e1: ldc.i4.0
+			IL_01e2: ldloc.s 8
+			IL_01e4: stelem.ref
+			IL_01e5: dup
+			IL_01e6: ldc.i4.1
+			IL_01e7: ldloc.s 9
+			IL_01e9: stelem.ref
+			IL_01ea: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_01ef: stloc.2
+			IL_01f0: ldarg.0
+			IL_01f1: ldc.i4.1
+			IL_01f2: ldelem.ref
+			IL_01f3: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_01f8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Append_Rename_Unlink/Scope::path
+			IL_01fd: stloc.s 12
+			IL_01ff: ldarg.0
+			IL_0200: ldc.i4.1
+			IL_0201: ldelem.ref
+			IL_0202: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0207: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Append_Rename_Unlink/Scope::os
+			IL_020c: stloc.s 13
+			IL_020e: ldloc.s 13
+			IL_0210: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_0215: stloc.s 8
+			IL_0217: ldloc.1
+			IL_0218: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_021d: stloc.s 9
+			IL_021f: ldstr "jroc-fs-append-"
+			IL_0224: ldloc.s 9
+			IL_0226: call string [System.Runtime]System.String::Concat(string, string)
+			IL_022b: ldstr "-renamed.txt"
+			IL_0230: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0235: stloc.s 9
+			IL_0237: ldloc.s 12
+			IL_0239: ldc.i4.2
+			IL_023a: newarr [System.Runtime]System.Object
+			IL_023f: dup
+			IL_0240: ldc.i4.0
+			IL_0241: ldloc.s 8
+			IL_0243: stelem.ref
+			IL_0244: dup
+			IL_0245: ldc.i4.1
+			IL_0246: ldloc.s 9
+			IL_0248: stelem.ref
+			IL_0249: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_024e: stloc.3
+			IL_024f: ldloc.0
+			IL_0250: ldc.i4.0
+			IL_0251: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0256: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_025b: ldloc.0
+			IL_025c: ldc.i4.0
+			IL_025d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0262: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0267: ldloc.0
+			IL_0268: ldc.i4.0
+			IL_0269: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_026e: ldloc.0
+			IL_026f: ldc.i4.0
+			IL_0270: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0275: ldarg.0
+			IL_0276: ldc.i4.1
+			IL_0277: ldelem.ref
+			IL_0278: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_027d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0282: stloc.s 14
+			IL_0284: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0289: dup
+			IL_028a: ldstr "force"
+			IL_028f: ldc.i4.1
+			IL_0290: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0295: stloc.s 15
+			IL_0297: ldloc.s 14
+			IL_0299: ldloc.2
+			IL_029a: ldloc.s 15
+			IL_029c: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_02a1: ldarg.0
+			IL_02a2: ldc.i4.1
+			IL_02a3: ldelem.ref
+			IL_02a4: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_02a9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_02ae: stloc.s 14
+			IL_02b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02b5: dup
+			IL_02b6: ldstr "force"
 			IL_02bb: ldc.i4.1
-			IL_02bc: ldelem.ref
-			IL_02bd: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_02c2: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_02c7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02cc: stloc.s 14
-			IL_02ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02d3: dup
-			IL_02d4: ldstr "force"
-			IL_02d9: ldc.i4.1
-			IL_02da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02df: stloc.s 15
-			IL_02e1: ldloc.s 14
-			IL_02e3: ldloc.3
-			IL_02e4: ldloc.s 15
-			IL_02e6: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_02eb: ldarg.0
-			IL_02ec: ldc.i4.1
-			IL_02ed: ldelem.ref
-			IL_02ee: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_02f3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_02f8: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02fd: stloc.s 14
-			IL_02ff: ldloc.s 14
-			IL_0301: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_0306: stloc.s 8
-			IL_0308: ldloc.s 8
-			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_030f: stloc.s 8
-			IL_0311: ldloc.s 8
-			IL_0313: ldstr "writeFile"
-			IL_0318: ldloc.2
-			IL_0319: ldstr "a"
-			IL_031e: ldstr "utf8"
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0328: stloc.s 8
-			IL_032a: ldloc.0
-			IL_032b: ldc.i4.4
-			IL_032c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0331: ldloc.0
-			IL_0332: ldloc.s 8
-			IL_0334: ldarg.0
-			IL_0335: ldc.i4.1
-			IL_0336: ldloc.0
-			IL_0337: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_033c: ldc.i4.3
-			IL_033d: ldstr "_pendingException"
-			IL_0342: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0347: ldloc.0
-			IL_0348: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_034d: dup
-			IL_034e: ldc.i4.0
-			IL_034f: ldloc.1
-			IL_0350: stelem.ref
-			IL_0351: dup
-			IL_0352: ldc.i4.1
-			IL_0353: ldloc.2
-			IL_0354: stelem.ref
-			IL_0355: dup
-			IL_0356: ldc.i4.2
-			IL_0357: ldloc.3
+			IL_02bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02c1: stloc.s 15
+			IL_02c3: ldloc.s 14
+			IL_02c5: ldloc.3
+			IL_02c6: ldloc.s 15
+			IL_02c8: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_02cd: ldarg.0
+			IL_02ce: ldc.i4.1
+			IL_02cf: ldelem.ref
+			IL_02d0: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_02d5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_02da: stloc.s 14
+			IL_02dc: ldloc.s 14
+			IL_02de: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_02e3: stloc.s 8
+			IL_02e5: ldloc.s 8
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ec: stloc.s 8
+			IL_02ee: ldloc.s 8
+			IL_02f0: ldstr "writeFile"
+			IL_02f5: ldloc.2
+			IL_02f6: ldstr "a"
+			IL_02fb: ldstr "utf8"
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0305: stloc.s 8
+			IL_0307: ldloc.0
+			IL_0308: ldc.i4.4
+			IL_0309: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030e: ldloc.0
+			IL_030f: ldloc.s 8
+			IL_0311: ldarg.0
+			IL_0312: ldc.i4.1
+			IL_0313: ldloc.0
+			IL_0314: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0319: ldc.i4.3
+			IL_031a: ldstr "_pendingException"
+			IL_031f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0324: ldloc.0
+			IL_0325: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_032a: dup
+			IL_032b: ldc.i4.0
+			IL_032c: ldloc.1
+			IL_032d: stelem.ref
+			IL_032e: dup
+			IL_032f: ldc.i4.1
+			IL_0330: ldloc.2
+			IL_0331: stelem.ref
+			IL_0332: dup
+			IL_0333: ldc.i4.2
+			IL_0334: ldloc.3
+			IL_0335: stelem.ref
+			IL_0336: dup
+			IL_0337: ldc.i4.3
+			IL_0338: ldloc.s 4
+			IL_033a: stelem.ref
+			IL_033b: dup
+			IL_033c: ldc.i4.4
+			IL_033d: ldloc.s 5
+			IL_033f: stelem.ref
+			IL_0340: dup
+			IL_0341: ldc.i4.5
+			IL_0342: ldloc.s 6
+			IL_0344: box [System.Runtime]System.Boolean
+			IL_0349: stelem.ref
+			IL_034a: dup
+			IL_034b: ldc.i4.6
+			IL_034c: ldloc.s 7
+			IL_034e: box [System.Runtime]System.Boolean
+			IL_0353: stelem.ref
+			IL_0354: dup
+			IL_0355: ldc.i4.7
+			IL_0356: ldloc.s 8
 			IL_0358: stelem.ref
 			IL_0359: dup
-			IL_035a: ldc.i4.3
-			IL_035b: ldloc.s 4
+			IL_035a: ldc.i4.8
+			IL_035b: ldloc.s 9
 			IL_035d: stelem.ref
 			IL_035e: dup
-			IL_035f: ldc.i4.4
-			IL_0360: ldloc.s 5
-			IL_0362: stelem.ref
-			IL_0363: dup
-			IL_0364: ldc.i4.5
-			IL_0365: ldloc.s 6
-			IL_0367: box [System.Runtime]System.Boolean
-			IL_036c: stelem.ref
-			IL_036d: dup
-			IL_036e: ldc.i4.6
-			IL_036f: ldloc.s 7
-			IL_0371: box [System.Runtime]System.Boolean
-			IL_0376: stelem.ref
-			IL_0377: dup
-			IL_0378: ldc.i4.7
-			IL_0379: ldloc.s 8
-			IL_037b: stelem.ref
-			IL_037c: dup
-			IL_037d: ldc.i4.8
-			IL_037e: ldloc.s 9
+			IL_035f: ldc.i4.s 9
+			IL_0361: ldloc.s 10
+			IL_0363: box [System.Runtime]System.Double
+			IL_0368: stelem.ref
+			IL_0369: dup
+			IL_036a: ldc.i4.s 10
+			IL_036c: ldloc.s 11
+			IL_036e: stelem.ref
+			IL_036f: dup
+			IL_0370: ldc.i4.s 11
+			IL_0372: ldloc.s 12
+			IL_0374: stelem.ref
+			IL_0375: dup
+			IL_0376: ldc.i4.s 12
+			IL_0378: ldloc.s 13
+			IL_037a: stelem.ref
+			IL_037b: dup
+			IL_037c: ldc.i4.s 13
+			IL_037e: ldloc.s 14
 			IL_0380: stelem.ref
 			IL_0381: dup
-			IL_0382: ldc.i4.s 9
-			IL_0384: ldloc.s 10
-			IL_0386: box [System.Runtime]System.Double
-			IL_038b: stelem.ref
-			IL_038c: dup
-			IL_038d: ldc.i4.s 10
-			IL_038f: ldloc.s 11
-			IL_0391: stelem.ref
-			IL_0392: dup
-			IL_0393: ldc.i4.s 11
-			IL_0395: ldloc.s 12
+			IL_0382: ldc.i4.s 14
+			IL_0384: ldloc.s 15
+			IL_0386: stelem.ref
+			IL_0387: dup
+			IL_0388: ldc.i4.s 15
+			IL_038a: ldloc.s 16
+			IL_038c: stelem.ref
+			IL_038d: dup
+			IL_038e: ldc.i4.s 16
+			IL_0390: ldloc.s 17
+			IL_0392: box [System.Runtime]System.Boolean
 			IL_0397: stelem.ref
 			IL_0398: dup
-			IL_0399: ldc.i4.s 12
-			IL_039b: ldloc.s 13
+			IL_0399: ldc.i4.s 17
+			IL_039b: ldloc.s 18
 			IL_039d: stelem.ref
 			IL_039e: dup
-			IL_039f: ldc.i4.s 13
-			IL_03a1: ldloc.s 14
+			IL_039f: ldc.i4.s 18
+			IL_03a1: ldloc.s 19
 			IL_03a3: stelem.ref
-			IL_03a4: dup
-			IL_03a5: ldc.i4.s 14
-			IL_03a7: ldloc.s 15
-			IL_03a9: stelem.ref
-			IL_03aa: dup
-			IL_03ab: ldc.i4.s 15
-			IL_03ad: ldloc.s 16
-			IL_03af: stelem.ref
-			IL_03b0: dup
-			IL_03b1: ldc.i4.s 16
-			IL_03b3: ldloc.s 17
-			IL_03b5: box [System.Runtime]System.Boolean
-			IL_03ba: stelem.ref
-			IL_03bb: dup
-			IL_03bc: ldc.i4.s 17
-			IL_03be: ldloc.s 18
-			IL_03c0: stelem.ref
-			IL_03c1: dup
-			IL_03c2: ldc.i4.s 18
-			IL_03c4: ldloc.s 19
-			IL_03c6: stelem.ref
-			IL_03c7: pop
-			IL_03c8: ldloc.0
-			IL_03c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03d3: ret
+			IL_03a4: pop
+			IL_03a5: ldloc.0
+			IL_03a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ab: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03b0: ret
 
-			IL_03d4: ldloc.0
-			IL_03d5: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
-			IL_03da: pop
-			IL_03db: ldarg.0
-			IL_03dc: ldc.i4.1
-			IL_03dd: ldelem.ref
-			IL_03de: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_03e3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_03e8: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_03ed: stloc.s 14
-			IL_03ef: ldloc.s 14
-			IL_03f1: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_03f6: stloc.s 8
-			IL_03f8: ldloc.s 8
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ff: stloc.s 8
-			IL_0401: ldloc.s 8
-			IL_0403: ldstr "appendFile"
-			IL_0408: ldloc.2
-			IL_0409: ldstr "b"
-			IL_040e: ldstr "utf8"
-			IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0418: stloc.s 8
-			IL_041a: ldloc.0
-			IL_041b: ldc.i4.5
-			IL_041c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0421: ldloc.0
-			IL_0422: ldloc.s 8
-			IL_0424: ldarg.0
-			IL_0425: ldc.i4.2
-			IL_0426: ldloc.0
-			IL_0427: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_042c: ldc.i4.3
-			IL_042d: ldstr "_pendingException"
-			IL_0432: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0437: ldloc.0
-			IL_0438: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_043d: dup
-			IL_043e: ldc.i4.0
-			IL_043f: ldloc.1
-			IL_0440: stelem.ref
-			IL_0441: dup
-			IL_0442: ldc.i4.1
-			IL_0443: ldloc.2
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.2
-			IL_0447: ldloc.3
+			IL_03b1: ldloc.0
+			IL_03b2: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03b7: pop
+			IL_03b8: ldarg.0
+			IL_03b9: ldc.i4.1
+			IL_03ba: ldelem.ref
+			IL_03bb: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_03c0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_03c5: stloc.s 14
+			IL_03c7: ldloc.s 14
+			IL_03c9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_03ce: stloc.s 8
+			IL_03d0: ldloc.s 8
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d7: stloc.s 8
+			IL_03d9: ldloc.s 8
+			IL_03db: ldstr "appendFile"
+			IL_03e0: ldloc.2
+			IL_03e1: ldstr "b"
+			IL_03e6: ldstr "utf8"
+			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_03f0: stloc.s 8
+			IL_03f2: ldloc.0
+			IL_03f3: ldc.i4.5
+			IL_03f4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03f9: ldloc.0
+			IL_03fa: ldloc.s 8
+			IL_03fc: ldarg.0
+			IL_03fd: ldc.i4.2
+			IL_03fe: ldloc.0
+			IL_03ff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0404: ldc.i4.3
+			IL_0405: ldstr "_pendingException"
+			IL_040a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_040f: ldloc.0
+			IL_0410: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0415: dup
+			IL_0416: ldc.i4.0
+			IL_0417: ldloc.1
+			IL_0418: stelem.ref
+			IL_0419: dup
+			IL_041a: ldc.i4.1
+			IL_041b: ldloc.2
+			IL_041c: stelem.ref
+			IL_041d: dup
+			IL_041e: ldc.i4.2
+			IL_041f: ldloc.3
+			IL_0420: stelem.ref
+			IL_0421: dup
+			IL_0422: ldc.i4.3
+			IL_0423: ldloc.s 4
+			IL_0425: stelem.ref
+			IL_0426: dup
+			IL_0427: ldc.i4.4
+			IL_0428: ldloc.s 5
+			IL_042a: stelem.ref
+			IL_042b: dup
+			IL_042c: ldc.i4.5
+			IL_042d: ldloc.s 6
+			IL_042f: box [System.Runtime]System.Boolean
+			IL_0434: stelem.ref
+			IL_0435: dup
+			IL_0436: ldc.i4.6
+			IL_0437: ldloc.s 7
+			IL_0439: box [System.Runtime]System.Boolean
+			IL_043e: stelem.ref
+			IL_043f: dup
+			IL_0440: ldc.i4.7
+			IL_0441: ldloc.s 8
+			IL_0443: stelem.ref
+			IL_0444: dup
+			IL_0445: ldc.i4.8
+			IL_0446: ldloc.s 9
 			IL_0448: stelem.ref
 			IL_0449: dup
-			IL_044a: ldc.i4.3
-			IL_044b: ldloc.s 4
-			IL_044d: stelem.ref
-			IL_044e: dup
-			IL_044f: ldc.i4.4
-			IL_0450: ldloc.s 5
-			IL_0452: stelem.ref
-			IL_0453: dup
-			IL_0454: ldc.i4.5
-			IL_0455: ldloc.s 6
-			IL_0457: box [System.Runtime]System.Boolean
-			IL_045c: stelem.ref
-			IL_045d: dup
-			IL_045e: ldc.i4.6
-			IL_045f: ldloc.s 7
-			IL_0461: box [System.Runtime]System.Boolean
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.7
-			IL_0469: ldloc.s 8
+			IL_044a: ldc.i4.s 9
+			IL_044c: ldloc.s 10
+			IL_044e: box [System.Runtime]System.Double
+			IL_0453: stelem.ref
+			IL_0454: dup
+			IL_0455: ldc.i4.s 10
+			IL_0457: ldloc.s 11
+			IL_0459: stelem.ref
+			IL_045a: dup
+			IL_045b: ldc.i4.s 11
+			IL_045d: ldloc.s 12
+			IL_045f: stelem.ref
+			IL_0460: dup
+			IL_0461: ldc.i4.s 12
+			IL_0463: ldloc.s 13
+			IL_0465: stelem.ref
+			IL_0466: dup
+			IL_0467: ldc.i4.s 13
+			IL_0469: ldloc.s 14
 			IL_046b: stelem.ref
 			IL_046c: dup
-			IL_046d: ldc.i4.8
-			IL_046e: ldloc.s 9
-			IL_0470: stelem.ref
-			IL_0471: dup
-			IL_0472: ldc.i4.s 9
-			IL_0474: ldloc.s 10
-			IL_0476: box [System.Runtime]System.Double
-			IL_047b: stelem.ref
-			IL_047c: dup
-			IL_047d: ldc.i4.s 10
-			IL_047f: ldloc.s 11
-			IL_0481: stelem.ref
-			IL_0482: dup
-			IL_0483: ldc.i4.s 11
-			IL_0485: ldloc.s 12
-			IL_0487: stelem.ref
-			IL_0488: dup
-			IL_0489: ldc.i4.s 12
-			IL_048b: ldloc.s 13
-			IL_048d: stelem.ref
-			IL_048e: dup
-			IL_048f: ldc.i4.s 13
-			IL_0491: ldloc.s 14
-			IL_0493: stelem.ref
-			IL_0494: dup
-			IL_0495: ldc.i4.s 14
-			IL_0497: ldloc.s 15
-			IL_0499: stelem.ref
-			IL_049a: dup
-			IL_049b: ldc.i4.s 15
-			IL_049d: ldloc.s 16
-			IL_049f: stelem.ref
-			IL_04a0: dup
-			IL_04a1: ldc.i4.s 16
-			IL_04a3: ldloc.s 17
-			IL_04a5: box [System.Runtime]System.Boolean
-			IL_04aa: stelem.ref
-			IL_04ab: dup
-			IL_04ac: ldc.i4.s 17
-			IL_04ae: ldloc.s 18
-			IL_04b0: stelem.ref
-			IL_04b1: dup
-			IL_04b2: ldc.i4.s 18
-			IL_04b4: ldloc.s 19
-			IL_04b6: stelem.ref
-			IL_04b7: pop
-			IL_04b8: ldloc.0
-			IL_04b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04be: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04c3: ret
+			IL_046d: ldc.i4.s 14
+			IL_046f: ldloc.s 15
+			IL_0471: stelem.ref
+			IL_0472: dup
+			IL_0473: ldc.i4.s 15
+			IL_0475: ldloc.s 16
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.s 16
+			IL_047b: ldloc.s 17
+			IL_047d: box [System.Runtime]System.Boolean
+			IL_0482: stelem.ref
+			IL_0483: dup
+			IL_0484: ldc.i4.s 17
+			IL_0486: ldloc.s 18
+			IL_0488: stelem.ref
+			IL_0489: dup
+			IL_048a: ldc.i4.s 18
+			IL_048c: ldloc.s 19
+			IL_048e: stelem.ref
+			IL_048f: pop
+			IL_0490: ldloc.0
+			IL_0491: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0496: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_049b: ret
 
-			IL_04c4: ldloc.0
-			IL_04c5: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
-			IL_04ca: pop
-			IL_04cb: ldarg.0
-			IL_04cc: ldc.i4.1
-			IL_04cd: ldelem.ref
-			IL_04ce: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_04d3: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_04d8: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_04dd: stloc.s 14
-			IL_04df: ldloc.s 14
-			IL_04e1: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_04e6: stloc.s 8
-			IL_04e8: ldloc.s 8
-			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ef: stloc.s 8
-			IL_04f1: ldloc.s 8
-			IL_04f3: ldstr "rename"
-			IL_04f8: ldloc.2
-			IL_04f9: ldloc.3
-			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04ff: stloc.s 8
-			IL_0501: ldloc.0
-			IL_0502: ldc.i4.6
-			IL_0503: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0508: ldloc.0
-			IL_0509: ldloc.s 8
-			IL_050b: ldarg.0
-			IL_050c: ldc.i4.3
-			IL_050d: ldloc.0
-			IL_050e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0513: ldc.i4.3
-			IL_0514: ldstr "_pendingException"
-			IL_0519: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_051e: ldloc.0
-			IL_051f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0524: dup
-			IL_0525: ldc.i4.0
-			IL_0526: ldloc.1
-			IL_0527: stelem.ref
-			IL_0528: dup
-			IL_0529: ldc.i4.1
-			IL_052a: ldloc.2
-			IL_052b: stelem.ref
-			IL_052c: dup
-			IL_052d: ldc.i4.2
-			IL_052e: ldloc.3
-			IL_052f: stelem.ref
-			IL_0530: dup
-			IL_0531: ldc.i4.3
-			IL_0532: ldloc.s 4
-			IL_0534: stelem.ref
-			IL_0535: dup
-			IL_0536: ldc.i4.4
-			IL_0537: ldloc.s 5
-			IL_0539: stelem.ref
-			IL_053a: dup
-			IL_053b: ldc.i4.5
-			IL_053c: ldloc.s 6
-			IL_053e: box [System.Runtime]System.Boolean
-			IL_0543: stelem.ref
-			IL_0544: dup
-			IL_0545: ldc.i4.6
-			IL_0546: ldloc.s 7
-			IL_0548: box [System.Runtime]System.Boolean
+			IL_049c: ldloc.0
+			IL_049d: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited2
+			IL_04a2: pop
+			IL_04a3: ldarg.0
+			IL_04a4: ldc.i4.1
+			IL_04a5: ldelem.ref
+			IL_04a6: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_04ab: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_04b0: stloc.s 14
+			IL_04b2: ldloc.s 14
+			IL_04b4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_04b9: stloc.s 8
+			IL_04bb: ldloc.s 8
+			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04c2: stloc.s 8
+			IL_04c4: ldloc.s 8
+			IL_04c6: ldstr "rename"
+			IL_04cb: ldloc.2
+			IL_04cc: ldloc.3
+			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04d2: stloc.s 8
+			IL_04d4: ldloc.0
+			IL_04d5: ldc.i4.6
+			IL_04d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04db: ldloc.0
+			IL_04dc: ldloc.s 8
+			IL_04de: ldarg.0
+			IL_04df: ldc.i4.3
+			IL_04e0: ldloc.0
+			IL_04e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04e6: ldc.i4.3
+			IL_04e7: ldstr "_pendingException"
+			IL_04ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_04f1: ldloc.0
+			IL_04f2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04f7: dup
+			IL_04f8: ldc.i4.0
+			IL_04f9: ldloc.1
+			IL_04fa: stelem.ref
+			IL_04fb: dup
+			IL_04fc: ldc.i4.1
+			IL_04fd: ldloc.2
+			IL_04fe: stelem.ref
+			IL_04ff: dup
+			IL_0500: ldc.i4.2
+			IL_0501: ldloc.3
+			IL_0502: stelem.ref
+			IL_0503: dup
+			IL_0504: ldc.i4.3
+			IL_0505: ldloc.s 4
+			IL_0507: stelem.ref
+			IL_0508: dup
+			IL_0509: ldc.i4.4
+			IL_050a: ldloc.s 5
+			IL_050c: stelem.ref
+			IL_050d: dup
+			IL_050e: ldc.i4.5
+			IL_050f: ldloc.s 6
+			IL_0511: box [System.Runtime]System.Boolean
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.6
+			IL_0519: ldloc.s 7
+			IL_051b: box [System.Runtime]System.Boolean
+			IL_0520: stelem.ref
+			IL_0521: dup
+			IL_0522: ldc.i4.7
+			IL_0523: ldloc.s 8
+			IL_0525: stelem.ref
+			IL_0526: dup
+			IL_0527: ldc.i4.8
+			IL_0528: ldloc.s 9
+			IL_052a: stelem.ref
+			IL_052b: dup
+			IL_052c: ldc.i4.s 9
+			IL_052e: ldloc.s 10
+			IL_0530: box [System.Runtime]System.Double
+			IL_0535: stelem.ref
+			IL_0536: dup
+			IL_0537: ldc.i4.s 10
+			IL_0539: ldloc.s 11
+			IL_053b: stelem.ref
+			IL_053c: dup
+			IL_053d: ldc.i4.s 11
+			IL_053f: ldloc.s 12
+			IL_0541: stelem.ref
+			IL_0542: dup
+			IL_0543: ldc.i4.s 12
+			IL_0545: ldloc.s 13
+			IL_0547: stelem.ref
+			IL_0548: dup
+			IL_0549: ldc.i4.s 13
+			IL_054b: ldloc.s 14
 			IL_054d: stelem.ref
 			IL_054e: dup
-			IL_054f: ldc.i4.7
-			IL_0550: ldloc.s 8
-			IL_0552: stelem.ref
-			IL_0553: dup
-			IL_0554: ldc.i4.8
-			IL_0555: ldloc.s 9
-			IL_0557: stelem.ref
-			IL_0558: dup
-			IL_0559: ldc.i4.s 9
-			IL_055b: ldloc.s 10
-			IL_055d: box [System.Runtime]System.Double
-			IL_0562: stelem.ref
-			IL_0563: dup
-			IL_0564: ldc.i4.s 10
-			IL_0566: ldloc.s 11
-			IL_0568: stelem.ref
-			IL_0569: dup
-			IL_056a: ldc.i4.s 11
-			IL_056c: ldloc.s 12
-			IL_056e: stelem.ref
-			IL_056f: dup
-			IL_0570: ldc.i4.s 12
-			IL_0572: ldloc.s 13
-			IL_0574: stelem.ref
-			IL_0575: dup
-			IL_0576: ldc.i4.s 13
-			IL_0578: ldloc.s 14
-			IL_057a: stelem.ref
-			IL_057b: dup
-			IL_057c: ldc.i4.s 14
-			IL_057e: ldloc.s 15
-			IL_0580: stelem.ref
-			IL_0581: dup
-			IL_0582: ldc.i4.s 15
-			IL_0584: ldloc.s 16
-			IL_0586: stelem.ref
-			IL_0587: dup
-			IL_0588: ldc.i4.s 16
-			IL_058a: ldloc.s 17
-			IL_058c: box [System.Runtime]System.Boolean
-			IL_0591: stelem.ref
-			IL_0592: dup
-			IL_0593: ldc.i4.s 17
-			IL_0595: ldloc.s 18
-			IL_0597: stelem.ref
-			IL_0598: dup
-			IL_0599: ldc.i4.s 18
-			IL_059b: ldloc.s 19
-			IL_059d: stelem.ref
-			IL_059e: pop
-			IL_059f: ldloc.0
-			IL_05a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05a5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05aa: ret
+			IL_054f: ldc.i4.s 14
+			IL_0551: ldloc.s 15
+			IL_0553: stelem.ref
+			IL_0554: dup
+			IL_0555: ldc.i4.s 15
+			IL_0557: ldloc.s 16
+			IL_0559: stelem.ref
+			IL_055a: dup
+			IL_055b: ldc.i4.s 16
+			IL_055d: ldloc.s 17
+			IL_055f: box [System.Runtime]System.Boolean
+			IL_0564: stelem.ref
+			IL_0565: dup
+			IL_0566: ldc.i4.s 17
+			IL_0568: ldloc.s 18
+			IL_056a: stelem.ref
+			IL_056b: dup
+			IL_056c: ldc.i4.s 18
+			IL_056e: ldloc.s 19
+			IL_0570: stelem.ref
+			IL_0571: pop
+			IL_0572: ldloc.0
+			IL_0573: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0578: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_057d: ret
 
-			IL_05ab: ldloc.0
-			IL_05ac: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
-			IL_05b1: pop
-			IL_05b2: ldarg.0
-			IL_05b3: ldc.i4.1
-			IL_05b4: ldelem.ref
-			IL_05b5: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_05ba: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_05bf: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_05c4: stloc.s 14
-			IL_05c6: ldloc.s 14
-			IL_05c8: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_05cd: stloc.s 8
-			IL_05cf: ldloc.s 8
-			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05d6: stloc.s 8
-			IL_05d8: ldloc.s 8
-			IL_05da: ldstr "readFile"
-			IL_05df: ldloc.3
-			IL_05e0: ldstr "utf8"
-			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05ea: stloc.s 8
-			IL_05ec: ldloc.0
-			IL_05ed: ldc.i4.7
-			IL_05ee: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05f3: ldloc.0
-			IL_05f4: ldloc.s 8
-			IL_05f6: ldarg.0
-			IL_05f7: ldc.i4.4
-			IL_05f8: ldloc.0
-			IL_05f9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05fe: ldc.i4.3
-			IL_05ff: ldstr "_pendingException"
-			IL_0604: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0609: ldloc.0
-			IL_060a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_060f: dup
-			IL_0610: ldc.i4.0
-			IL_0611: ldloc.1
-			IL_0612: stelem.ref
-			IL_0613: dup
-			IL_0614: ldc.i4.1
-			IL_0615: ldloc.2
-			IL_0616: stelem.ref
-			IL_0617: dup
-			IL_0618: ldc.i4.2
-			IL_0619: ldloc.3
-			IL_061a: stelem.ref
-			IL_061b: dup
-			IL_061c: ldc.i4.3
-			IL_061d: ldloc.s 4
-			IL_061f: stelem.ref
-			IL_0620: dup
-			IL_0621: ldc.i4.4
-			IL_0622: ldloc.s 5
-			IL_0624: stelem.ref
-			IL_0625: dup
-			IL_0626: ldc.i4.5
-			IL_0627: ldloc.s 6
-			IL_0629: box [System.Runtime]System.Boolean
-			IL_062e: stelem.ref
-			IL_062f: dup
-			IL_0630: ldc.i4.6
-			IL_0631: ldloc.s 7
-			IL_0633: box [System.Runtime]System.Boolean
-			IL_0638: stelem.ref
-			IL_0639: dup
-			IL_063a: ldc.i4.7
-			IL_063b: ldloc.s 8
-			IL_063d: stelem.ref
-			IL_063e: dup
-			IL_063f: ldc.i4.8
-			IL_0640: ldloc.s 9
-			IL_0642: stelem.ref
-			IL_0643: dup
-			IL_0644: ldc.i4.s 9
-			IL_0646: ldloc.s 10
-			IL_0648: box [System.Runtime]System.Double
-			IL_064d: stelem.ref
-			IL_064e: dup
-			IL_064f: ldc.i4.s 10
-			IL_0651: ldloc.s 11
-			IL_0653: stelem.ref
-			IL_0654: dup
-			IL_0655: ldc.i4.s 11
-			IL_0657: ldloc.s 12
-			IL_0659: stelem.ref
-			IL_065a: dup
-			IL_065b: ldc.i4.s 12
-			IL_065d: ldloc.s 13
-			IL_065f: stelem.ref
-			IL_0660: dup
-			IL_0661: ldc.i4.s 13
-			IL_0663: ldloc.s 14
-			IL_0665: stelem.ref
-			IL_0666: dup
-			IL_0667: ldc.i4.s 14
-			IL_0669: ldloc.s 15
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.s 15
-			IL_066f: ldloc.s 16
-			IL_0671: stelem.ref
-			IL_0672: dup
-			IL_0673: ldc.i4.s 16
-			IL_0675: ldloc.s 17
-			IL_0677: box [System.Runtime]System.Boolean
-			IL_067c: stelem.ref
-			IL_067d: dup
-			IL_067e: ldc.i4.s 17
-			IL_0680: ldloc.s 18
-			IL_0682: stelem.ref
-			IL_0683: dup
-			IL_0684: ldc.i4.s 18
-			IL_0686: ldloc.s 19
-			IL_0688: stelem.ref
-			IL_0689: pop
-			IL_068a: ldloc.0
-			IL_068b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0690: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0695: ret
+			IL_057e: ldloc.0
+			IL_057f: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0584: pop
+			IL_0585: ldarg.0
+			IL_0586: ldc.i4.1
+			IL_0587: ldelem.ref
+			IL_0588: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_058d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0592: stloc.s 14
+			IL_0594: ldloc.s 14
+			IL_0596: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_059b: stloc.s 8
+			IL_059d: ldloc.s 8
+			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a4: stloc.s 8
+			IL_05a6: ldloc.s 8
+			IL_05a8: ldstr "readFile"
+			IL_05ad: ldloc.3
+			IL_05ae: ldstr "utf8"
+			IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05b8: stloc.s 8
+			IL_05ba: ldloc.0
+			IL_05bb: ldc.i4.7
+			IL_05bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05c1: ldloc.0
+			IL_05c2: ldloc.s 8
+			IL_05c4: ldarg.0
+			IL_05c5: ldc.i4.4
+			IL_05c6: ldloc.0
+			IL_05c7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05cc: ldc.i4.3
+			IL_05cd: ldstr "_pendingException"
+			IL_05d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05d7: ldloc.0
+			IL_05d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05dd: dup
+			IL_05de: ldc.i4.0
+			IL_05df: ldloc.1
+			IL_05e0: stelem.ref
+			IL_05e1: dup
+			IL_05e2: ldc.i4.1
+			IL_05e3: ldloc.2
+			IL_05e4: stelem.ref
+			IL_05e5: dup
+			IL_05e6: ldc.i4.2
+			IL_05e7: ldloc.3
+			IL_05e8: stelem.ref
+			IL_05e9: dup
+			IL_05ea: ldc.i4.3
+			IL_05eb: ldloc.s 4
+			IL_05ed: stelem.ref
+			IL_05ee: dup
+			IL_05ef: ldc.i4.4
+			IL_05f0: ldloc.s 5
+			IL_05f2: stelem.ref
+			IL_05f3: dup
+			IL_05f4: ldc.i4.5
+			IL_05f5: ldloc.s 6
+			IL_05f7: box [System.Runtime]System.Boolean
+			IL_05fc: stelem.ref
+			IL_05fd: dup
+			IL_05fe: ldc.i4.6
+			IL_05ff: ldloc.s 7
+			IL_0601: box [System.Runtime]System.Boolean
+			IL_0606: stelem.ref
+			IL_0607: dup
+			IL_0608: ldc.i4.7
+			IL_0609: ldloc.s 8
+			IL_060b: stelem.ref
+			IL_060c: dup
+			IL_060d: ldc.i4.8
+			IL_060e: ldloc.s 9
+			IL_0610: stelem.ref
+			IL_0611: dup
+			IL_0612: ldc.i4.s 9
+			IL_0614: ldloc.s 10
+			IL_0616: box [System.Runtime]System.Double
+			IL_061b: stelem.ref
+			IL_061c: dup
+			IL_061d: ldc.i4.s 10
+			IL_061f: ldloc.s 11
+			IL_0621: stelem.ref
+			IL_0622: dup
+			IL_0623: ldc.i4.s 11
+			IL_0625: ldloc.s 12
+			IL_0627: stelem.ref
+			IL_0628: dup
+			IL_0629: ldc.i4.s 12
+			IL_062b: ldloc.s 13
+			IL_062d: stelem.ref
+			IL_062e: dup
+			IL_062f: ldc.i4.s 13
+			IL_0631: ldloc.s 14
+			IL_0633: stelem.ref
+			IL_0634: dup
+			IL_0635: ldc.i4.s 14
+			IL_0637: ldloc.s 15
+			IL_0639: stelem.ref
+			IL_063a: dup
+			IL_063b: ldc.i4.s 15
+			IL_063d: ldloc.s 16
+			IL_063f: stelem.ref
+			IL_0640: dup
+			IL_0641: ldc.i4.s 16
+			IL_0643: ldloc.s 17
+			IL_0645: box [System.Runtime]System.Boolean
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.s 17
+			IL_064e: ldloc.s 18
+			IL_0650: stelem.ref
+			IL_0651: dup
+			IL_0652: ldc.i4.s 18
+			IL_0654: ldloc.s 19
+			IL_0656: stelem.ref
+			IL_0657: pop
+			IL_0658: ldloc.0
+			IL_0659: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_065e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0663: ret
 
-			IL_0696: ldloc.0
-			IL_0697: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
-			IL_069c: stloc.s 4
-			IL_069e: ldstr "console"
-			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06a8: stloc.s 8
-			IL_06aa: ldloc.s 8
-			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b1: stloc.s 8
-			IL_06b3: ldloc.s 8
-			IL_06b5: ldstr "log"
-			IL_06ba: ldstr "Text:"
-			IL_06bf: ldloc.s 4
-			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06c6: pop
-			IL_06c7: ldarg.0
-			IL_06c8: ldc.i4.1
-			IL_06c9: ldelem.ref
-			IL_06ca: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_06cf: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_06d4: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_06d9: stloc.s 14
-			IL_06db: ldloc.s 14
-			IL_06dd: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_06e2: stloc.s 8
-			IL_06e4: ldloc.s 8
-			IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06eb: stloc.s 8
-			IL_06ed: ldloc.s 8
-			IL_06ef: ldstr "unlink"
-			IL_06f4: ldloc.3
-			IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06fa: stloc.s 8
-			IL_06fc: ldloc.0
-			IL_06fd: ldc.i4.8
-			IL_06fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0703: ldloc.0
-			IL_0704: ldloc.s 8
-			IL_0706: ldarg.0
-			IL_0707: ldc.i4.5
-			IL_0708: ldloc.0
-			IL_0709: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_070e: ldc.i4.3
-			IL_070f: ldstr "_pendingException"
-			IL_0714: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0719: ldloc.0
-			IL_071a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_071f: dup
-			IL_0720: ldc.i4.0
-			IL_0721: ldloc.1
-			IL_0722: stelem.ref
-			IL_0723: dup
-			IL_0724: ldc.i4.1
-			IL_0725: ldloc.2
+			IL_0664: ldloc.0
+			IL_0665: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited4
+			IL_066a: stloc.s 4
+			IL_066c: ldstr "console"
+			IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0676: stloc.s 8
+			IL_0678: ldloc.s 8
+			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_067f: stloc.s 8
+			IL_0681: ldloc.s 8
+			IL_0683: ldstr "log"
+			IL_0688: ldstr "Text:"
+			IL_068d: ldloc.s 4
+			IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0694: pop
+			IL_0695: ldarg.0
+			IL_0696: ldc.i4.1
+			IL_0697: ldelem.ref
+			IL_0698: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_069d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_06a2: stloc.s 14
+			IL_06a4: ldloc.s 14
+			IL_06a6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_06ab: stloc.s 8
+			IL_06ad: ldloc.s 8
+			IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06b4: stloc.s 8
+			IL_06b6: ldloc.s 8
+			IL_06b8: ldstr "unlink"
+			IL_06bd: ldloc.3
+			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06c3: stloc.s 8
+			IL_06c5: ldloc.0
+			IL_06c6: ldc.i4.8
+			IL_06c7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06cc: ldloc.0
+			IL_06cd: ldloc.s 8
+			IL_06cf: ldarg.0
+			IL_06d0: ldc.i4.5
+			IL_06d1: ldloc.0
+			IL_06d2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06d7: ldc.i4.3
+			IL_06d8: ldstr "_pendingException"
+			IL_06dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_06e2: ldloc.0
+			IL_06e3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_06e8: dup
+			IL_06e9: ldc.i4.0
+			IL_06ea: ldloc.1
+			IL_06eb: stelem.ref
+			IL_06ec: dup
+			IL_06ed: ldc.i4.1
+			IL_06ee: ldloc.2
+			IL_06ef: stelem.ref
+			IL_06f0: dup
+			IL_06f1: ldc.i4.2
+			IL_06f2: ldloc.3
+			IL_06f3: stelem.ref
+			IL_06f4: dup
+			IL_06f5: ldc.i4.3
+			IL_06f6: ldloc.s 4
+			IL_06f8: stelem.ref
+			IL_06f9: dup
+			IL_06fa: ldc.i4.4
+			IL_06fb: ldloc.s 5
+			IL_06fd: stelem.ref
+			IL_06fe: dup
+			IL_06ff: ldc.i4.5
+			IL_0700: ldloc.s 6
+			IL_0702: box [System.Runtime]System.Boolean
+			IL_0707: stelem.ref
+			IL_0708: dup
+			IL_0709: ldc.i4.6
+			IL_070a: ldloc.s 7
+			IL_070c: box [System.Runtime]System.Boolean
+			IL_0711: stelem.ref
+			IL_0712: dup
+			IL_0713: ldc.i4.7
+			IL_0714: ldloc.s 8
+			IL_0716: stelem.ref
+			IL_0717: dup
+			IL_0718: ldc.i4.8
+			IL_0719: ldloc.s 9
+			IL_071b: stelem.ref
+			IL_071c: dup
+			IL_071d: ldc.i4.s 9
+			IL_071f: ldloc.s 10
+			IL_0721: box [System.Runtime]System.Double
 			IL_0726: stelem.ref
 			IL_0727: dup
-			IL_0728: ldc.i4.2
-			IL_0729: ldloc.3
-			IL_072a: stelem.ref
-			IL_072b: dup
-			IL_072c: ldc.i4.3
-			IL_072d: ldloc.s 4
-			IL_072f: stelem.ref
-			IL_0730: dup
-			IL_0731: ldc.i4.4
-			IL_0732: ldloc.s 5
-			IL_0734: stelem.ref
-			IL_0735: dup
-			IL_0736: ldc.i4.5
-			IL_0737: ldloc.s 6
-			IL_0739: box [System.Runtime]System.Boolean
+			IL_0728: ldc.i4.s 10
+			IL_072a: ldloc.s 11
+			IL_072c: stelem.ref
+			IL_072d: dup
+			IL_072e: ldc.i4.s 11
+			IL_0730: ldloc.s 12
+			IL_0732: stelem.ref
+			IL_0733: dup
+			IL_0734: ldc.i4.s 12
+			IL_0736: ldloc.s 13
+			IL_0738: stelem.ref
+			IL_0739: dup
+			IL_073a: ldc.i4.s 13
+			IL_073c: ldloc.s 14
 			IL_073e: stelem.ref
 			IL_073f: dup
-			IL_0740: ldc.i4.6
-			IL_0741: ldloc.s 7
-			IL_0743: box [System.Runtime]System.Boolean
-			IL_0748: stelem.ref
-			IL_0749: dup
-			IL_074a: ldc.i4.7
-			IL_074b: ldloc.s 8
-			IL_074d: stelem.ref
-			IL_074e: dup
-			IL_074f: ldc.i4.8
-			IL_0750: ldloc.s 9
-			IL_0752: stelem.ref
-			IL_0753: dup
-			IL_0754: ldc.i4.s 9
-			IL_0756: ldloc.s 10
-			IL_0758: box [System.Runtime]System.Double
-			IL_075d: stelem.ref
-			IL_075e: dup
-			IL_075f: ldc.i4.s 10
-			IL_0761: ldloc.s 11
-			IL_0763: stelem.ref
-			IL_0764: dup
-			IL_0765: ldc.i4.s 11
-			IL_0767: ldloc.s 12
-			IL_0769: stelem.ref
-			IL_076a: dup
-			IL_076b: ldc.i4.s 12
-			IL_076d: ldloc.s 13
-			IL_076f: stelem.ref
-			IL_0770: dup
-			IL_0771: ldc.i4.s 13
-			IL_0773: ldloc.s 14
-			IL_0775: stelem.ref
-			IL_0776: dup
-			IL_0777: ldc.i4.s 14
-			IL_0779: ldloc.s 15
-			IL_077b: stelem.ref
-			IL_077c: dup
-			IL_077d: ldc.i4.s 15
-			IL_077f: ldloc.s 16
-			IL_0781: stelem.ref
-			IL_0782: dup
-			IL_0783: ldc.i4.s 16
-			IL_0785: ldloc.s 17
-			IL_0787: box [System.Runtime]System.Boolean
-			IL_078c: stelem.ref
-			IL_078d: dup
-			IL_078e: ldc.i4.s 17
-			IL_0790: ldloc.s 18
-			IL_0792: stelem.ref
-			IL_0793: dup
-			IL_0794: ldc.i4.s 18
-			IL_0796: ldloc.s 19
-			IL_0798: stelem.ref
-			IL_0799: pop
-			IL_079a: ldloc.0
-			IL_079b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07a0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07a5: ret
+			IL_0740: ldc.i4.s 14
+			IL_0742: ldloc.s 15
+			IL_0744: stelem.ref
+			IL_0745: dup
+			IL_0746: ldc.i4.s 15
+			IL_0748: ldloc.s 16
+			IL_074a: stelem.ref
+			IL_074b: dup
+			IL_074c: ldc.i4.s 16
+			IL_074e: ldloc.s 17
+			IL_0750: box [System.Runtime]System.Boolean
+			IL_0755: stelem.ref
+			IL_0756: dup
+			IL_0757: ldc.i4.s 17
+			IL_0759: ldloc.s 18
+			IL_075b: stelem.ref
+			IL_075c: dup
+			IL_075d: ldc.i4.s 18
+			IL_075f: ldloc.s 19
+			IL_0761: stelem.ref
+			IL_0762: pop
+			IL_0763: ldloc.0
+			IL_0764: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0769: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_076e: ret
 
-			IL_07a6: ldloc.0
-			IL_07a7: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
-			IL_07ac: pop
-			IL_07ad: ldstr "console"
-			IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07b7: stloc.s 8
-			IL_07b9: ldloc.s 8
-			IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07c0: stloc.s 8
-			IL_07c2: ldarg.0
+			IL_076f: ldloc.0
+			IL_0770: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
+			IL_0775: pop
+			IL_0776: ldstr "console"
+			IL_077b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0780: stloc.s 8
+			IL_0782: ldloc.s 8
+			IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0789: stloc.s 8
+			IL_078b: ldarg.0
+			IL_078c: ldc.i4.1
+			IL_078d: ldelem.ref
+			IL_078e: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0793: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0798: stloc.s 14
+			IL_079a: ldloc.s 14
+			IL_079c: ldloc.3
+			IL_079d: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_07a2: box [System.Runtime]System.Boolean
+			IL_07a7: stloc.s 16
+			IL_07a9: ldloc.s 8
+			IL_07ab: ldstr "log"
+			IL_07b0: ldstr "ExistsAfterUnlink:"
+			IL_07b5: ldloc.s 16
+			IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_07bc: pop
+			IL_07bd: br IL_0854
+
+			IL_07c2: ldloc.0
 			IL_07c3: ldc.i4.1
-			IL_07c4: ldelem.ref
-			IL_07c5: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_07ca: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_07cf: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_07d4: stloc.s 14
-			IL_07d6: ldloc.s 14
-			IL_07d8: ldloc.3
-			IL_07d9: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_07de: box [System.Runtime]System.Boolean
-			IL_07e3: stloc.s 16
-			IL_07e5: ldloc.s 8
-			IL_07e7: ldstr "log"
-			IL_07ec: ldstr "ExistsAfterUnlink:"
-			IL_07f1: ldloc.s 16
-			IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_07f8: pop
-			IL_07f9: br IL_0890
+			IL_07c4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07c9: ldloc.0
+			IL_07ca: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07cf: stloc.s 16
+			IL_07d1: ldloc.0
+			IL_07d2: ldc.i4.0
+			IL_07d3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07d8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07dd: ldloc.0
+			IL_07de: ldc.i4.0
+			IL_07df: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07e4: ldloc.s 16
+			IL_07e6: stloc.s 5
+			IL_07e8: ldstr "console"
+			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07f2: stloc.s 16
+			IL_07f4: ldloc.s 16
+			IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07fb: stloc.s 16
+			IL_07fd: ldloc.s 5
+			IL_07ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0804: stloc.s 17
+			IL_0806: ldloc.s 17
+			IL_0808: brfalse IL_0824
 
-			IL_07fe: ldloc.0
-			IL_07ff: ldc.i4.1
-			IL_0800: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0805: ldloc.0
-			IL_0806: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_080b: stloc.s 16
-			IL_080d: ldloc.0
-			IL_080e: ldc.i4.0
-			IL_080f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0814: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0819: ldloc.0
-			IL_081a: ldc.i4.0
-			IL_081b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0820: ldloc.s 16
-			IL_0822: stloc.s 5
-			IL_0824: ldstr "console"
-			IL_0829: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_082e: stloc.s 16
-			IL_0830: ldloc.s 16
-			IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0837: stloc.s 16
-			IL_0839: ldloc.s 5
-			IL_083b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0840: stloc.s 17
-			IL_0842: ldloc.s 17
-			IL_0844: brfalse IL_0860
+			IL_080d: ldloc.s 5
+			IL_080f: ldstr "message"
+			IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0819: stloc.s 8
+			IL_081b: ldloc.s 8
+			IL_081d: stloc.s 19
+			IL_081f: br IL_0828
 
-			IL_0849: ldloc.s 5
-			IL_084b: ldstr "message"
-			IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0855: stloc.s 8
-			IL_0857: ldloc.s 8
-			IL_0859: stloc.s 19
-			IL_085b: br IL_0864
+			IL_0824: ldloc.s 5
+			IL_0826: stloc.s 19
 
-			IL_0860: ldloc.s 5
-			IL_0862: stloc.s 19
+			IL_0828: ldloc.s 16
+			IL_082a: ldstr "log"
+			IL_082f: ldstr "Error:"
+			IL_0834: ldloc.s 19
+			IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_083b: pop
+			IL_083c: br IL_0854
 
-			IL_0864: ldloc.s 16
-			IL_0866: ldstr "log"
-			IL_086b: ldstr "Error:"
-			IL_0870: ldloc.s 19
-			IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0877: pop
-			IL_0878: br IL_0890
+			IL_0841: ldloc.0
+			IL_0842: ldc.i4.1
+			IL_0843: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0848: ldloc.0
+			IL_0849: ldc.i4.0
+			IL_084a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_084f: br IL_0854
 
-			IL_087d: ldloc.0
-			IL_087e: ldc.i4.1
-			IL_087f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0884: ldloc.0
-			IL_0885: ldc.i4.0
-			IL_0886: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_088b: br IL_0890
+			IL_0854: ldarg.0
+			IL_0855: ldc.i4.1
+			IL_0856: ldelem.ref
+			IL_0857: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_085c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0861: stloc.s 14
+			IL_0863: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0868: dup
+			IL_0869: ldstr "force"
+			IL_086e: ldc.i4.1
+			IL_086f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0874: stloc.s 15
+			IL_0876: ldloc.s 14
+			IL_0878: ldloc.2
+			IL_0879: ldloc.s 15
+			IL_087b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0880: ldarg.0
+			IL_0881: ldc.i4.1
+			IL_0882: ldelem.ref
+			IL_0883: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0888: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_088d: stloc.s 14
+			IL_088f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0894: dup
+			IL_0895: ldstr "force"
+			IL_089a: ldc.i4.1
+			IL_089b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08a0: stloc.s 15
+			IL_08a2: ldloc.s 14
+			IL_08a4: ldloc.3
+			IL_08a5: ldloc.s 15
+			IL_08a7: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_08ac: br IL_08c4
 
-			IL_0890: ldarg.0
-			IL_0891: ldc.i4.1
-			IL_0892: ldelem.ref
-			IL_0893: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0898: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_089d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_08a2: stloc.s 14
-			IL_08a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08a9: dup
-			IL_08aa: ldstr "force"
-			IL_08af: ldc.i4.1
-			IL_08b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08b5: stloc.s 15
-			IL_08b7: ldloc.s 14
-			IL_08b9: ldloc.2
-			IL_08ba: ldloc.s 15
-			IL_08bc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_08c1: ldarg.0
-			IL_08c2: ldc.i4.1
-			IL_08c3: ldelem.ref
-			IL_08c4: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_08c9: ldfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_08ce: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_08d3: stloc.s 14
-			IL_08d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08da: dup
-			IL_08db: ldstr "force"
-			IL_08e0: ldc.i4.1
-			IL_08e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08e6: stloc.s 15
-			IL_08e8: ldloc.s 14
-			IL_08ea: ldloc.3
-			IL_08eb: ldloc.s 15
-			IL_08ed: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_08f2: br IL_090a
+			IL_08b1: ldloc.0
+			IL_08b2: ldc.i4.1
+			IL_08b3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08b8: ldloc.0
+			IL_08b9: ldc.i4.0
+			IL_08ba: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08bf: br IL_08c4
 
-			IL_08f7: ldloc.0
-			IL_08f8: ldc.i4.1
-			IL_08f9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08fe: ldloc.0
-			IL_08ff: ldc.i4.0
-			IL_0900: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0905: br IL_090a
+			IL_08c4: ldloc.0
+			IL_08c5: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08ca: stloc.s 6
+			IL_08cc: ldloc.s 6
+			IL_08ce: brfalse IL_090b
 
-			IL_090a: ldloc.0
-			IL_090b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0910: stloc.s 6
-			IL_0912: ldloc.s 6
-			IL_0914: brfalse IL_0951
+			IL_08d3: ldloc.0
+			IL_08d4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_08d9: stloc.s 16
+			IL_08db: ldloc.0
+			IL_08dc: ldc.i4.m1
+			IL_08dd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08e2: ldloc.0
+			IL_08e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08ed: ldarg.0
+			IL_08ee: ldc.i4.1
+			IL_08ef: newarr [System.Runtime]System.Object
+			IL_08f4: dup
+			IL_08f5: ldc.i4.0
+			IL_08f6: ldloc.s 16
+			IL_08f8: stelem.ref
+			IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08fe: pop
+			IL_08ff: ldloc.0
+			IL_0900: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0905: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_090a: ret
 
-			IL_0919: ldloc.0
-			IL_091a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_091f: stloc.s 16
-			IL_0921: ldloc.0
-			IL_0922: ldc.i4.m1
-			IL_0923: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0928: ldloc.0
-			IL_0929: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_092e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0933: ldarg.0
-			IL_0934: ldc.i4.1
-			IL_0935: newarr [System.Runtime]System.Object
-			IL_093a: dup
-			IL_093b: ldc.i4.0
-			IL_093c: ldloc.s 16
-			IL_093e: stelem.ref
-			IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0944: pop
-			IL_0945: ldloc.0
-			IL_0946: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_094b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0950: ret
+			IL_090b: ldloc.0
+			IL_090c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0911: stloc.s 7
+			IL_0913: ldloc.s 7
+			IL_0915: brfalse IL_0952
 
-			IL_0951: ldloc.0
-			IL_0952: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0957: stloc.s 7
-			IL_0959: ldloc.s 7
-			IL_095b: brfalse IL_0998
+			IL_091a: ldloc.0
+			IL_091b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0920: stloc.s 16
+			IL_0922: ldloc.0
+			IL_0923: ldc.i4.m1
+			IL_0924: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0929: ldloc.0
+			IL_092a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_092f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0934: ldarg.0
+			IL_0935: ldc.i4.1
+			IL_0936: newarr [System.Runtime]System.Object
+			IL_093b: dup
+			IL_093c: ldc.i4.0
+			IL_093d: ldloc.s 16
+			IL_093f: stelem.ref
+			IL_0940: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0945: pop
+			IL_0946: ldloc.0
+			IL_0947: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_094c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0951: ret
 
-			IL_0960: ldloc.0
-			IL_0961: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0966: stloc.s 16
-			IL_0968: ldloc.0
-			IL_0969: ldc.i4.m1
-			IL_096a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_096f: ldloc.0
-			IL_0970: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0975: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_097a: ldarg.0
-			IL_097b: ldc.i4.1
-			IL_097c: newarr [System.Runtime]System.Object
-			IL_0981: dup
-			IL_0982: ldc.i4.0
-			IL_0983: ldloc.s 16
-			IL_0985: stelem.ref
-			IL_0986: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_098b: pop
-			IL_098c: ldloc.0
-			IL_098d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0992: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0997: ret
-
-			IL_0998: ldloc.0
-			IL_0999: ldc.i4.m1
-			IL_099a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_099f: ldloc.0
-			IL_09a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_09aa: ldarg.0
-			IL_09ab: ldc.i4.1
-			IL_09ac: newarr [System.Runtime]System.Object
-			IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09b6: pop
-			IL_09b7: ldloc.0
-			IL_09b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09c2: ret
+			IL_0952: ldloc.0
+			IL_0953: ldc.i4.m1
+			IL_0954: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0959: ldloc.0
+			IL_095a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_095f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0964: ldarg.0
+			IL_0965: ldc.i4.1
+			IL_0966: newarr [System.Runtime]System.Object
+			IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0970: pop
+			IL_0971: ldloc.0
+			IL_0972: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0977: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_097c: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1289,15 +1275,15 @@
 			73 3d 7b 6f 73 7d 00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object path
-		.field public object os
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule os
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2abf
+			// Method begins at RVA 0x2a79
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1343,21 +1329,21 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
 		IL_001a: ldarg.1
 		IL_001b: ldstr "path"
 		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0025: stloc.2
 		IL_0026: ldloc.0
 		IL_0027: ldloc.2
-		IL_0028: stfld object Modules.FSPromises_Append_Rename_Unlink/Scope::path
+		IL_0028: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Append_Rename_Unlink/Scope::path
 		IL_002d: ldarg.1
 		IL_002e: ldstr "os"
 		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.0
 		IL_003a: ldloc.3
-		IL_003b: stfld object Modules.FSPromises_Append_Rename_Unlink/Scope::os
+		IL_003b: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Append_Rename_Unlink/Scope::os
 		IL_0040: ldnull
 		IL_0041: ldftn object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2::__js_call__(object[], object)
 		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
@@ -1398,7 +1384,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2aec
+		// Method begins at RVA 0x2aa6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d68
+					// Method begins at RVA 0x2d45
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d71
+					// Method begins at RVA 0x2d4e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d7a
+					// Method begins at RVA 0x2d57
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -121,7 +121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d5f
+				// Method begins at RVA 0x2d3c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -147,7 +147,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 3162 (0xc5a)
+			// Code size: 3127 (0xc37)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope,
@@ -341,7 +341,7 @@
 
 			IL_0138: ldloc.0
 			IL_0139: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_013e: switch (IL_016b, IL_0b45, IL_0b8e, IL_0ac6, IL_03c2, IL_0525, IL_0657, IL_0761, IL_0863, IL_0956)
+			IL_013e: switch (IL_016b, IL_0b27, IL_0b6b, IL_0aa8, IL_03a9, IL_050c, IL_063e, IL_0748, IL_084a, IL_093d)
 
 			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0170: stloc.s 13
@@ -376,1258 +376,1251 @@
 			IL_01cf: ldc.i4.1
 			IL_01d0: ldelem.ref
 			IL_01d1: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_01d6: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
-			IL_01db: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_01e0: stloc.s 17
-			IL_01e2: ldarg.0
-			IL_01e3: ldc.i4.1
-			IL_01e4: ldelem.ref
-			IL_01e5: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_01ea: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
-			IL_01ef: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule
-			IL_01f4: stloc.s 18
-			IL_01f6: ldloc.s 18
-			IL_01f8: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01fd: stloc.s 13
-			IL_01ff: ldloc.1
-			IL_0200: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0205: stloc.s 14
-			IL_0207: ldstr "jroc-fs-open-position-"
-			IL_020c: ldloc.s 14
+			IL_01d6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
+			IL_01db: stloc.s 17
+			IL_01dd: ldarg.0
+			IL_01de: ldc.i4.1
+			IL_01df: ldelem.ref
+			IL_01e0: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_01e5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
+			IL_01ea: stloc.s 18
+			IL_01ec: ldloc.s 18
+			IL_01ee: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01f3: stloc.s 13
+			IL_01f5: ldloc.1
+			IL_01f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01fb: stloc.s 14
+			IL_01fd: ldstr "jroc-fs-open-position-"
+			IL_0202: ldloc.s 14
+			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0209: ldstr ".txt"
 			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0213: ldstr ".txt"
-			IL_0218: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021d: stloc.s 14
-			IL_021f: ldloc.s 17
-			IL_0221: ldc.i4.2
-			IL_0222: newarr [System.Runtime]System.Object
-			IL_0227: dup
-			IL_0228: ldc.i4.0
-			IL_0229: ldloc.s 13
-			IL_022b: stelem.ref
-			IL_022c: dup
-			IL_022d: ldc.i4.1
-			IL_022e: ldloc.s 14
-			IL_0230: stelem.ref
-			IL_0231: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0236: stloc.2
-			IL_0237: ldloc.0
-			IL_0238: ldc.i4.0
-			IL_0239: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_023e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0243: ldloc.0
-			IL_0244: ldc.i4.0
-			IL_0245: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_024a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_024f: ldloc.0
-			IL_0250: ldc.i4.0
-			IL_0251: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0256: ldloc.0
-			IL_0257: ldc.i4.0
-			IL_0258: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_025d: ldarg.0
-			IL_025e: ldc.i4.1
-			IL_025f: ldelem.ref
-			IL_0260: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0265: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_026a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_026f: stloc.s 19
-			IL_0271: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0276: dup
-			IL_0277: ldstr "force"
-			IL_027c: ldc.i4.1
-			IL_027d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0282: stloc.s 20
-			IL_0284: ldloc.s 19
-			IL_0286: ldloc.2
-			IL_0287: ldloc.s 20
-			IL_0289: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_028e: ldarg.0
-			IL_028f: ldc.i4.1
-			IL_0290: ldelem.ref
-			IL_0291: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0296: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_029b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02a0: stloc.s 19
-			IL_02a2: ldloc.s 19
-			IL_02a4: ldloc.2
-			IL_02a5: ldstr "hello"
-			IL_02aa: ldstr "utf8"
-			IL_02af: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_02b4: ldarg.0
-			IL_02b5: ldc.i4.1
-			IL_02b6: ldelem.ref
-			IL_02b7: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_02bc: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_02c1: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02c6: stloc.s 19
-			IL_02c8: ldloc.s 19
-			IL_02ca: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_02cf: stloc.s 13
-			IL_02d1: ldloc.s 13
-			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d8: stloc.s 13
-			IL_02da: ldloc.s 13
-			IL_02dc: ldstr "open"
-			IL_02e1: ldloc.2
-			IL_02e2: ldstr "r+"
-			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02ec: stloc.s 13
-			IL_02ee: ldloc.0
-			IL_02ef: ldc.i4.4
-			IL_02f0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02f5: ldloc.0
-			IL_02f6: ldloc.s 13
-			IL_02f8: ldarg.0
-			IL_02f9: ldc.i4.1
-			IL_02fa: ldloc.0
-			IL_02fb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0300: ldc.i4.3
-			IL_0301: ldstr "_pendingException"
-			IL_0306: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_030b: ldloc.0
-			IL_030c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0311: dup
-			IL_0312: ldc.i4.0
-			IL_0313: ldloc.1
-			IL_0314: stelem.ref
-			IL_0315: dup
-			IL_0316: ldc.i4.1
-			IL_0317: ldloc.2
-			IL_0318: stelem.ref
-			IL_0319: dup
-			IL_031a: ldc.i4.2
-			IL_031b: ldloc.3
+			IL_0213: stloc.s 14
+			IL_0215: ldloc.s 17
+			IL_0217: ldc.i4.2
+			IL_0218: newarr [System.Runtime]System.Object
+			IL_021d: dup
+			IL_021e: ldc.i4.0
+			IL_021f: ldloc.s 13
+			IL_0221: stelem.ref
+			IL_0222: dup
+			IL_0223: ldc.i4.1
+			IL_0224: ldloc.s 14
+			IL_0226: stelem.ref
+			IL_0227: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_022c: stloc.2
+			IL_022d: ldloc.0
+			IL_022e: ldc.i4.0
+			IL_022f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0234: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0239: ldloc.0
+			IL_023a: ldc.i4.0
+			IL_023b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0240: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0245: ldloc.0
+			IL_0246: ldc.i4.0
+			IL_0247: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_024c: ldloc.0
+			IL_024d: ldc.i4.0
+			IL_024e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0253: ldarg.0
+			IL_0254: ldc.i4.1
+			IL_0255: ldelem.ref
+			IL_0256: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_025b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0260: stloc.s 19
+			IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0267: dup
+			IL_0268: ldstr "force"
+			IL_026d: ldc.i4.1
+			IL_026e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0273: stloc.s 20
+			IL_0275: ldloc.s 19
+			IL_0277: ldloc.2
+			IL_0278: ldloc.s 20
+			IL_027a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_027f: ldarg.0
+			IL_0280: ldc.i4.1
+			IL_0281: ldelem.ref
+			IL_0282: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0287: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_028c: stloc.s 19
+			IL_028e: ldloc.s 19
+			IL_0290: ldloc.2
+			IL_0291: ldstr "hello"
+			IL_0296: ldstr "utf8"
+			IL_029b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_02a0: ldarg.0
+			IL_02a1: ldc.i4.1
+			IL_02a2: ldelem.ref
+			IL_02a3: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_02a8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_02ad: stloc.s 19
+			IL_02af: ldloc.s 19
+			IL_02b1: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_02b6: stloc.s 13
+			IL_02b8: ldloc.s 13
+			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02bf: stloc.s 13
+			IL_02c1: ldloc.s 13
+			IL_02c3: ldstr "open"
+			IL_02c8: ldloc.2
+			IL_02c9: ldstr "r+"
+			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02d3: stloc.s 13
+			IL_02d5: ldloc.0
+			IL_02d6: ldc.i4.4
+			IL_02d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02dc: ldloc.0
+			IL_02dd: ldloc.s 13
+			IL_02df: ldarg.0
+			IL_02e0: ldc.i4.1
+			IL_02e1: ldloc.0
+			IL_02e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02e7: ldc.i4.3
+			IL_02e8: ldstr "_pendingException"
+			IL_02ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02f2: ldloc.0
+			IL_02f3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02f8: dup
+			IL_02f9: ldc.i4.0
+			IL_02fa: ldloc.1
+			IL_02fb: stelem.ref
+			IL_02fc: dup
+			IL_02fd: ldc.i4.1
+			IL_02fe: ldloc.2
+			IL_02ff: stelem.ref
+			IL_0300: dup
+			IL_0301: ldc.i4.2
+			IL_0302: ldloc.3
+			IL_0303: stelem.ref
+			IL_0304: dup
+			IL_0305: ldc.i4.3
+			IL_0306: ldloc.s 4
+			IL_0308: stelem.ref
+			IL_0309: dup
+			IL_030a: ldc.i4.4
+			IL_030b: ldloc.s 5
+			IL_030d: stelem.ref
+			IL_030e: dup
+			IL_030f: ldc.i4.5
+			IL_0310: ldloc.s 6
+			IL_0312: stelem.ref
+			IL_0313: dup
+			IL_0314: ldc.i4.6
+			IL_0315: ldloc.s 7
+			IL_0317: stelem.ref
+			IL_0318: dup
+			IL_0319: ldc.i4.7
+			IL_031a: ldloc.s 8
 			IL_031c: stelem.ref
 			IL_031d: dup
-			IL_031e: ldc.i4.3
-			IL_031f: ldloc.s 4
+			IL_031e: ldc.i4.8
+			IL_031f: ldloc.s 9
 			IL_0321: stelem.ref
 			IL_0322: dup
-			IL_0323: ldc.i4.4
-			IL_0324: ldloc.s 5
-			IL_0326: stelem.ref
-			IL_0327: dup
-			IL_0328: ldc.i4.5
-			IL_0329: ldloc.s 6
-			IL_032b: stelem.ref
-			IL_032c: dup
-			IL_032d: ldc.i4.6
-			IL_032e: ldloc.s 7
-			IL_0330: stelem.ref
-			IL_0331: dup
-			IL_0332: ldc.i4.7
-			IL_0333: ldloc.s 8
-			IL_0335: stelem.ref
-			IL_0336: dup
-			IL_0337: ldc.i4.8
-			IL_0338: ldloc.s 9
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.s 9
-			IL_033e: ldloc.s 10
-			IL_0340: stelem.ref
-			IL_0341: dup
-			IL_0342: ldc.i4.s 10
-			IL_0344: ldloc.s 11
-			IL_0346: box [System.Runtime]System.Boolean
-			IL_034b: stelem.ref
-			IL_034c: dup
-			IL_034d: ldc.i4.s 11
-			IL_034f: ldloc.s 12
-			IL_0351: box [System.Runtime]System.Boolean
-			IL_0356: stelem.ref
-			IL_0357: dup
-			IL_0358: ldc.i4.s 12
-			IL_035a: ldloc.s 13
-			IL_035c: stelem.ref
-			IL_035d: dup
-			IL_035e: ldc.i4.s 13
-			IL_0360: ldloc.s 14
-			IL_0362: stelem.ref
-			IL_0363: dup
-			IL_0364: ldc.i4.s 14
-			IL_0366: ldloc.s 15
-			IL_0368: box [System.Runtime]System.Double
-			IL_036d: stelem.ref
-			IL_036e: dup
-			IL_036f: ldc.i4.s 15
-			IL_0371: ldloc.s 16
-			IL_0373: stelem.ref
-			IL_0374: dup
-			IL_0375: ldc.i4.s 16
-			IL_0377: ldloc.s 17
-			IL_0379: stelem.ref
-			IL_037a: dup
-			IL_037b: ldc.i4.s 17
-			IL_037d: ldloc.s 18
-			IL_037f: stelem.ref
-			IL_0380: dup
-			IL_0381: ldc.i4.s 18
-			IL_0383: ldloc.s 19
-			IL_0385: stelem.ref
-			IL_0386: dup
-			IL_0387: ldc.i4.s 19
-			IL_0389: ldloc.s 20
-			IL_038b: stelem.ref
-			IL_038c: dup
-			IL_038d: ldc.i4.s 20
-			IL_038f: ldloc.s 21
-			IL_0391: stelem.ref
-			IL_0392: dup
-			IL_0393: ldc.i4.s 21
-			IL_0395: ldloc.s 22
-			IL_0397: stelem.ref
-			IL_0398: dup
-			IL_0399: ldc.i4.s 22
-			IL_039b: ldloc.s 23
-			IL_039d: stelem.ref
-			IL_039e: dup
-			IL_039f: ldc.i4.s 23
-			IL_03a1: ldloc.s 24
-			IL_03a3: box [System.Runtime]System.Boolean
-			IL_03a8: stelem.ref
-			IL_03a9: dup
-			IL_03aa: ldc.i4.s 24
-			IL_03ac: ldloc.s 25
-			IL_03ae: stelem.ref
-			IL_03af: dup
-			IL_03b0: ldc.i4.s 25
-			IL_03b2: ldloc.s 26
-			IL_03b4: stelem.ref
-			IL_03b5: pop
-			IL_03b6: ldloc.0
-			IL_03b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03bc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03c1: ret
+			IL_0323: ldc.i4.s 9
+			IL_0325: ldloc.s 10
+			IL_0327: stelem.ref
+			IL_0328: dup
+			IL_0329: ldc.i4.s 10
+			IL_032b: ldloc.s 11
+			IL_032d: box [System.Runtime]System.Boolean
+			IL_0332: stelem.ref
+			IL_0333: dup
+			IL_0334: ldc.i4.s 11
+			IL_0336: ldloc.s 12
+			IL_0338: box [System.Runtime]System.Boolean
+			IL_033d: stelem.ref
+			IL_033e: dup
+			IL_033f: ldc.i4.s 12
+			IL_0341: ldloc.s 13
+			IL_0343: stelem.ref
+			IL_0344: dup
+			IL_0345: ldc.i4.s 13
+			IL_0347: ldloc.s 14
+			IL_0349: stelem.ref
+			IL_034a: dup
+			IL_034b: ldc.i4.s 14
+			IL_034d: ldloc.s 15
+			IL_034f: box [System.Runtime]System.Double
+			IL_0354: stelem.ref
+			IL_0355: dup
+			IL_0356: ldc.i4.s 15
+			IL_0358: ldloc.s 16
+			IL_035a: stelem.ref
+			IL_035b: dup
+			IL_035c: ldc.i4.s 16
+			IL_035e: ldloc.s 17
+			IL_0360: stelem.ref
+			IL_0361: dup
+			IL_0362: ldc.i4.s 17
+			IL_0364: ldloc.s 18
+			IL_0366: stelem.ref
+			IL_0367: dup
+			IL_0368: ldc.i4.s 18
+			IL_036a: ldloc.s 19
+			IL_036c: stelem.ref
+			IL_036d: dup
+			IL_036e: ldc.i4.s 19
+			IL_0370: ldloc.s 20
+			IL_0372: stelem.ref
+			IL_0373: dup
+			IL_0374: ldc.i4.s 20
+			IL_0376: ldloc.s 21
+			IL_0378: stelem.ref
+			IL_0379: dup
+			IL_037a: ldc.i4.s 21
+			IL_037c: ldloc.s 22
+			IL_037e: stelem.ref
+			IL_037f: dup
+			IL_0380: ldc.i4.s 22
+			IL_0382: ldloc.s 23
+			IL_0384: stelem.ref
+			IL_0385: dup
+			IL_0386: ldc.i4.s 23
+			IL_0388: ldloc.s 24
+			IL_038a: box [System.Runtime]System.Boolean
+			IL_038f: stelem.ref
+			IL_0390: dup
+			IL_0391: ldc.i4.s 24
+			IL_0393: ldloc.s 25
+			IL_0395: stelem.ref
+			IL_0396: dup
+			IL_0397: ldc.i4.s 25
+			IL_0399: ldloc.s 26
+			IL_039b: stelem.ref
+			IL_039c: pop
+			IL_039d: ldloc.0
+			IL_039e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03a8: ret
 
-			IL_03c2: ldloc.0
-			IL_03c3: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
-			IL_03c8: stloc.3
-			IL_03c9: ldc.r8 1
-			IL_03d2: box [System.Runtime]System.Double
-			IL_03d7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_03dc: stloc.s 4
-			IL_03de: ldc.r8 1
-			IL_03e7: box [System.Runtime]System.Double
-			IL_03ec: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_03f1: stloc.s 5
-			IL_03f3: ldloc.3
-			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f9: stloc.s 13
-			IL_03fb: ldloc.s 4
-			IL_03fd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_0402: stloc.s 15
-			IL_0404: ldloc.s 15
-			IL_0406: box [System.Runtime]System.Double
-			IL_040b: stloc.s 16
-			IL_040d: ldc.i4.4
-			IL_040e: newarr [System.Runtime]System.Object
-			IL_0413: dup
-			IL_0414: ldc.i4.0
-			IL_0415: ldloc.s 4
-			IL_0417: stelem.ref
-			IL_0418: dup
-			IL_0419: ldc.i4.1
-			IL_041a: ldc.r8 0.0
-			IL_0423: box [System.Runtime]System.Double
-			IL_0428: stelem.ref
-			IL_0429: dup
-			IL_042a: ldc.i4.2
-			IL_042b: ldloc.s 16
-			IL_042d: stelem.ref
-			IL_042e: dup
-			IL_042f: ldc.i4.3
-			IL_0430: ldc.r8 2
-			IL_0439: box [System.Runtime]System.Double
-			IL_043e: stelem.ref
-			IL_043f: stloc.s 21
-			IL_0441: ldloc.s 13
-			IL_0443: ldstr "read"
-			IL_0448: ldloc.s 21
-			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_044f: stloc.s 13
-			IL_0451: ldloc.0
-			IL_0452: ldc.i4.5
-			IL_0453: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0458: ldloc.0
-			IL_0459: ldloc.s 13
-			IL_045b: ldarg.0
-			IL_045c: ldc.i4.2
-			IL_045d: ldloc.0
-			IL_045e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0463: ldc.i4.3
-			IL_0464: ldstr "_pendingException"
-			IL_0469: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_046e: ldloc.0
-			IL_046f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0474: dup
-			IL_0475: ldc.i4.0
-			IL_0476: ldloc.1
-			IL_0477: stelem.ref
-			IL_0478: dup
-			IL_0479: ldc.i4.1
-			IL_047a: ldloc.2
-			IL_047b: stelem.ref
-			IL_047c: dup
-			IL_047d: ldc.i4.2
-			IL_047e: ldloc.3
+			IL_03a9: ldloc.0
+			IL_03aa: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited1
+			IL_03af: stloc.3
+			IL_03b0: ldc.r8 1
+			IL_03b9: box [System.Runtime]System.Double
+			IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03c3: stloc.s 4
+			IL_03c5: ldc.r8 1
+			IL_03ce: box [System.Runtime]System.Double
+			IL_03d3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_03d8: stloc.s 5
+			IL_03da: ldloc.3
+			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e0: stloc.s 13
+			IL_03e2: ldloc.s 4
+			IL_03e4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_03e9: stloc.s 15
+			IL_03eb: ldloc.s 15
+			IL_03ed: box [System.Runtime]System.Double
+			IL_03f2: stloc.s 16
+			IL_03f4: ldc.i4.4
+			IL_03f5: newarr [System.Runtime]System.Object
+			IL_03fa: dup
+			IL_03fb: ldc.i4.0
+			IL_03fc: ldloc.s 4
+			IL_03fe: stelem.ref
+			IL_03ff: dup
+			IL_0400: ldc.i4.1
+			IL_0401: ldc.r8 0.0
+			IL_040a: box [System.Runtime]System.Double
+			IL_040f: stelem.ref
+			IL_0410: dup
+			IL_0411: ldc.i4.2
+			IL_0412: ldloc.s 16
+			IL_0414: stelem.ref
+			IL_0415: dup
+			IL_0416: ldc.i4.3
+			IL_0417: ldc.r8 2
+			IL_0420: box [System.Runtime]System.Double
+			IL_0425: stelem.ref
+			IL_0426: stloc.s 21
+			IL_0428: ldloc.s 13
+			IL_042a: ldstr "read"
+			IL_042f: ldloc.s 21
+			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0436: stloc.s 13
+			IL_0438: ldloc.0
+			IL_0439: ldc.i4.5
+			IL_043a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_043f: ldloc.0
+			IL_0440: ldloc.s 13
+			IL_0442: ldarg.0
+			IL_0443: ldc.i4.2
+			IL_0444: ldloc.0
+			IL_0445: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_044a: ldc.i4.3
+			IL_044b: ldstr "_pendingException"
+			IL_0450: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0455: ldloc.0
+			IL_0456: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_045b: dup
+			IL_045c: ldc.i4.0
+			IL_045d: ldloc.1
+			IL_045e: stelem.ref
+			IL_045f: dup
+			IL_0460: ldc.i4.1
+			IL_0461: ldloc.2
+			IL_0462: stelem.ref
+			IL_0463: dup
+			IL_0464: ldc.i4.2
+			IL_0465: ldloc.3
+			IL_0466: stelem.ref
+			IL_0467: dup
+			IL_0468: ldc.i4.3
+			IL_0469: ldloc.s 4
+			IL_046b: stelem.ref
+			IL_046c: dup
+			IL_046d: ldc.i4.4
+			IL_046e: ldloc.s 5
+			IL_0470: stelem.ref
+			IL_0471: dup
+			IL_0472: ldc.i4.5
+			IL_0473: ldloc.s 6
+			IL_0475: stelem.ref
+			IL_0476: dup
+			IL_0477: ldc.i4.6
+			IL_0478: ldloc.s 7
+			IL_047a: stelem.ref
+			IL_047b: dup
+			IL_047c: ldc.i4.7
+			IL_047d: ldloc.s 8
 			IL_047f: stelem.ref
 			IL_0480: dup
-			IL_0481: ldc.i4.3
-			IL_0482: ldloc.s 4
+			IL_0481: ldc.i4.8
+			IL_0482: ldloc.s 9
 			IL_0484: stelem.ref
 			IL_0485: dup
-			IL_0486: ldc.i4.4
-			IL_0487: ldloc.s 5
-			IL_0489: stelem.ref
-			IL_048a: dup
-			IL_048b: ldc.i4.5
-			IL_048c: ldloc.s 6
-			IL_048e: stelem.ref
-			IL_048f: dup
-			IL_0490: ldc.i4.6
-			IL_0491: ldloc.s 7
-			IL_0493: stelem.ref
-			IL_0494: dup
-			IL_0495: ldc.i4.7
-			IL_0496: ldloc.s 8
-			IL_0498: stelem.ref
-			IL_0499: dup
-			IL_049a: ldc.i4.8
-			IL_049b: ldloc.s 9
-			IL_049d: stelem.ref
-			IL_049e: dup
-			IL_049f: ldc.i4.s 9
-			IL_04a1: ldloc.s 10
-			IL_04a3: stelem.ref
-			IL_04a4: dup
-			IL_04a5: ldc.i4.s 10
-			IL_04a7: ldloc.s 11
-			IL_04a9: box [System.Runtime]System.Boolean
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.s 11
-			IL_04b2: ldloc.s 12
-			IL_04b4: box [System.Runtime]System.Boolean
-			IL_04b9: stelem.ref
-			IL_04ba: dup
-			IL_04bb: ldc.i4.s 12
-			IL_04bd: ldloc.s 13
-			IL_04bf: stelem.ref
-			IL_04c0: dup
-			IL_04c1: ldc.i4.s 13
-			IL_04c3: ldloc.s 14
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.s 14
-			IL_04c9: ldloc.s 15
-			IL_04cb: box [System.Runtime]System.Double
-			IL_04d0: stelem.ref
-			IL_04d1: dup
-			IL_04d2: ldc.i4.s 15
-			IL_04d4: ldloc.s 16
-			IL_04d6: stelem.ref
-			IL_04d7: dup
-			IL_04d8: ldc.i4.s 16
-			IL_04da: ldloc.s 17
-			IL_04dc: stelem.ref
-			IL_04dd: dup
-			IL_04de: ldc.i4.s 17
-			IL_04e0: ldloc.s 18
-			IL_04e2: stelem.ref
-			IL_04e3: dup
-			IL_04e4: ldc.i4.s 18
-			IL_04e6: ldloc.s 19
-			IL_04e8: stelem.ref
-			IL_04e9: dup
-			IL_04ea: ldc.i4.s 19
-			IL_04ec: ldloc.s 20
-			IL_04ee: stelem.ref
-			IL_04ef: dup
-			IL_04f0: ldc.i4.s 20
-			IL_04f2: ldloc.s 21
-			IL_04f4: stelem.ref
-			IL_04f5: dup
-			IL_04f6: ldc.i4.s 21
-			IL_04f8: ldloc.s 22
-			IL_04fa: stelem.ref
-			IL_04fb: dup
-			IL_04fc: ldc.i4.s 22
-			IL_04fe: ldloc.s 23
-			IL_0500: stelem.ref
-			IL_0501: dup
-			IL_0502: ldc.i4.s 23
-			IL_0504: ldloc.s 24
-			IL_0506: box [System.Runtime]System.Boolean
-			IL_050b: stelem.ref
-			IL_050c: dup
-			IL_050d: ldc.i4.s 24
-			IL_050f: ldloc.s 25
-			IL_0511: stelem.ref
-			IL_0512: dup
-			IL_0513: ldc.i4.s 25
-			IL_0515: ldloc.s 26
-			IL_0517: stelem.ref
-			IL_0518: pop
-			IL_0519: ldloc.0
-			IL_051a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_051f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0524: ret
+			IL_0486: ldc.i4.s 9
+			IL_0488: ldloc.s 10
+			IL_048a: stelem.ref
+			IL_048b: dup
+			IL_048c: ldc.i4.s 10
+			IL_048e: ldloc.s 11
+			IL_0490: box [System.Runtime]System.Boolean
+			IL_0495: stelem.ref
+			IL_0496: dup
+			IL_0497: ldc.i4.s 11
+			IL_0499: ldloc.s 12
+			IL_049b: box [System.Runtime]System.Boolean
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.s 12
+			IL_04a4: ldloc.s 13
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.s 13
+			IL_04aa: ldloc.s 14
+			IL_04ac: stelem.ref
+			IL_04ad: dup
+			IL_04ae: ldc.i4.s 14
+			IL_04b0: ldloc.s 15
+			IL_04b2: box [System.Runtime]System.Double
+			IL_04b7: stelem.ref
+			IL_04b8: dup
+			IL_04b9: ldc.i4.s 15
+			IL_04bb: ldloc.s 16
+			IL_04bd: stelem.ref
+			IL_04be: dup
+			IL_04bf: ldc.i4.s 16
+			IL_04c1: ldloc.s 17
+			IL_04c3: stelem.ref
+			IL_04c4: dup
+			IL_04c5: ldc.i4.s 17
+			IL_04c7: ldloc.s 18
+			IL_04c9: stelem.ref
+			IL_04ca: dup
+			IL_04cb: ldc.i4.s 18
+			IL_04cd: ldloc.s 19
+			IL_04cf: stelem.ref
+			IL_04d0: dup
+			IL_04d1: ldc.i4.s 19
+			IL_04d3: ldloc.s 20
+			IL_04d5: stelem.ref
+			IL_04d6: dup
+			IL_04d7: ldc.i4.s 20
+			IL_04d9: ldloc.s 21
+			IL_04db: stelem.ref
+			IL_04dc: dup
+			IL_04dd: ldc.i4.s 21
+			IL_04df: ldloc.s 22
+			IL_04e1: stelem.ref
+			IL_04e2: dup
+			IL_04e3: ldc.i4.s 22
+			IL_04e5: ldloc.s 23
+			IL_04e7: stelem.ref
+			IL_04e8: dup
+			IL_04e9: ldc.i4.s 23
+			IL_04eb: ldloc.s 24
+			IL_04ed: box [System.Runtime]System.Boolean
+			IL_04f2: stelem.ref
+			IL_04f3: dup
+			IL_04f4: ldc.i4.s 24
+			IL_04f6: ldloc.s 25
+			IL_04f8: stelem.ref
+			IL_04f9: dup
+			IL_04fa: ldc.i4.s 25
+			IL_04fc: ldloc.s 26
+			IL_04fe: stelem.ref
+			IL_04ff: pop
+			IL_0500: ldloc.0
+			IL_0501: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0506: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_050b: ret
 
-			IL_0525: ldloc.0
-			IL_0526: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
-			IL_052b: stloc.s 6
-			IL_052d: ldloc.3
-			IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0533: stloc.s 13
-			IL_0535: ldloc.s 5
-			IL_0537: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_053c: stloc.s 15
-			IL_053e: ldloc.s 15
-			IL_0540: box [System.Runtime]System.Double
-			IL_0545: stloc.s 16
-			IL_0547: ldc.i4.4
-			IL_0548: newarr [System.Runtime]System.Object
-			IL_054d: dup
-			IL_054e: ldc.i4.0
-			IL_054f: ldloc.s 5
-			IL_0551: stelem.ref
-			IL_0552: dup
-			IL_0553: ldc.i4.1
-			IL_0554: ldc.r8 0.0
-			IL_055d: box [System.Runtime]System.Double
-			IL_0562: stelem.ref
-			IL_0563: dup
-			IL_0564: ldc.i4.2
-			IL_0565: ldloc.s 16
-			IL_0567: stelem.ref
-			IL_0568: dup
-			IL_0569: ldc.i4.3
-			IL_056a: ldc.i4.0
-			IL_056b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0570: stelem.ref
-			IL_0571: stloc.s 21
-			IL_0573: ldloc.s 13
-			IL_0575: ldstr "read"
-			IL_057a: ldloc.s 21
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_0581: stloc.s 13
-			IL_0583: ldloc.0
-			IL_0584: ldc.i4.6
-			IL_0585: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_058a: ldloc.0
-			IL_058b: ldloc.s 13
-			IL_058d: ldarg.0
-			IL_058e: ldc.i4.3
-			IL_058f: ldloc.0
-			IL_0590: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0595: ldc.i4.3
-			IL_0596: ldstr "_pendingException"
-			IL_059b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05a0: ldloc.0
-			IL_05a1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05a6: dup
-			IL_05a7: ldc.i4.0
-			IL_05a8: ldloc.1
-			IL_05a9: stelem.ref
-			IL_05aa: dup
-			IL_05ab: ldc.i4.1
-			IL_05ac: ldloc.2
-			IL_05ad: stelem.ref
-			IL_05ae: dup
-			IL_05af: ldc.i4.2
-			IL_05b0: ldloc.3
+			IL_050c: ldloc.0
+			IL_050d: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0512: stloc.s 6
+			IL_0514: ldloc.3
+			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_051a: stloc.s 13
+			IL_051c: ldloc.s 5
+			IL_051e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_0523: stloc.s 15
+			IL_0525: ldloc.s 15
+			IL_0527: box [System.Runtime]System.Double
+			IL_052c: stloc.s 16
+			IL_052e: ldc.i4.4
+			IL_052f: newarr [System.Runtime]System.Object
+			IL_0534: dup
+			IL_0535: ldc.i4.0
+			IL_0536: ldloc.s 5
+			IL_0538: stelem.ref
+			IL_0539: dup
+			IL_053a: ldc.i4.1
+			IL_053b: ldc.r8 0.0
+			IL_0544: box [System.Runtime]System.Double
+			IL_0549: stelem.ref
+			IL_054a: dup
+			IL_054b: ldc.i4.2
+			IL_054c: ldloc.s 16
+			IL_054e: stelem.ref
+			IL_054f: dup
+			IL_0550: ldc.i4.3
+			IL_0551: ldc.i4.0
+			IL_0552: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0557: stelem.ref
+			IL_0558: stloc.s 21
+			IL_055a: ldloc.s 13
+			IL_055c: ldstr "read"
+			IL_0561: ldloc.s 21
+			IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_0568: stloc.s 13
+			IL_056a: ldloc.0
+			IL_056b: ldc.i4.6
+			IL_056c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0571: ldloc.0
+			IL_0572: ldloc.s 13
+			IL_0574: ldarg.0
+			IL_0575: ldc.i4.3
+			IL_0576: ldloc.0
+			IL_0577: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_057c: ldc.i4.3
+			IL_057d: ldstr "_pendingException"
+			IL_0582: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0587: ldloc.0
+			IL_0588: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_058d: dup
+			IL_058e: ldc.i4.0
+			IL_058f: ldloc.1
+			IL_0590: stelem.ref
+			IL_0591: dup
+			IL_0592: ldc.i4.1
+			IL_0593: ldloc.2
+			IL_0594: stelem.ref
+			IL_0595: dup
+			IL_0596: ldc.i4.2
+			IL_0597: ldloc.3
+			IL_0598: stelem.ref
+			IL_0599: dup
+			IL_059a: ldc.i4.3
+			IL_059b: ldloc.s 4
+			IL_059d: stelem.ref
+			IL_059e: dup
+			IL_059f: ldc.i4.4
+			IL_05a0: ldloc.s 5
+			IL_05a2: stelem.ref
+			IL_05a3: dup
+			IL_05a4: ldc.i4.5
+			IL_05a5: ldloc.s 6
+			IL_05a7: stelem.ref
+			IL_05a8: dup
+			IL_05a9: ldc.i4.6
+			IL_05aa: ldloc.s 7
+			IL_05ac: stelem.ref
+			IL_05ad: dup
+			IL_05ae: ldc.i4.7
+			IL_05af: ldloc.s 8
 			IL_05b1: stelem.ref
 			IL_05b2: dup
-			IL_05b3: ldc.i4.3
-			IL_05b4: ldloc.s 4
+			IL_05b3: ldc.i4.8
+			IL_05b4: ldloc.s 9
 			IL_05b6: stelem.ref
 			IL_05b7: dup
-			IL_05b8: ldc.i4.4
-			IL_05b9: ldloc.s 5
-			IL_05bb: stelem.ref
-			IL_05bc: dup
-			IL_05bd: ldc.i4.5
-			IL_05be: ldloc.s 6
-			IL_05c0: stelem.ref
-			IL_05c1: dup
-			IL_05c2: ldc.i4.6
-			IL_05c3: ldloc.s 7
-			IL_05c5: stelem.ref
-			IL_05c6: dup
-			IL_05c7: ldc.i4.7
-			IL_05c8: ldloc.s 8
-			IL_05ca: stelem.ref
-			IL_05cb: dup
-			IL_05cc: ldc.i4.8
-			IL_05cd: ldloc.s 9
-			IL_05cf: stelem.ref
-			IL_05d0: dup
-			IL_05d1: ldc.i4.s 9
-			IL_05d3: ldloc.s 10
-			IL_05d5: stelem.ref
-			IL_05d6: dup
-			IL_05d7: ldc.i4.s 10
-			IL_05d9: ldloc.s 11
-			IL_05db: box [System.Runtime]System.Boolean
-			IL_05e0: stelem.ref
-			IL_05e1: dup
-			IL_05e2: ldc.i4.s 11
-			IL_05e4: ldloc.s 12
-			IL_05e6: box [System.Runtime]System.Boolean
-			IL_05eb: stelem.ref
-			IL_05ec: dup
-			IL_05ed: ldc.i4.s 12
-			IL_05ef: ldloc.s 13
-			IL_05f1: stelem.ref
-			IL_05f2: dup
-			IL_05f3: ldc.i4.s 13
-			IL_05f5: ldloc.s 14
-			IL_05f7: stelem.ref
-			IL_05f8: dup
-			IL_05f9: ldc.i4.s 14
-			IL_05fb: ldloc.s 15
-			IL_05fd: box [System.Runtime]System.Double
-			IL_0602: stelem.ref
-			IL_0603: dup
-			IL_0604: ldc.i4.s 15
-			IL_0606: ldloc.s 16
-			IL_0608: stelem.ref
-			IL_0609: dup
-			IL_060a: ldc.i4.s 16
-			IL_060c: ldloc.s 17
-			IL_060e: stelem.ref
-			IL_060f: dup
-			IL_0610: ldc.i4.s 17
-			IL_0612: ldloc.s 18
-			IL_0614: stelem.ref
-			IL_0615: dup
-			IL_0616: ldc.i4.s 18
-			IL_0618: ldloc.s 19
-			IL_061a: stelem.ref
-			IL_061b: dup
-			IL_061c: ldc.i4.s 19
-			IL_061e: ldloc.s 20
-			IL_0620: stelem.ref
-			IL_0621: dup
-			IL_0622: ldc.i4.s 20
-			IL_0624: ldloc.s 21
-			IL_0626: stelem.ref
-			IL_0627: dup
-			IL_0628: ldc.i4.s 21
-			IL_062a: ldloc.s 22
-			IL_062c: stelem.ref
-			IL_062d: dup
-			IL_062e: ldc.i4.s 22
-			IL_0630: ldloc.s 23
-			IL_0632: stelem.ref
-			IL_0633: dup
-			IL_0634: ldc.i4.s 23
-			IL_0636: ldloc.s 24
-			IL_0638: box [System.Runtime]System.Boolean
-			IL_063d: stelem.ref
-			IL_063e: dup
-			IL_063f: ldc.i4.s 24
-			IL_0641: ldloc.s 25
-			IL_0643: stelem.ref
-			IL_0644: dup
-			IL_0645: ldc.i4.s 25
-			IL_0647: ldloc.s 26
-			IL_0649: stelem.ref
-			IL_064a: pop
-			IL_064b: ldloc.0
-			IL_064c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0651: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0656: ret
+			IL_05b8: ldc.i4.s 9
+			IL_05ba: ldloc.s 10
+			IL_05bc: stelem.ref
+			IL_05bd: dup
+			IL_05be: ldc.i4.s 10
+			IL_05c0: ldloc.s 11
+			IL_05c2: box [System.Runtime]System.Boolean
+			IL_05c7: stelem.ref
+			IL_05c8: dup
+			IL_05c9: ldc.i4.s 11
+			IL_05cb: ldloc.s 12
+			IL_05cd: box [System.Runtime]System.Boolean
+			IL_05d2: stelem.ref
+			IL_05d3: dup
+			IL_05d4: ldc.i4.s 12
+			IL_05d6: ldloc.s 13
+			IL_05d8: stelem.ref
+			IL_05d9: dup
+			IL_05da: ldc.i4.s 13
+			IL_05dc: ldloc.s 14
+			IL_05de: stelem.ref
+			IL_05df: dup
+			IL_05e0: ldc.i4.s 14
+			IL_05e2: ldloc.s 15
+			IL_05e4: box [System.Runtime]System.Double
+			IL_05e9: stelem.ref
+			IL_05ea: dup
+			IL_05eb: ldc.i4.s 15
+			IL_05ed: ldloc.s 16
+			IL_05ef: stelem.ref
+			IL_05f0: dup
+			IL_05f1: ldc.i4.s 16
+			IL_05f3: ldloc.s 17
+			IL_05f5: stelem.ref
+			IL_05f6: dup
+			IL_05f7: ldc.i4.s 17
+			IL_05f9: ldloc.s 18
+			IL_05fb: stelem.ref
+			IL_05fc: dup
+			IL_05fd: ldc.i4.s 18
+			IL_05ff: ldloc.s 19
+			IL_0601: stelem.ref
+			IL_0602: dup
+			IL_0603: ldc.i4.s 19
+			IL_0605: ldloc.s 20
+			IL_0607: stelem.ref
+			IL_0608: dup
+			IL_0609: ldc.i4.s 20
+			IL_060b: ldloc.s 21
+			IL_060d: stelem.ref
+			IL_060e: dup
+			IL_060f: ldc.i4.s 21
+			IL_0611: ldloc.s 22
+			IL_0613: stelem.ref
+			IL_0614: dup
+			IL_0615: ldc.i4.s 22
+			IL_0617: ldloc.s 23
+			IL_0619: stelem.ref
+			IL_061a: dup
+			IL_061b: ldc.i4.s 23
+			IL_061d: ldloc.s 24
+			IL_061f: box [System.Runtime]System.Boolean
+			IL_0624: stelem.ref
+			IL_0625: dup
+			IL_0626: ldc.i4.s 24
+			IL_0628: ldloc.s 25
+			IL_062a: stelem.ref
+			IL_062b: dup
+			IL_062c: ldc.i4.s 25
+			IL_062e: ldloc.s 26
+			IL_0630: stelem.ref
+			IL_0631: pop
+			IL_0632: ldloc.0
+			IL_0633: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0638: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_063d: ret
 
-			IL_0657: ldloc.0
-			IL_0658: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
-			IL_065d: stloc.s 7
-			IL_065f: ldloc.3
-			IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0665: stloc.s 13
-			IL_0667: ldloc.s 13
-			IL_0669: ldstr "write"
-			IL_066e: ldstr "X"
-			IL_0673: ldc.r8 4
-			IL_067c: box [System.Runtime]System.Double
-			IL_0681: ldstr "utf8"
-			IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_068b: stloc.s 13
-			IL_068d: ldloc.0
-			IL_068e: ldc.i4.7
-			IL_068f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0694: ldloc.0
-			IL_0695: ldloc.s 13
-			IL_0697: ldarg.0
-			IL_0698: ldc.i4.4
-			IL_0699: ldloc.0
-			IL_069a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_069f: ldc.i4.3
-			IL_06a0: ldstr "_pendingException"
-			IL_06a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_06aa: ldloc.0
-			IL_06ab: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06b0: dup
-			IL_06b1: ldc.i4.0
-			IL_06b2: ldloc.1
-			IL_06b3: stelem.ref
-			IL_06b4: dup
-			IL_06b5: ldc.i4.1
-			IL_06b6: ldloc.2
-			IL_06b7: stelem.ref
-			IL_06b8: dup
-			IL_06b9: ldc.i4.2
-			IL_06ba: ldloc.3
+			IL_063e: ldloc.0
+			IL_063f: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0644: stloc.s 7
+			IL_0646: ldloc.3
+			IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_064c: stloc.s 13
+			IL_064e: ldloc.s 13
+			IL_0650: ldstr "write"
+			IL_0655: ldstr "X"
+			IL_065a: ldc.r8 4
+			IL_0663: box [System.Runtime]System.Double
+			IL_0668: ldstr "utf8"
+			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0672: stloc.s 13
+			IL_0674: ldloc.0
+			IL_0675: ldc.i4.7
+			IL_0676: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_067b: ldloc.0
+			IL_067c: ldloc.s 13
+			IL_067e: ldarg.0
+			IL_067f: ldc.i4.4
+			IL_0680: ldloc.0
+			IL_0681: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0686: ldc.i4.3
+			IL_0687: ldstr "_pendingException"
+			IL_068c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0691: ldloc.0
+			IL_0692: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0697: dup
+			IL_0698: ldc.i4.0
+			IL_0699: ldloc.1
+			IL_069a: stelem.ref
+			IL_069b: dup
+			IL_069c: ldc.i4.1
+			IL_069d: ldloc.2
+			IL_069e: stelem.ref
+			IL_069f: dup
+			IL_06a0: ldc.i4.2
+			IL_06a1: ldloc.3
+			IL_06a2: stelem.ref
+			IL_06a3: dup
+			IL_06a4: ldc.i4.3
+			IL_06a5: ldloc.s 4
+			IL_06a7: stelem.ref
+			IL_06a8: dup
+			IL_06a9: ldc.i4.4
+			IL_06aa: ldloc.s 5
+			IL_06ac: stelem.ref
+			IL_06ad: dup
+			IL_06ae: ldc.i4.5
+			IL_06af: ldloc.s 6
+			IL_06b1: stelem.ref
+			IL_06b2: dup
+			IL_06b3: ldc.i4.6
+			IL_06b4: ldloc.s 7
+			IL_06b6: stelem.ref
+			IL_06b7: dup
+			IL_06b8: ldc.i4.7
+			IL_06b9: ldloc.s 8
 			IL_06bb: stelem.ref
 			IL_06bc: dup
-			IL_06bd: ldc.i4.3
-			IL_06be: ldloc.s 4
+			IL_06bd: ldc.i4.8
+			IL_06be: ldloc.s 9
 			IL_06c0: stelem.ref
 			IL_06c1: dup
-			IL_06c2: ldc.i4.4
-			IL_06c3: ldloc.s 5
-			IL_06c5: stelem.ref
-			IL_06c6: dup
-			IL_06c7: ldc.i4.5
-			IL_06c8: ldloc.s 6
-			IL_06ca: stelem.ref
-			IL_06cb: dup
-			IL_06cc: ldc.i4.6
-			IL_06cd: ldloc.s 7
-			IL_06cf: stelem.ref
-			IL_06d0: dup
-			IL_06d1: ldc.i4.7
-			IL_06d2: ldloc.s 8
-			IL_06d4: stelem.ref
-			IL_06d5: dup
-			IL_06d6: ldc.i4.8
-			IL_06d7: ldloc.s 9
-			IL_06d9: stelem.ref
-			IL_06da: dup
-			IL_06db: ldc.i4.s 9
-			IL_06dd: ldloc.s 10
-			IL_06df: stelem.ref
-			IL_06e0: dup
-			IL_06e1: ldc.i4.s 10
-			IL_06e3: ldloc.s 11
-			IL_06e5: box [System.Runtime]System.Boolean
-			IL_06ea: stelem.ref
-			IL_06eb: dup
-			IL_06ec: ldc.i4.s 11
-			IL_06ee: ldloc.s 12
-			IL_06f0: box [System.Runtime]System.Boolean
-			IL_06f5: stelem.ref
-			IL_06f6: dup
-			IL_06f7: ldc.i4.s 12
-			IL_06f9: ldloc.s 13
-			IL_06fb: stelem.ref
-			IL_06fc: dup
-			IL_06fd: ldc.i4.s 13
-			IL_06ff: ldloc.s 14
-			IL_0701: stelem.ref
-			IL_0702: dup
-			IL_0703: ldc.i4.s 14
-			IL_0705: ldloc.s 15
-			IL_0707: box [System.Runtime]System.Double
-			IL_070c: stelem.ref
-			IL_070d: dup
-			IL_070e: ldc.i4.s 15
-			IL_0710: ldloc.s 16
-			IL_0712: stelem.ref
-			IL_0713: dup
-			IL_0714: ldc.i4.s 16
-			IL_0716: ldloc.s 17
-			IL_0718: stelem.ref
-			IL_0719: dup
-			IL_071a: ldc.i4.s 17
-			IL_071c: ldloc.s 18
-			IL_071e: stelem.ref
-			IL_071f: dup
-			IL_0720: ldc.i4.s 18
-			IL_0722: ldloc.s 19
-			IL_0724: stelem.ref
-			IL_0725: dup
-			IL_0726: ldc.i4.s 19
-			IL_0728: ldloc.s 20
-			IL_072a: stelem.ref
-			IL_072b: dup
-			IL_072c: ldc.i4.s 20
-			IL_072e: ldloc.s 21
-			IL_0730: stelem.ref
-			IL_0731: dup
-			IL_0732: ldc.i4.s 21
-			IL_0734: ldloc.s 22
-			IL_0736: stelem.ref
-			IL_0737: dup
-			IL_0738: ldc.i4.s 22
-			IL_073a: ldloc.s 23
-			IL_073c: stelem.ref
-			IL_073d: dup
-			IL_073e: ldc.i4.s 23
-			IL_0740: ldloc.s 24
-			IL_0742: box [System.Runtime]System.Boolean
-			IL_0747: stelem.ref
-			IL_0748: dup
-			IL_0749: ldc.i4.s 24
-			IL_074b: ldloc.s 25
-			IL_074d: stelem.ref
-			IL_074e: dup
-			IL_074f: ldc.i4.s 25
-			IL_0751: ldloc.s 26
-			IL_0753: stelem.ref
-			IL_0754: pop
-			IL_0755: ldloc.0
-			IL_0756: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_075b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0760: ret
+			IL_06c2: ldc.i4.s 9
+			IL_06c4: ldloc.s 10
+			IL_06c6: stelem.ref
+			IL_06c7: dup
+			IL_06c8: ldc.i4.s 10
+			IL_06ca: ldloc.s 11
+			IL_06cc: box [System.Runtime]System.Boolean
+			IL_06d1: stelem.ref
+			IL_06d2: dup
+			IL_06d3: ldc.i4.s 11
+			IL_06d5: ldloc.s 12
+			IL_06d7: box [System.Runtime]System.Boolean
+			IL_06dc: stelem.ref
+			IL_06dd: dup
+			IL_06de: ldc.i4.s 12
+			IL_06e0: ldloc.s 13
+			IL_06e2: stelem.ref
+			IL_06e3: dup
+			IL_06e4: ldc.i4.s 13
+			IL_06e6: ldloc.s 14
+			IL_06e8: stelem.ref
+			IL_06e9: dup
+			IL_06ea: ldc.i4.s 14
+			IL_06ec: ldloc.s 15
+			IL_06ee: box [System.Runtime]System.Double
+			IL_06f3: stelem.ref
+			IL_06f4: dup
+			IL_06f5: ldc.i4.s 15
+			IL_06f7: ldloc.s 16
+			IL_06f9: stelem.ref
+			IL_06fa: dup
+			IL_06fb: ldc.i4.s 16
+			IL_06fd: ldloc.s 17
+			IL_06ff: stelem.ref
+			IL_0700: dup
+			IL_0701: ldc.i4.s 17
+			IL_0703: ldloc.s 18
+			IL_0705: stelem.ref
+			IL_0706: dup
+			IL_0707: ldc.i4.s 18
+			IL_0709: ldloc.s 19
+			IL_070b: stelem.ref
+			IL_070c: dup
+			IL_070d: ldc.i4.s 19
+			IL_070f: ldloc.s 20
+			IL_0711: stelem.ref
+			IL_0712: dup
+			IL_0713: ldc.i4.s 20
+			IL_0715: ldloc.s 21
+			IL_0717: stelem.ref
+			IL_0718: dup
+			IL_0719: ldc.i4.s 21
+			IL_071b: ldloc.s 22
+			IL_071d: stelem.ref
+			IL_071e: dup
+			IL_071f: ldc.i4.s 22
+			IL_0721: ldloc.s 23
+			IL_0723: stelem.ref
+			IL_0724: dup
+			IL_0725: ldc.i4.s 23
+			IL_0727: ldloc.s 24
+			IL_0729: box [System.Runtime]System.Boolean
+			IL_072e: stelem.ref
+			IL_072f: dup
+			IL_0730: ldc.i4.s 24
+			IL_0732: ldloc.s 25
+			IL_0734: stelem.ref
+			IL_0735: dup
+			IL_0736: ldc.i4.s 25
+			IL_0738: ldloc.s 26
+			IL_073a: stelem.ref
+			IL_073b: pop
+			IL_073c: ldloc.0
+			IL_073d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0742: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0747: ret
 
-			IL_0761: ldloc.0
-			IL_0762: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
-			IL_0767: stloc.s 8
-			IL_0769: ldloc.3
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_076f: stloc.s 13
-			IL_0771: ldloc.s 13
-			IL_0773: ldstr "write"
-			IL_0778: ldstr "Y"
-			IL_077d: ldc.i4.0
-			IL_077e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0783: ldstr "utf8"
-			IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_078d: stloc.s 13
-			IL_078f: ldloc.0
-			IL_0790: ldc.i4.8
-			IL_0791: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0796: ldloc.0
-			IL_0797: ldloc.s 13
-			IL_0799: ldarg.0
-			IL_079a: ldc.i4.5
-			IL_079b: ldloc.0
-			IL_079c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07a1: ldc.i4.3
-			IL_07a2: ldstr "_pendingException"
-			IL_07a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_07ac: ldloc.0
-			IL_07ad: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07b2: dup
-			IL_07b3: ldc.i4.0
-			IL_07b4: ldloc.1
-			IL_07b5: stelem.ref
-			IL_07b6: dup
-			IL_07b7: ldc.i4.1
-			IL_07b8: ldloc.2
-			IL_07b9: stelem.ref
-			IL_07ba: dup
-			IL_07bb: ldc.i4.2
-			IL_07bc: ldloc.3
+			IL_0748: ldloc.0
+			IL_0749: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited4
+			IL_074e: stloc.s 8
+			IL_0750: ldloc.3
+			IL_0751: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0756: stloc.s 13
+			IL_0758: ldloc.s 13
+			IL_075a: ldstr "write"
+			IL_075f: ldstr "Y"
+			IL_0764: ldc.i4.0
+			IL_0765: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_076a: ldstr "utf8"
+			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0774: stloc.s 13
+			IL_0776: ldloc.0
+			IL_0777: ldc.i4.8
+			IL_0778: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_077d: ldloc.0
+			IL_077e: ldloc.s 13
+			IL_0780: ldarg.0
+			IL_0781: ldc.i4.5
+			IL_0782: ldloc.0
+			IL_0783: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0788: ldc.i4.3
+			IL_0789: ldstr "_pendingException"
+			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0793: ldloc.0
+			IL_0794: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0799: dup
+			IL_079a: ldc.i4.0
+			IL_079b: ldloc.1
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.1
+			IL_079f: ldloc.2
+			IL_07a0: stelem.ref
+			IL_07a1: dup
+			IL_07a2: ldc.i4.2
+			IL_07a3: ldloc.3
+			IL_07a4: stelem.ref
+			IL_07a5: dup
+			IL_07a6: ldc.i4.3
+			IL_07a7: ldloc.s 4
+			IL_07a9: stelem.ref
+			IL_07aa: dup
+			IL_07ab: ldc.i4.4
+			IL_07ac: ldloc.s 5
+			IL_07ae: stelem.ref
+			IL_07af: dup
+			IL_07b0: ldc.i4.5
+			IL_07b1: ldloc.s 6
+			IL_07b3: stelem.ref
+			IL_07b4: dup
+			IL_07b5: ldc.i4.6
+			IL_07b6: ldloc.s 7
+			IL_07b8: stelem.ref
+			IL_07b9: dup
+			IL_07ba: ldc.i4.7
+			IL_07bb: ldloc.s 8
 			IL_07bd: stelem.ref
 			IL_07be: dup
-			IL_07bf: ldc.i4.3
-			IL_07c0: ldloc.s 4
+			IL_07bf: ldc.i4.8
+			IL_07c0: ldloc.s 9
 			IL_07c2: stelem.ref
 			IL_07c3: dup
-			IL_07c4: ldc.i4.4
-			IL_07c5: ldloc.s 5
-			IL_07c7: stelem.ref
-			IL_07c8: dup
-			IL_07c9: ldc.i4.5
-			IL_07ca: ldloc.s 6
-			IL_07cc: stelem.ref
-			IL_07cd: dup
-			IL_07ce: ldc.i4.6
-			IL_07cf: ldloc.s 7
-			IL_07d1: stelem.ref
-			IL_07d2: dup
-			IL_07d3: ldc.i4.7
-			IL_07d4: ldloc.s 8
-			IL_07d6: stelem.ref
-			IL_07d7: dup
-			IL_07d8: ldc.i4.8
-			IL_07d9: ldloc.s 9
-			IL_07db: stelem.ref
-			IL_07dc: dup
-			IL_07dd: ldc.i4.s 9
-			IL_07df: ldloc.s 10
-			IL_07e1: stelem.ref
-			IL_07e2: dup
-			IL_07e3: ldc.i4.s 10
-			IL_07e5: ldloc.s 11
-			IL_07e7: box [System.Runtime]System.Boolean
-			IL_07ec: stelem.ref
-			IL_07ed: dup
-			IL_07ee: ldc.i4.s 11
-			IL_07f0: ldloc.s 12
-			IL_07f2: box [System.Runtime]System.Boolean
-			IL_07f7: stelem.ref
-			IL_07f8: dup
-			IL_07f9: ldc.i4.s 12
-			IL_07fb: ldloc.s 13
-			IL_07fd: stelem.ref
-			IL_07fe: dup
-			IL_07ff: ldc.i4.s 13
-			IL_0801: ldloc.s 14
-			IL_0803: stelem.ref
-			IL_0804: dup
-			IL_0805: ldc.i4.s 14
-			IL_0807: ldloc.s 15
-			IL_0809: box [System.Runtime]System.Double
-			IL_080e: stelem.ref
-			IL_080f: dup
-			IL_0810: ldc.i4.s 15
-			IL_0812: ldloc.s 16
-			IL_0814: stelem.ref
-			IL_0815: dup
-			IL_0816: ldc.i4.s 16
-			IL_0818: ldloc.s 17
-			IL_081a: stelem.ref
-			IL_081b: dup
-			IL_081c: ldc.i4.s 17
-			IL_081e: ldloc.s 18
-			IL_0820: stelem.ref
-			IL_0821: dup
-			IL_0822: ldc.i4.s 18
-			IL_0824: ldloc.s 19
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.s 19
-			IL_082a: ldloc.s 20
-			IL_082c: stelem.ref
-			IL_082d: dup
-			IL_082e: ldc.i4.s 20
-			IL_0830: ldloc.s 21
-			IL_0832: stelem.ref
-			IL_0833: dup
-			IL_0834: ldc.i4.s 21
-			IL_0836: ldloc.s 22
-			IL_0838: stelem.ref
-			IL_0839: dup
-			IL_083a: ldc.i4.s 22
-			IL_083c: ldloc.s 23
-			IL_083e: stelem.ref
-			IL_083f: dup
-			IL_0840: ldc.i4.s 23
-			IL_0842: ldloc.s 24
-			IL_0844: box [System.Runtime]System.Boolean
-			IL_0849: stelem.ref
-			IL_084a: dup
-			IL_084b: ldc.i4.s 24
-			IL_084d: ldloc.s 25
-			IL_084f: stelem.ref
-			IL_0850: dup
-			IL_0851: ldc.i4.s 25
-			IL_0853: ldloc.s 26
-			IL_0855: stelem.ref
-			IL_0856: pop
-			IL_0857: ldloc.0
-			IL_0858: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_085d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0862: ret
+			IL_07c4: ldc.i4.s 9
+			IL_07c6: ldloc.s 10
+			IL_07c8: stelem.ref
+			IL_07c9: dup
+			IL_07ca: ldc.i4.s 10
+			IL_07cc: ldloc.s 11
+			IL_07ce: box [System.Runtime]System.Boolean
+			IL_07d3: stelem.ref
+			IL_07d4: dup
+			IL_07d5: ldc.i4.s 11
+			IL_07d7: ldloc.s 12
+			IL_07d9: box [System.Runtime]System.Boolean
+			IL_07de: stelem.ref
+			IL_07df: dup
+			IL_07e0: ldc.i4.s 12
+			IL_07e2: ldloc.s 13
+			IL_07e4: stelem.ref
+			IL_07e5: dup
+			IL_07e6: ldc.i4.s 13
+			IL_07e8: ldloc.s 14
+			IL_07ea: stelem.ref
+			IL_07eb: dup
+			IL_07ec: ldc.i4.s 14
+			IL_07ee: ldloc.s 15
+			IL_07f0: box [System.Runtime]System.Double
+			IL_07f5: stelem.ref
+			IL_07f6: dup
+			IL_07f7: ldc.i4.s 15
+			IL_07f9: ldloc.s 16
+			IL_07fb: stelem.ref
+			IL_07fc: dup
+			IL_07fd: ldc.i4.s 16
+			IL_07ff: ldloc.s 17
+			IL_0801: stelem.ref
+			IL_0802: dup
+			IL_0803: ldc.i4.s 17
+			IL_0805: ldloc.s 18
+			IL_0807: stelem.ref
+			IL_0808: dup
+			IL_0809: ldc.i4.s 18
+			IL_080b: ldloc.s 19
+			IL_080d: stelem.ref
+			IL_080e: dup
+			IL_080f: ldc.i4.s 19
+			IL_0811: ldloc.s 20
+			IL_0813: stelem.ref
+			IL_0814: dup
+			IL_0815: ldc.i4.s 20
+			IL_0817: ldloc.s 21
+			IL_0819: stelem.ref
+			IL_081a: dup
+			IL_081b: ldc.i4.s 21
+			IL_081d: ldloc.s 22
+			IL_081f: stelem.ref
+			IL_0820: dup
+			IL_0821: ldc.i4.s 22
+			IL_0823: ldloc.s 23
+			IL_0825: stelem.ref
+			IL_0826: dup
+			IL_0827: ldc.i4.s 23
+			IL_0829: ldloc.s 24
+			IL_082b: box [System.Runtime]System.Boolean
+			IL_0830: stelem.ref
+			IL_0831: dup
+			IL_0832: ldc.i4.s 24
+			IL_0834: ldloc.s 25
+			IL_0836: stelem.ref
+			IL_0837: dup
+			IL_0838: ldc.i4.s 25
+			IL_083a: ldloc.s 26
+			IL_083c: stelem.ref
+			IL_083d: pop
+			IL_083e: ldloc.0
+			IL_083f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0844: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0849: ret
 
-			IL_0863: ldloc.0
-			IL_0864: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
-			IL_0869: stloc.s 9
-			IL_086b: ldloc.3
-			IL_086c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0871: stloc.s 13
-			IL_0873: ldloc.s 13
-			IL_0875: ldstr "close"
-			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_087f: stloc.s 13
-			IL_0881: ldloc.0
-			IL_0882: ldc.i4.s 9
-			IL_0884: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0889: ldloc.0
-			IL_088a: ldloc.s 13
-			IL_088c: ldarg.0
-			IL_088d: ldc.i4.6
-			IL_088e: ldloc.0
-			IL_088f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0894: ldc.i4.3
-			IL_0895: ldstr "_pendingException"
-			IL_089a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_089f: ldloc.0
-			IL_08a0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08a5: dup
-			IL_08a6: ldc.i4.0
-			IL_08a7: ldloc.1
-			IL_08a8: stelem.ref
-			IL_08a9: dup
-			IL_08aa: ldc.i4.1
-			IL_08ab: ldloc.2
-			IL_08ac: stelem.ref
-			IL_08ad: dup
-			IL_08ae: ldc.i4.2
-			IL_08af: ldloc.3
+			IL_084a: ldloc.0
+			IL_084b: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited5
+			IL_0850: stloc.s 9
+			IL_0852: ldloc.3
+			IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0858: stloc.s 13
+			IL_085a: ldloc.s 13
+			IL_085c: ldstr "close"
+			IL_0861: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0866: stloc.s 13
+			IL_0868: ldloc.0
+			IL_0869: ldc.i4.s 9
+			IL_086b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0870: ldloc.0
+			IL_0871: ldloc.s 13
+			IL_0873: ldarg.0
+			IL_0874: ldc.i4.6
+			IL_0875: ldloc.0
+			IL_0876: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_087b: ldc.i4.3
+			IL_087c: ldstr "_pendingException"
+			IL_0881: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0886: ldloc.0
+			IL_0887: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_088c: dup
+			IL_088d: ldc.i4.0
+			IL_088e: ldloc.1
+			IL_088f: stelem.ref
+			IL_0890: dup
+			IL_0891: ldc.i4.1
+			IL_0892: ldloc.2
+			IL_0893: stelem.ref
+			IL_0894: dup
+			IL_0895: ldc.i4.2
+			IL_0896: ldloc.3
+			IL_0897: stelem.ref
+			IL_0898: dup
+			IL_0899: ldc.i4.3
+			IL_089a: ldloc.s 4
+			IL_089c: stelem.ref
+			IL_089d: dup
+			IL_089e: ldc.i4.4
+			IL_089f: ldloc.s 5
+			IL_08a1: stelem.ref
+			IL_08a2: dup
+			IL_08a3: ldc.i4.5
+			IL_08a4: ldloc.s 6
+			IL_08a6: stelem.ref
+			IL_08a7: dup
+			IL_08a8: ldc.i4.6
+			IL_08a9: ldloc.s 7
+			IL_08ab: stelem.ref
+			IL_08ac: dup
+			IL_08ad: ldc.i4.7
+			IL_08ae: ldloc.s 8
 			IL_08b0: stelem.ref
 			IL_08b1: dup
-			IL_08b2: ldc.i4.3
-			IL_08b3: ldloc.s 4
+			IL_08b2: ldc.i4.8
+			IL_08b3: ldloc.s 9
 			IL_08b5: stelem.ref
 			IL_08b6: dup
-			IL_08b7: ldc.i4.4
-			IL_08b8: ldloc.s 5
-			IL_08ba: stelem.ref
-			IL_08bb: dup
-			IL_08bc: ldc.i4.5
-			IL_08bd: ldloc.s 6
-			IL_08bf: stelem.ref
-			IL_08c0: dup
-			IL_08c1: ldc.i4.6
-			IL_08c2: ldloc.s 7
-			IL_08c4: stelem.ref
-			IL_08c5: dup
-			IL_08c6: ldc.i4.7
-			IL_08c7: ldloc.s 8
-			IL_08c9: stelem.ref
-			IL_08ca: dup
-			IL_08cb: ldc.i4.8
-			IL_08cc: ldloc.s 9
-			IL_08ce: stelem.ref
-			IL_08cf: dup
-			IL_08d0: ldc.i4.s 9
-			IL_08d2: ldloc.s 10
-			IL_08d4: stelem.ref
-			IL_08d5: dup
-			IL_08d6: ldc.i4.s 10
-			IL_08d8: ldloc.s 11
-			IL_08da: box [System.Runtime]System.Boolean
-			IL_08df: stelem.ref
-			IL_08e0: dup
-			IL_08e1: ldc.i4.s 11
-			IL_08e3: ldloc.s 12
-			IL_08e5: box [System.Runtime]System.Boolean
-			IL_08ea: stelem.ref
-			IL_08eb: dup
-			IL_08ec: ldc.i4.s 12
-			IL_08ee: ldloc.s 13
-			IL_08f0: stelem.ref
-			IL_08f1: dup
-			IL_08f2: ldc.i4.s 13
-			IL_08f4: ldloc.s 14
-			IL_08f6: stelem.ref
-			IL_08f7: dup
-			IL_08f8: ldc.i4.s 14
-			IL_08fa: ldloc.s 15
-			IL_08fc: box [System.Runtime]System.Double
-			IL_0901: stelem.ref
-			IL_0902: dup
-			IL_0903: ldc.i4.s 15
-			IL_0905: ldloc.s 16
-			IL_0907: stelem.ref
-			IL_0908: dup
-			IL_0909: ldc.i4.s 16
-			IL_090b: ldloc.s 17
-			IL_090d: stelem.ref
-			IL_090e: dup
-			IL_090f: ldc.i4.s 17
-			IL_0911: ldloc.s 18
-			IL_0913: stelem.ref
-			IL_0914: dup
-			IL_0915: ldc.i4.s 18
-			IL_0917: ldloc.s 19
-			IL_0919: stelem.ref
-			IL_091a: dup
-			IL_091b: ldc.i4.s 19
-			IL_091d: ldloc.s 20
-			IL_091f: stelem.ref
-			IL_0920: dup
-			IL_0921: ldc.i4.s 20
-			IL_0923: ldloc.s 21
-			IL_0925: stelem.ref
-			IL_0926: dup
-			IL_0927: ldc.i4.s 21
-			IL_0929: ldloc.s 22
-			IL_092b: stelem.ref
-			IL_092c: dup
-			IL_092d: ldc.i4.s 22
-			IL_092f: ldloc.s 23
-			IL_0931: stelem.ref
-			IL_0932: dup
-			IL_0933: ldc.i4.s 23
-			IL_0935: ldloc.s 24
-			IL_0937: box [System.Runtime]System.Boolean
-			IL_093c: stelem.ref
-			IL_093d: dup
-			IL_093e: ldc.i4.s 24
-			IL_0940: ldloc.s 25
-			IL_0942: stelem.ref
-			IL_0943: dup
-			IL_0944: ldc.i4.s 25
-			IL_0946: ldloc.s 26
-			IL_0948: stelem.ref
-			IL_0949: pop
-			IL_094a: ldloc.0
-			IL_094b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0950: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0955: ret
+			IL_08b7: ldc.i4.s 9
+			IL_08b9: ldloc.s 10
+			IL_08bb: stelem.ref
+			IL_08bc: dup
+			IL_08bd: ldc.i4.s 10
+			IL_08bf: ldloc.s 11
+			IL_08c1: box [System.Runtime]System.Boolean
+			IL_08c6: stelem.ref
+			IL_08c7: dup
+			IL_08c8: ldc.i4.s 11
+			IL_08ca: ldloc.s 12
+			IL_08cc: box [System.Runtime]System.Boolean
+			IL_08d1: stelem.ref
+			IL_08d2: dup
+			IL_08d3: ldc.i4.s 12
+			IL_08d5: ldloc.s 13
+			IL_08d7: stelem.ref
+			IL_08d8: dup
+			IL_08d9: ldc.i4.s 13
+			IL_08db: ldloc.s 14
+			IL_08dd: stelem.ref
+			IL_08de: dup
+			IL_08df: ldc.i4.s 14
+			IL_08e1: ldloc.s 15
+			IL_08e3: box [System.Runtime]System.Double
+			IL_08e8: stelem.ref
+			IL_08e9: dup
+			IL_08ea: ldc.i4.s 15
+			IL_08ec: ldloc.s 16
+			IL_08ee: stelem.ref
+			IL_08ef: dup
+			IL_08f0: ldc.i4.s 16
+			IL_08f2: ldloc.s 17
+			IL_08f4: stelem.ref
+			IL_08f5: dup
+			IL_08f6: ldc.i4.s 17
+			IL_08f8: ldloc.s 18
+			IL_08fa: stelem.ref
+			IL_08fb: dup
+			IL_08fc: ldc.i4.s 18
+			IL_08fe: ldloc.s 19
+			IL_0900: stelem.ref
+			IL_0901: dup
+			IL_0902: ldc.i4.s 19
+			IL_0904: ldloc.s 20
+			IL_0906: stelem.ref
+			IL_0907: dup
+			IL_0908: ldc.i4.s 20
+			IL_090a: ldloc.s 21
+			IL_090c: stelem.ref
+			IL_090d: dup
+			IL_090e: ldc.i4.s 21
+			IL_0910: ldloc.s 22
+			IL_0912: stelem.ref
+			IL_0913: dup
+			IL_0914: ldc.i4.s 22
+			IL_0916: ldloc.s 23
+			IL_0918: stelem.ref
+			IL_0919: dup
+			IL_091a: ldc.i4.s 23
+			IL_091c: ldloc.s 24
+			IL_091e: box [System.Runtime]System.Boolean
+			IL_0923: stelem.ref
+			IL_0924: dup
+			IL_0925: ldc.i4.s 24
+			IL_0927: ldloc.s 25
+			IL_0929: stelem.ref
+			IL_092a: dup
+			IL_092b: ldc.i4.s 25
+			IL_092d: ldloc.s 26
+			IL_092f: stelem.ref
+			IL_0930: pop
+			IL_0931: ldloc.0
+			IL_0932: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0937: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_093c: ret
 
-			IL_0956: ldloc.0
-			IL_0957: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
-			IL_095c: pop
-			IL_095d: ldstr "console"
-			IL_0962: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0967: stloc.s 13
-			IL_0969: ldloc.s 13
-			IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0970: stloc.s 13
-			IL_0972: ldloc.s 4
-			IL_0974: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0979: stloc.s 22
-			IL_097b: ldloc.s 22
-			IL_097d: ldstr "toString"
-			IL_0982: ldstr "utf8"
-			IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_098c: stloc.s 22
-			IL_098e: ldloc.s 6
-			IL_0990: ldstr "bytesRead"
-			IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_099a: stloc.s 23
-			IL_099c: ldloc.s 13
-			IL_099e: ldstr "log"
-			IL_09a3: ldstr "ExplicitRead:"
-			IL_09a8: ldloc.s 22
-			IL_09aa: ldloc.s 23
-			IL_09ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_09b1: pop
-			IL_09b2: ldstr "console"
-			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09bc: stloc.s 23
-			IL_09be: ldloc.s 23
-			IL_09c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09c5: stloc.s 23
-			IL_09c7: ldloc.s 5
-			IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ce: stloc.s 22
-			IL_09d0: ldloc.s 22
-			IL_09d2: ldstr "toString"
-			IL_09d7: ldstr "utf8"
-			IL_09dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_09e1: stloc.s 22
-			IL_09e3: ldloc.s 7
-			IL_09e5: ldstr "bytesRead"
-			IL_09ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ef: stloc.s 13
-			IL_09f1: ldloc.s 23
-			IL_09f3: ldstr "log"
-			IL_09f8: ldstr "ImplicitReadAfterExplicit:"
-			IL_09fd: ldloc.s 22
-			IL_09ff: ldloc.s 13
-			IL_0a01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0a06: pop
-			IL_0a07: ldstr "console"
-			IL_0a0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a11: stloc.s 13
-			IL_0a13: ldloc.s 13
-			IL_0a15: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a1a: stloc.s 13
-			IL_0a1c: ldloc.s 8
-			IL_0a1e: ldstr "bytesWritten"
-			IL_0a23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a28: stloc.s 22
-			IL_0a2a: ldloc.s 13
-			IL_0a2c: ldstr "log"
-			IL_0a31: ldstr "ExplicitWriteBytes:"
-			IL_0a36: ldloc.s 22
-			IL_0a38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0a3d: pop
-			IL_0a3e: ldstr "console"
-			IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a48: stloc.s 22
-			IL_0a4a: ldloc.s 22
-			IL_0a4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a51: stloc.s 22
-			IL_0a53: ldloc.s 9
-			IL_0a55: ldstr "bytesWritten"
-			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a5f: stloc.s 13
-			IL_0a61: ldloc.s 22
-			IL_0a63: ldstr "log"
-			IL_0a68: ldstr "ImplicitWriteBytes:"
-			IL_0a6d: ldloc.s 13
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0a74: pop
-			IL_0a75: ldstr "console"
-			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a7f: stloc.s 13
-			IL_0a81: ldloc.s 13
-			IL_0a83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a88: stloc.s 13
-			IL_0a8a: ldarg.0
-			IL_0a8b: ldc.i4.1
-			IL_0a8c: ldelem.ref
-			IL_0a8d: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0a92: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0a97: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0a9c: stloc.s 19
-			IL_0a9e: ldloc.s 19
-			IL_0aa0: ldloc.2
-			IL_0aa1: ldstr "utf8"
-			IL_0aa6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0aab: stloc.s 22
-			IL_0aad: ldloc.s 13
-			IL_0aaf: ldstr "log"
-			IL_0ab4: ldstr "FinalText:"
-			IL_0ab9: ldloc.s 22
-			IL_0abb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0ac0: pop
-			IL_0ac1: br IL_0b58
+			IL_093d: ldloc.0
+			IL_093e: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope::_awaited6
+			IL_0943: pop
+			IL_0944: ldstr "console"
+			IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_094e: stloc.s 13
+			IL_0950: ldloc.s 13
+			IL_0952: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0957: stloc.s 13
+			IL_0959: ldloc.s 4
+			IL_095b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0960: stloc.s 22
+			IL_0962: ldloc.s 22
+			IL_0964: ldstr "toString"
+			IL_0969: ldstr "utf8"
+			IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0973: stloc.s 22
+			IL_0975: ldloc.s 6
+			IL_0977: ldstr "bytesRead"
+			IL_097c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0981: stloc.s 23
+			IL_0983: ldloc.s 13
+			IL_0985: ldstr "log"
+			IL_098a: ldstr "ExplicitRead:"
+			IL_098f: ldloc.s 22
+			IL_0991: ldloc.s 23
+			IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0998: pop
+			IL_0999: ldstr "console"
+			IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09a3: stloc.s 23
+			IL_09a5: ldloc.s 23
+			IL_09a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09ac: stloc.s 23
+			IL_09ae: ldloc.s 5
+			IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09b5: stloc.s 22
+			IL_09b7: ldloc.s 22
+			IL_09b9: ldstr "toString"
+			IL_09be: ldstr "utf8"
+			IL_09c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09c8: stloc.s 22
+			IL_09ca: ldloc.s 7
+			IL_09cc: ldstr "bytesRead"
+			IL_09d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d6: stloc.s 13
+			IL_09d8: ldloc.s 23
+			IL_09da: ldstr "log"
+			IL_09df: ldstr "ImplicitReadAfterExplicit:"
+			IL_09e4: ldloc.s 22
+			IL_09e6: ldloc.s 13
+			IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_09ed: pop
+			IL_09ee: ldstr "console"
+			IL_09f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09f8: stloc.s 13
+			IL_09fa: ldloc.s 13
+			IL_09fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a01: stloc.s 13
+			IL_0a03: ldloc.s 8
+			IL_0a05: ldstr "bytesWritten"
+			IL_0a0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0f: stloc.s 22
+			IL_0a11: ldloc.s 13
+			IL_0a13: ldstr "log"
+			IL_0a18: ldstr "ExplicitWriteBytes:"
+			IL_0a1d: ldloc.s 22
+			IL_0a1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0a24: pop
+			IL_0a25: ldstr "console"
+			IL_0a2a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a2f: stloc.s 22
+			IL_0a31: ldloc.s 22
+			IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a38: stloc.s 22
+			IL_0a3a: ldloc.s 9
+			IL_0a3c: ldstr "bytesWritten"
+			IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a46: stloc.s 13
+			IL_0a48: ldloc.s 22
+			IL_0a4a: ldstr "log"
+			IL_0a4f: ldstr "ImplicitWriteBytes:"
+			IL_0a54: ldloc.s 13
+			IL_0a56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0a5b: pop
+			IL_0a5c: ldstr "console"
+			IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a66: stloc.s 13
+			IL_0a68: ldloc.s 13
+			IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a6f: stloc.s 13
+			IL_0a71: ldarg.0
+			IL_0a72: ldc.i4.1
+			IL_0a73: ldelem.ref
+			IL_0a74: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0a79: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0a7e: stloc.s 19
+			IL_0a80: ldloc.s 19
+			IL_0a82: ldloc.2
+			IL_0a83: ldstr "utf8"
+			IL_0a88: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0a8d: stloc.s 22
+			IL_0a8f: ldloc.s 13
+			IL_0a91: ldstr "log"
+			IL_0a96: ldstr "FinalText:"
+			IL_0a9b: ldloc.s 22
+			IL_0a9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0aa2: pop
+			IL_0aa3: br IL_0b3a
 
-			IL_0ac6: ldloc.0
-			IL_0ac7: ldc.i4.1
-			IL_0ac8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0acd: ldloc.0
-			IL_0ace: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0ad3: stloc.s 22
-			IL_0ad5: ldloc.0
-			IL_0ad6: ldc.i4.0
-			IL_0ad7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0adc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0ae1: ldloc.0
-			IL_0ae2: ldc.i4.0
-			IL_0ae3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0ae8: ldloc.s 22
-			IL_0aea: stloc.s 10
-			IL_0aec: ldstr "console"
-			IL_0af1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0af6: stloc.s 22
-			IL_0af8: ldloc.s 22
-			IL_0afa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aff: stloc.s 22
-			IL_0b01: ldloc.s 10
-			IL_0b03: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0b08: stloc.s 24
-			IL_0b0a: ldloc.s 24
-			IL_0b0c: brfalse IL_0b28
+			IL_0aa8: ldloc.0
+			IL_0aa9: ldc.i4.1
+			IL_0aaa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0aaf: ldloc.0
+			IL_0ab0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0ab5: stloc.s 22
+			IL_0ab7: ldloc.0
+			IL_0ab8: ldc.i4.0
+			IL_0ab9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0abe: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0ac3: ldloc.0
+			IL_0ac4: ldc.i4.0
+			IL_0ac5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0aca: ldloc.s 22
+			IL_0acc: stloc.s 10
+			IL_0ace: ldstr "console"
+			IL_0ad3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ad8: stloc.s 22
+			IL_0ada: ldloc.s 22
+			IL_0adc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ae1: stloc.s 22
+			IL_0ae3: ldloc.s 10
+			IL_0ae5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0aea: stloc.s 24
+			IL_0aec: ldloc.s 24
+			IL_0aee: brfalse IL_0b0a
 
-			IL_0b11: ldloc.s 10
-			IL_0b13: ldstr "message"
-			IL_0b18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b1d: stloc.s 13
-			IL_0b1f: ldloc.s 13
-			IL_0b21: stloc.s 26
-			IL_0b23: br IL_0b2c
+			IL_0af3: ldloc.s 10
+			IL_0af5: ldstr "message"
+			IL_0afa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aff: stloc.s 13
+			IL_0b01: ldloc.s 13
+			IL_0b03: stloc.s 26
+			IL_0b05: br IL_0b0e
 
-			IL_0b28: ldloc.s 10
-			IL_0b2a: stloc.s 26
+			IL_0b0a: ldloc.s 10
+			IL_0b0c: stloc.s 26
 
-			IL_0b2c: ldloc.s 22
-			IL_0b2e: ldstr "log"
-			IL_0b33: ldstr "Error:"
-			IL_0b38: ldloc.s 26
-			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0b3f: pop
-			IL_0b40: br IL_0b58
+			IL_0b0e: ldloc.s 22
+			IL_0b10: ldstr "log"
+			IL_0b15: ldstr "Error:"
+			IL_0b1a: ldloc.s 26
+			IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0b21: pop
+			IL_0b22: br IL_0b3a
 
-			IL_0b45: ldloc.0
-			IL_0b46: ldc.i4.1
-			IL_0b47: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b4c: ldloc.0
-			IL_0b4d: ldc.i4.0
-			IL_0b4e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0b53: br IL_0b58
+			IL_0b27: ldloc.0
+			IL_0b28: ldc.i4.1
+			IL_0b29: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b2e: ldloc.0
+			IL_0b2f: ldc.i4.0
+			IL_0b30: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0b35: br IL_0b3a
 
-			IL_0b58: ldarg.0
-			IL_0b59: ldc.i4.1
-			IL_0b5a: ldelem.ref
-			IL_0b5b: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0b60: ldfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0b65: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0b6a: stloc.s 19
-			IL_0b6c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0b71: dup
-			IL_0b72: ldstr "force"
-			IL_0b77: ldc.i4.1
-			IL_0b78: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0b7d: stloc.s 20
-			IL_0b7f: ldloc.s 19
-			IL_0b81: ldloc.2
-			IL_0b82: ldloc.s 20
-			IL_0b84: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0b89: br IL_0ba1
+			IL_0b3a: ldarg.0
+			IL_0b3b: ldc.i4.1
+			IL_0b3c: ldelem.ref
+			IL_0b3d: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0b42: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0b47: stloc.s 19
+			IL_0b49: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0b4e: dup
+			IL_0b4f: ldstr "force"
+			IL_0b54: ldc.i4.1
+			IL_0b55: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0b5a: stloc.s 20
+			IL_0b5c: ldloc.s 19
+			IL_0b5e: ldloc.2
+			IL_0b5f: ldloc.s 20
+			IL_0b61: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0b66: br IL_0b7e
 
-			IL_0b8e: ldloc.0
-			IL_0b8f: ldc.i4.1
-			IL_0b90: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b6b: ldloc.0
+			IL_0b6c: ldc.i4.1
+			IL_0b6d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b72: ldloc.0
+			IL_0b73: ldc.i4.0
+			IL_0b74: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0b79: br IL_0b7e
+
+			IL_0b7e: ldloc.0
+			IL_0b7f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b84: stloc.s 11
+			IL_0b86: ldloc.s 11
+			IL_0b88: brfalse IL_0bc5
+
+			IL_0b8d: ldloc.0
+			IL_0b8e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0b93: stloc.s 22
 			IL_0b95: ldloc.0
-			IL_0b96: ldc.i4.0
-			IL_0b97: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0b9c: br IL_0ba1
+			IL_0b96: ldc.i4.m1
+			IL_0b97: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b9c: ldloc.0
+			IL_0b9d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ba2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0ba7: ldarg.0
+			IL_0ba8: ldc.i4.1
+			IL_0ba9: newarr [System.Runtime]System.Object
+			IL_0bae: dup
+			IL_0baf: ldc.i4.0
+			IL_0bb0: ldloc.s 22
+			IL_0bb2: stelem.ref
+			IL_0bb3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bb8: pop
+			IL_0bb9: ldloc.0
+			IL_0bba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bbf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0bc4: ret
 
-			IL_0ba1: ldloc.0
-			IL_0ba2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0ba7: stloc.s 11
-			IL_0ba9: ldloc.s 11
-			IL_0bab: brfalse IL_0be8
+			IL_0bc5: ldloc.0
+			IL_0bc6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0bcb: stloc.s 12
+			IL_0bcd: ldloc.s 12
+			IL_0bcf: brfalse IL_0c0c
 
-			IL_0bb0: ldloc.0
-			IL_0bb1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0bb6: stloc.s 22
-			IL_0bb8: ldloc.0
-			IL_0bb9: ldc.i4.m1
-			IL_0bba: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0bbf: ldloc.0
-			IL_0bc0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bc5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0bca: ldarg.0
-			IL_0bcb: ldc.i4.1
-			IL_0bcc: newarr [System.Runtime]System.Object
-			IL_0bd1: dup
-			IL_0bd2: ldc.i4.0
-			IL_0bd3: ldloc.s 22
-			IL_0bd5: stelem.ref
-			IL_0bd6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bdb: pop
+			IL_0bd4: ldloc.0
+			IL_0bd5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0bda: stloc.s 22
 			IL_0bdc: ldloc.0
-			IL_0bdd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0be2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0be7: ret
+			IL_0bdd: ldc.i4.m1
+			IL_0bde: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0be3: ldloc.0
+			IL_0be4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0be9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0bee: ldarg.0
+			IL_0bef: ldc.i4.1
+			IL_0bf0: newarr [System.Runtime]System.Object
+			IL_0bf5: dup
+			IL_0bf6: ldc.i4.0
+			IL_0bf7: ldloc.s 22
+			IL_0bf9: stelem.ref
+			IL_0bfa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0bff: pop
+			IL_0c00: ldloc.0
+			IL_0c01: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c06: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c0b: ret
 
-			IL_0be8: ldloc.0
-			IL_0be9: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0bee: stloc.s 12
-			IL_0bf0: ldloc.s 12
-			IL_0bf2: brfalse IL_0c2f
-
-			IL_0bf7: ldloc.0
-			IL_0bf8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0bfd: stloc.s 22
-			IL_0bff: ldloc.0
-			IL_0c00: ldc.i4.m1
-			IL_0c01: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c06: ldloc.0
-			IL_0c07: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c0c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c11: ldarg.0
-			IL_0c12: ldc.i4.1
-			IL_0c13: newarr [System.Runtime]System.Object
-			IL_0c18: dup
-			IL_0c19: ldc.i4.0
-			IL_0c1a: ldloc.s 22
-			IL_0c1c: stelem.ref
-			IL_0c1d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c22: pop
-			IL_0c23: ldloc.0
-			IL_0c24: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c29: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c2e: ret
-
-			IL_0c2f: ldloc.0
-			IL_0c30: ldc.i4.m1
-			IL_0c31: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c36: ldloc.0
-			IL_0c37: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c3c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c41: ldarg.0
-			IL_0c42: ldc.i4.1
-			IL_0c43: newarr [System.Runtime]System.Object
-			IL_0c48: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c4d: pop
-			IL_0c4e: ldloc.0
-			IL_0c4f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c54: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c59: ret
+			IL_0c0c: ldloc.0
+			IL_0c0d: ldc.i4.m1
+			IL_0c0e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c13: ldloc.0
+			IL_0c14: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c19: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c1e: ldarg.0
+			IL_0c1f: ldc.i4.1
+			IL_0c20: newarr [System.Runtime]System.Object
+			IL_0c25: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c2a: pop
+			IL_0c2b: ldloc.0
+			IL_0c2c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c31: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c36: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1641,15 +1634,15 @@
 			73 3d 7b 6f 73 7d 00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object path
-		.field public object os
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule os
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d56
+			// Method begins at RVA 0x2d33
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1695,21 +1688,21 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
 		IL_001a: ldarg.1
 		IL_001b: ldstr "path"
 		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0025: stloc.2
 		IL_0026: ldloc.0
 		IL_0027: ldloc.2
-		IL_0028: stfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
+		IL_0028: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::path
 		IL_002d: ldarg.1
 		IL_002e: ldstr "os"
 		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.0
 		IL_003a: ldloc.3
-		IL_003b: stfld object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
+		IL_003b: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::os
 		IL_0040: ldnull
 		IL_0041: ldftn object Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2::__js_call__(object[], object)
 		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
@@ -1750,7 +1743,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2d83
+		// Method begins at RVA 0x2d60
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a36
+					// Method begins at RVA 0x2a1d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a3f
+					// Method begins at RVA 0x2a26
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a48
+					// Method begins at RVA 0x2a2f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a2d
+				// Method begins at RVA 0x2a14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +139,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 2344 (0x928)
+			// Code size: 2319 (0x90f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope,
@@ -317,7 +317,7 @@
 
 			IL_0121: ldloc.0
 			IL_0122: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0127: switch (IL_014c, IL_0813, IL_085c, IL_0794, IL_036b, IL_0462, IL_059f, IL_067f)
+			IL_0127: switch (IL_014c, IL_07ff, IL_0843, IL_0780, IL_0357, IL_044e, IL_058b, IL_066b)
 
 			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_0151: stloc.s 10
@@ -352,858 +352,853 @@
 			IL_01b0: ldc.i4.1
 			IL_01b1: ldelem.ref
 			IL_01b2: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01b7: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
-			IL_01bc: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_01c1: stloc.s 14
-			IL_01c3: ldarg.0
-			IL_01c4: ldc.i4.1
-			IL_01c5: ldelem.ref
-			IL_01c6: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_01cb: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
-			IL_01d0: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule
-			IL_01d5: stloc.s 15
-			IL_01d7: ldloc.s 15
-			IL_01d9: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01de: stloc.s 10
-			IL_01e0: ldloc.1
-			IL_01e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01e6: stloc.s 11
-			IL_01e8: ldstr "jroc-fs-open-"
-			IL_01ed: ldloc.s 11
+			IL_01b7: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_Read_Write_Close/Scope::path
+			IL_01bc: stloc.s 14
+			IL_01be: ldarg.0
+			IL_01bf: ldc.i4.1
+			IL_01c0: ldelem.ref
+			IL_01c1: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_01c6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_Read_Write_Close/Scope::os
+			IL_01cb: stloc.s 15
+			IL_01cd: ldloc.s 15
+			IL_01cf: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01d4: stloc.s 10
+			IL_01d6: ldloc.1
+			IL_01d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01dc: stloc.s 11
+			IL_01de: ldstr "jroc-fs-open-"
+			IL_01e3: ldloc.s 11
+			IL_01e5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ea: ldstr ".txt"
 			IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f4: ldstr ".txt"
-			IL_01f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fe: stloc.s 11
-			IL_0200: ldloc.s 14
-			IL_0202: ldc.i4.2
-			IL_0203: newarr [System.Runtime]System.Object
-			IL_0208: dup
-			IL_0209: ldc.i4.0
-			IL_020a: ldloc.s 10
-			IL_020c: stelem.ref
-			IL_020d: dup
-			IL_020e: ldc.i4.1
-			IL_020f: ldloc.s 11
-			IL_0211: stelem.ref
-			IL_0212: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0217: stloc.2
-			IL_0218: ldloc.0
-			IL_0219: ldc.i4.0
-			IL_021a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_021f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0224: ldloc.0
-			IL_0225: ldc.i4.0
-			IL_0226: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_022b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0230: ldloc.0
-			IL_0231: ldc.i4.0
-			IL_0232: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0237: ldloc.0
-			IL_0238: ldc.i4.0
-			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_023e: ldarg.0
-			IL_023f: ldc.i4.1
-			IL_0240: ldelem.ref
-			IL_0241: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0246: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_024b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0250: stloc.s 16
-			IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0257: dup
-			IL_0258: ldstr "force"
-			IL_025d: ldc.i4.1
-			IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0263: stloc.s 17
-			IL_0265: ldloc.s 16
-			IL_0267: ldloc.2
-			IL_0268: ldloc.s 17
-			IL_026a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_026f: ldarg.0
-			IL_0270: ldc.i4.1
-			IL_0271: ldelem.ref
-			IL_0272: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0277: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_027c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0281: stloc.s 16
-			IL_0283: ldloc.s 16
-			IL_0285: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_028a: stloc.s 10
-			IL_028c: ldloc.s 10
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f4: stloc.s 11
+			IL_01f6: ldloc.s 14
+			IL_01f8: ldc.i4.2
+			IL_01f9: newarr [System.Runtime]System.Object
+			IL_01fe: dup
+			IL_01ff: ldc.i4.0
+			IL_0200: ldloc.s 10
+			IL_0202: stelem.ref
+			IL_0203: dup
+			IL_0204: ldc.i4.1
+			IL_0205: ldloc.s 11
+			IL_0207: stelem.ref
+			IL_0208: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_020d: stloc.2
+			IL_020e: ldloc.0
+			IL_020f: ldc.i4.0
+			IL_0210: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0215: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_021a: ldloc.0
+			IL_021b: ldc.i4.0
+			IL_021c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0221: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0226: ldloc.0
+			IL_0227: ldc.i4.0
+			IL_0228: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_022d: ldloc.0
+			IL_022e: ldc.i4.0
+			IL_022f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0234: ldarg.0
+			IL_0235: ldc.i4.1
+			IL_0236: ldelem.ref
+			IL_0237: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_023c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_0241: stloc.s 16
+			IL_0243: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0248: dup
+			IL_0249: ldstr "force"
+			IL_024e: ldc.i4.1
+			IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0254: stloc.s 17
+			IL_0256: ldloc.s 16
+			IL_0258: ldloc.2
+			IL_0259: ldloc.s 17
+			IL_025b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0260: ldarg.0
+			IL_0261: ldc.i4.1
+			IL_0262: ldelem.ref
+			IL_0263: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_0268: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_026d: stloc.s 16
+			IL_026f: ldloc.s 16
+			IL_0271: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_0276: stloc.s 10
+			IL_0278: ldloc.s 10
+			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027f: stloc.s 10
+			IL_0281: ldloc.s 10
+			IL_0283: ldstr "open"
+			IL_0288: ldloc.2
+			IL_0289: ldstr "w+"
+			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0293: stloc.s 10
-			IL_0295: ldloc.s 10
-			IL_0297: ldstr "open"
-			IL_029c: ldloc.2
-			IL_029d: ldstr "w+"
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02a7: stloc.s 10
-			IL_02a9: ldloc.0
-			IL_02aa: ldc.i4.4
-			IL_02ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02b0: ldloc.0
-			IL_02b1: ldloc.s 10
-			IL_02b3: ldarg.0
-			IL_02b4: ldc.i4.1
-			IL_02b5: ldloc.0
-			IL_02b6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02bb: ldc.i4.3
-			IL_02bc: ldstr "_pendingException"
-			IL_02c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02c6: ldloc.0
-			IL_02c7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02cc: dup
-			IL_02cd: ldc.i4.0
-			IL_02ce: ldloc.1
-			IL_02cf: stelem.ref
-			IL_02d0: dup
-			IL_02d1: ldc.i4.1
-			IL_02d2: ldloc.2
-			IL_02d3: stelem.ref
-			IL_02d4: dup
-			IL_02d5: ldc.i4.2
-			IL_02d6: ldloc.3
+			IL_0295: ldloc.0
+			IL_0296: ldc.i4.4
+			IL_0297: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_029c: ldloc.0
+			IL_029d: ldloc.s 10
+			IL_029f: ldarg.0
+			IL_02a0: ldc.i4.1
+			IL_02a1: ldloc.0
+			IL_02a2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02a7: ldc.i4.3
+			IL_02a8: ldstr "_pendingException"
+			IL_02ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02b2: ldloc.0
+			IL_02b3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02b8: dup
+			IL_02b9: ldc.i4.0
+			IL_02ba: ldloc.1
+			IL_02bb: stelem.ref
+			IL_02bc: dup
+			IL_02bd: ldc.i4.1
+			IL_02be: ldloc.2
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.2
+			IL_02c2: ldloc.3
+			IL_02c3: stelem.ref
+			IL_02c4: dup
+			IL_02c5: ldc.i4.3
+			IL_02c6: ldloc.s 4
+			IL_02c8: stelem.ref
+			IL_02c9: dup
+			IL_02ca: ldc.i4.4
+			IL_02cb: ldloc.s 5
+			IL_02cd: stelem.ref
+			IL_02ce: dup
+			IL_02cf: ldc.i4.5
+			IL_02d0: ldloc.s 6
+			IL_02d2: stelem.ref
+			IL_02d3: dup
+			IL_02d4: ldc.i4.6
+			IL_02d5: ldloc.s 7
 			IL_02d7: stelem.ref
 			IL_02d8: dup
-			IL_02d9: ldc.i4.3
-			IL_02da: ldloc.s 4
-			IL_02dc: stelem.ref
-			IL_02dd: dup
-			IL_02de: ldc.i4.4
-			IL_02df: ldloc.s 5
+			IL_02d9: ldc.i4.7
+			IL_02da: ldloc.s 8
+			IL_02dc: box [System.Runtime]System.Boolean
 			IL_02e1: stelem.ref
 			IL_02e2: dup
-			IL_02e3: ldc.i4.5
-			IL_02e4: ldloc.s 6
-			IL_02e6: stelem.ref
-			IL_02e7: dup
-			IL_02e8: ldc.i4.6
-			IL_02e9: ldloc.s 7
+			IL_02e3: ldc.i4.8
+			IL_02e4: ldloc.s 9
+			IL_02e6: box [System.Runtime]System.Boolean
 			IL_02eb: stelem.ref
 			IL_02ec: dup
-			IL_02ed: ldc.i4.7
-			IL_02ee: ldloc.s 8
-			IL_02f0: box [System.Runtime]System.Boolean
-			IL_02f5: stelem.ref
-			IL_02f6: dup
-			IL_02f7: ldc.i4.8
-			IL_02f8: ldloc.s 9
-			IL_02fa: box [System.Runtime]System.Boolean
-			IL_02ff: stelem.ref
-			IL_0300: dup
-			IL_0301: ldc.i4.s 9
-			IL_0303: ldloc.s 10
-			IL_0305: stelem.ref
-			IL_0306: dup
-			IL_0307: ldc.i4.s 10
-			IL_0309: ldloc.s 11
-			IL_030b: stelem.ref
-			IL_030c: dup
-			IL_030d: ldc.i4.s 11
-			IL_030f: ldloc.s 12
-			IL_0311: box [System.Runtime]System.Double
-			IL_0316: stelem.ref
-			IL_0317: dup
-			IL_0318: ldc.i4.s 12
-			IL_031a: ldloc.s 13
-			IL_031c: stelem.ref
-			IL_031d: dup
-			IL_031e: ldc.i4.s 13
-			IL_0320: ldloc.s 14
-			IL_0322: stelem.ref
-			IL_0323: dup
-			IL_0324: ldc.i4.s 14
-			IL_0326: ldloc.s 15
-			IL_0328: stelem.ref
-			IL_0329: dup
-			IL_032a: ldc.i4.s 15
-			IL_032c: ldloc.s 16
-			IL_032e: stelem.ref
-			IL_032f: dup
-			IL_0330: ldc.i4.s 16
-			IL_0332: ldloc.s 17
-			IL_0334: stelem.ref
-			IL_0335: dup
-			IL_0336: ldc.i4.s 17
-			IL_0338: ldloc.s 18
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.s 18
-			IL_033e: ldloc.s 19
-			IL_0340: stelem.ref
-			IL_0341: dup
-			IL_0342: ldc.i4.s 19
-			IL_0344: ldloc.s 20
-			IL_0346: box [System.Runtime]System.Boolean
-			IL_034b: stelem.ref
-			IL_034c: dup
-			IL_034d: ldc.i4.s 20
-			IL_034f: ldloc.s 21
-			IL_0351: stelem.ref
-			IL_0352: dup
-			IL_0353: ldc.i4.s 21
-			IL_0355: ldloc.s 22
-			IL_0357: stelem.ref
-			IL_0358: dup
-			IL_0359: ldc.i4.s 22
-			IL_035b: ldloc.s 23
-			IL_035d: stelem.ref
-			IL_035e: pop
-			IL_035f: ldloc.0
-			IL_0360: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0365: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_036a: ret
+			IL_02ed: ldc.i4.s 9
+			IL_02ef: ldloc.s 10
+			IL_02f1: stelem.ref
+			IL_02f2: dup
+			IL_02f3: ldc.i4.s 10
+			IL_02f5: ldloc.s 11
+			IL_02f7: stelem.ref
+			IL_02f8: dup
+			IL_02f9: ldc.i4.s 11
+			IL_02fb: ldloc.s 12
+			IL_02fd: box [System.Runtime]System.Double
+			IL_0302: stelem.ref
+			IL_0303: dup
+			IL_0304: ldc.i4.s 12
+			IL_0306: ldloc.s 13
+			IL_0308: stelem.ref
+			IL_0309: dup
+			IL_030a: ldc.i4.s 13
+			IL_030c: ldloc.s 14
+			IL_030e: stelem.ref
+			IL_030f: dup
+			IL_0310: ldc.i4.s 14
+			IL_0312: ldloc.s 15
+			IL_0314: stelem.ref
+			IL_0315: dup
+			IL_0316: ldc.i4.s 15
+			IL_0318: ldloc.s 16
+			IL_031a: stelem.ref
+			IL_031b: dup
+			IL_031c: ldc.i4.s 16
+			IL_031e: ldloc.s 17
+			IL_0320: stelem.ref
+			IL_0321: dup
+			IL_0322: ldc.i4.s 17
+			IL_0324: ldloc.s 18
+			IL_0326: stelem.ref
+			IL_0327: dup
+			IL_0328: ldc.i4.s 18
+			IL_032a: ldloc.s 19
+			IL_032c: stelem.ref
+			IL_032d: dup
+			IL_032e: ldc.i4.s 19
+			IL_0330: ldloc.s 20
+			IL_0332: box [System.Runtime]System.Boolean
+			IL_0337: stelem.ref
+			IL_0338: dup
+			IL_0339: ldc.i4.s 20
+			IL_033b: ldloc.s 21
+			IL_033d: stelem.ref
+			IL_033e: dup
+			IL_033f: ldc.i4.s 21
+			IL_0341: ldloc.s 22
+			IL_0343: stelem.ref
+			IL_0344: dup
+			IL_0345: ldc.i4.s 22
+			IL_0347: ldloc.s 23
+			IL_0349: stelem.ref
+			IL_034a: pop
+			IL_034b: ldloc.0
+			IL_034c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0351: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0356: ret
 
-			IL_036b: ldloc.0
-			IL_036c: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0371: stloc.3
-			IL_0372: ldloc.3
-			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0378: stloc.s 10
-			IL_037a: ldloc.s 10
-			IL_037c: ldstr "write"
-			IL_0381: ldstr "hello"
-			IL_0386: ldc.r8 0.0
-			IL_038f: box [System.Runtime]System.Double
-			IL_0394: ldstr "utf8"
-			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_039e: stloc.s 10
-			IL_03a0: ldloc.0
-			IL_03a1: ldc.i4.5
-			IL_03a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03a7: ldloc.0
-			IL_03a8: ldloc.s 10
-			IL_03aa: ldarg.0
-			IL_03ab: ldc.i4.2
-			IL_03ac: ldloc.0
-			IL_03ad: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03b2: ldc.i4.3
-			IL_03b3: ldstr "_pendingException"
-			IL_03b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03bd: ldloc.0
-			IL_03be: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03c3: dup
-			IL_03c4: ldc.i4.0
-			IL_03c5: ldloc.1
-			IL_03c6: stelem.ref
-			IL_03c7: dup
-			IL_03c8: ldc.i4.1
-			IL_03c9: ldloc.2
-			IL_03ca: stelem.ref
-			IL_03cb: dup
-			IL_03cc: ldc.i4.2
-			IL_03cd: ldloc.3
+			IL_0357: ldloc.0
+			IL_0358: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited1
+			IL_035d: stloc.3
+			IL_035e: ldloc.3
+			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0364: stloc.s 10
+			IL_0366: ldloc.s 10
+			IL_0368: ldstr "write"
+			IL_036d: ldstr "hello"
+			IL_0372: ldc.r8 0.0
+			IL_037b: box [System.Runtime]System.Double
+			IL_0380: ldstr "utf8"
+			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_038a: stloc.s 10
+			IL_038c: ldloc.0
+			IL_038d: ldc.i4.5
+			IL_038e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0393: ldloc.0
+			IL_0394: ldloc.s 10
+			IL_0396: ldarg.0
+			IL_0397: ldc.i4.2
+			IL_0398: ldloc.0
+			IL_0399: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_039e: ldc.i4.3
+			IL_039f: ldstr "_pendingException"
+			IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03a9: ldloc.0
+			IL_03aa: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03af: dup
+			IL_03b0: ldc.i4.0
+			IL_03b1: ldloc.1
+			IL_03b2: stelem.ref
+			IL_03b3: dup
+			IL_03b4: ldc.i4.1
+			IL_03b5: ldloc.2
+			IL_03b6: stelem.ref
+			IL_03b7: dup
+			IL_03b8: ldc.i4.2
+			IL_03b9: ldloc.3
+			IL_03ba: stelem.ref
+			IL_03bb: dup
+			IL_03bc: ldc.i4.3
+			IL_03bd: ldloc.s 4
+			IL_03bf: stelem.ref
+			IL_03c0: dup
+			IL_03c1: ldc.i4.4
+			IL_03c2: ldloc.s 5
+			IL_03c4: stelem.ref
+			IL_03c5: dup
+			IL_03c6: ldc.i4.5
+			IL_03c7: ldloc.s 6
+			IL_03c9: stelem.ref
+			IL_03ca: dup
+			IL_03cb: ldc.i4.6
+			IL_03cc: ldloc.s 7
 			IL_03ce: stelem.ref
 			IL_03cf: dup
-			IL_03d0: ldc.i4.3
-			IL_03d1: ldloc.s 4
-			IL_03d3: stelem.ref
-			IL_03d4: dup
-			IL_03d5: ldc.i4.4
-			IL_03d6: ldloc.s 5
+			IL_03d0: ldc.i4.7
+			IL_03d1: ldloc.s 8
+			IL_03d3: box [System.Runtime]System.Boolean
 			IL_03d8: stelem.ref
 			IL_03d9: dup
-			IL_03da: ldc.i4.5
-			IL_03db: ldloc.s 6
-			IL_03dd: stelem.ref
-			IL_03de: dup
-			IL_03df: ldc.i4.6
-			IL_03e0: ldloc.s 7
+			IL_03da: ldc.i4.8
+			IL_03db: ldloc.s 9
+			IL_03dd: box [System.Runtime]System.Boolean
 			IL_03e2: stelem.ref
 			IL_03e3: dup
-			IL_03e4: ldc.i4.7
-			IL_03e5: ldloc.s 8
-			IL_03e7: box [System.Runtime]System.Boolean
-			IL_03ec: stelem.ref
-			IL_03ed: dup
-			IL_03ee: ldc.i4.8
-			IL_03ef: ldloc.s 9
-			IL_03f1: box [System.Runtime]System.Boolean
-			IL_03f6: stelem.ref
-			IL_03f7: dup
-			IL_03f8: ldc.i4.s 9
-			IL_03fa: ldloc.s 10
-			IL_03fc: stelem.ref
-			IL_03fd: dup
-			IL_03fe: ldc.i4.s 10
-			IL_0400: ldloc.s 11
-			IL_0402: stelem.ref
-			IL_0403: dup
-			IL_0404: ldc.i4.s 11
-			IL_0406: ldloc.s 12
-			IL_0408: box [System.Runtime]System.Double
-			IL_040d: stelem.ref
-			IL_040e: dup
-			IL_040f: ldc.i4.s 12
-			IL_0411: ldloc.s 13
-			IL_0413: stelem.ref
-			IL_0414: dup
-			IL_0415: ldc.i4.s 13
-			IL_0417: ldloc.s 14
-			IL_0419: stelem.ref
-			IL_041a: dup
-			IL_041b: ldc.i4.s 14
-			IL_041d: ldloc.s 15
-			IL_041f: stelem.ref
-			IL_0420: dup
-			IL_0421: ldc.i4.s 15
-			IL_0423: ldloc.s 16
-			IL_0425: stelem.ref
-			IL_0426: dup
-			IL_0427: ldc.i4.s 16
-			IL_0429: ldloc.s 17
-			IL_042b: stelem.ref
-			IL_042c: dup
-			IL_042d: ldc.i4.s 17
-			IL_042f: ldloc.s 18
-			IL_0431: stelem.ref
-			IL_0432: dup
-			IL_0433: ldc.i4.s 18
-			IL_0435: ldloc.s 19
-			IL_0437: stelem.ref
-			IL_0438: dup
-			IL_0439: ldc.i4.s 19
-			IL_043b: ldloc.s 20
-			IL_043d: box [System.Runtime]System.Boolean
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.s 20
-			IL_0446: ldloc.s 21
-			IL_0448: stelem.ref
-			IL_0449: dup
-			IL_044a: ldc.i4.s 21
-			IL_044c: ldloc.s 22
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.s 22
-			IL_0452: ldloc.s 23
-			IL_0454: stelem.ref
-			IL_0455: pop
-			IL_0456: ldloc.0
-			IL_0457: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_045c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0461: ret
+			IL_03e4: ldc.i4.s 9
+			IL_03e6: ldloc.s 10
+			IL_03e8: stelem.ref
+			IL_03e9: dup
+			IL_03ea: ldc.i4.s 10
+			IL_03ec: ldloc.s 11
+			IL_03ee: stelem.ref
+			IL_03ef: dup
+			IL_03f0: ldc.i4.s 11
+			IL_03f2: ldloc.s 12
+			IL_03f4: box [System.Runtime]System.Double
+			IL_03f9: stelem.ref
+			IL_03fa: dup
+			IL_03fb: ldc.i4.s 12
+			IL_03fd: ldloc.s 13
+			IL_03ff: stelem.ref
+			IL_0400: dup
+			IL_0401: ldc.i4.s 13
+			IL_0403: ldloc.s 14
+			IL_0405: stelem.ref
+			IL_0406: dup
+			IL_0407: ldc.i4.s 14
+			IL_0409: ldloc.s 15
+			IL_040b: stelem.ref
+			IL_040c: dup
+			IL_040d: ldc.i4.s 15
+			IL_040f: ldloc.s 16
+			IL_0411: stelem.ref
+			IL_0412: dup
+			IL_0413: ldc.i4.s 16
+			IL_0415: ldloc.s 17
+			IL_0417: stelem.ref
+			IL_0418: dup
+			IL_0419: ldc.i4.s 17
+			IL_041b: ldloc.s 18
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.s 18
+			IL_0421: ldloc.s 19
+			IL_0423: stelem.ref
+			IL_0424: dup
+			IL_0425: ldc.i4.s 19
+			IL_0427: ldloc.s 20
+			IL_0429: box [System.Runtime]System.Boolean
+			IL_042e: stelem.ref
+			IL_042f: dup
+			IL_0430: ldc.i4.s 20
+			IL_0432: ldloc.s 21
+			IL_0434: stelem.ref
+			IL_0435: dup
+			IL_0436: ldc.i4.s 21
+			IL_0438: ldloc.s 22
+			IL_043a: stelem.ref
+			IL_043b: dup
+			IL_043c: ldc.i4.s 22
+			IL_043e: ldloc.s 23
+			IL_0440: stelem.ref
+			IL_0441: pop
+			IL_0442: ldloc.0
+			IL_0443: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0448: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_044d: ret
 
-			IL_0462: ldloc.0
-			IL_0463: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
-			IL_0468: stloc.s 4
-			IL_046a: ldc.r8 5
-			IL_0473: box [System.Runtime]System.Double
-			IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-			IL_047d: stloc.s 5
-			IL_047f: ldloc.3
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0485: stloc.s 10
-			IL_0487: ldloc.s 5
-			IL_0489: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-			IL_048e: stloc.s 12
-			IL_0490: ldloc.s 12
-			IL_0492: box [System.Runtime]System.Double
-			IL_0497: stloc.s 13
-			IL_0499: ldc.i4.4
-			IL_049a: newarr [System.Runtime]System.Object
-			IL_049f: dup
-			IL_04a0: ldc.i4.0
-			IL_04a1: ldloc.s 5
-			IL_04a3: stelem.ref
-			IL_04a4: dup
-			IL_04a5: ldc.i4.1
-			IL_04a6: ldc.r8 0.0
-			IL_04af: box [System.Runtime]System.Double
-			IL_04b4: stelem.ref
-			IL_04b5: dup
-			IL_04b6: ldc.i4.2
-			IL_04b7: ldloc.s 13
-			IL_04b9: stelem.ref
-			IL_04ba: dup
-			IL_04bb: ldc.i4.3
-			IL_04bc: ldc.r8 0.0
-			IL_04c5: box [System.Runtime]System.Double
-			IL_04ca: stelem.ref
-			IL_04cb: stloc.s 18
-			IL_04cd: ldloc.s 10
-			IL_04cf: ldstr "read"
-			IL_04d4: ldloc.s 18
-			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-			IL_04db: stloc.s 10
-			IL_04dd: ldloc.0
-			IL_04de: ldc.i4.6
-			IL_04df: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04e4: ldloc.0
-			IL_04e5: ldloc.s 10
-			IL_04e7: ldarg.0
-			IL_04e8: ldc.i4.3
-			IL_04e9: ldloc.0
-			IL_04ea: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04ef: ldc.i4.3
-			IL_04f0: ldstr "_pendingException"
-			IL_04f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04fa: ldloc.0
-			IL_04fb: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0500: dup
-			IL_0501: ldc.i4.0
-			IL_0502: ldloc.1
-			IL_0503: stelem.ref
-			IL_0504: dup
-			IL_0505: ldc.i4.1
-			IL_0506: ldloc.2
-			IL_0507: stelem.ref
-			IL_0508: dup
-			IL_0509: ldc.i4.2
-			IL_050a: ldloc.3
+			IL_044e: ldloc.0
+			IL_044f: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited2
+			IL_0454: stloc.s 4
+			IL_0456: ldc.r8 5
+			IL_045f: box [System.Runtime]System.Double
+			IL_0464: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+			IL_0469: stloc.s 5
+			IL_046b: ldloc.3
+			IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0471: stloc.s 10
+			IL_0473: ldloc.s 5
+			IL_0475: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+			IL_047a: stloc.s 12
+			IL_047c: ldloc.s 12
+			IL_047e: box [System.Runtime]System.Double
+			IL_0483: stloc.s 13
+			IL_0485: ldc.i4.4
+			IL_0486: newarr [System.Runtime]System.Object
+			IL_048b: dup
+			IL_048c: ldc.i4.0
+			IL_048d: ldloc.s 5
+			IL_048f: stelem.ref
+			IL_0490: dup
+			IL_0491: ldc.i4.1
+			IL_0492: ldc.r8 0.0
+			IL_049b: box [System.Runtime]System.Double
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.2
+			IL_04a3: ldloc.s 13
+			IL_04a5: stelem.ref
+			IL_04a6: dup
+			IL_04a7: ldc.i4.3
+			IL_04a8: ldc.r8 0.0
+			IL_04b1: box [System.Runtime]System.Double
+			IL_04b6: stelem.ref
+			IL_04b7: stloc.s 18
+			IL_04b9: ldloc.s 10
+			IL_04bb: ldstr "read"
+			IL_04c0: ldloc.s 18
+			IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+			IL_04c7: stloc.s 10
+			IL_04c9: ldloc.0
+			IL_04ca: ldc.i4.6
+			IL_04cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04d0: ldloc.0
+			IL_04d1: ldloc.s 10
+			IL_04d3: ldarg.0
+			IL_04d4: ldc.i4.3
+			IL_04d5: ldloc.0
+			IL_04d6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04db: ldc.i4.3
+			IL_04dc: ldstr "_pendingException"
+			IL_04e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_04e6: ldloc.0
+			IL_04e7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04ec: dup
+			IL_04ed: ldc.i4.0
+			IL_04ee: ldloc.1
+			IL_04ef: stelem.ref
+			IL_04f0: dup
+			IL_04f1: ldc.i4.1
+			IL_04f2: ldloc.2
+			IL_04f3: stelem.ref
+			IL_04f4: dup
+			IL_04f5: ldc.i4.2
+			IL_04f6: ldloc.3
+			IL_04f7: stelem.ref
+			IL_04f8: dup
+			IL_04f9: ldc.i4.3
+			IL_04fa: ldloc.s 4
+			IL_04fc: stelem.ref
+			IL_04fd: dup
+			IL_04fe: ldc.i4.4
+			IL_04ff: ldloc.s 5
+			IL_0501: stelem.ref
+			IL_0502: dup
+			IL_0503: ldc.i4.5
+			IL_0504: ldloc.s 6
+			IL_0506: stelem.ref
+			IL_0507: dup
+			IL_0508: ldc.i4.6
+			IL_0509: ldloc.s 7
 			IL_050b: stelem.ref
 			IL_050c: dup
-			IL_050d: ldc.i4.3
-			IL_050e: ldloc.s 4
-			IL_0510: stelem.ref
-			IL_0511: dup
-			IL_0512: ldc.i4.4
-			IL_0513: ldloc.s 5
+			IL_050d: ldc.i4.7
+			IL_050e: ldloc.s 8
+			IL_0510: box [System.Runtime]System.Boolean
 			IL_0515: stelem.ref
 			IL_0516: dup
-			IL_0517: ldc.i4.5
-			IL_0518: ldloc.s 6
-			IL_051a: stelem.ref
-			IL_051b: dup
-			IL_051c: ldc.i4.6
-			IL_051d: ldloc.s 7
+			IL_0517: ldc.i4.8
+			IL_0518: ldloc.s 9
+			IL_051a: box [System.Runtime]System.Boolean
 			IL_051f: stelem.ref
 			IL_0520: dup
-			IL_0521: ldc.i4.7
-			IL_0522: ldloc.s 8
-			IL_0524: box [System.Runtime]System.Boolean
-			IL_0529: stelem.ref
-			IL_052a: dup
-			IL_052b: ldc.i4.8
-			IL_052c: ldloc.s 9
-			IL_052e: box [System.Runtime]System.Boolean
-			IL_0533: stelem.ref
-			IL_0534: dup
-			IL_0535: ldc.i4.s 9
-			IL_0537: ldloc.s 10
-			IL_0539: stelem.ref
-			IL_053a: dup
-			IL_053b: ldc.i4.s 10
-			IL_053d: ldloc.s 11
-			IL_053f: stelem.ref
-			IL_0540: dup
-			IL_0541: ldc.i4.s 11
-			IL_0543: ldloc.s 12
-			IL_0545: box [System.Runtime]System.Double
-			IL_054a: stelem.ref
-			IL_054b: dup
-			IL_054c: ldc.i4.s 12
-			IL_054e: ldloc.s 13
-			IL_0550: stelem.ref
-			IL_0551: dup
-			IL_0552: ldc.i4.s 13
-			IL_0554: ldloc.s 14
-			IL_0556: stelem.ref
-			IL_0557: dup
-			IL_0558: ldc.i4.s 14
-			IL_055a: ldloc.s 15
-			IL_055c: stelem.ref
-			IL_055d: dup
-			IL_055e: ldc.i4.s 15
-			IL_0560: ldloc.s 16
-			IL_0562: stelem.ref
-			IL_0563: dup
-			IL_0564: ldc.i4.s 16
-			IL_0566: ldloc.s 17
-			IL_0568: stelem.ref
-			IL_0569: dup
-			IL_056a: ldc.i4.s 17
-			IL_056c: ldloc.s 18
-			IL_056e: stelem.ref
-			IL_056f: dup
-			IL_0570: ldc.i4.s 18
-			IL_0572: ldloc.s 19
-			IL_0574: stelem.ref
-			IL_0575: dup
-			IL_0576: ldc.i4.s 19
-			IL_0578: ldloc.s 20
-			IL_057a: box [System.Runtime]System.Boolean
-			IL_057f: stelem.ref
-			IL_0580: dup
-			IL_0581: ldc.i4.s 20
-			IL_0583: ldloc.s 21
-			IL_0585: stelem.ref
-			IL_0586: dup
-			IL_0587: ldc.i4.s 21
-			IL_0589: ldloc.s 22
-			IL_058b: stelem.ref
-			IL_058c: dup
-			IL_058d: ldc.i4.s 22
-			IL_058f: ldloc.s 23
-			IL_0591: stelem.ref
-			IL_0592: pop
-			IL_0593: ldloc.0
-			IL_0594: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0599: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_059e: ret
+			IL_0521: ldc.i4.s 9
+			IL_0523: ldloc.s 10
+			IL_0525: stelem.ref
+			IL_0526: dup
+			IL_0527: ldc.i4.s 10
+			IL_0529: ldloc.s 11
+			IL_052b: stelem.ref
+			IL_052c: dup
+			IL_052d: ldc.i4.s 11
+			IL_052f: ldloc.s 12
+			IL_0531: box [System.Runtime]System.Double
+			IL_0536: stelem.ref
+			IL_0537: dup
+			IL_0538: ldc.i4.s 12
+			IL_053a: ldloc.s 13
+			IL_053c: stelem.ref
+			IL_053d: dup
+			IL_053e: ldc.i4.s 13
+			IL_0540: ldloc.s 14
+			IL_0542: stelem.ref
+			IL_0543: dup
+			IL_0544: ldc.i4.s 14
+			IL_0546: ldloc.s 15
+			IL_0548: stelem.ref
+			IL_0549: dup
+			IL_054a: ldc.i4.s 15
+			IL_054c: ldloc.s 16
+			IL_054e: stelem.ref
+			IL_054f: dup
+			IL_0550: ldc.i4.s 16
+			IL_0552: ldloc.s 17
+			IL_0554: stelem.ref
+			IL_0555: dup
+			IL_0556: ldc.i4.s 17
+			IL_0558: ldloc.s 18
+			IL_055a: stelem.ref
+			IL_055b: dup
+			IL_055c: ldc.i4.s 18
+			IL_055e: ldloc.s 19
+			IL_0560: stelem.ref
+			IL_0561: dup
+			IL_0562: ldc.i4.s 19
+			IL_0564: ldloc.s 20
+			IL_0566: box [System.Runtime]System.Boolean
+			IL_056b: stelem.ref
+			IL_056c: dup
+			IL_056d: ldc.i4.s 20
+			IL_056f: ldloc.s 21
+			IL_0571: stelem.ref
+			IL_0572: dup
+			IL_0573: ldc.i4.s 21
+			IL_0575: ldloc.s 22
+			IL_0577: stelem.ref
+			IL_0578: dup
+			IL_0579: ldc.i4.s 22
+			IL_057b: ldloc.s 23
+			IL_057d: stelem.ref
+			IL_057e: pop
+			IL_057f: ldloc.0
+			IL_0580: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0585: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_058a: ret
 
-			IL_059f: ldloc.0
-			IL_05a0: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
-			IL_05a5: stloc.s 6
-			IL_05a7: ldloc.3
-			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ad: stloc.s 10
-			IL_05af: ldloc.s 10
-			IL_05b1: ldstr "close"
-			IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_05bb: stloc.s 10
-			IL_05bd: ldloc.0
-			IL_05be: ldc.i4.7
-			IL_05bf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c4: ldloc.0
-			IL_05c5: ldloc.s 10
-			IL_05c7: ldarg.0
-			IL_05c8: ldc.i4.4
-			IL_05c9: ldloc.0
-			IL_05ca: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05cf: ldc.i4.3
-			IL_05d0: ldstr "_pendingException"
-			IL_05d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05da: ldloc.0
-			IL_05db: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05e0: dup
-			IL_05e1: ldc.i4.0
-			IL_05e2: ldloc.1
-			IL_05e3: stelem.ref
-			IL_05e4: dup
-			IL_05e5: ldc.i4.1
-			IL_05e6: ldloc.2
-			IL_05e7: stelem.ref
-			IL_05e8: dup
-			IL_05e9: ldc.i4.2
-			IL_05ea: ldloc.3
+			IL_058b: ldloc.0
+			IL_058c: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited3
+			IL_0591: stloc.s 6
+			IL_0593: ldloc.3
+			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0599: stloc.s 10
+			IL_059b: ldloc.s 10
+			IL_059d: ldstr "close"
+			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_05a7: stloc.s 10
+			IL_05a9: ldloc.0
+			IL_05aa: ldc.i4.7
+			IL_05ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05b0: ldloc.0
+			IL_05b1: ldloc.s 10
+			IL_05b3: ldarg.0
+			IL_05b4: ldc.i4.4
+			IL_05b5: ldloc.0
+			IL_05b6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05bb: ldc.i4.3
+			IL_05bc: ldstr "_pendingException"
+			IL_05c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05c6: ldloc.0
+			IL_05c7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05cc: dup
+			IL_05cd: ldc.i4.0
+			IL_05ce: ldloc.1
+			IL_05cf: stelem.ref
+			IL_05d0: dup
+			IL_05d1: ldc.i4.1
+			IL_05d2: ldloc.2
+			IL_05d3: stelem.ref
+			IL_05d4: dup
+			IL_05d5: ldc.i4.2
+			IL_05d6: ldloc.3
+			IL_05d7: stelem.ref
+			IL_05d8: dup
+			IL_05d9: ldc.i4.3
+			IL_05da: ldloc.s 4
+			IL_05dc: stelem.ref
+			IL_05dd: dup
+			IL_05de: ldc.i4.4
+			IL_05df: ldloc.s 5
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.5
+			IL_05e4: ldloc.s 6
+			IL_05e6: stelem.ref
+			IL_05e7: dup
+			IL_05e8: ldc.i4.6
+			IL_05e9: ldloc.s 7
 			IL_05eb: stelem.ref
 			IL_05ec: dup
-			IL_05ed: ldc.i4.3
-			IL_05ee: ldloc.s 4
-			IL_05f0: stelem.ref
-			IL_05f1: dup
-			IL_05f2: ldc.i4.4
-			IL_05f3: ldloc.s 5
+			IL_05ed: ldc.i4.7
+			IL_05ee: ldloc.s 8
+			IL_05f0: box [System.Runtime]System.Boolean
 			IL_05f5: stelem.ref
 			IL_05f6: dup
-			IL_05f7: ldc.i4.5
-			IL_05f8: ldloc.s 6
-			IL_05fa: stelem.ref
-			IL_05fb: dup
-			IL_05fc: ldc.i4.6
-			IL_05fd: ldloc.s 7
+			IL_05f7: ldc.i4.8
+			IL_05f8: ldloc.s 9
+			IL_05fa: box [System.Runtime]System.Boolean
 			IL_05ff: stelem.ref
 			IL_0600: dup
-			IL_0601: ldc.i4.7
-			IL_0602: ldloc.s 8
-			IL_0604: box [System.Runtime]System.Boolean
-			IL_0609: stelem.ref
-			IL_060a: dup
-			IL_060b: ldc.i4.8
-			IL_060c: ldloc.s 9
-			IL_060e: box [System.Runtime]System.Boolean
-			IL_0613: stelem.ref
-			IL_0614: dup
-			IL_0615: ldc.i4.s 9
-			IL_0617: ldloc.s 10
-			IL_0619: stelem.ref
-			IL_061a: dup
-			IL_061b: ldc.i4.s 10
-			IL_061d: ldloc.s 11
-			IL_061f: stelem.ref
-			IL_0620: dup
-			IL_0621: ldc.i4.s 11
-			IL_0623: ldloc.s 12
-			IL_0625: box [System.Runtime]System.Double
-			IL_062a: stelem.ref
-			IL_062b: dup
-			IL_062c: ldc.i4.s 12
-			IL_062e: ldloc.s 13
-			IL_0630: stelem.ref
-			IL_0631: dup
-			IL_0632: ldc.i4.s 13
-			IL_0634: ldloc.s 14
-			IL_0636: stelem.ref
-			IL_0637: dup
-			IL_0638: ldc.i4.s 14
-			IL_063a: ldloc.s 15
-			IL_063c: stelem.ref
-			IL_063d: dup
-			IL_063e: ldc.i4.s 15
-			IL_0640: ldloc.s 16
-			IL_0642: stelem.ref
-			IL_0643: dup
-			IL_0644: ldc.i4.s 16
-			IL_0646: ldloc.s 17
-			IL_0648: stelem.ref
-			IL_0649: dup
-			IL_064a: ldc.i4.s 17
-			IL_064c: ldloc.s 18
-			IL_064e: stelem.ref
-			IL_064f: dup
-			IL_0650: ldc.i4.s 18
-			IL_0652: ldloc.s 19
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.s 19
-			IL_0658: ldloc.s 20
-			IL_065a: box [System.Runtime]System.Boolean
-			IL_065f: stelem.ref
-			IL_0660: dup
-			IL_0661: ldc.i4.s 20
-			IL_0663: ldloc.s 21
-			IL_0665: stelem.ref
-			IL_0666: dup
-			IL_0667: ldc.i4.s 21
-			IL_0669: ldloc.s 22
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.s 22
-			IL_066f: ldloc.s 23
-			IL_0671: stelem.ref
-			IL_0672: pop
-			IL_0673: ldloc.0
-			IL_0674: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0679: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_067e: ret
+			IL_0601: ldc.i4.s 9
+			IL_0603: ldloc.s 10
+			IL_0605: stelem.ref
+			IL_0606: dup
+			IL_0607: ldc.i4.s 10
+			IL_0609: ldloc.s 11
+			IL_060b: stelem.ref
+			IL_060c: dup
+			IL_060d: ldc.i4.s 11
+			IL_060f: ldloc.s 12
+			IL_0611: box [System.Runtime]System.Double
+			IL_0616: stelem.ref
+			IL_0617: dup
+			IL_0618: ldc.i4.s 12
+			IL_061a: ldloc.s 13
+			IL_061c: stelem.ref
+			IL_061d: dup
+			IL_061e: ldc.i4.s 13
+			IL_0620: ldloc.s 14
+			IL_0622: stelem.ref
+			IL_0623: dup
+			IL_0624: ldc.i4.s 14
+			IL_0626: ldloc.s 15
+			IL_0628: stelem.ref
+			IL_0629: dup
+			IL_062a: ldc.i4.s 15
+			IL_062c: ldloc.s 16
+			IL_062e: stelem.ref
+			IL_062f: dup
+			IL_0630: ldc.i4.s 16
+			IL_0632: ldloc.s 17
+			IL_0634: stelem.ref
+			IL_0635: dup
+			IL_0636: ldc.i4.s 17
+			IL_0638: ldloc.s 18
+			IL_063a: stelem.ref
+			IL_063b: dup
+			IL_063c: ldc.i4.s 18
+			IL_063e: ldloc.s 19
+			IL_0640: stelem.ref
+			IL_0641: dup
+			IL_0642: ldc.i4.s 19
+			IL_0644: ldloc.s 20
+			IL_0646: box [System.Runtime]System.Boolean
+			IL_064b: stelem.ref
+			IL_064c: dup
+			IL_064d: ldc.i4.s 20
+			IL_064f: ldloc.s 21
+			IL_0651: stelem.ref
+			IL_0652: dup
+			IL_0653: ldc.i4.s 21
+			IL_0655: ldloc.s 22
+			IL_0657: stelem.ref
+			IL_0658: dup
+			IL_0659: ldc.i4.s 22
+			IL_065b: ldloc.s 23
+			IL_065d: stelem.ref
+			IL_065e: pop
+			IL_065f: ldloc.0
+			IL_0660: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0665: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_066a: ret
 
-			IL_067f: ldloc.0
-			IL_0680: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
-			IL_0685: pop
-			IL_0686: ldstr "console"
-			IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0690: stloc.s 10
-			IL_0692: ldloc.s 10
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0699: stloc.s 10
-			IL_069b: ldloc.3
-			IL_069c: ldstr "fd"
-			IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06a6: stloc.s 19
-			IL_06a8: ldloc.s 19
-			IL_06aa: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_06af: stloc.s 11
-			IL_06b1: ldloc.s 11
-			IL_06b3: ldstr "number"
-			IL_06b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_06bd: stloc.s 20
-			IL_06bf: ldloc.s 20
-			IL_06c1: box [System.Runtime]System.Boolean
-			IL_06c6: stloc.s 21
-			IL_06c8: ldloc.s 10
-			IL_06ca: ldstr "log"
-			IL_06cf: ldstr "FDIsNumber:"
-			IL_06d4: ldloc.s 21
-			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06db: pop
-			IL_06dc: ldstr "console"
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06e6: stloc.s 10
-			IL_06e8: ldloc.s 10
-			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06ef: stloc.s 10
-			IL_06f1: ldloc.s 4
-			IL_06f3: ldstr "bytesWritten"
-			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06fd: stloc.s 19
-			IL_06ff: ldloc.s 10
-			IL_0701: ldstr "log"
-			IL_0706: ldstr "BytesWritten:"
+			IL_066b: ldloc.0
+			IL_066c: ldfld object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope::_awaited4
+			IL_0671: pop
+			IL_0672: ldstr "console"
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_067c: stloc.s 10
+			IL_067e: ldloc.s 10
+			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0685: stloc.s 10
+			IL_0687: ldloc.3
+			IL_0688: ldstr "fd"
+			IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0692: stloc.s 19
+			IL_0694: ldloc.s 19
+			IL_0696: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_069b: stloc.s 11
+			IL_069d: ldloc.s 11
+			IL_069f: ldstr "number"
+			IL_06a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_06a9: stloc.s 20
+			IL_06ab: ldloc.s 20
+			IL_06ad: box [System.Runtime]System.Boolean
+			IL_06b2: stloc.s 21
+			IL_06b4: ldloc.s 10
+			IL_06b6: ldstr "log"
+			IL_06bb: ldstr "FDIsNumber:"
+			IL_06c0: ldloc.s 21
+			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_06c7: pop
+			IL_06c8: ldstr "console"
+			IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06d2: stloc.s 10
+			IL_06d4: ldloc.s 10
+			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06db: stloc.s 10
+			IL_06dd: ldloc.s 4
+			IL_06df: ldstr "bytesWritten"
+			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06e9: stloc.s 19
+			IL_06eb: ldloc.s 10
+			IL_06ed: ldstr "log"
+			IL_06f2: ldstr "BytesWritten:"
+			IL_06f7: ldloc.s 19
+			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_06fe: pop
+			IL_06ff: ldstr "console"
+			IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0709: stloc.s 19
 			IL_070b: ldloc.s 19
-			IL_070d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0712: pop
-			IL_0713: ldstr "console"
-			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_071d: stloc.s 19
-			IL_071f: ldloc.s 19
-			IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0726: stloc.s 19
-			IL_0728: ldloc.s 6
-			IL_072a: ldstr "bytesRead"
-			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0734: stloc.s 10
-			IL_0736: ldloc.s 19
-			IL_0738: ldstr "log"
-			IL_073d: ldstr "BytesRead:"
+			IL_070d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0712: stloc.s 19
+			IL_0714: ldloc.s 6
+			IL_0716: ldstr "bytesRead"
+			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0720: stloc.s 10
+			IL_0722: ldloc.s 19
+			IL_0724: ldstr "log"
+			IL_0729: ldstr "BytesRead:"
+			IL_072e: ldloc.s 10
+			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0735: pop
+			IL_0736: ldstr "console"
+			IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0740: stloc.s 10
 			IL_0742: ldloc.s 10
-			IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0749: pop
-			IL_074a: ldstr "console"
-			IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0754: stloc.s 10
-			IL_0756: ldloc.s 10
-			IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_075d: stloc.s 10
-			IL_075f: ldloc.s 5
-			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0766: stloc.s 19
-			IL_0768: ldloc.s 19
-			IL_076a: ldstr "toString"
-			IL_076f: ldstr "utf8"
-			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0779: stloc.s 19
-			IL_077b: ldloc.s 10
-			IL_077d: ldstr "log"
-			IL_0782: ldstr "BufferText:"
-			IL_0787: ldloc.s 19
-			IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_078e: pop
-			IL_078f: br IL_0826
+			IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0749: stloc.s 10
+			IL_074b: ldloc.s 5
+			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0752: stloc.s 19
+			IL_0754: ldloc.s 19
+			IL_0756: ldstr "toString"
+			IL_075b: ldstr "utf8"
+			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0765: stloc.s 19
+			IL_0767: ldloc.s 10
+			IL_0769: ldstr "log"
+			IL_076e: ldstr "BufferText:"
+			IL_0773: ldloc.s 19
+			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_077a: pop
+			IL_077b: br IL_0812
 
-			IL_0794: ldloc.0
-			IL_0795: ldc.i4.1
-			IL_0796: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0780: ldloc.0
+			IL_0781: ldc.i4.1
+			IL_0782: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0787: ldloc.0
+			IL_0788: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_078d: stloc.s 19
+			IL_078f: ldloc.0
+			IL_0790: ldc.i4.0
+			IL_0791: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0796: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
 			IL_079b: ldloc.0
-			IL_079c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07a1: stloc.s 19
-			IL_07a3: ldloc.0
-			IL_07a4: ldc.i4.0
-			IL_07a5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07aa: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07af: ldloc.0
-			IL_07b0: ldc.i4.0
-			IL_07b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07b6: ldloc.s 19
-			IL_07b8: stloc.s 7
-			IL_07ba: ldstr "console"
-			IL_07bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07c4: stloc.s 19
-			IL_07c6: ldloc.s 19
-			IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07cd: stloc.s 19
-			IL_07cf: ldloc.s 7
-			IL_07d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07d6: stloc.s 20
-			IL_07d8: ldloc.s 20
-			IL_07da: brfalse IL_07f6
+			IL_079c: ldc.i4.0
+			IL_079d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07a2: ldloc.s 19
+			IL_07a4: stloc.s 7
+			IL_07a6: ldstr "console"
+			IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07b0: stloc.s 19
+			IL_07b2: ldloc.s 19
+			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07b9: stloc.s 19
+			IL_07bb: ldloc.s 7
+			IL_07bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_07c2: stloc.s 20
+			IL_07c4: ldloc.s 20
+			IL_07c6: brfalse IL_07e2
 
-			IL_07df: ldloc.s 7
-			IL_07e1: ldstr "message"
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07eb: stloc.s 10
-			IL_07ed: ldloc.s 10
-			IL_07ef: stloc.s 23
-			IL_07f1: br IL_07fa
+			IL_07cb: ldloc.s 7
+			IL_07cd: ldstr "message"
+			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d7: stloc.s 10
+			IL_07d9: ldloc.s 10
+			IL_07db: stloc.s 23
+			IL_07dd: br IL_07e6
 
-			IL_07f6: ldloc.s 7
-			IL_07f8: stloc.s 23
+			IL_07e2: ldloc.s 7
+			IL_07e4: stloc.s 23
 
-			IL_07fa: ldloc.s 19
-			IL_07fc: ldstr "log"
-			IL_0801: ldstr "Error:"
-			IL_0806: ldloc.s 23
-			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_080d: pop
-			IL_080e: br IL_0826
+			IL_07e6: ldloc.s 19
+			IL_07e8: ldstr "log"
+			IL_07ed: ldstr "Error:"
+			IL_07f2: ldloc.s 23
+			IL_07f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_07f9: pop
+			IL_07fa: br IL_0812
 
-			IL_0813: ldloc.0
-			IL_0814: ldc.i4.1
-			IL_0815: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_081a: ldloc.0
-			IL_081b: ldc.i4.0
-			IL_081c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0821: br IL_0826
+			IL_07ff: ldloc.0
+			IL_0800: ldc.i4.1
+			IL_0801: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0806: ldloc.0
+			IL_0807: ldc.i4.0
+			IL_0808: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_080d: br IL_0812
 
-			IL_0826: ldarg.0
-			IL_0827: ldc.i4.1
-			IL_0828: ldelem.ref
-			IL_0829: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_082e: ldfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_0833: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0838: stloc.s 16
-			IL_083a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_083f: dup
-			IL_0840: ldstr "force"
-			IL_0845: ldc.i4.1
-			IL_0846: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_084b: stloc.s 17
-			IL_084d: ldloc.s 16
-			IL_084f: ldloc.2
-			IL_0850: ldloc.s 17
-			IL_0852: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0857: br IL_086f
+			IL_0812: ldarg.0
+			IL_0813: ldc.i4.1
+			IL_0814: ldelem.ref
+			IL_0815: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_081a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_081f: stloc.s 16
+			IL_0821: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0826: dup
+			IL_0827: ldstr "force"
+			IL_082c: ldc.i4.1
+			IL_082d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0832: stloc.s 17
+			IL_0834: ldloc.s 16
+			IL_0836: ldloc.2
+			IL_0837: ldloc.s 17
+			IL_0839: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_083e: br IL_0856
 
-			IL_085c: ldloc.0
-			IL_085d: ldc.i4.1
-			IL_085e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0863: ldloc.0
-			IL_0864: ldc.i4.0
-			IL_0865: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_086a: br IL_086f
+			IL_0843: ldloc.0
+			IL_0844: ldc.i4.1
+			IL_0845: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_084a: ldloc.0
+			IL_084b: ldc.i4.0
+			IL_084c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0851: br IL_0856
 
-			IL_086f: ldloc.0
-			IL_0870: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0875: stloc.s 8
-			IL_0877: ldloc.s 8
-			IL_0879: brfalse IL_08b6
+			IL_0856: ldloc.0
+			IL_0857: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_085c: stloc.s 8
+			IL_085e: ldloc.s 8
+			IL_0860: brfalse IL_089d
 
-			IL_087e: ldloc.0
-			IL_087f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0884: stloc.s 19
-			IL_0886: ldloc.0
-			IL_0887: ldc.i4.m1
-			IL_0888: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_088d: ldloc.0
-			IL_088e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0893: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0898: ldarg.0
-			IL_0899: ldc.i4.1
-			IL_089a: newarr [System.Runtime]System.Object
-			IL_089f: dup
-			IL_08a0: ldc.i4.0
-			IL_08a1: ldloc.s 19
-			IL_08a3: stelem.ref
-			IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08a9: pop
-			IL_08aa: ldloc.0
-			IL_08ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08b5: ret
+			IL_0865: ldloc.0
+			IL_0866: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_086b: stloc.s 19
+			IL_086d: ldloc.0
+			IL_086e: ldc.i4.m1
+			IL_086f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0874: ldloc.0
+			IL_0875: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_087a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_087f: ldarg.0
+			IL_0880: ldc.i4.1
+			IL_0881: newarr [System.Runtime]System.Object
+			IL_0886: dup
+			IL_0887: ldc.i4.0
+			IL_0888: ldloc.s 19
+			IL_088a: stelem.ref
+			IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0890: pop
+			IL_0891: ldloc.0
+			IL_0892: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0897: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_089c: ret
 
-			IL_08b6: ldloc.0
-			IL_08b7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08bc: stloc.s 9
-			IL_08be: ldloc.s 9
-			IL_08c0: brfalse IL_08fd
+			IL_089d: ldloc.0
+			IL_089e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08a3: stloc.s 9
+			IL_08a5: ldloc.s 9
+			IL_08a7: brfalse IL_08e4
 
-			IL_08c5: ldloc.0
-			IL_08c6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_08cb: stloc.s 19
-			IL_08cd: ldloc.0
-			IL_08ce: ldc.i4.m1
-			IL_08cf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08d4: ldloc.0
-			IL_08d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_08df: ldarg.0
-			IL_08e0: ldc.i4.1
-			IL_08e1: newarr [System.Runtime]System.Object
-			IL_08e6: dup
-			IL_08e7: ldc.i4.0
-			IL_08e8: ldloc.s 19
-			IL_08ea: stelem.ref
-			IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08f0: pop
-			IL_08f1: ldloc.0
-			IL_08f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08fc: ret
+			IL_08ac: ldloc.0
+			IL_08ad: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_08b2: stloc.s 19
+			IL_08b4: ldloc.0
+			IL_08b5: ldc.i4.m1
+			IL_08b6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08bb: ldloc.0
+			IL_08bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08c6: ldarg.0
+			IL_08c7: ldc.i4.1
+			IL_08c8: newarr [System.Runtime]System.Object
+			IL_08cd: dup
+			IL_08ce: ldc.i4.0
+			IL_08cf: ldloc.s 19
+			IL_08d1: stelem.ref
+			IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08d7: pop
+			IL_08d8: ldloc.0
+			IL_08d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08e3: ret
 
-			IL_08fd: ldloc.0
-			IL_08fe: ldc.i4.m1
-			IL_08ff: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0904: ldloc.0
-			IL_0905: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_090a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_090f: ldarg.0
-			IL_0910: ldc.i4.1
-			IL_0911: newarr [System.Runtime]System.Object
-			IL_0916: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_091b: pop
-			IL_091c: ldloc.0
-			IL_091d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0922: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0927: ret
+			IL_08e4: ldloc.0
+			IL_08e5: ldc.i4.m1
+			IL_08e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08eb: ldloc.0
+			IL_08ec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_08f6: ldarg.0
+			IL_08f7: ldc.i4.1
+			IL_08f8: newarr [System.Runtime]System.Object
+			IL_08fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0902: pop
+			IL_0903: ldloc.0
+			IL_0904: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0909: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_090e: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1217,15 +1212,15 @@
 			73 3d 7b 6f 73 7d 00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object path
-		.field public object os
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule os
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a24
+			// Method begins at RVA 0x2a0b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1271,21 +1266,21 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
 		IL_001a: ldarg.1
 		IL_001b: ldstr "path"
 		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0025: stloc.2
 		IL_0026: ldloc.0
 		IL_0027: ldloc.2
-		IL_0028: stfld object Modules.FSPromises_Open_Read_Write_Close/Scope::path
+		IL_0028: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Open_Read_Write_Close/Scope::path
 		IL_002d: ldarg.1
 		IL_002e: ldstr "os"
 		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.0
 		IL_003a: ldloc.3
-		IL_003b: stfld object Modules.FSPromises_Open_Read_Write_Close/Scope::os
+		IL_003b: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Open_Read_Write_Close/Scope::os
 		IL_0040: ldnull
 		IL_0041: ldftn object Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2::__js_call__(object[], object)
 		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
@@ -1326,7 +1321,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a51
+		// Method begins at RVA 0x2a38
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x241f
+					// Method begins at RVA 0x2407
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -52,7 +52,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23e4
+				// Method begins at RVA 0x23cc
 				// Header size: 12
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -87,7 +87,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2416
+				// Method begins at RVA 0x23fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22cc
 			// Header size: 12
 			// Code size: 114 (0x72)
 			.maxstack 8
@@ -181,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2428
+				// Method begins at RVA 0x2410
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -205,7 +205,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2360
+			// Method begins at RVA 0x234c
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -245,7 +245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2431
+				// Method begins at RVA 0x2419
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,9 +271,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x239c
+			// Method begins at RVA 0x2388
 			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
@@ -282,28 +282,27 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-			IL_0012: stloc.1
-			IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0018: dup
-			IL_0019: ldstr "recursive"
-			IL_001e: ldc.i4.1
-			IL_001f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0024: dup
-			IL_0025: ldstr "force"
-			IL_002a: ldc.i4.1
-			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0030: stloc.2
-			IL_0031: ldloc.0
-			IL_0032: ldloc.1
-			IL_0033: ldloc.2
-			IL_0034: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0039: ldnull
-			IL_003a: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_Names/Scope::syncFs
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+			IL_000d: stloc.1
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0013: dup
+			IL_0014: ldstr "recursive"
+			IL_0019: ldc.i4.1
+			IL_001a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_001f: dup
+			IL_0020: ldstr "force"
+			IL_0025: ldc.i4.1
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002b: stloc.2
+			IL_002c: ldloc.0
+			IL_002d: ldloc.1
+			IL_002e: ldloc.2
+			IL_002f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method ArrowFunction_L21C14::__js_call__
 
 	} // end of class ArrowFunction_L21C14
@@ -317,14 +316,14 @@
 			69 72 7d 00 00
 		)
 		// Fields
-		.field public object syncFs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule syncFs
 		.field public object dir
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x240d
+			// Method begins at RVA 0x23f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -350,7 +349,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 641 (0x281)
+		// Code size: 621 (0x26d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_Names/Scope,
@@ -379,7 +378,7 @@
 		IL_001e: stloc.s 4
 		IL_0020: ldloc.0
 		IL_0021: ldloc.s 4
-		IL_0023: stfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_0023: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_Names/Scope::syncFs
 		IL_0028: ldarg.1
 		IL_0029: ldstr "path"
 		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -414,190 +413,186 @@
 		IL_0076: ldloc.s 5
 		IL_0078: stfld object Modules.FSPromises_Readdir_Names/Scope::dir
 		IL_007d: ldloc.0
-		IL_007e: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_0083: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0088: stloc.s 4
-		IL_008a: ldloc.0
-		IL_008b: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_0090: stloc.s 5
-		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0097: dup
-		IL_0098: ldstr "recursive"
-		IL_009d: ldc.i4.1
-		IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00a3: stloc.s 8
-		IL_00a5: ldloc.s 4
-		IL_00a7: ldloc.s 5
-		IL_00a9: ldloc.s 8
-		IL_00ab: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-		IL_00b0: pop
-		IL_00b1: ldloc.0
-		IL_00b2: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_00b7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00bc: stloc.s 4
-		IL_00be: ldloc.0
-		IL_00bf: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.2
-		IL_00c7: ldc.i4.2
-		IL_00c8: newarr [System.Runtime]System.Object
-		IL_00cd: dup
-		IL_00ce: ldc.i4.0
-		IL_00cf: ldloc.s 5
-		IL_00d1: stelem.ref
-		IL_00d2: dup
-		IL_00d3: ldc.i4.1
-		IL_00d4: ldstr "alpha.txt"
-		IL_00d9: stelem.ref
-		IL_00da: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_00df: stloc.s 5
-		IL_00e1: ldloc.s 4
-		IL_00e3: ldloc.s 5
-		IL_00e5: ldstr ""
-		IL_00ea: ldstr "utf8"
-		IL_00ef: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-		IL_00f4: ldloc.0
-		IL_00f5: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_00fa: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.0
-		IL_0102: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_0107: stloc.s 5
-		IL_0109: ldloc.2
-		IL_010a: ldc.i4.2
-		IL_010b: newarr [System.Runtime]System.Object
-		IL_0110: dup
-		IL_0111: ldc.i4.0
-		IL_0112: ldloc.s 5
-		IL_0114: stelem.ref
-		IL_0115: dup
-		IL_0116: ldc.i4.1
-		IL_0117: ldstr "beta.txt"
-		IL_011c: stelem.ref
-		IL_011d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0122: stloc.s 5
-		IL_0124: ldloc.s 4
-		IL_0126: ldloc.s 5
-		IL_0128: ldstr ""
-		IL_012d: ldstr "utf8"
-		IL_0132: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-		IL_0137: ldloc.0
-		IL_0138: ldfld object Modules.FSPromises_Readdir_Names/Scope::syncFs
-		IL_013d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0142: stloc.s 4
-		IL_0144: ldloc.0
-		IL_0145: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_014a: stloc.s 5
-		IL_014c: ldloc.2
-		IL_014d: ldc.i4.2
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
+		IL_007e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_0083: stloc.s 4
+		IL_0085: ldloc.0
+		IL_0086: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_008b: stloc.s 5
+		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0092: dup
+		IL_0093: ldstr "recursive"
+		IL_0098: ldc.i4.1
+		IL_0099: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_009e: stloc.s 8
+		IL_00a0: ldloc.s 4
+		IL_00a2: ldloc.s 5
+		IL_00a4: ldloc.s 8
+		IL_00a6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+		IL_00ab: pop
+		IL_00ac: ldloc.0
+		IL_00ad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.0
+		IL_00b5: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.2
+		IL_00bd: ldc.i4.2
+		IL_00be: newarr [System.Runtime]System.Object
+		IL_00c3: dup
+		IL_00c4: ldc.i4.0
+		IL_00c5: ldloc.s 5
+		IL_00c7: stelem.ref
+		IL_00c8: dup
+		IL_00c9: ldc.i4.1
+		IL_00ca: ldstr "alpha.txt"
+		IL_00cf: stelem.ref
+		IL_00d0: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.s 4
+		IL_00d9: ldloc.s 5
+		IL_00db: ldstr ""
+		IL_00e0: ldstr "utf8"
+		IL_00e5: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+		IL_00ea: ldloc.0
+		IL_00eb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_00f0: stloc.s 4
+		IL_00f2: ldloc.0
+		IL_00f3: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_00f8: stloc.s 5
+		IL_00fa: ldloc.2
+		IL_00fb: ldc.i4.2
+		IL_00fc: newarr [System.Runtime]System.Object
+		IL_0101: dup
+		IL_0102: ldc.i4.0
+		IL_0103: ldloc.s 5
+		IL_0105: stelem.ref
+		IL_0106: dup
+		IL_0107: ldc.i4.1
+		IL_0108: ldstr "beta.txt"
+		IL_010d: stelem.ref
+		IL_010e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_0113: stloc.s 5
+		IL_0115: ldloc.s 4
+		IL_0117: ldloc.s 5
+		IL_0119: ldstr ""
+		IL_011e: ldstr "utf8"
+		IL_0123: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+		IL_0128: ldloc.0
+		IL_0129: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_Names/Scope::syncFs
+		IL_012e: stloc.s 4
+		IL_0130: ldloc.0
+		IL_0131: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0136: stloc.s 5
+		IL_0138: ldloc.2
+		IL_0139: ldc.i4.2
+		IL_013a: newarr [System.Runtime]System.Object
+		IL_013f: dup
+		IL_0140: ldc.i4.0
+		IL_0141: ldloc.s 5
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.1
+		IL_0146: ldstr "subdir"
+		IL_014b: stelem.ref
+		IL_014c: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_0151: stloc.s 5
+		IL_0153: ldloc.s 4
 		IL_0155: ldloc.s 5
-		IL_0157: stelem.ref
-		IL_0158: dup
-		IL_0159: ldc.i4.1
-		IL_015a: ldstr "subdir"
-		IL_015f: stelem.ref
-		IL_0160: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0165: stloc.s 5
-		IL_0167: ldloc.s 4
-		IL_0169: ldloc.s 5
-		IL_016b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object)
-		IL_0170: pop
-		IL_0171: ldloc.0
-		IL_0172: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
-		IL_0177: stloc.s 5
-		IL_0179: ldloc.1
-		IL_017a: ldloc.s 5
-		IL_017c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::readdir(object)
-		IL_0181: stloc.s 5
-		IL_0183: ldloc.s 5
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018a: stloc.s 5
-		IL_018c: ldnull
-		IL_018d: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11::__js_call__(object, object)
-		IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0198: ldc.i4.1
-		IL_0199: newarr [System.Runtime]System.Object
-		IL_019e: dup
-		IL_019f: ldc.i4.0
-		IL_01a0: ldloc.0
-		IL_01a1: stelem.ref
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01ac: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01b1: ldc.i4.1
-		IL_01b2: conv.r8
-		IL_01b3: ldstr ""
-		IL_01b8: ldc.i4.0
-		IL_01b9: ldc.i4.0
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_01c4: stloc.s 9
-		IL_01c6: ldloc.s 5
-		IL_01c8: ldstr "then"
-		IL_01cd: ldloc.s 9
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d4: stloc.s 5
-		IL_01d6: ldloc.s 5
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dd: stloc.s 5
-		IL_01df: ldnull
-		IL_01e0: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12::__js_call__(object, object)
-		IL_01e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01eb: ldc.i4.1
-		IL_01ec: newarr [System.Runtime]System.Object
-		IL_01f1: dup
-		IL_01f2: ldc.i4.0
-		IL_01f3: ldloc.0
-		IL_01f4: stelem.ref
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01ff: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0204: ldc.i4.1
-		IL_0205: conv.r8
-		IL_0206: ldstr ""
-		IL_020b: ldc.i4.0
-		IL_020c: ldc.i4.0
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0217: stloc.s 9
-		IL_0219: ldloc.s 5
-		IL_021b: ldstr "catch"
-		IL_0220: ldloc.s 9
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0227: stloc.s 5
-		IL_0229: ldloc.s 5
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0230: stloc.s 5
-		IL_0232: ldloc.0
-		IL_0233: castclass Modules.FSPromises_Readdir_Names/Scope
-		IL_0238: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_Names/Scope, object)
-		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0243: ldc.i4.1
-		IL_0244: newarr [System.Runtime]System.Object
-		IL_0249: dup
-		IL_024a: ldc.i4.0
-		IL_024b: ldloc.0
-		IL_024c: stelem.ref
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0257: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_025c: ldc.i4.0
-		IL_025d: conv.r8
-		IL_025e: ldstr ""
-		IL_0263: ldc.i4.0
-		IL_0264: ldc.i4.0
-		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_026a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_026f: stloc.s 10
-		IL_0271: ldloc.s 5
-		IL_0273: ldstr "finally"
-		IL_0278: ldloc.s 10
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027f: pop
-		IL_0280: ret
+		IL_0157: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object)
+		IL_015c: pop
+		IL_015d: ldloc.0
+		IL_015e: ldfld object Modules.FSPromises_Readdir_Names/Scope::dir
+		IL_0163: stloc.s 5
+		IL_0165: ldloc.1
+		IL_0166: ldloc.s 5
+		IL_0168: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::readdir(object)
+		IL_016d: stloc.s 5
+		IL_016f: ldloc.s 5
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0176: stloc.s 5
+		IL_0178: ldnull
+		IL_0179: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11::__js_call__(object, object)
+		IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0184: ldc.i4.1
+		IL_0185: newarr [System.Runtime]System.Object
+		IL_018a: dup
+		IL_018b: ldc.i4.0
+		IL_018c: ldloc.0
+		IL_018d: stelem.ref
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0198: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_019d: ldc.i4.1
+		IL_019e: conv.r8
+		IL_019f: ldstr ""
+		IL_01a4: ldc.i4.0
+		IL_01a5: ldc.i4.0
+		IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_01b0: stloc.s 9
+		IL_01b2: ldloc.s 5
+		IL_01b4: ldstr "then"
+		IL_01b9: ldloc.s 9
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c0: stloc.s 5
+		IL_01c2: ldloc.s 5
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c9: stloc.s 5
+		IL_01cb: ldnull
+		IL_01cc: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12::__js_call__(object, object)
+		IL_01d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01d7: ldc.i4.1
+		IL_01d8: newarr [System.Runtime]System.Object
+		IL_01dd: dup
+		IL_01de: ldc.i4.0
+		IL_01df: ldloc.0
+		IL_01e0: stelem.ref
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01eb: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01f0: ldc.i4.1
+		IL_01f1: conv.r8
+		IL_01f2: ldstr ""
+		IL_01f7: ldc.i4.0
+		IL_01f8: ldc.i4.0
+		IL_01f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0203: stloc.s 9
+		IL_0205: ldloc.s 5
+		IL_0207: ldstr "catch"
+		IL_020c: ldloc.s 9
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0213: stloc.s 5
+		IL_0215: ldloc.s 5
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021c: stloc.s 5
+		IL_021e: ldloc.0
+		IL_021f: castclass Modules.FSPromises_Readdir_Names/Scope
+		IL_0224: ldftn object Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_Names/Scope, object)
+		IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_022f: ldc.i4.1
+		IL_0230: newarr [System.Runtime]System.Object
+		IL_0235: dup
+		IL_0236: ldc.i4.0
+		IL_0237: ldloc.0
+		IL_0238: stelem.ref
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0243: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0248: ldc.i4.0
+		IL_0249: conv.r8
+		IL_024a: ldstr ""
+		IL_024f: ldc.i4.0
+		IL_0250: ldc.i4.0
+		IL_0251: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_025b: stloc.s 10
+		IL_025d: ldloc.s 5
+		IL_025f: ldstr "finally"
+		IL_0264: ldloc.s 10
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026b: pop
+		IL_026c: ret
 	} // end of method FSPromises_Readdir_Names::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_Names
@@ -609,7 +604,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x243a
+		// Method begins at RVA 0x2422
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
@@ -28,7 +28,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2487
+					// Method begins at RVA 0x2473
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -52,7 +52,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23ec
+				// Method begins at RVA 0x23d8
 				// Header size: 12
 				// Code size: 81 (0x51)
 				.maxstack 8
@@ -116,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2490
+					// Method begins at RVA 0x247c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -140,7 +140,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x2438
 				// Header size: 12
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -175,7 +175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x247e
+				// Method begins at RVA 0x246a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +199,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22b0
+			// Method begins at RVA 0x22a0
 			// Header size: 12
 			// Code size: 169 (0xa9)
 			.maxstack 8
@@ -287,7 +287,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2499
+				// Method begins at RVA 0x2485
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -311,7 +311,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x2358
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -351,7 +351,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a2
+				// Method begins at RVA 0x248e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -377,9 +377,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23a4
+			// Method begins at RVA 0x2394
 			// Header size: 12
-			// Code size: 59 (0x3b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
@@ -388,28 +388,27 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_000b: stloc.0
-			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-			IL_0012: stloc.1
-			IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0018: dup
-			IL_0019: ldstr "recursive"
-			IL_001e: ldc.i4.1
-			IL_001f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0024: dup
-			IL_0025: ldstr "force"
-			IL_002a: ldc.i4.1
-			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0030: stloc.2
-			IL_0031: ldloc.0
-			IL_0032: ldloc.1
-			IL_0033: ldloc.2
-			IL_0034: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0039: ldnull
-			IL_003a: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+			IL_000d: stloc.1
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0013: dup
+			IL_0014: ldstr "recursive"
+			IL_0019: ldc.i4.1
+			IL_001a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_001f: dup
+			IL_0020: ldstr "force"
+			IL_0025: ldc.i4.1
+			IL_0026: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002b: stloc.2
+			IL_002c: ldloc.0
+			IL_002d: ldloc.1
+			IL_002e: ldloc.2
+			IL_002f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method ArrowFunction_L21C14::__js_call__
 
 	} // end of class ArrowFunction_L21C14
@@ -423,14 +422,14 @@
 			69 72 7d 00 00
 		)
 		// Fields
-		.field public object syncFs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule syncFs
 		.field public object dir
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2475
+			// Method begins at RVA 0x2461
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -456,7 +455,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 595 (0x253)
+		// Code size: 580 (0x244)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_WithFileTypes/Scope,
@@ -485,7 +484,7 @@
 		IL_001e: stloc.s 4
 		IL_0020: ldloc.0
 		IL_0021: ldloc.s 4
-		IL_0023: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_0023: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
 		IL_0028: ldarg.1
 		IL_0029: ldstr "path"
 		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -520,172 +519,169 @@
 		IL_0076: ldloc.s 5
 		IL_0078: stfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
 		IL_007d: ldloc.0
-		IL_007e: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_0083: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0088: stloc.s 4
-		IL_008a: ldloc.0
-		IL_008b: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_0090: stloc.s 5
-		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0097: dup
-		IL_0098: ldstr "recursive"
-		IL_009d: ldc.i4.1
-		IL_009e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00a3: stloc.s 8
-		IL_00a5: ldloc.s 4
-		IL_00a7: ldloc.s 5
-		IL_00a9: ldloc.s 8
-		IL_00ab: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-		IL_00b0: pop
-		IL_00b1: ldloc.0
-		IL_00b2: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_00b7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00bc: stloc.s 4
-		IL_00be: ldloc.0
-		IL_00bf: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.2
-		IL_00c7: ldc.i4.2
-		IL_00c8: newarr [System.Runtime]System.Object
-		IL_00cd: dup
-		IL_00ce: ldc.i4.0
-		IL_00cf: ldloc.s 5
-		IL_00d1: stelem.ref
-		IL_00d2: dup
-		IL_00d3: ldc.i4.1
-		IL_00d4: ldstr "alpha.txt"
-		IL_00d9: stelem.ref
-		IL_00da: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_00df: stloc.s 5
-		IL_00e1: ldloc.s 4
-		IL_00e3: ldloc.s 5
-		IL_00e5: ldstr ""
-		IL_00ea: ldstr "utf8"
-		IL_00ef: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-		IL_00f4: ldloc.0
-		IL_00f5: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
-		IL_00fa: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.0
-		IL_0102: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_0107: stloc.s 5
-		IL_0109: ldloc.2
-		IL_010a: ldc.i4.2
-		IL_010b: newarr [System.Runtime]System.Object
-		IL_0110: dup
-		IL_0111: ldc.i4.0
-		IL_0112: ldloc.s 5
-		IL_0114: stelem.ref
-		IL_0115: dup
-		IL_0116: ldc.i4.1
-		IL_0117: ldstr "subdir"
-		IL_011c: stelem.ref
-		IL_011d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0122: stloc.s 5
-		IL_0124: ldloc.s 4
-		IL_0126: ldloc.s 5
-		IL_0128: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object)
-		IL_012d: pop
-		IL_012e: ldloc.0
-		IL_012f: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
-		IL_0134: stloc.s 5
-		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_013b: dup
-		IL_013c: ldstr "withFileTypes"
-		IL_0141: ldc.i4.1
-		IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0147: stloc.s 8
-		IL_0149: ldloc.1
-		IL_014a: ldloc.s 5
-		IL_014c: ldloc.s 8
-		IL_014e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::readdir(object, object)
-		IL_0153: stloc.s 5
-		IL_0155: ldloc.s 5
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015c: stloc.s 5
-		IL_015e: ldnull
-		IL_015f: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11::__js_call__(object, object)
-		IL_0165: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_016a: ldc.i4.1
-		IL_016b: newarr [System.Runtime]System.Object
-		IL_0170: dup
-		IL_0171: ldc.i4.0
-		IL_0172: ldloc.0
-		IL_0173: stelem.ref
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_017e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0183: ldc.i4.1
-		IL_0184: conv.r8
-		IL_0185: ldstr ""
-		IL_018a: ldc.i4.0
-		IL_018b: ldc.i4.0
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0191: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0196: stloc.s 9
-		IL_0198: ldloc.s 5
-		IL_019a: ldstr "then"
-		IL_019f: ldloc.s 9
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a6: stloc.s 5
-		IL_01a8: ldloc.s 5
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01af: stloc.s 5
-		IL_01b1: ldnull
-		IL_01b2: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12::__js_call__(object, object)
-		IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01bd: ldc.i4.1
-		IL_01be: newarr [System.Runtime]System.Object
-		IL_01c3: dup
-		IL_01c4: ldc.i4.0
-		IL_01c5: ldloc.0
-		IL_01c6: stelem.ref
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01d1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01d6: ldc.i4.1
-		IL_01d7: conv.r8
-		IL_01d8: ldstr ""
-		IL_01dd: ldc.i4.0
-		IL_01de: ldc.i4.0
-		IL_01df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_01e9: stloc.s 9
-		IL_01eb: ldloc.s 5
-		IL_01ed: ldstr "catch"
-		IL_01f2: ldloc.s 9
-		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f9: stloc.s 5
-		IL_01fb: ldloc.s 5
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0202: stloc.s 5
-		IL_0204: ldloc.0
-		IL_0205: castclass Modules.FSPromises_Readdir_WithFileTypes/Scope
-		IL_020a: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_WithFileTypes/Scope, object)
-		IL_0210: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0215: ldc.i4.1
-		IL_0216: newarr [System.Runtime]System.Object
-		IL_021b: dup
-		IL_021c: ldc.i4.0
-		IL_021d: ldloc.0
-		IL_021e: stelem.ref
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0229: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_022e: ldc.i4.0
-		IL_022f: conv.r8
-		IL_0230: ldstr ""
-		IL_0235: ldc.i4.0
-		IL_0236: ldc.i4.0
-		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_023c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0241: stloc.s 10
-		IL_0243: ldloc.s 5
-		IL_0245: ldstr "finally"
-		IL_024a: ldloc.s 10
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0251: pop
-		IL_0252: ret
+		IL_007e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_0083: stloc.s 4
+		IL_0085: ldloc.0
+		IL_0086: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_008b: stloc.s 5
+		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0092: dup
+		IL_0093: ldstr "recursive"
+		IL_0098: ldc.i4.1
+		IL_0099: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_009e: stloc.s 8
+		IL_00a0: ldloc.s 4
+		IL_00a2: ldloc.s 5
+		IL_00a4: ldloc.s 8
+		IL_00a6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+		IL_00ab: pop
+		IL_00ac: ldloc.0
+		IL_00ad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_00b2: stloc.s 4
+		IL_00b4: ldloc.0
+		IL_00b5: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.2
+		IL_00bd: ldc.i4.2
+		IL_00be: newarr [System.Runtime]System.Object
+		IL_00c3: dup
+		IL_00c4: ldc.i4.0
+		IL_00c5: ldloc.s 5
+		IL_00c7: stelem.ref
+		IL_00c8: dup
+		IL_00c9: ldc.i4.1
+		IL_00ca: ldstr "alpha.txt"
+		IL_00cf: stelem.ref
+		IL_00d0: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.s 4
+		IL_00d9: ldloc.s 5
+		IL_00db: ldstr ""
+		IL_00e0: ldstr "utf8"
+		IL_00e5: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+		IL_00ea: ldloc.0
+		IL_00eb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Readdir_WithFileTypes/Scope::syncFs
+		IL_00f0: stloc.s 4
+		IL_00f2: ldloc.0
+		IL_00f3: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_00f8: stloc.s 5
+		IL_00fa: ldloc.2
+		IL_00fb: ldc.i4.2
+		IL_00fc: newarr [System.Runtime]System.Object
+		IL_0101: dup
+		IL_0102: ldc.i4.0
+		IL_0103: ldloc.s 5
+		IL_0105: stelem.ref
+		IL_0106: dup
+		IL_0107: ldc.i4.1
+		IL_0108: ldstr "subdir"
+		IL_010d: stelem.ref
+		IL_010e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_0113: stloc.s 5
+		IL_0115: ldloc.s 4
+		IL_0117: ldloc.s 5
+		IL_0119: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object)
+		IL_011e: pop
+		IL_011f: ldloc.0
+		IL_0120: ldfld object Modules.FSPromises_Readdir_WithFileTypes/Scope::dir
+		IL_0125: stloc.s 5
+		IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_012c: dup
+		IL_012d: ldstr "withFileTypes"
+		IL_0132: ldc.i4.1
+		IL_0133: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0138: stloc.s 8
+		IL_013a: ldloc.1
+		IL_013b: ldloc.s 5
+		IL_013d: ldloc.s 8
+		IL_013f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::readdir(object, object)
+		IL_0144: stloc.s 5
+		IL_0146: ldloc.s 5
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014d: stloc.s 5
+		IL_014f: ldnull
+		IL_0150: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11::__js_call__(object, object)
+		IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_015b: ldc.i4.1
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: dup
+		IL_0162: ldc.i4.0
+		IL_0163: ldloc.0
+		IL_0164: stelem.ref
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_016f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0174: ldc.i4.1
+		IL_0175: conv.r8
+		IL_0176: ldstr ""
+		IL_017b: ldc.i4.0
+		IL_017c: ldc.i4.0
+		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0187: stloc.s 9
+		IL_0189: ldloc.s 5
+		IL_018b: ldstr "then"
+		IL_0190: ldloc.s 9
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0197: stloc.s 5
+		IL_0199: ldloc.s 5
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a0: stloc.s 5
+		IL_01a2: ldnull
+		IL_01a3: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12::__js_call__(object, object)
+		IL_01a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01ae: ldc.i4.1
+		IL_01af: newarr [System.Runtime]System.Object
+		IL_01b4: dup
+		IL_01b5: ldc.i4.0
+		IL_01b6: ldloc.0
+		IL_01b7: stelem.ref
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01c2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01c7: ldc.i4.1
+		IL_01c8: conv.r8
+		IL_01c9: ldstr ""
+		IL_01ce: ldc.i4.0
+		IL_01cf: ldc.i4.0
+		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_01da: stloc.s 9
+		IL_01dc: ldloc.s 5
+		IL_01de: ldstr "catch"
+		IL_01e3: ldloc.s 9
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ea: stloc.s 5
+		IL_01ec: ldloc.s 5
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f3: stloc.s 5
+		IL_01f5: ldloc.0
+		IL_01f6: castclass Modules.FSPromises_Readdir_WithFileTypes/Scope
+		IL_01fb: ldftn object Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14::__js_call__(class Modules.FSPromises_Readdir_WithFileTypes/Scope, object)
+		IL_0201: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0206: ldc.i4.1
+		IL_0207: newarr [System.Runtime]System.Object
+		IL_020c: dup
+		IL_020d: ldc.i4.0
+		IL_020e: ldloc.0
+		IL_020f: stelem.ref
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_021a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_021f: ldc.i4.0
+		IL_0220: conv.r8
+		IL_0221: ldstr ""
+		IL_0226: ldc.i4.0
+		IL_0227: ldc.i4.0
+		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_022d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0232: stloc.s 10
+		IL_0234: ldloc.s 5
+		IL_0236: ldstr "finally"
+		IL_023b: ldloc.s 10
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0242: pop
+		IL_0243: ret
 	} // end of method FSPromises_Readdir_WithFileTypes::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_WithFileTypes
@@ -697,7 +693,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24ab
+		// Method begins at RVA 0x2497
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Rename_ExistingDirectory_Rejects.verified.txt
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2868
+						// Method begins at RVA 0x2822
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2871
+						// Method begins at RVA 0x282b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x285f
+					// Method begins at RVA 0x2819
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x287a
+					// Method begins at RVA 0x2834
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2856
+				// Method begins at RVA 0x2810
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 1873 (0x751)
+			// Code size: 1803 (0x70b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope,
@@ -325,7 +325,7 @@
 
 			IL_0116: ldloc.0
 			IL_0117: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_011c: switch (IL_0135, IL_0630, IL_0685, IL_04aa, IL_0472)
+			IL_011c: switch (IL_0135, IL_05ef, IL_063f, IL_0478, IL_0440)
 
 			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_013a: stloc.s 9
@@ -360,572 +360,558 @@
 			IL_0199: ldc.i4.1
 			IL_019a: ldelem.ref
 			IL_019b: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01a0: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_01a5: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_01aa: stloc.s 13
-			IL_01ac: ldarg.0
-			IL_01ad: ldc.i4.1
-			IL_01ae: ldelem.ref
-			IL_01af: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01b4: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
-			IL_01b9: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule
-			IL_01be: stloc.s 14
-			IL_01c0: ldloc.s 14
-			IL_01c2: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
-			IL_01c7: stloc.s 9
-			IL_01c9: ldloc.1
-			IL_01ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cf: stloc.s 10
-			IL_01d1: ldstr "jroc-fs-rename-existing-dir-"
-			IL_01d6: ldloc.s 10
-			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01dd: stloc.s 10
-			IL_01df: ldloc.s 13
-			IL_01e1: ldc.i4.2
-			IL_01e2: newarr [System.Runtime]System.Object
-			IL_01e7: dup
-			IL_01e8: ldc.i4.0
-			IL_01e9: ldloc.s 9
-			IL_01eb: stelem.ref
-			IL_01ec: dup
-			IL_01ed: ldc.i4.1
-			IL_01ee: ldloc.s 10
-			IL_01f0: stelem.ref
-			IL_01f1: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_01f6: stloc.2
-			IL_01f7: ldarg.0
-			IL_01f8: ldc.i4.1
-			IL_01f9: ldelem.ref
-			IL_01fa: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_01ff: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0204: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0209: stloc.s 13
-			IL_020b: ldloc.s 13
-			IL_020d: ldc.i4.2
-			IL_020e: newarr [System.Runtime]System.Object
-			IL_0213: dup
-			IL_0214: ldc.i4.0
-			IL_0215: ldloc.2
-			IL_0216: stelem.ref
-			IL_0217: dup
-			IL_0218: ldc.i4.1
-			IL_0219: ldstr "source"
-			IL_021e: stelem.ref
-			IL_021f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0224: stloc.3
-			IL_0225: ldarg.0
-			IL_0226: ldc.i4.1
-			IL_0227: ldelem.ref
-			IL_0228: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_022d: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0232: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0237: stloc.s 13
-			IL_0239: ldloc.s 13
-			IL_023b: ldc.i4.2
-			IL_023c: newarr [System.Runtime]System.Object
-			IL_0241: dup
-			IL_0242: ldc.i4.0
-			IL_0243: ldloc.2
-			IL_0244: stelem.ref
-			IL_0245: dup
-			IL_0246: ldc.i4.1
-			IL_0247: ldstr "destination"
-			IL_024c: stelem.ref
-			IL_024d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0252: stloc.s 4
-			IL_0254: ldarg.0
-			IL_0255: ldc.i4.1
-			IL_0256: ldelem.ref
-			IL_0257: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_025c: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
-			IL_0261: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0266: stloc.s 13
-			IL_0268: ldloc.s 13
-			IL_026a: ldc.i4.2
-			IL_026b: newarr [System.Runtime]System.Object
-			IL_0270: dup
-			IL_0271: ldc.i4.0
-			IL_0272: ldloc.s 4
-			IL_0274: stelem.ref
-			IL_0275: dup
-			IL_0276: ldc.i4.1
-			IL_0277: ldstr "keep.txt"
-			IL_027c: stelem.ref
-			IL_027d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0282: stloc.s 5
-			IL_0284: ldloc.0
-			IL_0285: ldc.i4.0
-			IL_0286: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_028b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0290: ldloc.0
-			IL_0291: ldc.i4.0
-			IL_0292: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0297: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_029c: ldloc.0
-			IL_029d: ldc.i4.0
-			IL_029e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02a3: ldloc.0
-			IL_02a4: ldc.i4.0
-			IL_02a5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02aa: ldarg.0
+			IL_01a0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01a5: stloc.s 13
+			IL_01a7: ldarg.0
+			IL_01a8: ldc.i4.1
+			IL_01a9: ldelem.ref
+			IL_01aa: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01af: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
+			IL_01b4: stloc.s 14
+			IL_01b6: ldloc.s 14
+			IL_01b8: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule::tmpdir()
+			IL_01bd: stloc.s 9
+			IL_01bf: ldloc.1
+			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01c5: stloc.s 10
+			IL_01c7: ldstr "jroc-fs-rename-existing-dir-"
+			IL_01cc: ldloc.s 10
+			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d3: stloc.s 10
+			IL_01d5: ldloc.s 13
+			IL_01d7: ldc.i4.2
+			IL_01d8: newarr [System.Runtime]System.Object
+			IL_01dd: dup
+			IL_01de: ldc.i4.0
+			IL_01df: ldloc.s 9
+			IL_01e1: stelem.ref
+			IL_01e2: dup
+			IL_01e3: ldc.i4.1
+			IL_01e4: ldloc.s 10
+			IL_01e6: stelem.ref
+			IL_01e7: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_01ec: stloc.2
+			IL_01ed: ldarg.0
+			IL_01ee: ldc.i4.1
+			IL_01ef: ldelem.ref
+			IL_01f0: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_01f5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_01fa: stloc.s 13
+			IL_01fc: ldloc.s 13
+			IL_01fe: ldc.i4.2
+			IL_01ff: newarr [System.Runtime]System.Object
+			IL_0204: dup
+			IL_0205: ldc.i4.0
+			IL_0206: ldloc.2
+			IL_0207: stelem.ref
+			IL_0208: dup
+			IL_0209: ldc.i4.1
+			IL_020a: ldstr "source"
+			IL_020f: stelem.ref
+			IL_0210: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0215: stloc.3
+			IL_0216: ldarg.0
+			IL_0217: ldc.i4.1
+			IL_0218: ldelem.ref
+			IL_0219: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_021e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_0223: stloc.s 13
+			IL_0225: ldloc.s 13
+			IL_0227: ldc.i4.2
+			IL_0228: newarr [System.Runtime]System.Object
+			IL_022d: dup
+			IL_022e: ldc.i4.0
+			IL_022f: ldloc.2
+			IL_0230: stelem.ref
+			IL_0231: dup
+			IL_0232: ldc.i4.1
+			IL_0233: ldstr "destination"
+			IL_0238: stelem.ref
+			IL_0239: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_023e: stloc.s 4
+			IL_0240: ldarg.0
+			IL_0241: ldc.i4.1
+			IL_0242: ldelem.ref
+			IL_0243: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0248: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+			IL_024d: stloc.s 13
+			IL_024f: ldloc.s 13
+			IL_0251: ldc.i4.2
+			IL_0252: newarr [System.Runtime]System.Object
+			IL_0257: dup
+			IL_0258: ldc.i4.0
+			IL_0259: ldloc.s 4
+			IL_025b: stelem.ref
+			IL_025c: dup
+			IL_025d: ldc.i4.1
+			IL_025e: ldstr "keep.txt"
+			IL_0263: stelem.ref
+			IL_0264: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0269: stloc.s 5
+			IL_026b: ldloc.0
+			IL_026c: ldc.i4.0
+			IL_026d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0272: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0277: ldloc.0
+			IL_0278: ldc.i4.0
+			IL_0279: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_027e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0283: ldloc.0
+			IL_0284: ldc.i4.0
+			IL_0285: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_028a: ldloc.0
+			IL_028b: ldc.i4.0
+			IL_028c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0291: ldarg.0
+			IL_0292: ldc.i4.1
+			IL_0293: ldelem.ref
+			IL_0294: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0299: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_029e: stloc.s 15
+			IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a5: dup
+			IL_02a6: ldstr "recursive"
 			IL_02ab: ldc.i4.1
-			IL_02ac: ldelem.ref
-			IL_02ad: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02b2: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02b7: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02bc: stloc.s 15
-			IL_02be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02c3: dup
-			IL_02c4: ldstr "recursive"
-			IL_02c9: ldc.i4.1
-			IL_02ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02cf: dup
-			IL_02d0: ldstr "force"
-			IL_02d5: ldc.i4.1
-			IL_02d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02db: stloc.s 16
-			IL_02dd: ldloc.s 15
-			IL_02df: ldloc.2
-			IL_02e0: ldloc.s 16
-			IL_02e2: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_02e7: ldarg.0
-			IL_02e8: ldc.i4.1
-			IL_02e9: ldelem.ref
-			IL_02ea: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_02ef: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_02f4: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_02f9: stloc.s 15
-			IL_02fb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0300: dup
-			IL_0301: ldstr "recursive"
-			IL_0306: ldc.i4.1
-			IL_0307: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_030c: stloc.s 16
-			IL_030e: ldloc.s 15
-			IL_0310: ldloc.3
-			IL_0311: ldloc.s 16
-			IL_0313: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_0318: pop
-			IL_0319: ldarg.0
-			IL_031a: ldc.i4.1
-			IL_031b: ldelem.ref
-			IL_031c: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0321: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0326: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_032b: stloc.s 15
-			IL_032d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0332: dup
-			IL_0333: ldstr "recursive"
-			IL_0338: ldc.i4.1
-			IL_0339: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_033e: stloc.s 16
-			IL_0340: ldloc.s 15
-			IL_0342: ldloc.s 4
-			IL_0344: ldloc.s 16
-			IL_0346: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_034b: pop
-			IL_034c: ldarg.0
-			IL_034d: ldc.i4.1
-			IL_034e: ldelem.ref
-			IL_034f: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0354: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0359: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_035e: stloc.s 15
-			IL_0360: ldloc.s 15
-			IL_0362: ldloc.s 5
-			IL_0364: ldstr "keep"
-			IL_0369: ldstr "utf8"
-			IL_036e: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0373: ldloc.0
-			IL_0374: ldc.i4.0
-			IL_0375: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_037a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_037f: ldarg.0
-			IL_0380: ldc.i4.1
-			IL_0381: ldelem.ref
-			IL_0382: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0387: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_038c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0391: stloc.s 15
-			IL_0393: ldloc.s 15
-			IL_0395: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
-			IL_039a: stloc.s 9
-			IL_039c: ldloc.s 9
-			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a3: stloc.s 9
-			IL_03a5: ldloc.s 9
-			IL_03a7: ldstr "rename"
-			IL_03ac: ldloc.3
-			IL_03ad: ldloc.s 4
-			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03b4: stloc.s 9
-			IL_03b6: ldloc.0
-			IL_03b7: ldc.i4.4
-			IL_03b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03bd: ldloc.0
-			IL_03be: ldloc.s 9
-			IL_03c0: ldarg.0
-			IL_03c1: ldc.i4.1
-			IL_03c2: ldloc.0
-			IL_03c3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03c8: ldc.i4.3
-			IL_03c9: ldstr "_pendingException"
-			IL_03ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_03d3: ldloc.0
-			IL_03d4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03d9: dup
-			IL_03da: ldc.i4.0
-			IL_03db: ldloc.1
-			IL_03dc: stelem.ref
-			IL_03dd: dup
-			IL_03de: ldc.i4.1
-			IL_03df: ldloc.2
+			IL_02ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02b1: dup
+			IL_02b2: ldstr "force"
+			IL_02b7: ldc.i4.1
+			IL_02b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02bd: stloc.s 16
+			IL_02bf: ldloc.s 15
+			IL_02c1: ldloc.2
+			IL_02c2: ldloc.s 16
+			IL_02c4: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_02c9: ldarg.0
+			IL_02ca: ldc.i4.1
+			IL_02cb: ldelem.ref
+			IL_02cc: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02d1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_02d6: stloc.s 15
+			IL_02d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02dd: dup
+			IL_02de: ldstr "recursive"
+			IL_02e3: ldc.i4.1
+			IL_02e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02e9: stloc.s 16
+			IL_02eb: ldloc.s 15
+			IL_02ed: ldloc.3
+			IL_02ee: ldloc.s 16
+			IL_02f0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_02f5: pop
+			IL_02f6: ldarg.0
+			IL_02f7: ldc.i4.1
+			IL_02f8: ldelem.ref
+			IL_02f9: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_02fe: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0303: stloc.s 15
+			IL_0305: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_030a: dup
+			IL_030b: ldstr "recursive"
+			IL_0310: ldc.i4.1
+			IL_0311: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0316: stloc.s 16
+			IL_0318: ldloc.s 15
+			IL_031a: ldloc.s 4
+			IL_031c: ldloc.s 16
+			IL_031e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_0323: pop
+			IL_0324: ldarg.0
+			IL_0325: ldc.i4.1
+			IL_0326: ldelem.ref
+			IL_0327: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_032c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0331: stloc.s 15
+			IL_0333: ldloc.s 15
+			IL_0335: ldloc.s 5
+			IL_0337: ldstr "keep"
+			IL_033c: ldstr "utf8"
+			IL_0341: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0346: ldloc.0
+			IL_0347: ldc.i4.0
+			IL_0348: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_034d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0352: ldarg.0
+			IL_0353: ldc.i4.1
+			IL_0354: ldelem.ref
+			IL_0355: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_035a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_035f: stloc.s 15
+			IL_0361: ldloc.s 15
+			IL_0363: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::get_promises()
+			IL_0368: stloc.s 9
+			IL_036a: ldloc.s 9
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0371: stloc.s 9
+			IL_0373: ldloc.s 9
+			IL_0375: ldstr "rename"
+			IL_037a: ldloc.3
+			IL_037b: ldloc.s 4
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0382: stloc.s 9
+			IL_0384: ldloc.0
+			IL_0385: ldc.i4.4
+			IL_0386: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_038b: ldloc.0
+			IL_038c: ldloc.s 9
+			IL_038e: ldarg.0
+			IL_038f: ldc.i4.1
+			IL_0390: ldloc.0
+			IL_0391: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0396: ldc.i4.3
+			IL_0397: ldstr "_pendingException"
+			IL_039c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_03a1: ldloc.0
+			IL_03a2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03a7: dup
+			IL_03a8: ldc.i4.0
+			IL_03a9: ldloc.1
+			IL_03aa: stelem.ref
+			IL_03ab: dup
+			IL_03ac: ldc.i4.1
+			IL_03ad: ldloc.2
+			IL_03ae: stelem.ref
+			IL_03af: dup
+			IL_03b0: ldc.i4.2
+			IL_03b1: ldloc.3
+			IL_03b2: stelem.ref
+			IL_03b3: dup
+			IL_03b4: ldc.i4.3
+			IL_03b5: ldloc.s 4
+			IL_03b7: stelem.ref
+			IL_03b8: dup
+			IL_03b9: ldc.i4.4
+			IL_03ba: ldloc.s 5
+			IL_03bc: stelem.ref
+			IL_03bd: dup
+			IL_03be: ldc.i4.5
+			IL_03bf: ldloc.s 6
+			IL_03c1: stelem.ref
+			IL_03c2: dup
+			IL_03c3: ldc.i4.6
+			IL_03c4: ldloc.s 7
+			IL_03c6: box [System.Runtime]System.Boolean
+			IL_03cb: stelem.ref
+			IL_03cc: dup
+			IL_03cd: ldc.i4.7
+			IL_03ce: ldloc.s 8
+			IL_03d0: box [System.Runtime]System.Boolean
+			IL_03d5: stelem.ref
+			IL_03d6: dup
+			IL_03d7: ldc.i4.8
+			IL_03d8: ldloc.s 9
+			IL_03da: stelem.ref
+			IL_03db: dup
+			IL_03dc: ldc.i4.s 9
+			IL_03de: ldloc.s 10
 			IL_03e0: stelem.ref
 			IL_03e1: dup
-			IL_03e2: ldc.i4.2
-			IL_03e3: ldloc.3
-			IL_03e4: stelem.ref
-			IL_03e5: dup
-			IL_03e6: ldc.i4.3
-			IL_03e7: ldloc.s 4
-			IL_03e9: stelem.ref
-			IL_03ea: dup
-			IL_03eb: ldc.i4.4
-			IL_03ec: ldloc.s 5
-			IL_03ee: stelem.ref
-			IL_03ef: dup
-			IL_03f0: ldc.i4.5
-			IL_03f1: ldloc.s 6
-			IL_03f3: stelem.ref
-			IL_03f4: dup
-			IL_03f5: ldc.i4.6
-			IL_03f6: ldloc.s 7
-			IL_03f8: box [System.Runtime]System.Boolean
+			IL_03e2: ldc.i4.s 10
+			IL_03e4: ldloc.s 11
+			IL_03e6: box [System.Runtime]System.Double
+			IL_03eb: stelem.ref
+			IL_03ec: dup
+			IL_03ed: ldc.i4.s 11
+			IL_03ef: ldloc.s 12
+			IL_03f1: stelem.ref
+			IL_03f2: dup
+			IL_03f3: ldc.i4.s 12
+			IL_03f5: ldloc.s 13
+			IL_03f7: stelem.ref
+			IL_03f8: dup
+			IL_03f9: ldc.i4.s 13
+			IL_03fb: ldloc.s 14
 			IL_03fd: stelem.ref
 			IL_03fe: dup
-			IL_03ff: ldc.i4.7
-			IL_0400: ldloc.s 8
-			IL_0402: box [System.Runtime]System.Boolean
-			IL_0407: stelem.ref
-			IL_0408: dup
-			IL_0409: ldc.i4.8
-			IL_040a: ldloc.s 9
-			IL_040c: stelem.ref
-			IL_040d: dup
-			IL_040e: ldc.i4.s 9
-			IL_0410: ldloc.s 10
-			IL_0412: stelem.ref
-			IL_0413: dup
-			IL_0414: ldc.i4.s 10
-			IL_0416: ldloc.s 11
-			IL_0418: box [System.Runtime]System.Double
-			IL_041d: stelem.ref
-			IL_041e: dup
-			IL_041f: ldc.i4.s 11
-			IL_0421: ldloc.s 12
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.s 12
-			IL_0427: ldloc.s 13
-			IL_0429: stelem.ref
-			IL_042a: dup
-			IL_042b: ldc.i4.s 13
-			IL_042d: ldloc.s 14
-			IL_042f: stelem.ref
-			IL_0430: dup
-			IL_0431: ldc.i4.s 14
-			IL_0433: ldloc.s 15
-			IL_0435: stelem.ref
-			IL_0436: dup
-			IL_0437: ldc.i4.s 15
-			IL_0439: ldloc.s 16
-			IL_043b: stelem.ref
-			IL_043c: dup
-			IL_043d: ldc.i4.s 16
-			IL_043f: ldloc.s 17
-			IL_0441: stelem.ref
-			IL_0442: dup
-			IL_0443: ldc.i4.s 17
-			IL_0445: ldloc.s 18
-			IL_0447: stelem.ref
-			IL_0448: dup
-			IL_0449: ldc.i4.s 18
-			IL_044b: ldloc.s 19
-			IL_044d: box [System.Runtime]System.Boolean
-			IL_0452: stelem.ref
-			IL_0453: dup
-			IL_0454: ldc.i4.s 19
-			IL_0456: ldloc.s 20
-			IL_0458: stelem.ref
-			IL_0459: dup
-			IL_045a: ldc.i4.s 20
-			IL_045c: ldloc.s 21
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.s 21
-			IL_0462: ldloc.s 22
-			IL_0464: stelem.ref
-			IL_0465: pop
-			IL_0466: ldloc.0
-			IL_0467: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_046c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0471: ret
+			IL_03ff: ldc.i4.s 14
+			IL_0401: ldloc.s 15
+			IL_0403: stelem.ref
+			IL_0404: dup
+			IL_0405: ldc.i4.s 15
+			IL_0407: ldloc.s 16
+			IL_0409: stelem.ref
+			IL_040a: dup
+			IL_040b: ldc.i4.s 16
+			IL_040d: ldloc.s 17
+			IL_040f: stelem.ref
+			IL_0410: dup
+			IL_0411: ldc.i4.s 17
+			IL_0413: ldloc.s 18
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.s 18
+			IL_0419: ldloc.s 19
+			IL_041b: box [System.Runtime]System.Boolean
+			IL_0420: stelem.ref
+			IL_0421: dup
+			IL_0422: ldc.i4.s 19
+			IL_0424: ldloc.s 20
+			IL_0426: stelem.ref
+			IL_0427: dup
+			IL_0428: ldc.i4.s 20
+			IL_042a: ldloc.s 21
+			IL_042c: stelem.ref
+			IL_042d: dup
+			IL_042e: ldc.i4.s 21
+			IL_0430: ldloc.s 22
+			IL_0432: stelem.ref
+			IL_0433: pop
+			IL_0434: ldloc.0
+			IL_0435: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_043a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_043f: ret
 
-			IL_0472: ldloc.0
-			IL_0473: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
-			IL_0478: pop
-			IL_0479: ldstr "console"
-			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0483: stloc.s 9
-			IL_0485: ldloc.s 9
-			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_048c: stloc.s 9
-			IL_048e: ldloc.s 9
-			IL_0490: ldstr "log"
-			IL_0495: ldstr "RenameResult:"
-			IL_049a: ldstr "success"
-			IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04a4: pop
-			IL_04a5: br IL_0545
+			IL_0440: ldloc.0
+			IL_0441: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2/Scope::_awaited1
+			IL_0446: pop
+			IL_0447: ldstr "console"
+			IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0451: stloc.s 9
+			IL_0453: ldloc.s 9
+			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_045a: stloc.s 9
+			IL_045c: ldloc.s 9
+			IL_045e: ldstr "log"
+			IL_0463: ldstr "RenameResult:"
+			IL_0468: ldstr "success"
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0472: pop
+			IL_0473: br IL_0513
 
-			IL_04aa: ldloc.0
-			IL_04ab: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04b0: stloc.s 9
-			IL_04b2: ldloc.0
-			IL_04b3: ldc.i4.0
-			IL_04b4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04b9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04be: ldloc.s 9
-			IL_04c0: stloc.s 6
-			IL_04c2: ldstr "console"
-			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04cc: stloc.s 9
-			IL_04ce: ldloc.s 9
-			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04d5: stloc.s 9
-			IL_04d7: ldstr "^EPERM: "
-			IL_04dc: ldstr ""
-			IL_04e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_04e6: stloc.s 17
-			IL_04e8: ldloc.s 17
-			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ef: stloc.s 18
-			IL_04f1: ldloc.s 6
-			IL_04f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04f8: stloc.s 19
-			IL_04fa: ldloc.s 19
-			IL_04fc: brfalse IL_0518
+			IL_0478: ldloc.0
+			IL_0479: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_047e: stloc.s 9
+			IL_0480: ldloc.0
+			IL_0481: ldc.i4.0
+			IL_0482: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0487: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_048c: ldloc.s 9
+			IL_048e: stloc.s 6
+			IL_0490: ldstr "console"
+			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_049a: stloc.s 9
+			IL_049c: ldloc.s 9
+			IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04a3: stloc.s 9
+			IL_04a5: ldstr "^EPERM: "
+			IL_04aa: ldstr ""
+			IL_04af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_04b4: stloc.s 17
+			IL_04b6: ldloc.s 17
+			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04bd: stloc.s 18
+			IL_04bf: ldloc.s 6
+			IL_04c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04c6: stloc.s 19
+			IL_04c8: ldloc.s 19
+			IL_04ca: brfalse IL_04e6
 
-			IL_0501: ldloc.s 6
-			IL_0503: ldstr "message"
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050d: stloc.s 20
-			IL_050f: ldloc.s 20
-			IL_0511: stloc.s 22
-			IL_0513: br IL_051c
+			IL_04cf: ldloc.s 6
+			IL_04d1: ldstr "message"
+			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04db: stloc.s 20
+			IL_04dd: ldloc.s 20
+			IL_04df: stloc.s 22
+			IL_04e1: br IL_04ea
 
-			IL_0518: ldloc.s 6
-			IL_051a: stloc.s 22
+			IL_04e6: ldloc.s 6
+			IL_04e8: stloc.s 22
 
-			IL_051c: ldloc.s 18
-			IL_051e: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-			IL_0523: ldloc.s 22
-			IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_052a: stloc.s 18
-			IL_052c: ldloc.s 9
-			IL_052e: ldstr "log"
-			IL_0533: ldstr "RenameStartsWithEPERM:"
-			IL_0538: ldloc.s 18
-			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_053f: pop
-			IL_0540: br IL_0545
+			IL_04ea: ldloc.s 18
+			IL_04ec: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+			IL_04f1: ldloc.s 22
+			IL_04f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_04f8: stloc.s 18
+			IL_04fa: ldloc.s 9
+			IL_04fc: ldstr "log"
+			IL_0501: ldstr "RenameStartsWithEPERM:"
+			IL_0506: ldloc.s 18
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_050d: pop
+			IL_050e: br IL_0513
 
-			IL_0545: ldstr "console"
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_054f: stloc.s 18
-			IL_0551: ldloc.s 18
-			IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0558: stloc.s 18
-			IL_055a: ldarg.0
-			IL_055b: ldc.i4.1
-			IL_055c: ldelem.ref
-			IL_055d: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_0562: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0567: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_056c: stloc.s 15
-			IL_056e: ldloc.s 15
-			IL_0570: ldloc.3
-			IL_0571: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0576: box [System.Runtime]System.Boolean
-			IL_057b: stloc.s 9
-			IL_057d: ldloc.s 18
-			IL_057f: ldstr "log"
-			IL_0584: ldstr "SourceExists:"
-			IL_0589: ldloc.s 9
-			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0590: pop
-			IL_0591: ldstr "console"
-			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_059b: stloc.s 9
-			IL_059d: ldloc.s 9
-			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a4: stloc.s 9
-			IL_05a6: ldarg.0
-			IL_05a7: ldc.i4.1
-			IL_05a8: ldelem.ref
-			IL_05a9: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_05ae: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_05b3: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_05b8: stloc.s 15
-			IL_05ba: ldloc.s 15
-			IL_05bc: ldloc.s 4
-			IL_05be: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_05c3: box [System.Runtime]System.Boolean
-			IL_05c8: stloc.s 18
-			IL_05ca: ldloc.s 9
-			IL_05cc: ldstr "log"
-			IL_05d1: ldstr "DestinationExists:"
+			IL_0513: ldstr "console"
+			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_051d: stloc.s 18
+			IL_051f: ldloc.s 18
+			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0526: stloc.s 18
+			IL_0528: ldarg.0
+			IL_0529: ldc.i4.1
+			IL_052a: ldelem.ref
+			IL_052b: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0530: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_0535: stloc.s 15
+			IL_0537: ldloc.s 15
+			IL_0539: ldloc.3
+			IL_053a: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_053f: box [System.Runtime]System.Boolean
+			IL_0544: stloc.s 9
+			IL_0546: ldloc.s 18
+			IL_0548: ldstr "log"
+			IL_054d: ldstr "SourceExists:"
+			IL_0552: ldloc.s 9
+			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0559: pop
+			IL_055a: ldstr "console"
+			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0564: stloc.s 9
+			IL_0566: ldloc.s 9
+			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_056d: stloc.s 9
+			IL_056f: ldarg.0
+			IL_0570: ldc.i4.1
+			IL_0571: ldelem.ref
+			IL_0572: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_0577: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_057c: stloc.s 15
+			IL_057e: ldloc.s 15
+			IL_0580: ldloc.s 4
+			IL_0582: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0587: box [System.Runtime]System.Boolean
+			IL_058c: stloc.s 18
+			IL_058e: ldloc.s 9
+			IL_0590: ldstr "log"
+			IL_0595: ldstr "DestinationExists:"
+			IL_059a: ldloc.s 18
+			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05a1: pop
+			IL_05a2: ldstr "console"
+			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05ac: stloc.s 18
+			IL_05ae: ldloc.s 18
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05b5: stloc.s 18
+			IL_05b7: ldarg.0
+			IL_05b8: ldc.i4.1
+			IL_05b9: ldelem.ref
+			IL_05ba: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_05bf: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_05c4: stloc.s 15
+			IL_05c6: ldloc.s 15
+			IL_05c8: ldloc.s 5
+			IL_05ca: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_05cf: box [System.Runtime]System.Boolean
+			IL_05d4: stloc.s 9
 			IL_05d6: ldloc.s 18
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05dd: pop
-			IL_05de: ldstr "console"
-			IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05e8: stloc.s 18
-			IL_05ea: ldloc.s 18
-			IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05f1: stloc.s 18
-			IL_05f3: ldarg.0
-			IL_05f4: ldc.i4.1
-			IL_05f5: ldelem.ref
-			IL_05f6: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_05fb: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0600: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0605: stloc.s 15
-			IL_0607: ldloc.s 15
-			IL_0609: ldloc.s 5
-			IL_060b: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0610: box [System.Runtime]System.Boolean
-			IL_0615: stloc.s 9
-			IL_0617: ldloc.s 18
-			IL_0619: ldstr "log"
-			IL_061e: ldstr "SentinelExists:"
-			IL_0623: ldloc.s 9
-			IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_062a: pop
-			IL_062b: br IL_0643
+			IL_05d8: ldstr "log"
+			IL_05dd: ldstr "SentinelExists:"
+			IL_05e2: ldloc.s 9
+			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05e9: pop
+			IL_05ea: br IL_0602
 
-			IL_0630: ldloc.0
-			IL_0631: ldc.i4.1
-			IL_0632: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0637: ldloc.0
-			IL_0638: ldc.i4.0
-			IL_0639: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_063e: br IL_0643
+			IL_05ef: ldloc.0
+			IL_05f0: ldc.i4.1
+			IL_05f1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_05f6: ldloc.0
+			IL_05f7: ldc.i4.0
+			IL_05f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_05fd: br IL_0602
 
-			IL_0643: ldarg.0
-			IL_0644: ldc.i4.1
-			IL_0645: ldelem.ref
-			IL_0646: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
-			IL_064b: ldfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
-			IL_0650: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0655: stloc.s 15
-			IL_0657: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_065c: dup
-			IL_065d: ldstr "recursive"
-			IL_0662: ldc.i4.1
-			IL_0663: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0668: dup
-			IL_0669: ldstr "force"
-			IL_066e: ldc.i4.1
-			IL_066f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0674: stloc.s 16
-			IL_0676: ldloc.s 15
-			IL_0678: ldloc.2
-			IL_0679: ldloc.s 16
-			IL_067b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0680: br IL_0698
+			IL_0602: ldarg.0
+			IL_0603: ldc.i4.1
+			IL_0604: ldelem.ref
+			IL_0605: castclass Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope
+			IL_060a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+			IL_060f: stloc.s 15
+			IL_0611: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0616: dup
+			IL_0617: ldstr "recursive"
+			IL_061c: ldc.i4.1
+			IL_061d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0622: dup
+			IL_0623: ldstr "force"
+			IL_0628: ldc.i4.1
+			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_062e: stloc.s 16
+			IL_0630: ldloc.s 15
+			IL_0632: ldloc.2
+			IL_0633: ldloc.s 16
+			IL_0635: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_063a: br IL_0652
 
-			IL_0685: ldloc.0
-			IL_0686: ldc.i4.1
-			IL_0687: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_068c: ldloc.0
-			IL_068d: ldc.i4.0
-			IL_068e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0693: br IL_0698
+			IL_063f: ldloc.0
+			IL_0640: ldc.i4.1
+			IL_0641: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0646: ldloc.0
+			IL_0647: ldc.i4.0
+			IL_0648: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_064d: br IL_0652
 
-			IL_0698: ldloc.0
-			IL_0699: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_069e: stloc.s 7
-			IL_06a0: ldloc.s 7
-			IL_06a2: brfalse IL_06df
+			IL_0652: ldloc.0
+			IL_0653: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0658: stloc.s 7
+			IL_065a: ldloc.s 7
+			IL_065c: brfalse IL_0699
 
-			IL_06a7: ldloc.0
-			IL_06a8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_06ad: stloc.s 9
-			IL_06af: ldloc.0
-			IL_06b0: ldc.i4.m1
-			IL_06b1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06b6: ldloc.0
-			IL_06b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_06c1: ldarg.0
-			IL_06c2: ldc.i4.1
-			IL_06c3: newarr [System.Runtime]System.Object
-			IL_06c8: dup
-			IL_06c9: ldc.i4.0
-			IL_06ca: ldloc.s 9
-			IL_06cc: stelem.ref
-			IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_06d2: pop
-			IL_06d3: ldloc.0
-			IL_06d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06de: ret
+			IL_0661: ldloc.0
+			IL_0662: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0667: stloc.s 9
+			IL_0669: ldloc.0
+			IL_066a: ldc.i4.m1
+			IL_066b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0670: ldloc.0
+			IL_0671: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0676: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_067b: ldarg.0
+			IL_067c: ldc.i4.1
+			IL_067d: newarr [System.Runtime]System.Object
+			IL_0682: dup
+			IL_0683: ldc.i4.0
+			IL_0684: ldloc.s 9
+			IL_0686: stelem.ref
+			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_068c: pop
+			IL_068d: ldloc.0
+			IL_068e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0693: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0698: ret
 
-			IL_06df: ldloc.0
-			IL_06e0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_06e5: stloc.s 8
-			IL_06e7: ldloc.s 8
-			IL_06e9: brfalse IL_0726
+			IL_0699: ldloc.0
+			IL_069a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_069f: stloc.s 8
+			IL_06a1: ldloc.s 8
+			IL_06a3: brfalse IL_06e0
 
-			IL_06ee: ldloc.0
-			IL_06ef: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_06f4: stloc.s 9
-			IL_06f6: ldloc.0
-			IL_06f7: ldc.i4.m1
-			IL_06f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06fd: ldloc.0
-			IL_06fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0703: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0708: ldarg.0
-			IL_0709: ldc.i4.1
-			IL_070a: newarr [System.Runtime]System.Object
-			IL_070f: dup
-			IL_0710: ldc.i4.0
-			IL_0711: ldloc.s 9
-			IL_0713: stelem.ref
-			IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0719: pop
-			IL_071a: ldloc.0
-			IL_071b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0720: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0725: ret
+			IL_06a8: ldloc.0
+			IL_06a9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_06ae: stloc.s 9
+			IL_06b0: ldloc.0
+			IL_06b1: ldc.i4.m1
+			IL_06b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06b7: ldloc.0
+			IL_06b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06c2: ldarg.0
+			IL_06c3: ldc.i4.1
+			IL_06c4: newarr [System.Runtime]System.Object
+			IL_06c9: dup
+			IL_06ca: ldc.i4.0
+			IL_06cb: ldloc.s 9
+			IL_06cd: stelem.ref
+			IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06d3: pop
+			IL_06d4: ldloc.0
+			IL_06d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06df: ret
 
-			IL_0726: ldloc.0
-			IL_0727: ldc.i4.m1
-			IL_0728: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_072d: ldloc.0
-			IL_072e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0733: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0738: ldarg.0
-			IL_0739: ldc.i4.1
-			IL_073a: newarr [System.Runtime]System.Object
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0744: pop
-			IL_0745: ldloc.0
-			IL_0746: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_074b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0750: ret
+			IL_06e0: ldloc.0
+			IL_06e1: ldc.i4.m1
+			IL_06e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06e7: ldloc.0
+			IL_06e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06f2: ldarg.0
+			IL_06f3: ldc.i4.1
+			IL_06f4: newarr [System.Runtime]System.Object
+			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06fe: pop
+			IL_06ff: ldloc.0
+			IL_0700: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0705: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_070a: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -939,15 +925,15 @@
 			73 3d 7b 6f 73 7d 00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object path
-		.field public object os
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule os
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x284d
+			// Method begins at RVA 0x2807
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -993,21 +979,21 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::fs
 		IL_001a: ldarg.1
 		IL_001b: ldstr "path"
 		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0025: stloc.2
 		IL_0026: ldloc.0
 		IL_0027: ldloc.2
-		IL_0028: stfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
+		IL_0028: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::path
 		IL_002d: ldarg.1
 		IL_002e: ldstr "os"
 		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0038: stloc.3
 		IL_0039: ldloc.0
 		IL_003a: ldloc.3
-		IL_003b: stfld object Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
+		IL_003b: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IOsModule Modules.FSPromises_Rename_ExistingDirectory_Rejects/Scope::os
 		IL_0040: ldnull
 		IL_0041: ldftn object Modules.FSPromises_Rename_ExistingDirectory_Rejects/ArrowFunction_L7C2::__js_call__(object[], object)
 		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
@@ -1048,7 +1034,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2883
+		// Method begins at RVA 0x283d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2830
+				// Method begins at RVA 0x27fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,9 +52,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2380
+			// Method begins at RVA 0x2368
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule,
@@ -65,18 +65,17 @@
 			IL_0001: ldarg.2
 			IL_0002: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_0007: ldarg.0
-			IL_0008: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
-			IL_000d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule
-			IL_0012: stloc.0
-			IL_0013: ldarg.0
-			IL_0014: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_0019: stloc.1
-			IL_001a: ldloc.0
-			IL_001b: ldloc.1
-			IL_001c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::stat(object)
-			IL_0021: stloc.1
-			IL_0022: ldloc.1
-			IL_0023: ret
+			IL_0008: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule Modules.FSPromises_Stat_RichMetadata/Scope::fs
+			IL_000d: stloc.0
+			IL_000e: ldarg.0
+			IL_000f: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0014: stloc.1
+			IL_0015: ldloc.0
+			IL_0016: ldloc.1
+			IL_0017: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::stat(object)
+			IL_001c: stloc.1
+			IL_001d: ldloc.1
+			IL_001e: ret
 		} // end of method ArrowFunction_L18C20::__js_call__
 
 	} // end of class ArrowFunction_L18C20
@@ -99,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2839
+				// Method begins at RVA 0x2807
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,9 +125,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x23b0
+			// Method begins at RVA 0x2394
 			// Header size: 12
-			// Code size: 934 (0x3a6)
+			// Code size: 924 (0x39c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -410,45 +409,43 @@
 			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0335: pop
 			IL_0336: ldarg.0
-			IL_0337: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_033c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0341: stloc.s 10
-			IL_0343: ldarg.0
-			IL_0344: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_0349: stloc.0
-			IL_034a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_034f: dup
-			IL_0350: ldstr "force"
-			IL_0355: ldc.i4.1
-			IL_0356: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_035b: stloc.s 11
-			IL_035d: ldloc.s 10
-			IL_035f: ldloc.0
-			IL_0360: ldloc.s 11
-			IL_0362: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0367: ldarg.0
-			IL_0368: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_036d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0372: stloc.s 10
-			IL_0374: ldarg.0
-			IL_0375: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_037a: stloc.0
-			IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0380: dup
-			IL_0381: ldstr "force"
-			IL_0386: ldc.i4.1
-			IL_0387: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_038c: dup
-			IL_038d: ldstr "recursive"
-			IL_0392: ldc.i4.1
-			IL_0393: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0398: stloc.s 11
-			IL_039a: ldloc.s 10
-			IL_039c: ldloc.0
-			IL_039d: ldloc.s 11
-			IL_039f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_03a4: ldnull
-			IL_03a5: ret
+			IL_0337: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_033c: stloc.s 10
+			IL_033e: ldarg.0
+			IL_033f: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+			IL_0344: stloc.0
+			IL_0345: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_034a: dup
+			IL_034b: ldstr "force"
+			IL_0350: ldc.i4.1
+			IL_0351: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0356: stloc.s 11
+			IL_0358: ldloc.s 10
+			IL_035a: ldloc.0
+			IL_035b: ldloc.s 11
+			IL_035d: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0362: ldarg.0
+			IL_0363: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_0368: stloc.s 10
+			IL_036a: ldarg.0
+			IL_036b: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0370: stloc.0
+			IL_0371: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0376: dup
+			IL_0377: ldstr "force"
+			IL_037c: ldc.i4.1
+			IL_037d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0382: dup
+			IL_0383: ldstr "recursive"
+			IL_0388: ldc.i4.1
+			IL_0389: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_038e: stloc.s 11
+			IL_0390: ldloc.s 10
+			IL_0392: ldloc.0
+			IL_0393: ldloc.s 11
+			IL_0395: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_039a: ldnull
+			IL_039b: ret
 		} // end of method ArrowFunction_L21C9::__js_call__
 
 	} // end of class ArrowFunction_L21C9
@@ -471,7 +468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2842
+				// Method begins at RVA 0x2810
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -498,9 +495,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2764
+			// Method begins at RVA 0x273c
 			// Header size: 12
-			// Code size: 183 (0xb7)
+			// Code size: 173 (0xad)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -540,45 +537,43 @@
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0046: pop
 			IL_0047: ldarg.0
-			IL_0048: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_004d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0052: stloc.s 5
-			IL_0054: ldarg.0
-			IL_0055: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-			IL_005a: stloc.0
-			IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0060: dup
-			IL_0061: ldstr "force"
-			IL_0066: ldc.i4.1
-			IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006c: stloc.s 6
-			IL_006e: ldloc.s 5
-			IL_0070: ldloc.0
-			IL_0071: ldloc.s 6
-			IL_0073: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0078: ldarg.0
-			IL_0079: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-			IL_007e: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0083: stloc.s 5
-			IL_0085: ldarg.0
-			IL_0086: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-			IL_008b: stloc.0
-			IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0091: dup
-			IL_0092: ldstr "force"
-			IL_0097: ldc.i4.1
-			IL_0098: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009d: dup
-			IL_009e: ldstr "recursive"
-			IL_00a3: ldc.i4.1
-			IL_00a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a9: stloc.s 6
-			IL_00ab: ldloc.s 5
-			IL_00ad: ldloc.0
-			IL_00ae: ldloc.s 6
-			IL_00b0: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_00b5: ldnull
-			IL_00b6: ret
+			IL_0048: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_004d: stloc.s 5
+			IL_004f: ldarg.0
+			IL_0050: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+			IL_0055: stloc.0
+			IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005b: dup
+			IL_005c: ldstr "force"
+			IL_0061: ldc.i4.1
+			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0067: stloc.s 6
+			IL_0069: ldloc.s 5
+			IL_006b: ldloc.0
+			IL_006c: ldloc.s 6
+			IL_006e: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0073: ldarg.0
+			IL_0074: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+			IL_0079: stloc.s 5
+			IL_007b: ldarg.0
+			IL_007c: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+			IL_0081: stloc.0
+			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0087: dup
+			IL_0088: ldstr "force"
+			IL_008d: ldc.i4.1
+			IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0093: dup
+			IL_0094: ldstr "recursive"
+			IL_0099: ldc.i4.1
+			IL_009a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_009f: stloc.s 6
+			IL_00a1: ldloc.s 5
+			IL_00a3: ldloc.0
+			IL_00a4: ldloc.s 6
+			IL_00a6: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_00ab: ldnull
+			IL_00ac: ret
 		} // end of method ArrowFunction_L36C10::__js_call__
 
 	} // end of class ArrowFunction_L36C10
@@ -595,8 +590,8 @@
 			00 00
 		)
 		// Fields
-		.field public object fs
-		.field public object syncFs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule syncFs
 		.field public object file
 		.field public object dir
 		.field public object fileStats
@@ -605,7 +600,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2827
+			// Method begins at RVA 0x27f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -631,7 +626,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 803 (0x323)
+		// Code size: 778 (0x30a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Stat_RichMetadata/Scope,
@@ -656,14 +651,14 @@
 		IL_0012: stloc.s 4
 		IL_0014: ldloc.0
 		IL_0015: ldloc.s 4
-		IL_0017: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
+		IL_0017: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule Modules.FSPromises_Stat_RichMetadata/Scope::fs
 		IL_001c: ldarg.1
 		IL_001d: ldstr "fs"
 		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_0027: stloc.s 5
 		IL_0029: ldloc.0
 		IL_002a: ldloc.s 5
-		IL_002c: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_002c: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
 		IL_0031: ldarg.1
 		IL_0032: ldstr "path"
 		IL_0037: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -750,175 +745,170 @@
 		IL_011f: ldloc.s 6
 		IL_0121: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
 		IL_0126: ldloc.0
-		IL_0127: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_012c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0131: stloc.s 5
-		IL_0133: ldloc.0
-		IL_0134: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-		IL_0139: stloc.s 6
-		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0140: dup
-		IL_0141: ldstr "force"
-		IL_0146: ldc.i4.1
-		IL_0147: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_014c: stloc.s 9
-		IL_014e: ldloc.s 5
-		IL_0150: ldloc.s 6
-		IL_0152: ldloc.s 9
-		IL_0154: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_0159: ldloc.0
-		IL_015a: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_015f: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0164: stloc.s 5
-		IL_0166: ldloc.0
-		IL_0167: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-		IL_016c: stloc.s 6
-		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0173: dup
-		IL_0174: ldstr "force"
-		IL_0179: ldc.i4.1
-		IL_017a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_017f: dup
-		IL_0180: ldstr "recursive"
-		IL_0185: ldc.i4.1
-		IL_0186: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_018b: stloc.s 9
-		IL_018d: ldloc.s 5
-		IL_018f: ldloc.s 6
-		IL_0191: ldloc.s 9
-		IL_0193: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_0198: ldloc.0
-		IL_0199: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_019e: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_01a3: stloc.s 5
-		IL_01a5: ldloc.0
-		IL_01a6: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-		IL_01ab: stloc.s 6
-		IL_01ad: ldloc.s 5
-		IL_01af: ldloc.s 6
-		IL_01b1: ldstr "hello"
-		IL_01b6: ldstr "utf8"
-		IL_01bb: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-		IL_01c0: ldloc.0
-		IL_01c1: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
-		IL_01c6: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_01cb: stloc.s 5
-		IL_01cd: ldloc.0
-		IL_01ce: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
-		IL_01d3: stloc.s 6
-		IL_01d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01da: dup
-		IL_01db: ldstr "recursive"
-		IL_01e0: ldc.i4.1
-		IL_01e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_01e6: stloc.s 9
-		IL_01e8: ldloc.s 5
-		IL_01ea: ldloc.s 6
-		IL_01ec: ldloc.s 9
-		IL_01ee: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-		IL_01f3: pop
-		IL_01f4: ldloc.0
-		IL_01f5: ldnull
-		IL_01f6: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
-		IL_01fb: ldloc.0
-		IL_01fc: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fs
-		IL_0201: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule
-		IL_0206: stloc.s 4
-		IL_0208: ldloc.0
-		IL_0209: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
-		IL_020e: stloc.s 6
-		IL_0210: ldloc.s 4
-		IL_0212: ldloc.s 6
-		IL_0214: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::stat(object)
-		IL_0219: stloc.s 6
-		IL_021b: ldloc.s 6
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0222: stloc.s 6
+		IL_0127: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_012c: stloc.s 5
+		IL_012e: ldloc.0
+		IL_012f: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+		IL_0134: stloc.s 6
+		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_013b: dup
+		IL_013c: ldstr "force"
+		IL_0141: ldc.i4.1
+		IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0147: stloc.s 9
+		IL_0149: ldloc.s 5
+		IL_014b: ldloc.s 6
+		IL_014d: ldloc.s 9
+		IL_014f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_0154: ldloc.0
+		IL_0155: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_015a: stloc.s 5
+		IL_015c: ldloc.0
+		IL_015d: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+		IL_0162: stloc.s 6
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0169: dup
+		IL_016a: ldstr "force"
+		IL_016f: ldc.i4.1
+		IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0175: dup
+		IL_0176: ldstr "recursive"
+		IL_017b: ldc.i4.1
+		IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0181: stloc.s 9
+		IL_0183: ldloc.s 5
+		IL_0185: ldloc.s 6
+		IL_0187: ldloc.s 9
+		IL_0189: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_018e: ldloc.0
+		IL_018f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_0194: stloc.s 5
+		IL_0196: ldloc.0
+		IL_0197: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+		IL_019c: stloc.s 6
+		IL_019e: ldloc.s 5
+		IL_01a0: ldloc.s 6
+		IL_01a2: ldstr "hello"
+		IL_01a7: ldstr "utf8"
+		IL_01ac: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+		IL_01b1: ldloc.0
+		IL_01b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Stat_RichMetadata/Scope::syncFs
+		IL_01b7: stloc.s 5
+		IL_01b9: ldloc.0
+		IL_01ba: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::dir
+		IL_01bf: stloc.s 6
+		IL_01c1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01c6: dup
+		IL_01c7: ldstr "recursive"
+		IL_01cc: ldc.i4.1
+		IL_01cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_01d2: stloc.s 9
+		IL_01d4: ldloc.s 5
+		IL_01d6: ldloc.s 6
+		IL_01d8: ldloc.s 9
+		IL_01da: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+		IL_01df: pop
+		IL_01e0: ldloc.0
+		IL_01e1: ldnull
+		IL_01e2: stfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
+		IL_01e7: ldloc.0
+		IL_01e8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule Modules.FSPromises_Stat_RichMetadata/Scope::fs
+		IL_01ed: stloc.s 4
+		IL_01ef: ldloc.0
+		IL_01f0: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::file
+		IL_01f5: stloc.s 6
+		IL_01f7: ldloc.s 4
+		IL_01f9: ldloc.s 6
+		IL_01fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsPromisesModule::stat(object)
+		IL_0200: stloc.s 6
+		IL_0202: ldloc.s 6
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0209: stloc.s 6
+		IL_020b: ldloc.0
+		IL_020c: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_0211: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L18C20::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
+		IL_0217: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_021c: ldc.i4.1
+		IL_021d: newarr [System.Runtime]System.Object
+		IL_0222: dup
+		IL_0223: ldc.i4.0
 		IL_0224: ldloc.0
-		IL_0225: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_022a: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L18C20::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
-		IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0225: stelem.ref
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0230: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		IL_0235: ldc.i4.1
-		IL_0236: newarr [System.Runtime]System.Object
-		IL_023b: dup
+		IL_0236: conv.r8
+		IL_0237: ldstr ""
 		IL_023c: ldc.i4.0
-		IL_023d: ldloc.0
-		IL_023e: stelem.ref
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0249: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_024e: ldc.i4.1
-		IL_024f: conv.r8
-		IL_0250: ldstr ""
-		IL_0255: ldc.i4.0
-		IL_0256: ldc.i4.0
-		IL_0257: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_025c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0261: stloc.s 10
-		IL_0263: ldloc.s 6
-		IL_0265: ldstr "then"
-		IL_026a: ldloc.s 10
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0271: stloc.s 6
-		IL_0273: ldloc.s 6
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027a: stloc.s 6
+		IL_023d: ldc.i4.0
+		IL_023e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0248: stloc.s 10
+		IL_024a: ldloc.s 6
+		IL_024c: ldstr "then"
+		IL_0251: ldloc.s 10
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0258: stloc.s 6
+		IL_025a: ldloc.s 6
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0261: stloc.s 6
+		IL_0263: ldloc.0
+		IL_0264: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_0269: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
+		IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0274: ldc.i4.1
+		IL_0275: newarr [System.Runtime]System.Object
+		IL_027a: dup
+		IL_027b: ldc.i4.0
 		IL_027c: ldloc.0
-		IL_027d: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_0282: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
-		IL_0288: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_027d: stelem.ref
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0288: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		IL_028d: ldc.i4.1
-		IL_028e: newarr [System.Runtime]System.Object
-		IL_0293: dup
+		IL_028e: conv.r8
+		IL_028f: ldstr ""
 		IL_0294: ldc.i4.0
-		IL_0295: ldloc.0
-		IL_0296: stelem.ref
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02a1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_02a6: ldc.i4.1
-		IL_02a7: conv.r8
-		IL_02a8: ldstr ""
-		IL_02ad: ldc.i4.0
-		IL_02ae: ldc.i4.0
-		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_02b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_02b9: stloc.s 10
-		IL_02bb: ldloc.s 6
-		IL_02bd: ldstr "then"
-		IL_02c2: ldloc.s 10
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c9: stloc.s 6
-		IL_02cb: ldloc.s 6
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d2: stloc.s 6
+		IL_0295: ldc.i4.0
+		IL_0296: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_029b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_02a0: stloc.s 10
+		IL_02a2: ldloc.s 6
+		IL_02a4: ldstr "then"
+		IL_02a9: ldloc.s 10
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b0: stloc.s 6
+		IL_02b2: ldloc.s 6
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b9: stloc.s 6
+		IL_02bb: ldloc.0
+		IL_02bc: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_02c1: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
+		IL_02c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02cc: ldc.i4.1
+		IL_02cd: newarr [System.Runtime]System.Object
+		IL_02d2: dup
+		IL_02d3: ldc.i4.0
 		IL_02d4: ldloc.0
-		IL_02d5: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_02da: ldftn object Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10::__js_call__(class Modules.FSPromises_Stat_RichMetadata/Scope, object, object)
-		IL_02e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02d5: stelem.ref
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02e0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
 		IL_02e5: ldc.i4.1
-		IL_02e6: newarr [System.Runtime]System.Object
-		IL_02eb: dup
+		IL_02e6: conv.r8
+		IL_02e7: ldstr ""
 		IL_02ec: ldc.i4.0
-		IL_02ed: ldloc.0
-		IL_02ee: stelem.ref
-		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02f9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_02fe: ldc.i4.1
-		IL_02ff: conv.r8
-		IL_0300: ldstr ""
-		IL_0305: ldc.i4.0
-		IL_0306: ldc.i4.0
-		IL_0307: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_030c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0311: stloc.s 10
-		IL_0313: ldloc.s 6
-		IL_0315: ldstr "catch"
-		IL_031a: ldloc.s 10
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0321: pop
-		IL_0322: ret
+		IL_02ed: ldc.i4.0
+		IL_02ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_02f8: stloc.s 10
+		IL_02fa: ldloc.s 6
+		IL_02fc: ldstr "catch"
+		IL_0301: ldloc.s 10
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0308: pop
+		IL_0309: ret
 	} // end of method FSPromises_Stat_RichMetadata::__js_module_init__
 
 } // end of class Modules.FSPromises_Stat_RichMetadata
@@ -930,7 +920,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x284b
+		// Method begins at RVA 0x2819
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Append_Rename_Unlink_Callback.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Append_Rename_Unlink_Callback.verified.txt
@@ -34,7 +34,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2581
+							// Method begins at RVA 0x2557
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -55,7 +55,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2578
+						// Method begins at RVA 0x254e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -80,9 +80,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2430
+					// Method begins at RVA 0x2410
 					// Header size: 12
-					// Code size: 271 (0x10f)
+					// Code size: 261 (0x105)
 					.maxstack 8
 					.locals init (
 						[0] bool,
@@ -138,56 +138,54 @@
 					IL_007e: ldc.i4.0
 					IL_007f: ldelem.ref
 					IL_0080: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_0085: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-					IL_008a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_008f: stloc.3
-					IL_0090: ldarg.0
-					IL_0091: ldc.i4.0
-					IL_0092: ldelem.ref
-					IL_0093: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_0098: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-					IL_009d: stloc.2
-					IL_009e: ldloc.3
-					IL_009f: ldloc.2
-					IL_00a0: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_00a5: box [System.Runtime]System.Boolean
-					IL_00aa: stloc.2
-					IL_00ab: ldloc.1
-					IL_00ac: ldstr "log"
-					IL_00b1: ldstr "SourceExists:"
-					IL_00b6: ldloc.2
-					IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_00bc: pop
-					IL_00bd: ldstr "console"
-					IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-					IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00cc: stloc.2
-					IL_00cd: ldarg.0
-					IL_00ce: ldc.i4.0
-					IL_00cf: ldelem.ref
-					IL_00d0: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_00d5: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-					IL_00da: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-					IL_00df: stloc.3
-					IL_00e0: ldarg.0
-					IL_00e1: ldc.i4.0
-					IL_00e2: ldelem.ref
-					IL_00e3: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-					IL_00e8: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-					IL_00ed: stloc.1
-					IL_00ee: ldloc.3
-					IL_00ef: ldloc.1
-					IL_00f0: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_00f5: box [System.Runtime]System.Boolean
-					IL_00fa: stloc.1
-					IL_00fb: ldloc.2
-					IL_00fc: ldstr "log"
-					IL_0101: ldstr "RenamedExists:"
-					IL_0106: ldloc.1
-					IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_010c: pop
-					IL_010d: ldnull
-					IL_010e: ret
+					IL_0085: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+					IL_008a: stloc.3
+					IL_008b: ldarg.0
+					IL_008c: ldc.i4.0
+					IL_008d: ldelem.ref
+					IL_008e: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_0093: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+					IL_0098: stloc.2
+					IL_0099: ldloc.3
+					IL_009a: ldloc.2
+					IL_009b: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_00a0: box [System.Runtime]System.Boolean
+					IL_00a5: stloc.2
+					IL_00a6: ldloc.1
+					IL_00a7: ldstr "log"
+					IL_00ac: ldstr "SourceExists:"
+					IL_00b1: ldloc.2
+					IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_00b7: pop
+					IL_00b8: ldstr "console"
+					IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+					IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00c7: stloc.2
+					IL_00c8: ldarg.0
+					IL_00c9: ldc.i4.0
+					IL_00ca: ldelem.ref
+					IL_00cb: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_00d0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+					IL_00d5: stloc.3
+					IL_00d6: ldarg.0
+					IL_00d7: ldc.i4.0
+					IL_00d8: ldelem.ref
+					IL_00d9: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+					IL_00de: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+					IL_00e3: stloc.1
+					IL_00e4: ldloc.3
+					IL_00e5: ldloc.1
+					IL_00e6: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_00eb: box [System.Runtime]System.Boolean
+					IL_00f0: stloc.1
+					IL_00f1: ldloc.2
+					IL_00f2: ldstr "log"
+					IL_00f7: ldstr "RenamedExists:"
+					IL_00fc: ldloc.1
+					IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0102: pop
+					IL_0103: ldnull
+					IL_0104: ret
 				} // end of method ArrowFunction_L28C28::__js_call__
 
 			} // end of class ArrowFunction_L28C28
@@ -208,7 +206,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x256f
+						// Method begins at RVA 0x2545
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -230,7 +228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2566
+					// Method begins at RVA 0x253c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -255,9 +253,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2330
+				// Method begins at RVA 0x2318
 				// Header size: 12
-				// Code size: 243 (0xf3)
+				// Code size: 233 (0xe9)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope,
@@ -297,75 +295,73 @@
 				IL_0044: ldc.i4.0
 				IL_0045: ldelem.ref
 				IL_0046: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_004b: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-				IL_0050: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_0055: stloc.s 4
-				IL_0057: ldarg.0
-				IL_0058: ldc.i4.0
-				IL_0059: ldelem.ref
-				IL_005a: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_005f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-				IL_0064: stloc.3
-				IL_0065: ldloc.s 4
-				IL_0067: ldloc.3
-				IL_0068: ldstr "utf8"
-				IL_006d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-				IL_0072: stloc.3
-				IL_0073: ldloc.0
-				IL_0074: ldloc.3
-				IL_0075: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
-				IL_007a: ldarg.0
-				IL_007b: ldc.i4.0
-				IL_007c: ldelem.ref
-				IL_007d: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_0082: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-				IL_0087: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_008c: stloc.s 4
-				IL_008e: ldarg.0
-				IL_008f: ldc.i4.0
-				IL_0090: ldelem.ref
-				IL_0091: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-				IL_0096: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-				IL_009b: stloc.3
-				IL_009c: ldnull
-				IL_009d: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28::__js_call__(object[], object, object)
-				IL_00a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-				IL_00a8: ldc.i4.3
-				IL_00a9: newarr [System.Runtime]System.Object
-				IL_00ae: dup
-				IL_00af: ldc.i4.0
-				IL_00b0: ldarg.0
-				IL_00b1: ldc.i4.0
-				IL_00b2: ldelem.ref
+				IL_004b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+				IL_0050: stloc.s 4
+				IL_0052: ldarg.0
+				IL_0053: ldc.i4.0
+				IL_0054: ldelem.ref
+				IL_0055: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_005a: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+				IL_005f: stloc.3
+				IL_0060: ldloc.s 4
+				IL_0062: ldloc.3
+				IL_0063: ldstr "utf8"
+				IL_0068: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+				IL_006d: stloc.3
+				IL_006e: ldloc.0
+				IL_006f: ldloc.3
+				IL_0070: stfld object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/Scope::text
+				IL_0075: ldarg.0
+				IL_0076: ldc.i4.0
+				IL_0077: ldelem.ref
+				IL_0078: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_007d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+				IL_0082: stloc.s 4
+				IL_0084: ldarg.0
+				IL_0085: ldc.i4.0
+				IL_0086: ldelem.ref
+				IL_0087: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+				IL_008c: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+				IL_0091: stloc.3
+				IL_0092: ldnull
+				IL_0093: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32/ArrowFunction_L28C28::__js_call__(object[], object, object)
+				IL_0099: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+				IL_009e: ldc.i4.3
+				IL_009f: newarr [System.Runtime]System.Object
+				IL_00a4: dup
+				IL_00a5: ldc.i4.0
+				IL_00a6: ldarg.0
+				IL_00a7: ldc.i4.0
+				IL_00a8: ldelem.ref
+				IL_00a9: stelem.ref
+				IL_00aa: dup
+				IL_00ab: ldc.i4.1
+				IL_00ac: ldarg.0
+				IL_00ad: ldc.i4.1
+				IL_00ae: ldelem.ref
+				IL_00af: stelem.ref
+				IL_00b0: dup
+				IL_00b1: ldc.i4.2
+				IL_00b2: ldloc.0
 				IL_00b3: stelem.ref
-				IL_00b4: dup
-				IL_00b5: ldc.i4.1
-				IL_00b6: ldarg.0
-				IL_00b7: ldc.i4.1
-				IL_00b8: ldelem.ref
-				IL_00b9: stelem.ref
-				IL_00ba: dup
-				IL_00bb: ldc.i4.2
-				IL_00bc: ldloc.0
-				IL_00bd: stelem.ref
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-				IL_00c8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-				IL_00cd: ldc.i4.1
-				IL_00ce: conv.r8
-				IL_00cf: ldstr ""
-				IL_00d4: ldc.i4.0
-				IL_00d5: ldc.i4.0
-				IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-				IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-				IL_00e0: stloc.s 5
-				IL_00e2: ldloc.s 4
-				IL_00e4: ldloc.3
-				IL_00e5: ldloc.s 5
-				IL_00e7: castclass [System.Runtime]System.Delegate
-				IL_00ec: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::unlink(object, class [System.Runtime]System.Delegate)
-				IL_00f1: ldnull
-				IL_00f2: ret
+				IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+				IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+				IL_00be: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+				IL_00c3: ldc.i4.1
+				IL_00c4: conv.r8
+				IL_00c5: ldstr ""
+				IL_00ca: ldc.i4.0
+				IL_00cb: ldc.i4.0
+				IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+				IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+				IL_00d6: stloc.s 5
+				IL_00d8: ldloc.s 4
+				IL_00da: ldloc.3
+				IL_00db: ldloc.s 5
+				IL_00dd: castclass [System.Runtime]System.Delegate
+				IL_00e2: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::unlink(object, class [System.Runtime]System.Delegate)
+				IL_00e7: ldnull
+				IL_00e8: ret
 			} // end of method ArrowFunction_L21C32::__js_call__
 
 		} // end of class ArrowFunction_L21C32
@@ -385,7 +381,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x255d
+					// Method begins at RVA 0x2533
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -406,7 +402,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2554
+				// Method begins at RVA 0x252a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -433,9 +429,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x2260
 			// Header size: 12
-			// Code size: 174 (0xae)
+			// Code size: 169 (0xa9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/Scope,
@@ -472,47 +468,46 @@
 			IL_0042: ret
 
 			IL_0043: ldarg.0
-			IL_0044: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-			IL_0049: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_004e: stloc.s 4
-			IL_0050: ldarg.0
-			IL_0051: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-			IL_0056: stloc.3
-			IL_0057: ldarg.0
-			IL_0058: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-			IL_005d: stloc.2
-			IL_005e: ldnull
-			IL_005f: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32::__js_call__(object[], object, object)
-			IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_006a: ldc.i4.2
-			IL_006b: newarr [System.Runtime]System.Object
-			IL_0070: dup
-			IL_0071: ldc.i4.0
-			IL_0072: ldarg.0
-			IL_0073: stelem.ref
-			IL_0074: dup
-			IL_0075: ldc.i4.1
-			IL_0076: ldloc.0
-			IL_0077: stelem.ref
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0082: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_0087: ldc.i4.1
-			IL_0088: conv.r8
-			IL_0089: ldstr ""
-			IL_008e: ldc.i4.0
-			IL_008f: ldc.i4.0
-			IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.s 4
-			IL_009e: ldloc.3
-			IL_009f: ldloc.2
-			IL_00a0: ldloc.s 5
-			IL_00a2: castclass [System.Runtime]System.Delegate
-			IL_00a7: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rename(object, object, class [System.Runtime]System.Delegate)
-			IL_00ac: ldnull
-			IL_00ad: ret
+			IL_0044: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+			IL_0049: stloc.s 4
+			IL_004b: ldarg.0
+			IL_004c: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+			IL_0051: stloc.3
+			IL_0052: ldarg.0
+			IL_0053: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+			IL_0058: stloc.2
+			IL_0059: ldnull
+			IL_005a: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36/ArrowFunction_L21C32::__js_call__(object[], object, object)
+			IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0065: ldc.i4.2
+			IL_0066: newarr [System.Runtime]System.Object
+			IL_006b: dup
+			IL_006c: ldc.i4.0
+			IL_006d: ldarg.0
+			IL_006e: stelem.ref
+			IL_006f: dup
+			IL_0070: ldc.i4.1
+			IL_0071: ldloc.0
+			IL_0072: stelem.ref
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_007d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_0082: ldc.i4.1
+			IL_0083: conv.r8
+			IL_0084: ldstr ""
+			IL_0089: ldc.i4.0
+			IL_008a: ldc.i4.0
+			IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_0095: stloc.s 5
+			IL_0097: ldloc.s 4
+			IL_0099: ldloc.3
+			IL_009a: ldloc.2
+			IL_009b: ldloc.s 5
+			IL_009d: castclass [System.Runtime]System.Delegate
+			IL_00a2: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rename(object, object, class [System.Runtime]System.Delegate)
+			IL_00a7: ldnull
+			IL_00a8: ret
 		} // end of method ArrowFunction_L15C36::__js_call__
 
 	} // end of class ArrowFunction_L15C36
@@ -527,7 +522,7 @@
 			6d 65 64 7d 00 00
 		)
 		// Fields
-		.field public object fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
 		.field public object source
 		.field public object renamed
 
@@ -535,7 +530,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x254b
+			// Method begins at RVA 0x2521
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -561,7 +556,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 536 (0x218)
+		// Code size: 516 (0x204)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_Append_Rename_Unlink_Callback/Scope,
@@ -585,7 +580,7 @@
 		IL_0012: stloc.s 4
 		IL_0014: ldloc.0
 		IL_0015: ldloc.s 4
-		IL_0017: stfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_0017: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
 		IL_001c: ldarg.1
 		IL_001d: ldstr "path"
 		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -674,87 +669,83 @@
 		IL_0114: ldloc.s 5
 		IL_0116: stfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
 		IL_011b: ldloc.0
-		IL_011c: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_0121: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0126: stloc.s 4
-		IL_0128: ldloc.0
-		IL_0129: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-		IL_012e: stloc.s 5
-		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0135: dup
-		IL_0136: ldstr "force"
-		IL_013b: ldc.i4.1
-		IL_013c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0141: stloc.s 8
-		IL_0143: ldloc.s 4
-		IL_0145: ldloc.s 5
-		IL_0147: ldloc.s 8
-		IL_0149: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_014e: ldloc.0
-		IL_014f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_0154: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0159: stloc.s 4
-		IL_015b: ldloc.0
-		IL_015c: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
-		IL_0161: stloc.s 5
-		IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0168: dup
-		IL_0169: ldstr "force"
-		IL_016e: ldc.i4.1
-		IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0174: stloc.s 8
-		IL_0176: ldloc.s 4
-		IL_0178: ldloc.s 5
-		IL_017a: ldloc.s 8
-		IL_017c: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_0181: ldloc.0
-		IL_0182: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_0187: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_018c: stloc.s 4
-		IL_018e: ldloc.0
-		IL_018f: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-		IL_0194: stloc.s 5
-		IL_0196: ldloc.s 4
-		IL_0198: ldloc.s 5
-		IL_019a: ldstr "a"
-		IL_019f: ldstr "utf8"
-		IL_01a4: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-		IL_01a9: ldloc.0
-		IL_01aa: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
-		IL_01af: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_01b4: stloc.s 4
-		IL_01b6: ldloc.0
-		IL_01b7: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
-		IL_01bc: stloc.s 5
-		IL_01be: ldloc.0
-		IL_01bf: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
-		IL_01c4: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36::__js_call__(class Modules.FS_Append_Rename_Unlink_Callback/Scope, object, object)
-		IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01cf: ldc.i4.1
-		IL_01d0: newarr [System.Runtime]System.Object
-		IL_01d5: dup
-		IL_01d6: ldc.i4.0
-		IL_01d7: ldloc.0
-		IL_01d8: stelem.ref
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01e3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01e8: ldc.i4.1
-		IL_01e9: conv.r8
-		IL_01ea: ldstr ""
-		IL_01ef: ldc.i4.0
-		IL_01f0: ldc.i4.0
-		IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_01fb: stloc.s 9
-		IL_01fd: ldloc.s 4
-		IL_01ff: ldloc.s 5
-		IL_0201: ldstr "b"
-		IL_0206: ldstr "utf8"
-		IL_020b: ldloc.s 9
-		IL_020d: castclass [System.Runtime]System.Delegate
-		IL_0212: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::appendFile(object, object, object, class [System.Runtime]System.Delegate)
-		IL_0217: ret
+		IL_011c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_0121: stloc.s 4
+		IL_0123: ldloc.0
+		IL_0124: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+		IL_0129: stloc.s 5
+		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0130: dup
+		IL_0131: ldstr "force"
+		IL_0136: ldc.i4.1
+		IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_013c: stloc.s 8
+		IL_013e: ldloc.s 4
+		IL_0140: ldloc.s 5
+		IL_0142: ldloc.s 8
+		IL_0144: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_0149: ldloc.0
+		IL_014a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_014f: stloc.s 4
+		IL_0151: ldloc.0
+		IL_0152: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::renamed
+		IL_0157: stloc.s 5
+		IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_015e: dup
+		IL_015f: ldstr "force"
+		IL_0164: ldc.i4.1
+		IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_016a: stloc.s 8
+		IL_016c: ldloc.s 4
+		IL_016e: ldloc.s 5
+		IL_0170: ldloc.s 8
+		IL_0172: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_0177: ldloc.0
+		IL_0178: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_017d: stloc.s 4
+		IL_017f: ldloc.0
+		IL_0180: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+		IL_0185: stloc.s 5
+		IL_0187: ldloc.s 4
+		IL_0189: ldloc.s 5
+		IL_018b: ldstr "a"
+		IL_0190: ldstr "utf8"
+		IL_0195: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+		IL_019a: ldloc.0
+		IL_019b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Append_Rename_Unlink_Callback/Scope::fs
+		IL_01a0: stloc.s 4
+		IL_01a2: ldloc.0
+		IL_01a3: ldfld object Modules.FS_Append_Rename_Unlink_Callback/Scope::source
+		IL_01a8: stloc.s 5
+		IL_01aa: ldloc.0
+		IL_01ab: castclass Modules.FS_Append_Rename_Unlink_Callback/Scope
+		IL_01b0: ldftn object Modules.FS_Append_Rename_Unlink_Callback/ArrowFunction_L15C36::__js_call__(class Modules.FS_Append_Rename_Unlink_Callback/Scope, object, object)
+		IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01bb: ldc.i4.1
+		IL_01bc: newarr [System.Runtime]System.Object
+		IL_01c1: dup
+		IL_01c2: ldc.i4.0
+		IL_01c3: ldloc.0
+		IL_01c4: stelem.ref
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01cf: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01d4: ldc.i4.1
+		IL_01d5: conv.r8
+		IL_01d6: ldstr ""
+		IL_01db: ldc.i4.0
+		IL_01dc: ldc.i4.0
+		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_01e7: stloc.s 9
+		IL_01e9: ldloc.s 4
+		IL_01eb: ldloc.s 5
+		IL_01ed: ldstr "b"
+		IL_01f2: ldstr "utf8"
+		IL_01f7: ldloc.s 9
+		IL_01f9: castclass [System.Runtime]System.Delegate
+		IL_01fe: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::appendFile(object, object, object, class [System.Runtime]System.Delegate)
+		IL_0203: ret
 	} // end of method FS_Append_Rename_Unlink_Callback::__js_module_init__
 
 } // end of class Modules.FS_Append_Rename_Unlink_Callback
@@ -766,7 +757,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x258a
+		// Method begins at RVA 0x2560
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateReadStream_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2443
+				// Method begins at RVA 0x242e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x2437
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,9 +118,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x233c
+			// Method begins at RVA 0x2330
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -150,24 +150,23 @@
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_003b: pop
 			IL_003c: ldarg.0
-			IL_003d: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_0042: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0047: stloc.2
-			IL_0048: ldarg.0
-			IL_0049: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_004e: stloc.0
-			IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0054: dup
-			IL_0055: ldstr "force"
-			IL_005a: ldc.i4.1
-			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0060: stloc.3
-			IL_0061: ldloc.2
-			IL_0062: ldloc.0
-			IL_0063: ldloc.3
-			IL_0064: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_003d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateReadStream_Basic/Scope::fs
+			IL_0042: stloc.2
+			IL_0043: ldarg.0
+			IL_0044: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+			IL_0049: stloc.0
+			IL_004a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004f: dup
+			IL_0050: ldstr "force"
+			IL_0055: ldc.i4.1
+			IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005b: stloc.3
+			IL_005c: ldloc.2
+			IL_005d: ldloc.0
+			IL_005e: ldloc.3
+			IL_005f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method ArrowFunction_L20C18::__js_call__
 
 	} // end of class ArrowFunction_L20C18
@@ -190,7 +189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2455
+				// Method begins at RVA 0x2440
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -217,9 +216,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x23a4
 			// Header size: 12
-			// Code size: 122 (0x7a)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -259,24 +258,23 @@
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0046: pop
 			IL_0047: ldarg.0
-			IL_0048: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-			IL_004d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0052: stloc.s 5
-			IL_0054: ldarg.0
-			IL_0055: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-			IL_005a: stloc.0
-			IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0060: dup
-			IL_0061: ldstr "force"
-			IL_0066: ldc.i4.1
-			IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006c: stloc.s 6
-			IL_006e: ldloc.s 5
-			IL_0070: ldloc.0
-			IL_0071: ldloc.s 6
-			IL_0073: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0078: ldnull
-			IL_0079: ret
+			IL_0048: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateReadStream_Basic/Scope::fs
+			IL_004d: stloc.s 5
+			IL_004f: ldarg.0
+			IL_0050: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+			IL_0055: stloc.0
+			IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005b: dup
+			IL_005c: ldstr "force"
+			IL_0061: ldc.i4.1
+			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0067: stloc.s 6
+			IL_0069: ldloc.s 5
+			IL_006b: ldloc.0
+			IL_006c: ldloc.s 6
+			IL_006e: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method ArrowFunction_L25C20::__js_call__
 
 	} // end of class ArrowFunction_L25C20
@@ -290,7 +288,7 @@
 			68 75 6e 6b 73 3d 7b 63 68 75 6e 6b 73 7d 00 00
 		)
 		// Fields
-		.field public object fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
 		.field public object file
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array chunks
 
@@ -298,7 +296,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x243a
+			// Method begins at RVA 0x2425
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -324,7 +322,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 672 (0x2a0)
+		// Code size: 657 (0x291)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_CreateReadStream_Basic/Scope,
@@ -351,7 +349,7 @@
 		IL_0012: stloc.s 5
 		IL_0014: ldloc.0
 		IL_0015: ldloc.s 5
-		IL_0017: stfld object Modules.FS_CreateReadStream_Basic/Scope::fs
+		IL_0017: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateReadStream_Basic/Scope::fs
 		IL_001c: ldarg.1
 		IL_001d: ldstr "path"
 		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -412,153 +410,150 @@
 		IL_00cc: ldloc.s 6
 		IL_00ce: stfld object Modules.FS_CreateReadStream_Basic/Scope::file
 		IL_00d3: ldloc.0
-		IL_00d4: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-		IL_00d9: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00de: stloc.s 5
-		IL_00e0: ldloc.0
-		IL_00e1: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-		IL_00e6: stloc.s 6
-		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ed: dup
-		IL_00ee: ldstr "force"
-		IL_00f3: ldc.i4.1
-		IL_00f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00f9: stloc.s 9
-		IL_00fb: ldloc.s 5
-		IL_00fd: ldloc.s 6
-		IL_00ff: ldloc.s 9
-		IL_0101: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_0106: ldloc.0
-		IL_0107: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-		IL_010c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0111: stloc.s 5
-		IL_0113: ldloc.0
-		IL_0114: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-		IL_0119: stloc.s 6
-		IL_011b: ldloc.s 5
-		IL_011d: ldloc.s 6
-		IL_011f: ldstr "hello world"
-		IL_0124: ldstr "utf8"
-		IL_0129: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-		IL_012e: ldc.i4.0
-		IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0134: stloc.s 10
-		IL_0136: ldloc.0
-		IL_0137: ldloc.s 10
-		IL_0139: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
-		IL_013e: ldloc.0
-		IL_013f: ldfld object Modules.FS_CreateReadStream_Basic/Scope::fs
-		IL_0144: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0149: stloc.s 5
-		IL_014b: ldloc.0
-		IL_014c: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
-		IL_0151: stloc.s 6
-		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0158: dup
-		IL_0159: ldstr "encoding"
-		IL_015e: ldstr "utf8"
-		IL_0163: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0168: dup
-		IL_0169: ldstr "highWaterMark"
-		IL_016e: ldc.r8 5
-		IL_0177: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_017c: stloc.s 9
-		IL_017e: ldloc.s 5
-		IL_0180: ldloc.s 6
-		IL_0182: ldloc.s 9
-		IL_0184: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::createReadStream(object, object)
-		IL_0189: stloc.s 4
-		IL_018b: ldloc.s 4
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0192: stloc.s 6
-		IL_0194: ldloc.0
-		IL_0195: castclass Modules.FS_CreateReadStream_Basic/Scope
-		IL_019a: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L15C19::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
-		IL_01a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01a5: ldc.i4.1
-		IL_01a6: newarr [System.Runtime]System.Object
-		IL_01ab: dup
-		IL_01ac: ldc.i4.0
-		IL_01ad: ldloc.0
-		IL_01ae: stelem.ref
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01b9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_01be: ldc.i4.1
-		IL_01bf: conv.r8
-		IL_01c0: ldstr ""
-		IL_01c5: ldc.i4.0
-		IL_01c6: ldc.i4.0
-		IL_01c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_01cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_01d1: stloc.s 11
-		IL_01d3: ldloc.s 6
-		IL_01d5: ldstr "on"
-		IL_01da: ldstr "data"
-		IL_01df: ldloc.s 11
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01e6: pop
-		IL_01e7: ldloc.s 4
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ee: stloc.s 6
-		IL_01f0: ldloc.0
-		IL_01f1: castclass Modules.FS_CreateReadStream_Basic/Scope
-		IL_01f6: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L20C18::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object)
-		IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0201: ldc.i4.1
-		IL_0202: newarr [System.Runtime]System.Object
-		IL_0207: dup
-		IL_0208: ldc.i4.0
-		IL_0209: ldloc.0
-		IL_020a: stelem.ref
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0215: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_021a: ldc.i4.0
-		IL_021b: conv.r8
-		IL_021c: ldstr ""
-		IL_0221: ldc.i4.0
-		IL_0222: ldc.i4.0
-		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_022d: stloc.s 12
-		IL_022f: ldloc.s 6
-		IL_0231: ldstr "on"
-		IL_0236: ldstr "end"
-		IL_023b: ldloc.s 12
-		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0242: pop
-		IL_0243: ldloc.s 4
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024a: stloc.s 6
-		IL_024c: ldloc.0
-		IL_024d: castclass Modules.FS_CreateReadStream_Basic/Scope
-		IL_0252: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L25C20::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
-		IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_025d: ldc.i4.1
-		IL_025e: newarr [System.Runtime]System.Object
-		IL_0263: dup
-		IL_0264: ldc.i4.0
-		IL_0265: ldloc.0
-		IL_0266: stelem.ref
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0271: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0276: ldc.i4.1
-		IL_0277: conv.r8
-		IL_0278: ldstr ""
-		IL_027d: ldc.i4.0
-		IL_027e: ldc.i4.0
-		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0284: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0289: stloc.s 11
-		IL_028b: ldloc.s 6
-		IL_028d: ldstr "on"
-		IL_0292: ldstr "error"
-		IL_0297: ldloc.s 11
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_029e: pop
-		IL_029f: ret
+		IL_00d4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateReadStream_Basic/Scope::fs
+		IL_00d9: stloc.s 5
+		IL_00db: ldloc.0
+		IL_00dc: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+		IL_00e1: stloc.s 6
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e8: dup
+		IL_00e9: ldstr "force"
+		IL_00ee: ldc.i4.1
+		IL_00ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00f4: stloc.s 9
+		IL_00f6: ldloc.s 5
+		IL_00f8: ldloc.s 6
+		IL_00fa: ldloc.s 9
+		IL_00fc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_0101: ldloc.0
+		IL_0102: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateReadStream_Basic/Scope::fs
+		IL_0107: stloc.s 5
+		IL_0109: ldloc.0
+		IL_010a: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+		IL_010f: stloc.s 6
+		IL_0111: ldloc.s 5
+		IL_0113: ldloc.s 6
+		IL_0115: ldstr "hello world"
+		IL_011a: ldstr "utf8"
+		IL_011f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+		IL_0124: ldc.i4.0
+		IL_0125: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_012a: stloc.s 10
+		IL_012c: ldloc.0
+		IL_012d: ldloc.s 10
+		IL_012f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.FS_CreateReadStream_Basic/Scope::chunks
+		IL_0134: ldloc.0
+		IL_0135: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateReadStream_Basic/Scope::fs
+		IL_013a: stloc.s 5
+		IL_013c: ldloc.0
+		IL_013d: ldfld object Modules.FS_CreateReadStream_Basic/Scope::file
+		IL_0142: stloc.s 6
+		IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0149: dup
+		IL_014a: ldstr "encoding"
+		IL_014f: ldstr "utf8"
+		IL_0154: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0159: dup
+		IL_015a: ldstr "highWaterMark"
+		IL_015f: ldc.r8 5
+		IL_0168: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_016d: stloc.s 9
+		IL_016f: ldloc.s 5
+		IL_0171: ldloc.s 6
+		IL_0173: ldloc.s 9
+		IL_0175: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::createReadStream(object, object)
+		IL_017a: stloc.s 4
+		IL_017c: ldloc.s 4
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: stloc.s 6
+		IL_0185: ldloc.0
+		IL_0186: castclass Modules.FS_CreateReadStream_Basic/Scope
+		IL_018b: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L15C19::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
+		IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0196: ldc.i4.1
+		IL_0197: newarr [System.Runtime]System.Object
+		IL_019c: dup
+		IL_019d: ldc.i4.0
+		IL_019e: ldloc.0
+		IL_019f: stelem.ref
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01aa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_01af: ldc.i4.1
+		IL_01b0: conv.r8
+		IL_01b1: ldstr ""
+		IL_01b6: ldc.i4.0
+		IL_01b7: ldc.i4.0
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_01bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_01c2: stloc.s 11
+		IL_01c4: ldloc.s 6
+		IL_01c6: ldstr "on"
+		IL_01cb: ldstr "data"
+		IL_01d0: ldloc.s 11
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01d7: pop
+		IL_01d8: ldloc.s 4
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01df: stloc.s 6
+		IL_01e1: ldloc.0
+		IL_01e2: castclass Modules.FS_CreateReadStream_Basic/Scope
+		IL_01e7: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L20C18::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object)
+		IL_01ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01f2: ldc.i4.1
+		IL_01f3: newarr [System.Runtime]System.Object
+		IL_01f8: dup
+		IL_01f9: ldc.i4.0
+		IL_01fa: ldloc.0
+		IL_01fb: stelem.ref
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0206: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_020b: ldc.i4.0
+		IL_020c: conv.r8
+		IL_020d: ldstr ""
+		IL_0212: ldc.i4.0
+		IL_0213: ldc.i4.0
+		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_021e: stloc.s 12
+		IL_0220: ldloc.s 6
+		IL_0222: ldstr "on"
+		IL_0227: ldstr "end"
+		IL_022c: ldloc.s 12
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0233: pop
+		IL_0234: ldloc.s 4
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023b: stloc.s 6
+		IL_023d: ldloc.0
+		IL_023e: castclass Modules.FS_CreateReadStream_Basic/Scope
+		IL_0243: ldftn object Modules.FS_CreateReadStream_Basic/ArrowFunction_L25C20::__js_call__(class Modules.FS_CreateReadStream_Basic/Scope, object, object)
+		IL_0249: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_024e: ldc.i4.1
+		IL_024f: newarr [System.Runtime]System.Object
+		IL_0254: dup
+		IL_0255: ldc.i4.0
+		IL_0256: ldloc.0
+		IL_0257: stelem.ref
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0262: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0267: ldc.i4.1
+		IL_0268: conv.r8
+		IL_0269: ldstr ""
+		IL_026e: ldc.i4.0
+		IL_026f: ldc.i4.0
+		IL_0270: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0275: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_027a: stloc.s 11
+		IL_027c: ldloc.s 6
+		IL_027e: ldstr "on"
+		IL_0283: ldstr "error"
+		IL_0288: ldloc.s 11
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_028f: pop
+		IL_0290: ret
 	} // end of method FS_CreateReadStream_Basic::__js_module_init__
 
 } // end of class Modules.FS_CreateReadStream_Basic
@@ -570,7 +565,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x245e
+		// Method begins at RVA 0x2449
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2413
+				// Method begins at RVA 0x23f6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,9 +44,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x22dc
+			// Method begins at RVA 0x22d0
 			// Header size: 12
-			// Code size: 113 (0x71)
+			// Code size: 103 (0x67)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -60,42 +60,40 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: ldarg.0
-			IL_0011: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0016: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_001b: stloc.1
-			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_0022: stloc.2
-			IL_0023: ldloc.1
-			IL_0024: ldloc.2
-			IL_0025: ldstr "utf8"
-			IL_002a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_002f: stloc.2
-			IL_0030: ldloc.0
-			IL_0031: ldstr "log"
-			IL_0036: ldstr "FileText:"
-			IL_003b: ldloc.2
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0041: pop
-			IL_0042: ldarg.0
-			IL_0043: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_0048: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_004d: stloc.1
-			IL_004e: ldarg.0
-			IL_004f: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_0054: stloc.2
-			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005a: dup
-			IL_005b: ldstr "force"
-			IL_0060: ldc.i4.1
-			IL_0061: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0066: stloc.3
-			IL_0067: ldloc.1
-			IL_0068: ldloc.2
-			IL_0069: ldloc.3
-			IL_006a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_006f: ldnull
-			IL_0070: ret
+			IL_0011: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateWriteStream_Basic/Scope::fs
+			IL_0016: stloc.1
+			IL_0017: ldarg.0
+			IL_0018: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_001d: stloc.2
+			IL_001e: ldloc.1
+			IL_001f: ldloc.2
+			IL_0020: ldstr "utf8"
+			IL_0025: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_002a: stloc.2
+			IL_002b: ldloc.0
+			IL_002c: ldstr "log"
+			IL_0031: ldstr "FileText:"
+			IL_0036: ldloc.2
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_003c: pop
+			IL_003d: ldarg.0
+			IL_003e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateWriteStream_Basic/Scope::fs
+			IL_0043: stloc.1
+			IL_0044: ldarg.0
+			IL_0045: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_004a: stloc.2
+			IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0050: dup
+			IL_0051: ldstr "force"
+			IL_0056: ldc.i4.1
+			IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005c: stloc.3
+			IL_005d: ldloc.1
+			IL_005e: ldloc.2
+			IL_005f: ldloc.3
+			IL_0060: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0065: ldnull
+			IL_0066: ret
 		} // end of method ArrowFunction_L13C21::__js_call__
 
 	} // end of class ArrowFunction_L13C21
@@ -111,7 +109,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241c
+				// Method begins at RVA 0x23ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -134,7 +132,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2359
+			// Method begins at RVA 0x2343
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -172,7 +170,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2425
+				// Method begins at RVA 0x2408
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,9 +197,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2384
+			// Method begins at RVA 0x236c
 			// Header size: 12
-			// Code size: 122 (0x7a)
+			// Code size: 117 (0x75)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -241,24 +239,23 @@
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0046: pop
 			IL_0047: ldarg.0
-			IL_0048: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-			IL_004d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0052: stloc.s 5
-			IL_0054: ldarg.0
-			IL_0055: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-			IL_005a: stloc.0
-			IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0060: dup
-			IL_0061: ldstr "force"
-			IL_0066: ldc.i4.1
-			IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006c: stloc.s 6
-			IL_006e: ldloc.s 5
-			IL_0070: ldloc.0
-			IL_0071: ldloc.s 6
-			IL_0073: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0078: ldnull
-			IL_0079: ret
+			IL_0048: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateWriteStream_Basic/Scope::fs
+			IL_004d: stloc.s 5
+			IL_004f: ldarg.0
+			IL_0050: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+			IL_0055: stloc.0
+			IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005b: dup
+			IL_005c: ldstr "force"
+			IL_0061: ldc.i4.1
+			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0067: stloc.s 6
+			IL_0069: ldloc.s 5
+			IL_006b: ldloc.0
+			IL_006c: ldloc.s 6
+			IL_006e: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0073: ldnull
+			IL_0074: ret
 		} // end of method ArrowFunction_L22C20::__js_call__
 
 	} // end of class ArrowFunction_L22C20
@@ -271,14 +268,14 @@
 			2c 20 66 69 6c 65 3d 7b 66 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
 		.field public object file
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x240a
+			// Method begins at RVA 0x23ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -304,7 +301,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 637 (0x27d)
+		// Code size: 627 (0x273)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_CreateWriteStream_Basic/Scope,
@@ -330,7 +327,7 @@
 		IL_0012: stloc.s 5
 		IL_0014: ldloc.0
 		IL_0015: ldloc.s 5
-		IL_0017: stfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
+		IL_0017: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateWriteStream_Basic/Scope::fs
 		IL_001c: ldarg.1
 		IL_001d: ldstr "path"
 		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -391,142 +388,140 @@
 		IL_00cc: ldloc.s 6
 		IL_00ce: stfld object Modules.FS_CreateWriteStream_Basic/Scope::file
 		IL_00d3: ldloc.0
-		IL_00d4: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-		IL_00d9: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00de: stloc.s 5
-		IL_00e0: ldloc.0
-		IL_00e1: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-		IL_00e6: stloc.s 6
-		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ed: dup
-		IL_00ee: ldstr "force"
-		IL_00f3: ldc.i4.1
-		IL_00f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00f9: stloc.s 9
-		IL_00fb: ldloc.s 5
-		IL_00fd: ldloc.s 6
-		IL_00ff: ldloc.s 9
-		IL_0101: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_0106: ldloc.0
-		IL_0107: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::fs
-		IL_010c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0111: stloc.s 5
-		IL_0113: ldloc.0
-		IL_0114: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
-		IL_0119: stloc.s 6
-		IL_011b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0120: dup
-		IL_0121: ldstr "encoding"
-		IL_0126: ldstr "utf8"
-		IL_012b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0130: stloc.s 9
-		IL_0132: ldloc.s 5
-		IL_0134: ldloc.s 6
-		IL_0136: ldloc.s 9
-		IL_0138: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::createWriteStream(object, object)
-		IL_013d: stloc.s 4
-		IL_013f: ldloc.s 4
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0146: stloc.s 6
-		IL_0148: ldloc.0
-		IL_0149: castclass Modules.FS_CreateWriteStream_Basic/Scope
-		IL_014e: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L13C21::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object)
-		IL_0154: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0159: ldc.i4.1
-		IL_015a: newarr [System.Runtime]System.Object
-		IL_015f: dup
-		IL_0160: ldc.i4.0
-		IL_0161: ldloc.0
-		IL_0162: stelem.ref
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_016d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0172: ldc.i4.0
-		IL_0173: conv.r8
-		IL_0174: ldstr ""
-		IL_0179: ldc.i4.0
-		IL_017a: ldc.i4.0
-		IL_017b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0185: stloc.s 10
-		IL_0187: ldloc.s 6
-		IL_0189: ldstr "on"
-		IL_018e: ldstr "finish"
-		IL_0193: ldloc.s 10
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_019a: pop
-		IL_019b: ldloc.s 4
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a2: stloc.s 6
-		IL_01a4: ldnull
-		IL_01a5: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L18C20::__js_call__(object)
-		IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b0: ldc.i4.1
-		IL_01b1: newarr [System.Runtime]System.Object
-		IL_01b6: dup
-		IL_01b7: ldc.i4.0
-		IL_01b8: ldloc.0
-		IL_01b9: stelem.ref
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01c4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_01c9: ldc.i4.0
-		IL_01ca: conv.r8
-		IL_01cb: ldstr ""
-		IL_01d0: ldc.i4.0
-		IL_01d1: ldc.i4.0
-		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_01d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_01dc: stloc.s 10
-		IL_01de: ldloc.s 6
-		IL_01e0: ldstr "on"
-		IL_01e5: ldstr "close"
-		IL_01ea: ldloc.s 10
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01f1: pop
-		IL_01f2: ldloc.s 4
-		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f9: stloc.s 6
-		IL_01fb: ldloc.0
-		IL_01fc: castclass Modules.FS_CreateWriteStream_Basic/Scope
-		IL_0201: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L22C20::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object, object)
-		IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_020c: ldc.i4.1
-		IL_020d: newarr [System.Runtime]System.Object
-		IL_0212: dup
-		IL_0213: ldc.i4.0
-		IL_0214: ldloc.0
-		IL_0215: stelem.ref
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0220: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0225: ldc.i4.1
-		IL_0226: conv.r8
-		IL_0227: ldstr ""
-		IL_022c: ldc.i4.0
-		IL_022d: ldc.i4.0
-		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_0238: stloc.s 11
-		IL_023a: ldloc.s 6
-		IL_023c: ldstr "on"
-		IL_0241: ldstr "error"
-		IL_0246: ldloc.s 11
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_024d: pop
-		IL_024e: ldloc.s 4
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0255: ldstr "write"
-		IL_025a: ldstr "hello "
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0264: pop
-		IL_0265: ldloc.s 4
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_026c: ldstr "end"
-		IL_0271: ldstr "world"
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027b: pop
-		IL_027c: ret
+		IL_00d4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateWriteStream_Basic/Scope::fs
+		IL_00d9: stloc.s 5
+		IL_00db: ldloc.0
+		IL_00dc: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+		IL_00e1: stloc.s 6
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e8: dup
+		IL_00e9: ldstr "force"
+		IL_00ee: ldc.i4.1
+		IL_00ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00f4: stloc.s 9
+		IL_00f6: ldloc.s 5
+		IL_00f8: ldloc.s 6
+		IL_00fa: ldloc.s 9
+		IL_00fc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_0101: ldloc.0
+		IL_0102: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_CreateWriteStream_Basic/Scope::fs
+		IL_0107: stloc.s 5
+		IL_0109: ldloc.0
+		IL_010a: ldfld object Modules.FS_CreateWriteStream_Basic/Scope::file
+		IL_010f: stloc.s 6
+		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0116: dup
+		IL_0117: ldstr "encoding"
+		IL_011c: ldstr "utf8"
+		IL_0121: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0126: stloc.s 9
+		IL_0128: ldloc.s 5
+		IL_012a: ldloc.s 6
+		IL_012c: ldloc.s 9
+		IL_012e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::createWriteStream(object, object)
+		IL_0133: stloc.s 4
+		IL_0135: ldloc.s 4
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013c: stloc.s 6
+		IL_013e: ldloc.0
+		IL_013f: castclass Modules.FS_CreateWriteStream_Basic/Scope
+		IL_0144: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L13C21::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object)
+		IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_014f: ldc.i4.1
+		IL_0150: newarr [System.Runtime]System.Object
+		IL_0155: dup
+		IL_0156: ldc.i4.0
+		IL_0157: ldloc.0
+		IL_0158: stelem.ref
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0163: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0168: ldc.i4.0
+		IL_0169: conv.r8
+		IL_016a: ldstr ""
+		IL_016f: ldc.i4.0
+		IL_0170: ldc.i4.0
+		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_017b: stloc.s 10
+		IL_017d: ldloc.s 6
+		IL_017f: ldstr "on"
+		IL_0184: ldstr "finish"
+		IL_0189: ldloc.s 10
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0190: pop
+		IL_0191: ldloc.s 4
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0198: stloc.s 6
+		IL_019a: ldnull
+		IL_019b: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L18C20::__js_call__(object)
+		IL_01a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01a6: ldc.i4.1
+		IL_01a7: newarr [System.Runtime]System.Object
+		IL_01ac: dup
+		IL_01ad: ldc.i4.0
+		IL_01ae: ldloc.0
+		IL_01af: stelem.ref
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01ba: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01bf: ldc.i4.0
+		IL_01c0: conv.r8
+		IL_01c1: ldstr ""
+		IL_01c6: ldc.i4.0
+		IL_01c7: ldc.i4.0
+		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_01d2: stloc.s 10
+		IL_01d4: ldloc.s 6
+		IL_01d6: ldstr "on"
+		IL_01db: ldstr "close"
+		IL_01e0: ldloc.s 10
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01e7: pop
+		IL_01e8: ldloc.s 4
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ef: stloc.s 6
+		IL_01f1: ldloc.0
+		IL_01f2: castclass Modules.FS_CreateWriteStream_Basic/Scope
+		IL_01f7: ldftn object Modules.FS_CreateWriteStream_Basic/ArrowFunction_L22C20::__js_call__(class Modules.FS_CreateWriteStream_Basic/Scope, object, object)
+		IL_01fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0202: ldc.i4.1
+		IL_0203: newarr [System.Runtime]System.Object
+		IL_0208: dup
+		IL_0209: ldc.i4.0
+		IL_020a: ldloc.0
+		IL_020b: stelem.ref
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0216: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_021b: ldc.i4.1
+		IL_021c: conv.r8
+		IL_021d: ldstr ""
+		IL_0222: ldc.i4.0
+		IL_0223: ldc.i4.0
+		IL_0224: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0229: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_022e: stloc.s 11
+		IL_0230: ldloc.s 6
+		IL_0232: ldstr "on"
+		IL_0237: ldstr "error"
+		IL_023c: ldloc.s 11
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0243: pop
+		IL_0244: ldloc.s 4
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024b: ldstr "write"
+		IL_0250: ldstr "hello "
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025a: pop
+		IL_025b: ldloc.s 4
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0262: ldstr "end"
+		IL_0267: ldstr "world"
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0271: pop
+		IL_0272: ret
 	} // end of method FS_CreateWriteStream_Basic::__js_module_init__
 
 } // end of class Modules.FS_CreateWriteStream_Basic
@@ -538,7 +533,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x242e
+		// Method begins at RVA 0x2411
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2533
+					// Method begins at RVA 0x2516
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23bc
+				// Method begins at RVA 0x23b0
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -80,7 +80,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x253c
+					// Method begins at RVA 0x251f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -104,9 +104,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23e8
+				// Method begins at RVA 0x23dc
 				// Header size: 12
-				// Code size: 141 (0x8d)
+				// Code size: 131 (0x83)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -123,51 +123,49 @@
 				IL_0011: ldc.i4.0
 				IL_0012: ldelem.ref
 				IL_0013: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0018: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_001d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_0022: stloc.1
-				IL_0023: ldarg.0
-				IL_0024: ldc.i4.0
-				IL_0025: ldelem.ref
-				IL_0026: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_002b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0030: stloc.2
-				IL_0031: ldloc.1
-				IL_0032: ldloc.2
-				IL_0033: ldstr "utf8"
-				IL_0038: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-				IL_003d: stloc.2
-				IL_003e: ldloc.0
-				IL_003f: ldstr "log"
-				IL_0044: ldstr "FileText:"
-				IL_0049: ldloc.2
-				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_004f: pop
-				IL_0050: ldarg.0
-				IL_0051: ldc.i4.0
-				IL_0052: ldelem.ref
-				IL_0053: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0058: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_005d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_0062: stloc.1
-				IL_0063: ldarg.0
-				IL_0064: ldc.i4.0
-				IL_0065: ldelem.ref
-				IL_0066: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_006b: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0070: stloc.2
-				IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0076: dup
-				IL_0077: ldstr "force"
-				IL_007c: ldc.i4.1
-				IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_0082: stloc.3
-				IL_0083: ldloc.1
-				IL_0084: ldloc.2
-				IL_0085: ldloc.3
-				IL_0086: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-				IL_008b: ldnull
-				IL_008c: ret
+				IL_0018: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
+				IL_001d: stloc.1
+				IL_001e: ldarg.0
+				IL_001f: ldc.i4.0
+				IL_0020: ldelem.ref
+				IL_0021: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0026: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_002b: stloc.2
+				IL_002c: ldloc.1
+				IL_002d: ldloc.2
+				IL_002e: ldstr "utf8"
+				IL_0033: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+				IL_0038: stloc.2
+				IL_0039: ldloc.0
+				IL_003a: ldstr "log"
+				IL_003f: ldstr "FileText:"
+				IL_0044: ldloc.2
+				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_004a: pop
+				IL_004b: ldarg.0
+				IL_004c: ldc.i4.0
+				IL_004d: ldelem.ref
+				IL_004e: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0053: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
+				IL_0058: stloc.1
+				IL_0059: ldarg.0
+				IL_005a: ldc.i4.0
+				IL_005b: ldelem.ref
+				IL_005c: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_0061: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_0066: stloc.2
+				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_006c: dup
+				IL_006d: ldstr "force"
+				IL_0072: ldc.i4.1
+				IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0078: stloc.3
+				IL_0079: ldloc.1
+				IL_007a: ldloc.2
+				IL_007b: ldloc.3
+				IL_007c: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+				IL_0081: ldnull
+				IL_0082: ret
 			} // end of method ArrowFunction_L20C67::__js_call__
 
 		} // end of class ArrowFunction_L20C67
@@ -190,7 +188,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2545
+					// Method begins at RVA 0x2528
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -215,9 +213,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2484
+				// Method begins at RVA 0x246c
 				// Header size: 12
-				// Code size: 136 (0x88)
+				// Code size: 131 (0x83)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -260,27 +258,26 @@
 				IL_0048: ldc.i4.0
 				IL_0049: ldelem.ref
 				IL_004a: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_004f: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-				IL_0054: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-				IL_0059: stloc.s 5
-				IL_005b: ldarg.0
-				IL_005c: ldc.i4.0
-				IL_005d: ldelem.ref
-				IL_005e: castclass Modules.FS_Open_Callback_FileHandle/Scope
-				IL_0063: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-				IL_0068: stloc.0
-				IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_006e: dup
-				IL_006f: ldstr "force"
-				IL_0074: ldc.i4.1
-				IL_0075: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-				IL_007a: stloc.s 6
-				IL_007c: ldloc.s 5
-				IL_007e: ldloc.0
-				IL_007f: ldloc.s 6
-				IL_0081: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-				IL_0086: ldnull
-				IL_0087: ret
+				IL_004f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
+				IL_0054: stloc.s 5
+				IL_0056: ldarg.0
+				IL_0057: ldc.i4.0
+				IL_0058: ldelem.ref
+				IL_0059: castclass Modules.FS_Open_Callback_FileHandle/Scope
+				IL_005e: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+				IL_0063: stloc.0
+				IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0069: dup
+				IL_006a: ldstr "force"
+				IL_006f: ldc.i4.1
+				IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+				IL_0075: stloc.s 6
+				IL_0077: ldloc.s 5
+				IL_0079: ldloc.0
+				IL_007a: ldloc.s 6
+				IL_007c: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+				IL_0081: ldnull
+				IL_0082: ret
 			} // end of method ArrowFunction_L23C8::__js_call__
 
 		} // end of class ArrowFunction_L23C8
@@ -301,7 +298,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x252a
+					// Method begins at RVA 0x250d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -323,7 +320,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2521
+				// Method begins at RVA 0x2504
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -351,9 +348,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21cc
+			// Method begins at RVA 0x21c4
 			// Header size: 12
-			// Code size: 482 (0x1e2)
+			// Code size: 477 (0x1dd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope,
@@ -377,7 +374,7 @@
 			IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0013: stloc.1
 			IL_0014: ldloc.1
-			IL_0015: brfalse IL_007b
+			IL_0015: brfalse IL_0076
 
 			IL_001a: ldstr "console"
 			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -394,151 +391,150 @@
 			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 			IL_0047: pop
 			IL_0048: ldarg.0
-			IL_0049: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-			IL_004e: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-			IL_0053: stloc.s 4
-			IL_0055: ldarg.0
-			IL_0056: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-			IL_005b: stloc.3
-			IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0061: dup
-			IL_0062: ldstr "force"
-			IL_0067: ldc.i4.1
-			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_006d: stloc.s 5
-			IL_006f: ldloc.s 4
-			IL_0071: ldloc.3
-			IL_0072: ldloc.s 5
-			IL_0074: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0079: ldnull
-			IL_007a: ret
+			IL_0049: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
+			IL_004e: stloc.s 4
+			IL_0050: ldarg.0
+			IL_0051: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+			IL_0056: stloc.3
+			IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005c: dup
+			IL_005d: ldstr "force"
+			IL_0062: ldc.i4.1
+			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0068: stloc.s 5
+			IL_006a: ldloc.s 4
+			IL_006c: ldloc.3
+			IL_006d: ldloc.s 5
+			IL_006f: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0074: ldnull
+			IL_0075: ret
 
-			IL_007b: ldstr "console"
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008a: stloc.3
-			IL_008b: ldloc.0
-			IL_008c: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-			IL_0091: ldstr "fd"
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009b: stloc.2
-			IL_009c: ldloc.2
-			IL_009d: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_00a2: stloc.s 6
-			IL_00a4: ldloc.s 6
-			IL_00a6: ldstr "number"
-			IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00b0: stloc.1
-			IL_00b1: ldloc.1
-			IL_00b2: box [System.Runtime]System.Boolean
-			IL_00b7: stloc.s 7
-			IL_00b9: ldloc.3
-			IL_00ba: ldstr "log"
-			IL_00bf: ldstr "FDIsNumber:"
-			IL_00c4: ldloc.s 7
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00cb: pop
-			IL_00cc: ldloc.0
-			IL_00cd: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d7: ldstr "write"
-			IL_00dc: ldstr "ok"
-			IL_00e1: ldc.r8 0.0
-			IL_00ea: box [System.Runtime]System.Double
-			IL_00ef: ldstr "utf8"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_00f9: stloc.3
-			IL_00fa: ldloc.3
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0100: stloc.3
-			IL_0101: ldnull
-			IL_0102: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40::__js_call__(object[], object)
-			IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_010d: ldc.i4.2
-			IL_010e: newarr [System.Runtime]System.Object
-			IL_0113: dup
-			IL_0114: ldc.i4.0
-			IL_0115: ldarg.0
-			IL_0116: stelem.ref
-			IL_0117: dup
-			IL_0118: ldc.i4.1
-			IL_0119: ldloc.0
-			IL_011a: stelem.ref
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0125: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_012a: ldc.i4.0
-			IL_012b: conv.r8
-			IL_012c: ldstr ""
-			IL_0131: ldc.i4.0
-			IL_0132: ldc.i4.0
-			IL_0133: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_013d: stloc.s 8
-			IL_013f: ldloc.3
-			IL_0140: ldstr "then"
-			IL_0145: ldloc.s 8
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014c: stloc.3
-			IL_014d: ldloc.3
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0153: stloc.3
-			IL_0154: ldnull
-			IL_0155: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67::__js_call__(object[], object)
-			IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0160: ldc.i4.2
-			IL_0161: newarr [System.Runtime]System.Object
-			IL_0166: dup
-			IL_0167: ldc.i4.0
-			IL_0168: ldarg.0
-			IL_0169: stelem.ref
-			IL_016a: dup
-			IL_016b: ldc.i4.1
-			IL_016c: ldloc.0
-			IL_016d: stelem.ref
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0178: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_017d: ldc.i4.0
-			IL_017e: conv.r8
-			IL_017f: ldstr ""
-			IL_0184: ldc.i4.0
-			IL_0185: ldc.i4.0
-			IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_018b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0190: stloc.s 8
-			IL_0192: ldnull
-			IL_0193: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8::__js_call__(object[], object, object)
-			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_019e: ldc.i4.2
-			IL_019f: newarr [System.Runtime]System.Object
-			IL_01a4: dup
-			IL_01a5: ldc.i4.0
-			IL_01a6: ldarg.0
-			IL_01a7: stelem.ref
-			IL_01a8: dup
-			IL_01a9: ldc.i4.1
-			IL_01aa: ldloc.0
-			IL_01ab: stelem.ref
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01b6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_01bb: ldc.i4.1
-			IL_01bc: conv.r8
-			IL_01bd: ldstr ""
-			IL_01c2: ldc.i4.0
-			IL_01c3: ldc.i4.0
-			IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_01c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_01ce: stloc.s 9
-			IL_01d0: ldloc.3
-			IL_01d1: ldstr "then"
-			IL_01d6: ldloc.s 8
-			IL_01d8: ldloc.s 9
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01df: pop
-			IL_01e0: ldnull
-			IL_01e1: ret
+			IL_0076: ldstr "console"
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0085: stloc.3
+			IL_0086: ldloc.0
+			IL_0087: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
+			IL_008c: ldstr "fd"
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0096: stloc.2
+			IL_0097: ldloc.2
+			IL_0098: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_009d: stloc.s 6
+			IL_009f: ldloc.s 6
+			IL_00a1: ldstr "number"
+			IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00ab: stloc.1
+			IL_00ac: ldloc.1
+			IL_00ad: box [System.Runtime]System.Boolean
+			IL_00b2: stloc.s 7
+			IL_00b4: ldloc.3
+			IL_00b5: ldstr "log"
+			IL_00ba: ldstr "FDIsNumber:"
+			IL_00bf: ldloc.s 7
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00c6: pop
+			IL_00c7: ldloc.0
+			IL_00c8: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d2: ldstr "write"
+			IL_00d7: ldstr "ok"
+			IL_00dc: ldc.r8 0.0
+			IL_00e5: box [System.Runtime]System.Double
+			IL_00ea: ldstr "utf8"
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_00f4: stloc.3
+			IL_00f5: ldloc.3
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fb: stloc.3
+			IL_00fc: ldnull
+			IL_00fd: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40::__js_call__(object[], object)
+			IL_0103: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0108: ldc.i4.2
+			IL_0109: newarr [System.Runtime]System.Object
+			IL_010e: dup
+			IL_010f: ldc.i4.0
+			IL_0110: ldarg.0
+			IL_0111: stelem.ref
+			IL_0112: dup
+			IL_0113: ldc.i4.1
+			IL_0114: ldloc.0
+			IL_0115: stelem.ref
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0120: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0125: ldc.i4.0
+			IL_0126: conv.r8
+			IL_0127: ldstr ""
+			IL_012c: ldc.i4.0
+			IL_012d: ldc.i4.0
+			IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0133: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0138: stloc.s 8
+			IL_013a: ldloc.3
+			IL_013b: ldstr "then"
+			IL_0140: ldloc.s 8
+			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0147: stloc.3
+			IL_0148: ldloc.3
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014e: stloc.3
+			IL_014f: ldnull
+			IL_0150: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67::__js_call__(object[], object)
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_015b: ldc.i4.2
+			IL_015c: newarr [System.Runtime]System.Object
+			IL_0161: dup
+			IL_0162: ldc.i4.0
+			IL_0163: ldarg.0
+			IL_0164: stelem.ref
+			IL_0165: dup
+			IL_0166: ldc.i4.1
+			IL_0167: ldloc.0
+			IL_0168: stelem.ref
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0173: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0178: ldc.i4.0
+			IL_0179: conv.r8
+			IL_017a: ldstr ""
+			IL_017f: ldc.i4.0
+			IL_0180: ldc.i4.0
+			IL_0181: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_018b: stloc.s 8
+			IL_018d: ldnull
+			IL_018e: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8::__js_call__(object[], object, object)
+			IL_0194: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0199: ldc.i4.2
+			IL_019a: newarr [System.Runtime]System.Object
+			IL_019f: dup
+			IL_01a0: ldc.i4.0
+			IL_01a1: ldarg.0
+			IL_01a2: stelem.ref
+			IL_01a3: dup
+			IL_01a4: ldc.i4.1
+			IL_01a5: ldloc.0
+			IL_01a6: stelem.ref
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01b1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_01b6: ldc.i4.1
+			IL_01b7: conv.r8
+			IL_01b8: ldstr ""
+			IL_01bd: ldc.i4.0
+			IL_01be: ldc.i4.0
+			IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_01c9: stloc.s 9
+			IL_01cb: ldloc.3
+			IL_01cc: ldstr "then"
+			IL_01d1: ldloc.s 8
+			IL_01d3: ldloc.s 9
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01da: pop
+			IL_01db: ldnull
+			IL_01dc: ret
 		} // end of method ArrowFunction_L11C21::__js_call__
 
 	} // end of class ArrowFunction_L11C21
@@ -551,14 +547,14 @@
 			2c 20 66 69 6c 65 3d 7b 66 69 6c 65 7d 00 00
 		)
 		// Fields
-		.field public object fs
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule fs
 		.field public object file
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2518
+			// Method begins at RVA 0x24fb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -584,7 +580,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 368 (0x170)
+		// Code size: 358 (0x166)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_Open_Callback_FileHandle/Scope,
@@ -608,7 +604,7 @@
 		IL_0012: stloc.s 4
 		IL_0014: ldloc.0
 		IL_0015: ldloc.s 4
-		IL_0017: stfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
+		IL_0017: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
 		IL_001c: ldarg.1
 		IL_001d: ldstr "path"
 		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -669,57 +665,55 @@
 		IL_00cc: ldloc.s 5
 		IL_00ce: stfld object Modules.FS_Open_Callback_FileHandle/Scope::file
 		IL_00d3: ldloc.0
-		IL_00d4: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-		IL_00d9: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_00de: stloc.s 4
-		IL_00e0: ldloc.0
-		IL_00e1: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-		IL_00e6: stloc.s 5
-		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ed: dup
-		IL_00ee: ldstr "force"
-		IL_00f3: ldc.i4.1
-		IL_00f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00f9: stloc.s 8
-		IL_00fb: ldloc.s 4
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldloc.s 8
-		IL_0101: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-		IL_0106: ldloc.0
-		IL_0107: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::fs
-		IL_010c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
-		IL_0111: stloc.s 4
-		IL_0113: ldloc.0
-		IL_0114: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
-		IL_0119: stloc.s 5
-		IL_011b: ldloc.0
-		IL_011c: castclass Modules.FS_Open_Callback_FileHandle/Scope
-		IL_0121: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21::__js_call__(class Modules.FS_Open_Callback_FileHandle/Scope, object, object, object)
-		IL_0127: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_012c: ldc.i4.1
-		IL_012d: newarr [System.Runtime]System.Object
-		IL_0132: dup
-		IL_0133: ldc.i4.0
-		IL_0134: ldloc.0
-		IL_0135: stelem.ref
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0140: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_0145: ldc.i4.2
-		IL_0146: conv.r8
-		IL_0147: ldstr ""
-		IL_014c: ldc.i4.0
-		IL_014d: ldc.i4.0
-		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_0158: stloc.s 9
-		IL_015a: ldloc.s 4
-		IL_015c: ldloc.s 5
-		IL_015e: ldstr "w+"
-		IL_0163: ldloc.s 9
-		IL_0165: castclass [System.Runtime]System.Delegate
-		IL_016a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::open(object, object, class [System.Runtime]System.Delegate)
-		IL_016f: ret
+		IL_00d4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
+		IL_00d9: stloc.s 4
+		IL_00db: ldloc.0
+		IL_00dc: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+		IL_00e1: stloc.s 5
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e8: dup
+		IL_00e9: ldstr "force"
+		IL_00ee: ldc.i4.1
+		IL_00ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00f4: stloc.s 8
+		IL_00f6: ldloc.s 4
+		IL_00f8: ldloc.s 5
+		IL_00fa: ldloc.s 8
+		IL_00fc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+		IL_0101: ldloc.0
+		IL_0102: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FS_Open_Callback_FileHandle/Scope::fs
+		IL_0107: stloc.s 4
+		IL_0109: ldloc.0
+		IL_010a: ldfld object Modules.FS_Open_Callback_FileHandle/Scope::file
+		IL_010f: stloc.s 5
+		IL_0111: ldloc.0
+		IL_0112: castclass Modules.FS_Open_Callback_FileHandle/Scope
+		IL_0117: ldftn object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21::__js_call__(class Modules.FS_Open_Callback_FileHandle/Scope, object, object, object)
+		IL_011d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0122: ldc.i4.1
+		IL_0123: newarr [System.Runtime]System.Object
+		IL_0128: dup
+		IL_0129: ldc.i4.0
+		IL_012a: ldloc.0
+		IL_012b: stelem.ref
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0136: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_013b: ldc.i4.2
+		IL_013c: conv.r8
+		IL_013d: ldstr ""
+		IL_0142: ldc.i4.0
+		IL_0143: ldc.i4.0
+		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0149: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_014e: stloc.s 9
+		IL_0150: ldloc.s 4
+		IL_0152: ldloc.s 5
+		IL_0154: ldstr "w+"
+		IL_0159: ldloc.s 9
+		IL_015b: castclass [System.Runtime]System.Delegate
+		IL_0160: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::open(object, object, class [System.Runtime]System.Delegate)
+		IL_0165: ret
 	} // end of method FS_Open_Callback_FileHandle::__js_module_init__
 
 } // end of class Modules.FS_Open_Callback_FileHandle
@@ -731,7 +725,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x254e
+		// Method begins at RVA 0x2531
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2818
+				// Method begins at RVA 0x2800
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x21a8
 			// Header size: 12
 			// Code size: 98 (0x62)
 			.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2821
+				// Method begins at RVA 0x2809
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -131,7 +131,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x2218
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -175,7 +175,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x283c
+						// Method begins at RVA 0x2824
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -200,7 +200,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x244c
+					// Method begins at RVA 0x2438
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -250,7 +250,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x2857
+								// Method begins at RVA 0x283f
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -275,7 +275,7 @@
 							.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 								01 00 02 00 00 00 00 00
 							)
-							// Method begins at RVA 0x26d8
+							// Method begins at RVA 0x26c0
 							// Header size: 12
 							// Code size: 38 (0x26)
 							.maxstack 8
@@ -321,7 +321,7 @@
 								.method public hidebysig specialname rtspecialname 
 									instance void .ctor () cil managed 
 								{
-									// Method begins at RVA 0x2869
+									// Method begins at RVA 0x2851
 									// Header size: 1
 									// Code size: 8 (0x8)
 									.maxstack 8
@@ -344,7 +344,7 @@
 								.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 									01 00 00 00 00 00 00 00
 								)
-								// Method begins at RVA 0x27ed
+								// Method begins at RVA 0x27d5
 								// Header size: 1
 								// Code size: 33 (0x21)
 								.maxstack 8
@@ -369,7 +369,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x2860
+								// Method begins at RVA 0x2848
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -393,7 +393,7 @@
 							.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 								01 00 02 00 00 00 00 00
 							)
-							// Method begins at RVA 0x270c
+							// Method begins at RVA 0x26f4
 							// Header size: 12
 							// Code size: 213 (0xd5)
 							.maxstack 8
@@ -497,7 +497,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x284e
+							// Method begins at RVA 0x2836
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -522,7 +522,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x25a8
+						// Method begins at RVA 0x2590
 						// Header size: 12
 						// Code size: 290 (0x122)
 						.maxstack 8
@@ -678,7 +678,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2845
+						// Method begins at RVA 0x282d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -702,9 +702,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2480
+					// Method begins at RVA 0x246c
 					// Header size: 12
-					// Code size: 283 (0x11b)
+					// Code size: 278 (0x116)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope,
@@ -742,91 +742,90 @@
 					IL_003e: ldc.i4.0
 					IL_003f: ldelem.ref
 					IL_0040: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-					IL_0045: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-					IL_004a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-					IL_004f: stloc.s 4
-					IL_0051: ldarg.0
-					IL_0052: ldc.i4.1
-					IL_0053: ldelem.ref
-					IL_0054: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-					IL_0059: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-					IL_005e: ldstr "address"
-					IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0068: stloc.1
-					IL_0069: ldarg.0
-					IL_006a: ldc.i4.1
-					IL_006b: ldelem.ref
-					IL_006c: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-					IL_0071: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-					IL_0076: ldstr "port"
-					IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0080: stloc.2
-					IL_0081: ldarg.0
-					IL_0082: ldc.i4.0
-					IL_0083: ldelem.ref
-					IL_0084: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-					IL_0089: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-					IL_008e: stloc.s 5
-					IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-					IL_0095: dup
-					IL_0096: ldstr "host"
-					IL_009b: ldloc.1
-					IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00a1: dup
-					IL_00a2: ldstr "port"
-					IL_00a7: ldloc.2
-					IL_00a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00ad: dup
-					IL_00ae: ldstr "path"
-					IL_00b3: ldstr "/two"
-					IL_00b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00bd: dup
-					IL_00be: ldstr "agent"
-					IL_00c3: ldloc.s 5
-					IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-					IL_00ca: stloc.s 6
-					IL_00cc: ldc.i4.4
-					IL_00cd: newarr [System.Runtime]System.Object
-					IL_00d2: dup
-					IL_00d3: ldc.i4.0
-					IL_00d4: ldarg.0
-					IL_00d5: ldc.i4.0
-					IL_00d6: ldelem.ref
-					IL_00d7: stelem.ref
-					IL_00d8: dup
-					IL_00d9: ldc.i4.1
-					IL_00da: ldarg.0
-					IL_00db: ldc.i4.1
-					IL_00dc: ldelem.ref
-					IL_00dd: stelem.ref
-					IL_00de: dup
-					IL_00df: ldc.i4.2
-					IL_00e0: ldarg.0
-					IL_00e1: ldc.i4.2
-					IL_00e2: ldelem.ref
-					IL_00e3: stelem.ref
-					IL_00e4: dup
-					IL_00e5: ldc.i4.3
-					IL_00e6: ldloc.0
-					IL_00e7: stelem.ref
-					IL_00e8: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
-					IL_00ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_00f3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-					IL_00f8: ldc.i4.1
-					IL_00f9: conv.r8
-					IL_00fa: ldstr ""
-					IL_00ff: ldc.i4.0
-					IL_0100: ldc.i4.1
-					IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-					IL_0106: stloc.s 7
-					IL_0108: ldloc.s 4
-					IL_010a: ldloc.s 6
-					IL_010c: ldloc.s 7
-					IL_010e: castclass [System.Runtime]System.Delegate
-					IL_0113: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
-					IL_0118: pop
-					IL_0119: ldnull
-					IL_011a: ret
+					IL_0045: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+					IL_004a: stloc.s 4
+					IL_004c: ldarg.0
+					IL_004d: ldc.i4.1
+					IL_004e: ldelem.ref
+					IL_004f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+					IL_0054: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+					IL_0059: ldstr "address"
+					IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0063: stloc.1
+					IL_0064: ldarg.0
+					IL_0065: ldc.i4.1
+					IL_0066: ldelem.ref
+					IL_0067: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+					IL_006c: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+					IL_0071: ldstr "port"
+					IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_007b: stloc.2
+					IL_007c: ldarg.0
+					IL_007d: ldc.i4.0
+					IL_007e: ldelem.ref
+					IL_007f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+					IL_0084: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+					IL_0089: stloc.s 5
+					IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+					IL_0090: dup
+					IL_0091: ldstr "host"
+					IL_0096: ldloc.1
+					IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_009c: dup
+					IL_009d: ldstr "port"
+					IL_00a2: ldloc.2
+					IL_00a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_00a8: dup
+					IL_00a9: ldstr "path"
+					IL_00ae: ldstr "/two"
+					IL_00b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_00b8: dup
+					IL_00b9: ldstr "agent"
+					IL_00be: ldloc.s 5
+					IL_00c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+					IL_00c5: stloc.s 6
+					IL_00c7: ldc.i4.4
+					IL_00c8: newarr [System.Runtime]System.Object
+					IL_00cd: dup
+					IL_00ce: ldc.i4.0
+					IL_00cf: ldarg.0
+					IL_00d0: ldc.i4.0
+					IL_00d1: ldelem.ref
+					IL_00d2: stelem.ref
+					IL_00d3: dup
+					IL_00d4: ldc.i4.1
+					IL_00d5: ldarg.0
+					IL_00d6: ldc.i4.1
+					IL_00d7: ldelem.ref
+					IL_00d8: stelem.ref
+					IL_00d9: dup
+					IL_00da: ldc.i4.2
+					IL_00db: ldarg.0
+					IL_00dc: ldc.i4.2
+					IL_00dd: ldelem.ref
+					IL_00de: stelem.ref
+					IL_00df: dup
+					IL_00e0: ldc.i4.3
+					IL_00e1: ldloc.0
+					IL_00e2: stelem.ref
+					IL_00e3: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
+					IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+					IL_00ee: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+					IL_00f3: ldc.i4.1
+					IL_00f4: conv.r8
+					IL_00f5: ldstr ""
+					IL_00fa: ldc.i4.0
+					IL_00fb: ldc.i4.1
+					IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+					IL_0101: stloc.s 7
+					IL_0103: ldloc.s 4
+					IL_0105: ldloc.s 6
+					IL_0107: ldloc.s 7
+					IL_0109: castclass [System.Runtime]System.Delegate
+					IL_010e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
+					IL_0113: pop
+					IL_0114: ldnull
+					IL_0115: ret
 				} // end of method FunctionExpression_L38C20::__js_call__
 
 			} // end of class FunctionExpression_L38C20
@@ -845,7 +844,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2833
+					// Method begins at RVA 0x281b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -870,7 +869,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2334
+				// Method begins at RVA 0x2320
 				// Header size: 12
 				// Code size: 266 (0x10a)
 				.maxstack 8
@@ -1009,7 +1008,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x282a
+				// Method begins at RVA 0x2812
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1035,9 +1034,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2250
+			// Method begins at RVA 0x2244
 			// Header size: 12
-			// Code size: 213 (0xd5)
+			// Code size: 208 (0xd0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope,
@@ -1061,68 +1060,67 @@
 			IL_001d: ldloc.1
 			IL_001e: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
 			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-			IL_0029: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-			IL_002e: stloc.2
-			IL_002f: ldloc.0
-			IL_0030: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_0035: ldstr "address"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.1
-			IL_0040: ldloc.0
-			IL_0041: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
-			IL_0046: ldstr "port"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: stloc.3
-			IL_0051: ldarg.0
-			IL_0052: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-			IL_0057: stloc.s 4
-			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005e: dup
-			IL_005f: ldstr "host"
-			IL_0064: ldloc.1
-			IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006a: dup
-			IL_006b: ldstr "port"
-			IL_0070: ldloc.3
-			IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0076: dup
-			IL_0077: ldstr "path"
-			IL_007c: ldstr "/one"
-			IL_0081: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0086: dup
-			IL_0087: ldstr "agent"
-			IL_008c: ldloc.s 4
-			IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0093: stloc.s 5
-			IL_0095: ldc.i4.2
-			IL_0096: newarr [System.Runtime]System.Object
-			IL_009b: dup
-			IL_009c: ldc.i4.0
-			IL_009d: ldarg.0
-			IL_009e: stelem.ref
-			IL_009f: dup
-			IL_00a0: ldc.i4.1
-			IL_00a1: ldloc.0
-			IL_00a2: stelem.ref
-			IL_00a3: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
-			IL_00a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ae: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00b3: ldc.i4.1
-			IL_00b4: conv.r8
-			IL_00b5: ldstr ""
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldc.i4.1
-			IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00c1: stloc.s 6
-			IL_00c3: ldloc.2
-			IL_00c4: ldloc.s 5
-			IL_00c6: ldloc.s 6
-			IL_00c8: castclass [System.Runtime]System.Delegate
-			IL_00cd: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
-			IL_00d2: pop
-			IL_00d3: ldnull
-			IL_00d4: ret
+			IL_0024: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+			IL_0029: stloc.2
+			IL_002a: ldloc.0
+			IL_002b: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_0030: ldstr "address"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003a: stloc.1
+			IL_003b: ldloc.0
+			IL_003c: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
+			IL_0041: ldstr "port"
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004b: stloc.3
+			IL_004c: ldarg.0
+			IL_004d: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+			IL_0052: stloc.s 4
+			IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0059: dup
+			IL_005a: ldstr "host"
+			IL_005f: ldloc.1
+			IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0065: dup
+			IL_0066: ldstr "port"
+			IL_006b: ldloc.3
+			IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0071: dup
+			IL_0072: ldstr "path"
+			IL_0077: ldstr "/one"
+			IL_007c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0081: dup
+			IL_0082: ldstr "agent"
+			IL_0087: ldloc.s 4
+			IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_008e: stloc.s 5
+			IL_0090: ldc.i4.2
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: stelem.ref
+			IL_009a: dup
+			IL_009b: ldc.i4.1
+			IL_009c: ldloc.0
+			IL_009d: stelem.ref
+			IL_009e: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
+			IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00a9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00ae: ldc.i4.1
+			IL_00af: conv.r8
+			IL_00b0: ldstr ""
+			IL_00b5: ldc.i4.0
+			IL_00b6: ldc.i4.1
+			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00bc: stloc.s 6
+			IL_00be: ldloc.2
+			IL_00bf: ldloc.s 5
+			IL_00c1: ldloc.s 6
+			IL_00c3: castclass [System.Runtime]System.Delegate
+			IL_00c8: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
+			IL_00cd: pop
+			IL_00ce: ldnull
+			IL_00cf: ret
 		} // end of method FunctionExpression_L19C30::__js_call__
 
 	} // end of class FunctionExpression_L19C30
@@ -1140,7 +1138,7 @@
 			65 72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
 		.field public object agent
 		.field public object connections
 		.field public object responses
@@ -1150,7 +1148,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x280f
+			// Method begins at RVA 0x27f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1176,7 +1174,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 342 (0x156)
+		// Code size: 332 (0x14c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope,
@@ -1195,108 +1193,106 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.1
-		IL_0027: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get_Agent()
-		IL_002c: stloc.2
-		IL_002d: ldloc.2
-		IL_002e: ldc.i4.1
-		IL_002f: newarr [System.Runtime]System.Object
-		IL_0034: dup
-		IL_0035: ldc.i4.0
-		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_003b: dup
-		IL_003c: ldstr "keepAlive"
-		IL_0041: ldc.i4.1
-		IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0047: stelem.ref
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-		IL_004d: stloc.2
-		IL_004e: ldloc.0
-		IL_004f: ldloc.2
-		IL_0050: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
-		IL_0055: ldloc.0
-		IL_0056: ldc.r8 0.0
-		IL_005f: box [System.Runtime]System.Double
-		IL_0064: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
-		IL_0069: ldloc.0
-		IL_006a: ldc.r8 0.0
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
-		IL_007d: ldloc.0
-		IL_007e: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
-		IL_0083: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-		IL_0088: stloc.1
-		IL_0089: ldloc.0
-		IL_008a: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_008f: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
-		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_009a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_009f: ldc.i4.2
-		IL_00a0: conv.r8
-		IL_00a1: ldstr ""
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldc.i4.1
-		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_00ad: stloc.3
-		IL_00ae: ldloc.1
-		IL_00af: ldloc.3
-		IL_00b0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
-		IL_00b5: stloc.2
-		IL_00b6: ldloc.0
-		IL_00b7: ldloc.2
-		IL_00b8: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-		IL_00bd: ldloc.0
-		IL_00be: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c8: stloc.2
-		IL_00c9: ldloc.0
-		IL_00ca: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_00cf: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_00d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00da: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_00df: ldc.i4.0
-		IL_00e0: conv.r8
-		IL_00e1: ldstr ""
-		IL_00e6: ldc.i4.0
-		IL_00e7: ldc.i4.1
-		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_00ed: stloc.s 4
-		IL_00ef: ldloc.2
-		IL_00f0: ldstr "on"
-		IL_00f5: ldstr "connection"
-		IL_00fa: ldloc.s 4
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0101: pop
-		IL_0102: ldloc.0
-		IL_0103: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010d: stloc.2
-		IL_010e: ldloc.0
-		IL_010f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_0114: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_011a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_011f: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0124: ldc.i4.0
-		IL_0125: conv.r8
-		IL_0126: ldstr ""
-		IL_012b: ldc.i4.0
-		IL_012c: ldc.i4.1
-		IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0132: stloc.s 4
-		IL_0134: ldloc.2
-		IL_0135: ldstr "listen"
-		IL_013a: ldc.r8 0.0
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: ldstr "127.0.0.1"
-		IL_014d: ldloc.s 4
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0154: pop
-		IL_0155: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+		IL_0020: stloc.1
+		IL_0021: ldloc.1
+		IL_0022: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get_Agent()
+		IL_0027: stloc.2
+		IL_0028: ldloc.2
+		IL_0029: ldc.i4.1
+		IL_002a: newarr [System.Runtime]System.Object
+		IL_002f: dup
+		IL_0030: ldc.i4.0
+		IL_0031: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0036: dup
+		IL_0037: ldstr "keepAlive"
+		IL_003c: ldc.i4.1
+		IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0042: stelem.ref
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+		IL_0048: stloc.2
+		IL_0049: ldloc.0
+		IL_004a: ldloc.2
+		IL_004b: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
+		IL_0050: ldloc.0
+		IL_0051: ldc.r8 0.0
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::connections
+		IL_0064: ldloc.0
+		IL_0065: ldc.r8 0.0
+		IL_006e: box [System.Runtime]System.Double
+		IL_0073: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::responses
+		IL_0078: ldloc.0
+		IL_0079: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::http
+		IL_007e: stloc.1
+		IL_007f: ldloc.0
+		IL_0080: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+		IL_0085: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
+		IL_008b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0090: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0095: ldc.i4.2
+		IL_0096: conv.r8
+		IL_0097: ldstr ""
+		IL_009c: ldc.i4.0
+		IL_009d: ldc.i4.1
+		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_00a3: stloc.3
+		IL_00a4: ldloc.1
+		IL_00a5: ldloc.3
+		IL_00a6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
+		IL_00ab: stloc.2
+		IL_00ac: ldloc.0
+		IL_00ad: ldloc.2
+		IL_00ae: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+		IL_00b3: ldloc.0
+		IL_00b4: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00be: stloc.2
+		IL_00bf: ldloc.0
+		IL_00c0: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+		IL_00c5: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+		IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00d0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00d5: ldc.i4.0
+		IL_00d6: conv.r8
+		IL_00d7: ldstr ""
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldc.i4.1
+		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_00e3: stloc.s 4
+		IL_00e5: ldloc.2
+		IL_00e6: ldstr "on"
+		IL_00eb: ldstr "connection"
+		IL_00f0: ldloc.s 4
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00f7: pop
+		IL_00f8: ldloc.0
+		IL_00f9: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0103: stloc.2
+		IL_0104: ldloc.0
+		IL_0105: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+		IL_010a: ldftn object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+		IL_0110: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0115: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_011a: ldc.i4.0
+		IL_011b: conv.r8
+		IL_011c: ldstr ""
+		IL_0121: ldc.i4.0
+		IL_0122: ldc.i4.1
+		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0128: stloc.s 4
+		IL_012a: ldloc.2
+		IL_012b: ldstr "listen"
+		IL_0130: ldc.r8 0.0
+		IL_0139: box [System.Runtime]System.Double
+		IL_013e: ldstr "127.0.0.1"
+		IL_0143: ldloc.s 4
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_014a: pop
+		IL_014b: ret
 	} // end of method Http_Agent_KeepAlive_Reuses_Connection::__js_module_init__
 
 } // end of class Modules.Http_Agent_KeepAlive_Reuses_Connection
@@ -1308,7 +1304,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2872
+		// Method begins at RVA 0x285a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c8
+				// Method begins at RVA 0x25b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2108
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 318 (0x13e)
 			.maxstack 8
@@ -178,7 +178,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25e3
+						// Method begins at RVA 0x25d3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -203,7 +203,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24dc
+					// Method begins at RVA 0x24cc
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -249,7 +249,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x25f5
+							// Method begins at RVA 0x25e5
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -272,7 +272,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x259d
+						// Method begins at RVA 0x258d
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -297,7 +297,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25ec
+						// Method begins at RVA 0x25dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -321,7 +321,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2510
+					// Method begins at RVA 0x2500
 					// Header size: 12
 					// Code size: 129 (0x81)
 					.maxstack 8
@@ -397,7 +397,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25da
+					// Method begins at RVA 0x25ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -422,7 +422,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2390
+				// Method begins at RVA 0x2380
 				// Header size: 12
 				// Code size: 319 (0x13f)
 				.maxstack 8
@@ -571,7 +571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d1
+				// Method begins at RVA 0x25c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,9 +597,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2254
+			// Method begins at RVA 0x224c
 			// Header size: 12
-			// Code size: 301 (0x12d)
+			// Code size: 296 (0x128)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/Scope,
@@ -659,61 +659,60 @@
 			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0093: pop
 			IL_0094: ldarg.0
-			IL_0095: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-			IL_009a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-			IL_009f: stloc.s 7
-			IL_00a1: ldloc.1
-			IL_00a2: ldstr "address"
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ac: stloc.2
-			IL_00ad: ldstr "http://"
-			IL_00b2: ldloc.2
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00b8: stloc.s 4
-			IL_00ba: ldloc.s 4
-			IL_00bc: ldstr ":"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00c6: stloc.s 4
-			IL_00c8: ldloc.1
-			IL_00c9: ldstr "port"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d3: stloc.2
-			IL_00d4: ldloc.s 4
-			IL_00d6: ldloc.2
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00dc: stloc.s 4
-			IL_00de: ldloc.s 4
-			IL_00e0: ldstr "/hello?name=jroc"
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ea: stloc.s 4
-			IL_00ec: ldc.i4.2
-			IL_00ed: newarr [System.Runtime]System.Object
-			IL_00f2: dup
-			IL_00f3: ldc.i4.0
-			IL_00f4: ldarg.0
-			IL_00f5: stelem.ref
-			IL_00f6: dup
-			IL_00f7: ldc.i4.1
-			IL_00f8: ldloc.0
-			IL_00f9: stelem.ref
-			IL_00fa: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
-			IL_0100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0105: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_010a: ldc.i4.1
-			IL_010b: conv.r8
-			IL_010c: ldstr ""
-			IL_0111: ldc.i4.0
-			IL_0112: ldc.i4.1
-			IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_0118: stloc.s 8
-			IL_011a: ldloc.s 7
-			IL_011c: ldloc.s 4
-			IL_011e: ldloc.s 8
-			IL_0120: castclass [System.Runtime]System.Delegate
-			IL_0125: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
-			IL_012a: pop
-			IL_012b: ldnull
-			IL_012c: ret
+			IL_0095: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_CreateServer_Get_Loopback/Scope::http
+			IL_009a: stloc.s 7
+			IL_009c: ldloc.1
+			IL_009d: ldstr "address"
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a7: stloc.2
+			IL_00a8: ldstr "http://"
+			IL_00ad: ldloc.2
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b3: stloc.s 4
+			IL_00b5: ldloc.s 4
+			IL_00b7: ldstr ":"
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c1: stloc.s 4
+			IL_00c3: ldloc.1
+			IL_00c4: ldstr "port"
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ce: stloc.2
+			IL_00cf: ldloc.s 4
+			IL_00d1: ldloc.2
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d7: stloc.s 4
+			IL_00d9: ldloc.s 4
+			IL_00db: ldstr "/hello?name=jroc"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00e5: stloc.s 4
+			IL_00e7: ldc.i4.2
+			IL_00e8: newarr [System.Runtime]System.Object
+			IL_00ed: dup
+			IL_00ee: ldc.i4.0
+			IL_00ef: ldarg.0
+			IL_00f0: stelem.ref
+			IL_00f1: dup
+			IL_00f2: ldc.i4.1
+			IL_00f3: ldloc.0
+			IL_00f4: stelem.ref
+			IL_00f5: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
+			IL_00fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0100: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0105: ldc.i4.1
+			IL_0106: conv.r8
+			IL_0107: ldstr ""
+			IL_010c: ldc.i4.0
+			IL_010d: ldc.i4.1
+			IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0113: stloc.s 8
+			IL_0115: ldloc.s 7
+			IL_0117: ldloc.s 4
+			IL_0119: ldloc.s 8
+			IL_011b: castclass [System.Runtime]System.Delegate
+			IL_0120: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
+			IL_0125: pop
+			IL_0126: ldnull
+			IL_0127: ret
 		} // end of method FunctionExpression_L15C30::__js_call__
 
 	} // end of class FunctionExpression_L15C30
@@ -727,14 +726,14 @@
 			72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25bf
+			// Method begins at RVA 0x25af
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -760,7 +759,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 169 (0xa9)
+		// Code size: 164 (0xa4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_CreateServer_Get_Loopback/Scope,
@@ -779,54 +778,53 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_CreateServer_Get_Loopback/Scope::http
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::http
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-		IL_0025: stloc.1
-		IL_0026: ldnull
-		IL_0027: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
-		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_0037: ldc.i4.2
-		IL_0038: conv.r8
-		IL_0039: ldstr ""
-		IL_003e: ldc.i4.0
-		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0045: stloc.2
-		IL_0046: ldloc.1
-		IL_0047: ldloc.2
-		IL_0048: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.0
-		IL_004f: ldloc.3
-		IL_0050: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-		IL_0055: ldloc.0
-		IL_0056: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0060: stloc.3
-		IL_0061: ldloc.0
-		IL_0062: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-		IL_0067: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
-		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0072: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0077: ldc.i4.0
-		IL_0078: conv.r8
-		IL_0079: ldstr ""
-		IL_007e: ldc.i4.0
-		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0085: stloc.s 4
-		IL_0087: ldloc.3
-		IL_0088: ldstr "listen"
-		IL_008d: ldc.r8 0.0
-		IL_0096: box [System.Runtime]System.Double
-		IL_009b: ldstr "127.0.0.1"
-		IL_00a0: ldloc.s 4
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00a7: pop
-		IL_00a8: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_CreateServer_Get_Loopback/Scope::http
+		IL_0020: stloc.1
+		IL_0021: ldnull
+		IL_0022: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
+		IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_002d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0032: ldc.i4.2
+		IL_0033: conv.r8
+		IL_0034: ldstr ""
+		IL_0039: ldc.i4.0
+		IL_003a: ldc.i4.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0040: stloc.2
+		IL_0041: ldloc.1
+		IL_0042: ldloc.2
+		IL_0043: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
+		IL_0048: stloc.3
+		IL_0049: ldloc.0
+		IL_004a: ldloc.3
+		IL_004b: stfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
+		IL_0050: ldloc.0
+		IL_0051: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005b: stloc.3
+		IL_005c: ldloc.0
+		IL_005d: castclass Modules.Http_CreateServer_Get_Loopback/Scope
+		IL_0062: ldftn object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
+		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0072: ldc.i4.0
+		IL_0073: conv.r8
+		IL_0074: ldstr ""
+		IL_0079: ldc.i4.0
+		IL_007a: ldc.i4.1
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "listen"
+		IL_0088: ldc.r8 0.0
+		IL_0091: box [System.Runtime]System.Double
+		IL_0096: ldstr "127.0.0.1"
+		IL_009b: ldloc.s 4
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00a2: pop
+		IL_00a3: ret
 	} // end of method Http_CreateServer_Get_Loopback::__js_module_init__
 
 } // end of class Modules.Http_CreateServer_Get_Loopback
@@ -838,7 +836,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25fe
+		// Method begins at RVA 0x25ee
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27a5
+					// Method begins at RVA 0x279d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x230c
+				// Method begins at RVA 0x2304
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -89,7 +89,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27ae
+					// Method begins at RVA 0x27a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -113,7 +113,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2340
+				// Method begins at RVA 0x2338
 				// Header size: 12
 				// Code size: 472 (0x1d8)
 				.maxstack 8
@@ -300,7 +300,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x279c
+				// Method begins at RVA 0x2794
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -328,7 +328,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 210 (0xd2)
 			.maxstack 8
@@ -442,7 +442,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27c9
+						// Method begins at RVA 0x27c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -467,7 +467,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x26b0
+					// Method begins at RVA 0x26a8
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -513,7 +513,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x27db
+							// Method begins at RVA 0x27d3
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -536,7 +536,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2771
+						// Method begins at RVA 0x2769
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -561,7 +561,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27d2
+						// Method begins at RVA 0x27ca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -585,7 +585,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x26e4
+					// Method begins at RVA 0x26dc
 					// Header size: 12
 					// Code size: 129 (0x81)
 					.maxstack 8
@@ -662,7 +662,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27c0
+					// Method begins at RVA 0x27b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -687,7 +687,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2524
+				// Method begins at RVA 0x251c
 				// Header size: 12
 				// Code size: 384 (0x180)
 				.maxstack 8
@@ -857,7 +857,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b7
+				// Method begins at RVA 0x27af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -883,9 +883,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x21ec
+			// Method begins at RVA 0x21e8
 			// Header size: 12
-			// Code size: 275 (0x113)
+			// Code size: 270 (0x10e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/Scope,
@@ -907,85 +907,84 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Http_Request_Post_Basic/Scope::http
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-			IL_0027: stloc.3
-			IL_0028: ldloc.1
-			IL_0029: ldstr "address"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0033: stloc.s 4
-			IL_0035: ldloc.1
-			IL_0036: ldstr "port"
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0040: stloc.s 5
-			IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0047: dup
-			IL_0048: ldstr "Content-Type"
-			IL_004d: ldstr "text/plain"
-			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0057: stloc.s 6
-			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005e: dup
-			IL_005f: ldstr "host"
-			IL_0064: ldloc.s 4
-			IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006b: dup
-			IL_006c: ldstr "port"
-			IL_0071: ldloc.s 5
-			IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0078: dup
-			IL_0079: ldstr "path"
-			IL_007e: ldstr "/submit"
-			IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0088: dup
-			IL_0089: ldstr "method"
-			IL_008e: ldstr "POST"
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0098: dup
-			IL_0099: ldstr "headers"
-			IL_009e: ldloc.s 6
-			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a5: stloc.s 6
-			IL_00a7: ldc.i4.2
-			IL_00a8: newarr [System.Runtime]System.Object
-			IL_00ad: dup
-			IL_00ae: ldc.i4.0
-			IL_00af: ldarg.0
-			IL_00b0: stelem.ref
-			IL_00b1: dup
-			IL_00b2: ldc.i4.1
-			IL_00b3: ldloc.0
-			IL_00b4: stelem.ref
-			IL_00b5: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
-			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00c0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00c5: ldc.i4.1
-			IL_00c6: conv.r8
-			IL_00c7: ldstr ""
-			IL_00cc: ldc.i4.0
-			IL_00cd: ldc.i4.1
-			IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00d3: stloc.s 7
-			IL_00d5: ldloc.3
-			IL_00d6: ldloc.s 6
-			IL_00d8: ldloc.s 7
-			IL_00da: castclass [System.Runtime]System.Delegate
-			IL_00df: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::'request'(object, class [System.Runtime]System.Delegate)
-			IL_00e4: stloc.2
-			IL_00e5: ldloc.2
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00eb: ldstr "write"
-			IL_00f0: ldstr "node "
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fa: pop
-			IL_00fb: ldloc.2
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0101: ldstr "end"
-			IL_0106: ldstr "baseline"
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0110: pop
-			IL_0111: ldnull
-			IL_0112: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Post_Basic/Scope::http
+			IL_0022: stloc.3
+			IL_0023: ldloc.1
+			IL_0024: ldstr "address"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002e: stloc.s 4
+			IL_0030: ldloc.1
+			IL_0031: ldstr "port"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: stloc.s 5
+			IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0042: dup
+			IL_0043: ldstr "Content-Type"
+			IL_0048: ldstr "text/plain"
+			IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0052: stloc.s 6
+			IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0059: dup
+			IL_005a: ldstr "host"
+			IL_005f: ldloc.s 4
+			IL_0061: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0066: dup
+			IL_0067: ldstr "port"
+			IL_006c: ldloc.s 5
+			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0073: dup
+			IL_0074: ldstr "path"
+			IL_0079: ldstr "/submit"
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0083: dup
+			IL_0084: ldstr "method"
+			IL_0089: ldstr "POST"
+			IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0093: dup
+			IL_0094: ldstr "headers"
+			IL_0099: ldloc.s 6
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a0: stloc.s 6
+			IL_00a2: ldc.i4.2
+			IL_00a3: newarr [System.Runtime]System.Object
+			IL_00a8: dup
+			IL_00a9: ldc.i4.0
+			IL_00aa: ldarg.0
+			IL_00ab: stelem.ref
+			IL_00ac: dup
+			IL_00ad: ldc.i4.1
+			IL_00ae: ldloc.0
+			IL_00af: stelem.ref
+			IL_00b0: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
+			IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00bb: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00c0: ldc.i4.1
+			IL_00c1: conv.r8
+			IL_00c2: ldstr ""
+			IL_00c7: ldc.i4.0
+			IL_00c8: ldc.i4.1
+			IL_00c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00ce: stloc.s 7
+			IL_00d0: ldloc.3
+			IL_00d1: ldloc.s 6
+			IL_00d3: ldloc.s 7
+			IL_00d5: castclass [System.Runtime]System.Delegate
+			IL_00da: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::'request'(object, class [System.Runtime]System.Delegate)
+			IL_00df: stloc.2
+			IL_00e0: ldloc.2
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e6: ldstr "write"
+			IL_00eb: ldstr "node "
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f5: pop
+			IL_00f6: ldloc.2
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fc: ldstr "end"
+			IL_0101: ldstr "baseline"
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_010b: pop
+			IL_010c: ldnull
+			IL_010d: ret
 		} // end of method FunctionExpression_L28C30::__js_call__
 
 	} // end of class FunctionExpression_L28C30
@@ -999,14 +998,14 @@
 			72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2793
+			// Method begins at RVA 0x278b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1032,7 +1031,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 174 (0xae)
+		// Code size: 169 (0xa9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Post_Basic/Scope,
@@ -1051,55 +1050,54 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Http_Request_Post_Basic/Scope::http
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Post_Basic/Scope::http
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Http_Request_Post_Basic/Scope::http
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.0
-		IL_0027: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_002c: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
-		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_003c: ldc.i4.2
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_004a: stloc.2
-		IL_004b: ldloc.1
-		IL_004c: ldloc.2
-		IL_004d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
-		IL_0052: stloc.3
-		IL_0053: ldloc.0
-		IL_0054: ldloc.3
-		IL_0055: stfld object Modules.Http_Request_Post_Basic/Scope::server
-		IL_005a: ldloc.0
-		IL_005b: ldfld object Modules.Http_Request_Post_Basic/Scope::server
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0065: stloc.3
-		IL_0066: ldloc.0
-		IL_0067: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_006c: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
-		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0077: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_007c: ldc.i4.0
-		IL_007d: conv.r8
-		IL_007e: ldstr ""
-		IL_0083: ldc.i4.0
-		IL_0084: ldc.i4.1
-		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.3
-		IL_008d: ldstr "listen"
-		IL_0092: ldc.r8 0.0
-		IL_009b: box [System.Runtime]System.Double
-		IL_00a0: ldstr "127.0.0.1"
-		IL_00a5: ldloc.s 4
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00ac: pop
-		IL_00ad: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Post_Basic/Scope::http
+		IL_0020: stloc.1
+		IL_0021: ldloc.0
+		IL_0022: castclass Modules.Http_Request_Post_Basic/Scope
+		IL_0027: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0037: ldc.i4.2
+		IL_0038: conv.r8
+		IL_0039: ldstr ""
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldloc.1
+		IL_0047: ldloc.2
+		IL_0048: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
+		IL_004d: stloc.3
+		IL_004e: ldloc.0
+		IL_004f: ldloc.3
+		IL_0050: stfld object Modules.Http_Request_Post_Basic/Scope::server
+		IL_0055: ldloc.0
+		IL_0056: ldfld object Modules.Http_Request_Post_Basic/Scope::server
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0060: stloc.3
+		IL_0061: ldloc.0
+		IL_0062: castclass Modules.Http_Request_Post_Basic/Scope
+		IL_0067: ldftn object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
+		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0072: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr ""
+		IL_007e: ldc.i4.0
+		IL_007f: ldc.i4.1
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0085: stloc.s 4
+		IL_0087: ldloc.3
+		IL_0088: ldstr "listen"
+		IL_008d: ldc.r8 0.0
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: ldstr "127.0.0.1"
+		IL_00a0: ldloc.s 4
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00a7: pop
+		IL_00a8: ret
 	} // end of method Http_Request_Post_Basic::__js_module_init__
 
 } // end of class Modules.Http_Request_Post_Basic
@@ -1111,7 +1109,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27e4
+		// Method begins at RVA 0x27dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2665
+					// Method begins at RVA 0x265d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2350
+				// Method begins at RVA 0x2348
 				// Header size: 12
 				// Code size: 157 (0x9d)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x266e
+					// Method begins at RVA 0x2666
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -157,7 +157,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23fc
+				// Method begins at RVA 0x23f4
 				// Header size: 12
 				// Code size: 146 (0x92)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x265c
+				// Method begins at RVA 0x2654
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -267,7 +267,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 277 (0x115)
 			.maxstack 8
@@ -402,7 +402,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2689
+						// Method begins at RVA 0x2681
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -427,7 +427,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2570
+					// Method begins at RVA 0x2568
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -473,7 +473,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x269b
+							// Method begins at RVA 0x2693
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -496,7 +496,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2631
+						// Method begins at RVA 0x2629
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -521,7 +521,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2692
+						// Method begins at RVA 0x268a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -545,7 +545,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25a4
+					// Method begins at RVA 0x259c
 					// Header size: 12
 					// Code size: 129 (0x81)
 					.maxstack 8
@@ -622,7 +622,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2680
+					// Method begins at RVA 0x2678
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -647,7 +647,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x249c
+				// Method begins at RVA 0x2494
 				// Header size: 12
 				// Code size: 197 (0xc5)
 				.maxstack 8
@@ -756,7 +756,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2677
+				// Method begins at RVA 0x266f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -782,9 +782,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x222c
 			// Header size: 12
-			// Code size: 275 (0x113)
+			// Code size: 270 (0x10e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/Scope,
@@ -806,85 +806,84 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-			IL_0027: stloc.3
-			IL_0028: ldloc.1
-			IL_0029: ldstr "address"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0033: stloc.s 4
-			IL_0035: ldloc.1
-			IL_0036: ldstr "port"
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0040: stloc.s 5
-			IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0047: dup
-			IL_0048: ldstr "Content-Type"
-			IL_004d: ldstr "text/plain"
-			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0057: stloc.s 6
-			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005e: dup
-			IL_005f: ldstr "host"
-			IL_0064: ldloc.s 4
-			IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006b: dup
-			IL_006c: ldstr "port"
-			IL_0071: ldloc.s 5
-			IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0078: dup
-			IL_0079: ldstr "path"
-			IL_007e: ldstr "/stream"
-			IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0088: dup
-			IL_0089: ldstr "method"
-			IL_008e: ldstr "POST"
-			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0098: dup
-			IL_0099: ldstr "headers"
-			IL_009e: ldloc.s 6
-			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a5: stloc.s 6
-			IL_00a7: ldc.i4.2
-			IL_00a8: newarr [System.Runtime]System.Object
-			IL_00ad: dup
-			IL_00ae: ldc.i4.0
-			IL_00af: ldarg.0
-			IL_00b0: stelem.ref
-			IL_00b1: dup
-			IL_00b2: ldc.i4.1
-			IL_00b3: ldloc.0
-			IL_00b4: stelem.ref
-			IL_00b5: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
-			IL_00bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00c0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00c5: ldc.i4.1
-			IL_00c6: conv.r8
-			IL_00c7: ldstr ""
-			IL_00cc: ldc.i4.0
-			IL_00cd: ldc.i4.1
-			IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00d3: stloc.s 7
-			IL_00d5: ldloc.3
-			IL_00d6: ldloc.s 6
-			IL_00d8: ldloc.s 7
-			IL_00da: castclass [System.Runtime]System.Delegate
-			IL_00df: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::'request'(object, class [System.Runtime]System.Delegate)
-			IL_00e4: stloc.2
-			IL_00e5: ldloc.2
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00eb: ldstr "write"
-			IL_00f0: ldstr "alpha"
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fa: pop
-			IL_00fb: ldloc.2
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0101: ldstr "end"
-			IL_0106: ldstr "beta"
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0110: pop
-			IL_0111: ldnull
-			IL_0112: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
+			IL_0022: stloc.3
+			IL_0023: ldloc.1
+			IL_0024: ldstr "address"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002e: stloc.s 4
+			IL_0030: ldloc.1
+			IL_0031: ldstr "port"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: stloc.s 5
+			IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0042: dup
+			IL_0043: ldstr "Content-Type"
+			IL_0048: ldstr "text/plain"
+			IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0052: stloc.s 6
+			IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0059: dup
+			IL_005a: ldstr "host"
+			IL_005f: ldloc.s 4
+			IL_0061: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0066: dup
+			IL_0067: ldstr "port"
+			IL_006c: ldloc.s 5
+			IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0073: dup
+			IL_0074: ldstr "path"
+			IL_0079: ldstr "/stream"
+			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0083: dup
+			IL_0084: ldstr "method"
+			IL_0089: ldstr "POST"
+			IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0093: dup
+			IL_0094: ldstr "headers"
+			IL_0099: ldloc.s 6
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00a0: stloc.s 6
+			IL_00a2: ldc.i4.2
+			IL_00a3: newarr [System.Runtime]System.Object
+			IL_00a8: dup
+			IL_00a9: ldc.i4.0
+			IL_00aa: ldarg.0
+			IL_00ab: stelem.ref
+			IL_00ac: dup
+			IL_00ad: ldc.i4.1
+			IL_00ae: ldloc.0
+			IL_00af: stelem.ref
+			IL_00b0: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
+			IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00bb: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00c0: ldc.i4.1
+			IL_00c1: conv.r8
+			IL_00c2: ldstr ""
+			IL_00c7: ldc.i4.0
+			IL_00c8: ldc.i4.1
+			IL_00c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00ce: stloc.s 7
+			IL_00d0: ldloc.3
+			IL_00d1: ldloc.s 6
+			IL_00d3: ldloc.s 7
+			IL_00d5: castclass [System.Runtime]System.Delegate
+			IL_00da: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::'request'(object, class [System.Runtime]System.Delegate)
+			IL_00df: stloc.2
+			IL_00e0: ldloc.2
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e6: ldstr "write"
+			IL_00eb: ldstr "alpha"
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f5: pop
+			IL_00f6: ldloc.2
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fc: ldstr "end"
+			IL_0101: ldstr "beta"
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_010b: pop
+			IL_010c: ldnull
+			IL_010d: ret
 		} // end of method FunctionExpression_L26C30::__js_call__
 
 	} // end of class FunctionExpression_L26C30
@@ -898,14 +897,14 @@
 			72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2653
+			// Method begins at RVA 0x264b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -931,7 +930,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 174 (0xae)
+		// Code size: 169 (0xa9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope,
@@ -950,55 +949,54 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.0
-		IL_0027: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_002c: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
-		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_003c: ldc.i4.2
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_004a: stloc.2
-		IL_004b: ldloc.1
-		IL_004c: ldloc.2
-		IL_004d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
-		IL_0052: stloc.3
-		IL_0053: ldloc.0
-		IL_0054: ldloc.3
-		IL_0055: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-		IL_005a: ldloc.0
-		IL_005b: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0065: stloc.3
-		IL_0066: ldloc.0
-		IL_0067: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_006c: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
-		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0077: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_007c: ldc.i4.0
-		IL_007d: conv.r8
-		IL_007e: ldstr ""
-		IL_0083: ldc.i4.0
-		IL_0084: ldc.i4.1
-		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.3
-		IL_008d: ldstr "listen"
-		IL_0092: ldc.r8 0.0
-		IL_009b: box [System.Runtime]System.Double
-		IL_00a0: ldstr "127.0.0.1"
-		IL_00a5: ldloc.s 4
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00ac: pop
-		IL_00ad: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
+		IL_0020: stloc.1
+		IL_0021: ldloc.0
+		IL_0022: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+		IL_0027: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0037: ldc.i4.2
+		IL_0038: conv.r8
+		IL_0039: ldstr ""
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldloc.1
+		IL_0047: ldloc.2
+		IL_0048: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
+		IL_004d: stloc.3
+		IL_004e: ldloc.0
+		IL_004f: ldloc.3
+		IL_0050: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
+		IL_0055: ldloc.0
+		IL_0056: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0060: stloc.3
+		IL_0061: ldloc.0
+		IL_0062: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+		IL_0067: ldftn object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
+		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0072: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr ""
+		IL_007e: ldc.i4.0
+		IL_007f: ldc.i4.1
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0085: stloc.s 4
+		IL_0087: ldloc.3
+		IL_0088: ldstr "listen"
+		IL_008d: ldc.r8 0.0
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: ldstr "127.0.0.1"
+		IL_00a0: ldloc.s 4
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00a7: pop
+		IL_00a8: ret
 	} // end of method Http_Request_Streaming_Chunked_RequestBody::__js_module_init__
 
 } // end of class Modules.Http_Request_Streaming_Chunked_RequestBody
@@ -1010,7 +1008,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26a4
+		// Method begins at RVA 0x269c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e7
+				// Method begins at RVA 0x24d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2108
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 73 (0x49)
 			.maxstack 8
@@ -92,7 +92,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2502
+						// Method begins at RVA 0x24f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -117,7 +117,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x234c
+					// Method begins at RVA 0x233c
 					// Header size: 12
 					// Code size: 157 (0x9d)
 					.maxstack 8
@@ -207,7 +207,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2514
+							// Method begins at RVA 0x2504
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -230,7 +230,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x24bc
+						// Method begins at RVA 0x24ac
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -255,7 +255,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x250b
+						// Method begins at RVA 0x24fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -279,7 +279,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x23f8
+					// Method begins at RVA 0x23e8
 					// Header size: 12
 					// Code size: 184 (0xb8)
 					.maxstack 8
@@ -376,7 +376,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24f9
+					// Method begins at RVA 0x24e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -401,7 +401,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x2210
 				// Header size: 12
 				// Code size: 286 (0x11e)
 				.maxstack 8
@@ -537,7 +537,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f0
+				// Method begins at RVA 0x24e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -563,9 +563,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x2158
 			// Header size: 12
-			// Code size: 177 (0xb1)
+			// Code size: 172 (0xac)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/Scope,
@@ -586,59 +586,58 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-			IL_0027: stloc.2
-			IL_0028: ldloc.1
-			IL_0029: ldstr "address"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0033: stloc.3
-			IL_0034: ldloc.1
-			IL_0035: ldstr "port"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003f: stloc.s 4
-			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0046: dup
-			IL_0047: ldstr "host"
-			IL_004c: ldloc.3
-			IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0052: dup
-			IL_0053: ldstr "port"
-			IL_0058: ldloc.s 4
-			IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_005f: dup
-			IL_0060: ldstr "path"
-			IL_0065: ldstr "/stream"
-			IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006f: stloc.s 5
-			IL_0071: ldc.i4.2
-			IL_0072: newarr [System.Runtime]System.Object
-			IL_0077: dup
-			IL_0078: ldc.i4.0
-			IL_0079: ldarg.0
-			IL_007a: stelem.ref
-			IL_007b: dup
-			IL_007c: ldc.i4.1
-			IL_007d: ldloc.0
-			IL_007e: stelem.ref
-			IL_007f: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
-			IL_0085: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_008a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_008f: ldc.i4.1
-			IL_0090: conv.r8
-			IL_0091: ldstr ""
-			IL_0096: ldc.i4.0
-			IL_0097: ldc.i4.1
-			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_009d: stloc.s 6
-			IL_009f: ldloc.2
-			IL_00a0: ldloc.s 5
-			IL_00a2: ldloc.s 6
-			IL_00a4: castclass [System.Runtime]System.Delegate
-			IL_00a9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
-			IL_00ae: pop
-			IL_00af: ldnull
-			IL_00b0: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
+			IL_0022: stloc.2
+			IL_0023: ldloc.1
+			IL_0024: ldstr "address"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002e: stloc.3
+			IL_002f: ldloc.1
+			IL_0030: ldstr "port"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003a: stloc.s 4
+			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0041: dup
+			IL_0042: ldstr "host"
+			IL_0047: ldloc.3
+			IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004d: dup
+			IL_004e: ldstr "port"
+			IL_0053: ldloc.s 4
+			IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005a: dup
+			IL_005b: ldstr "path"
+			IL_0060: ldstr "/stream"
+			IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_006a: stloc.s 5
+			IL_006c: ldc.i4.2
+			IL_006d: newarr [System.Runtime]System.Object
+			IL_0072: dup
+			IL_0073: ldc.i4.0
+			IL_0074: ldarg.0
+			IL_0075: stelem.ref
+			IL_0076: dup
+			IL_0077: ldc.i4.1
+			IL_0078: ldloc.0
+			IL_0079: stelem.ref
+			IL_007a: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
+			IL_0080: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0085: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_008a: ldc.i4.1
+			IL_008b: conv.r8
+			IL_008c: ldstr ""
+			IL_0091: ldc.i4.0
+			IL_0092: ldc.i4.1
+			IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0098: stloc.s 6
+			IL_009a: ldloc.2
+			IL_009b: ldloc.s 5
+			IL_009d: ldloc.s 6
+			IL_009f: castclass [System.Runtime]System.Delegate
+			IL_00a4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::get(object, class [System.Runtime]System.Delegate)
+			IL_00a9: pop
+			IL_00aa: ldnull
+			IL_00ab: ret
 		} // end of method FunctionExpression_L11C30::__js_call__
 
 	} // end of class FunctionExpression_L11C30
@@ -652,14 +651,14 @@
 			72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object http
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule http
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24de
+			// Method begins at RVA 0x24ce
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -685,7 +684,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 169 (0xa9)
+		// Code size: 164 (0xa4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope,
@@ -704,54 +703,53 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule
-		IL_0025: stloc.1
-		IL_0026: ldnull
-		IL_0027: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
-		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_0037: ldc.i4.2
-		IL_0038: conv.r8
-		IL_0039: ldstr ""
-		IL_003e: ldc.i4.0
-		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_0045: stloc.2
-		IL_0046: ldloc.1
-		IL_0047: ldloc.2
-		IL_0048: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.0
-		IL_004f: ldloc.3
-		IL_0050: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-		IL_0055: ldloc.0
-		IL_0056: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0060: stloc.3
-		IL_0061: ldloc.0
-		IL_0062: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-		IL_0067: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
-		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0072: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0077: ldc.i4.0
-		IL_0078: conv.r8
-		IL_0079: ldstr ""
-		IL_007e: ldc.i4.0
-		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0085: stloc.s 4
-		IL_0087: ldloc.3
-		IL_0088: ldstr "listen"
-		IL_008d: ldc.r8 0.0
-		IL_0096: box [System.Runtime]System.Double
-		IL_009b: ldstr "127.0.0.1"
-		IL_00a0: ldloc.s 4
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00a7: pop
-		IL_00a8: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
+		IL_0020: stloc.1
+		IL_0021: ldnull
+		IL_0022: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
+		IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_002d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_0032: ldc.i4.2
+		IL_0033: conv.r8
+		IL_0034: ldstr ""
+		IL_0039: ldc.i4.0
+		IL_003a: ldc.i4.1
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0040: stloc.2
+		IL_0041: ldloc.1
+		IL_0042: ldloc.2
+		IL_0043: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule::createServer(object)
+		IL_0048: stloc.3
+		IL_0049: ldloc.0
+		IL_004a: ldloc.3
+		IL_004b: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
+		IL_0050: ldloc.0
+		IL_0051: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005b: stloc.3
+		IL_005c: ldloc.0
+		IL_005d: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
+		IL_0062: ldftn object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
+		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0072: ldc.i4.0
+		IL_0073: conv.r8
+		IL_0074: ldstr ""
+		IL_0079: ldc.i4.0
+		IL_007a: ldc.i4.1
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldstr "listen"
+		IL_0088: ldc.r8 0.0
+		IL_0091: box [System.Runtime]System.Double
+		IL_0096: ldstr "127.0.0.1"
+		IL_009b: ldloc.s 4
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00a2: pop
+		IL_00a3: ret
 	} // end of method Http_Response_Streaming_Chunked_ResponseBody::__js_module_init__
 
 } // end of class Modules.Http_Response_Streaming_Chunked_ResponseBody
@@ -763,7 +761,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x251d
+		// Method begins at RVA 0x250d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25db
+				// Method begins at RVA 0x25cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21ec
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -141,7 +141,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25f6
+						// Method begins at RVA 0x25ea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -166,7 +166,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24d4
+					// Method begins at RVA 0x24c8
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -212,7 +212,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2608
+							// Method begins at RVA 0x25fc
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -235,7 +235,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x25b0
+						// Method begins at RVA 0x25a4
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -260,7 +260,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25ff
+						// Method begins at RVA 0x25f3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -284,7 +284,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2508
+					// Method begins at RVA 0x24fc
 					// Header size: 12
 					// Code size: 156 (0x9c)
 					.maxstack 8
@@ -372,7 +372,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ed
+					// Method begins at RVA 0x25e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -397,7 +397,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23a8
+				// Method begins at RVA 0x239c
 				// Header size: 12
 				// Code size: 286 (0x11e)
 				.maxstack 8
@@ -533,7 +533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e4
+				// Method begins at RVA 0x25d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -559,9 +559,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x22a0
+			// Method begins at RVA 0x2298
 			// Header size: 12
-			// Code size: 251 (0xfb)
+			// Code size: 246 (0xf6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/Scope,
@@ -604,60 +604,59 @@
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0060: pop
 			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
-			IL_0067: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-			IL_006c: stloc.s 5
-			IL_006e: ldloc.1
-			IL_006f: ldstr "port"
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0079: stloc.2
-			IL_007a: ldstr "https://127.0.0.1:"
-			IL_007f: ldloc.2
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0085: stloc.s 4
-			IL_0087: ldloc.s 4
-			IL_0089: ldstr "/hello?x=1"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0093: stloc.s 4
-			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_009a: dup
-			IL_009b: ldstr "rejectUnauthorized"
-			IL_00a0: ldc.i4.0
-			IL_00a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a6: stloc.s 6
-			IL_00a8: ldnull
-			IL_00a9: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5::__js_call__(object[], object, object)
-			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00b4: ldc.i4.2
-			IL_00b5: newarr [System.Runtime]System.Object
-			IL_00ba: dup
-			IL_00bb: ldc.i4.0
-			IL_00bc: ldarg.0
-			IL_00bd: stelem.ref
-			IL_00be: dup
-			IL_00bf: ldc.i4.1
-			IL_00c0: ldloc.0
-			IL_00c1: stelem.ref
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00cc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_00d1: ldc.i4.1
-			IL_00d2: conv.r8
-			IL_00d3: ldstr ""
-			IL_00d8: ldc.i4.0
-			IL_00d9: ldc.i4.0
-			IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_00e4: stloc.s 7
-			IL_00e6: ldloc.s 5
-			IL_00e8: ldloc.s 4
-			IL_00ea: ldloc.s 6
-			IL_00ec: ldloc.s 7
-			IL_00ee: castclass [System.Runtime]System.Delegate
-			IL_00f3: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::get(object, object, class [System.Runtime]System.Delegate)
-			IL_00f8: pop
-			IL_00f9: ldnull
-			IL_00fa: ret
+			IL_0062: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Get_Loopback_SelfSigned/Scope::https
+			IL_0067: stloc.s 5
+			IL_0069: ldloc.1
+			IL_006a: ldstr "port"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0074: stloc.2
+			IL_0075: ldstr "https://127.0.0.1:"
+			IL_007a: ldloc.2
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0080: stloc.s 4
+			IL_0082: ldloc.s 4
+			IL_0084: ldstr "/hello?x=1"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_008e: stloc.s 4
+			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0095: dup
+			IL_0096: ldstr "rejectUnauthorized"
+			IL_009b: ldc.i4.0
+			IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00a1: stloc.s 6
+			IL_00a3: ldnull
+			IL_00a4: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5::__js_call__(object[], object, object)
+			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00af: ldc.i4.2
+			IL_00b0: newarr [System.Runtime]System.Object
+			IL_00b5: dup
+			IL_00b6: ldc.i4.0
+			IL_00b7: ldarg.0
+			IL_00b8: stelem.ref
+			IL_00b9: dup
+			IL_00ba: ldc.i4.1
+			IL_00bb: ldloc.0
+			IL_00bc: stelem.ref
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00c7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_00cc: ldc.i4.1
+			IL_00cd: conv.r8
+			IL_00ce: ldstr ""
+			IL_00d3: ldc.i4.0
+			IL_00d4: ldc.i4.0
+			IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_00df: stloc.s 7
+			IL_00e1: ldloc.s 5
+			IL_00e3: ldloc.s 4
+			IL_00e5: ldloc.s 6
+			IL_00e7: ldloc.s 7
+			IL_00e9: castclass [System.Runtime]System.Delegate
+			IL_00ee: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::get(object, object, class [System.Runtime]System.Delegate)
+			IL_00f3: pop
+			IL_00f4: ldnull
+			IL_00f5: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -671,14 +670,14 @@
 			73 65 72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object https
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule https
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25d2
+			// Method begins at RVA 0x25c6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -704,7 +703,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 333 (0x14d)
+		// Code size: 328 (0x148)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Https_Get_Loopback_SelfSigned/Scope,
@@ -726,7 +725,7 @@
 		IL_0012: stloc.3
 		IL_0013: ldloc.0
 		IL_0014: ldloc.3
-		IL_0015: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Get_Loopback_SelfSigned/Scope::https
 		IL_001a: ldarg.1
 		IL_001b: ldstr "./Tls_TestCertificates"
 		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
@@ -752,81 +751,80 @@
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0064: stloc.2
 		IL_0065: ldloc.0
-		IL_0066: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::https
-		IL_006b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-		IL_0070: stloc.3
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0076: dup
-		IL_0077: ldstr "key"
-		IL_007c: ldloc.2
-		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0082: dup
-		IL_0083: ldstr "cert"
-		IL_0088: ldloc.1
-		IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008e: stloc.s 5
-		IL_0090: ldnull
-		IL_0091: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L6C67::__js_call__(object, object, object)
-		IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_00b5: ldc.i4.2
-		IL_00b6: conv.r8
-		IL_00b7: ldstr ""
-		IL_00bc: ldc.i4.0
-		IL_00bd: ldc.i4.0
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_00c8: stloc.s 6
-		IL_00ca: ldloc.3
-		IL_00cb: ldloc.s 5
-		IL_00cd: ldloc.s 6
-		IL_00cf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::createServer(object, object)
-		IL_00d4: stloc.s 4
-		IL_00d6: ldloc.0
-		IL_00d7: ldloc.s 4
-		IL_00d9: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-		IL_00de: ldloc.0
-		IL_00df: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: stloc.s 4
-		IL_00eb: ldloc.0
-		IL_00ec: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
-		IL_00f1: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31::__js_call__(class Modules.Https_Get_Loopback_SelfSigned/Scope, object)
-		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fc: ldc.i4.1
-		IL_00fd: newarr [System.Runtime]System.Object
-		IL_0102: dup
-		IL_0103: ldc.i4.0
-		IL_0104: ldloc.0
-		IL_0105: stelem.ref
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0110: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0115: ldc.i4.0
-		IL_0116: conv.r8
-		IL_0117: ldstr ""
-		IL_011c: ldc.i4.0
-		IL_011d: ldc.i4.0
-		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0128: stloc.s 7
-		IL_012a: ldloc.s 4
-		IL_012c: ldstr "listen"
-		IL_0131: ldc.r8 0.0
-		IL_013a: box [System.Runtime]System.Double
-		IL_013f: ldstr "127.0.0.1"
-		IL_0144: ldloc.s 7
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_014b: pop
-		IL_014c: ret
+		IL_0066: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Get_Loopback_SelfSigned/Scope::https
+		IL_006b: stloc.3
+		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0071: dup
+		IL_0072: ldstr "key"
+		IL_0077: ldloc.2
+		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_007d: dup
+		IL_007e: ldstr "cert"
+		IL_0083: ldloc.1
+		IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0089: stloc.s 5
+		IL_008b: ldnull
+		IL_008c: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L6C67::__js_call__(object, object, object)
+		IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ab: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_00b0: ldc.i4.2
+		IL_00b1: conv.r8
+		IL_00b2: ldstr ""
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldc.i4.0
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_00c3: stloc.s 6
+		IL_00c5: ldloc.3
+		IL_00c6: ldloc.s 5
+		IL_00c8: ldloc.s 6
+		IL_00ca: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::createServer(object, object)
+		IL_00cf: stloc.s 4
+		IL_00d1: ldloc.0
+		IL_00d2: ldloc.s 4
+		IL_00d4: stfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
+		IL_00d9: ldloc.0
+		IL_00da: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e4: stloc.s 4
+		IL_00e6: ldloc.0
+		IL_00e7: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
+		IL_00ec: ldftn object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31::__js_call__(class Modules.Https_Get_Loopback_SelfSigned/Scope, object)
+		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00f7: ldc.i4.1
+		IL_00f8: newarr [System.Runtime]System.Object
+		IL_00fd: dup
+		IL_00fe: ldc.i4.0
+		IL_00ff: ldloc.0
+		IL_0100: stelem.ref
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_010b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0110: ldc.i4.0
+		IL_0111: conv.r8
+		IL_0112: ldstr ""
+		IL_0117: ldc.i4.0
+		IL_0118: ldc.i4.0
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0123: stloc.s 7
+		IL_0125: ldloc.s 4
+		IL_0127: ldstr "listen"
+		IL_012c: ldc.r8 0.0
+		IL_0135: box [System.Runtime]System.Double
+		IL_013a: ldstr "127.0.0.1"
+		IL_013f: ldloc.s 7
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0146: pop
+		IL_0147: ret
 	} // end of method Https_Get_Loopback_SelfSigned::__js_module_init__
 
 } // end of class Modules.Https_Get_Loopback_SelfSigned
@@ -842,7 +840,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2611
+			// Method begins at RVA 0x2605
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -866,7 +864,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21ac
+		// Method begins at RVA 0x21a4
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 8
@@ -906,7 +904,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x261a
+		// Method begins at RVA 0x260e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x275c
+					// Method begins at RVA 0x2754
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23f0
+				// Method begins at RVA 0x23e8
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -96,7 +96,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2765
+					// Method begins at RVA 0x275d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2424
+				// Method begins at RVA 0x241c
 				// Header size: 12
 				// Code size: 239 (0xef)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2753
+				// Method begins at RVA 0x274b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -267,7 +267,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21f4
 			// Header size: 12
 			// Code size: 242 (0xf2)
 			.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2780
+						// Method begins at RVA 0x2778
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -421,7 +421,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x264c
+					// Method begins at RVA 0x2644
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -467,7 +467,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2792
+							// Method begins at RVA 0x278a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -490,7 +490,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x2728
+						// Method begins at RVA 0x2720
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -515,7 +515,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2789
+						// Method begins at RVA 0x2781
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -539,7 +539,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2680
+					// Method begins at RVA 0x2678
 					// Header size: 12
 					// Code size: 156 (0x9c)
 					.maxstack 8
@@ -627,7 +627,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2777
+					// Method begins at RVA 0x276f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -652,7 +652,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2520
+				// Method begins at RVA 0x2518
 				// Header size: 12
 				// Code size: 286 (0x11e)
 				.maxstack 8
@@ -788,7 +788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x276e
+				// Method begins at RVA 0x2766
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -814,9 +814,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x22f8
+			// Method begins at RVA 0x22f4
 			// Header size: 12
-			// Code size: 235 (0xeb)
+			// Code size: 230 (0xe6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/Scope,
@@ -837,73 +837,72 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Https_Request_Post_Basic/Scope::https
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-			IL_0027: stloc.3
-			IL_0028: ldloc.1
-			IL_0029: ldstr "port"
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0033: stloc.s 4
-			IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_003a: dup
-			IL_003b: ldstr "host"
-			IL_0040: ldstr "127.0.0.1"
-			IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_004a: dup
-			IL_004b: ldstr "port"
-			IL_0050: ldloc.s 4
-			IL_0052: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0057: dup
-			IL_0058: ldstr "method"
-			IL_005d: ldstr "POST"
-			IL_0062: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0067: dup
-			IL_0068: ldstr "path"
-			IL_006d: ldstr "/submit"
-			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0077: dup
-			IL_0078: ldstr "rejectUnauthorized"
-			IL_007d: ldc.i4.0
-			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0083: stloc.s 5
-			IL_0085: ldnull
-			IL_0086: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5::__js_call__(object[], object, object)
-			IL_008c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0091: ldc.i4.2
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldarg.0
-			IL_009a: stelem.ref
-			IL_009b: dup
-			IL_009c: ldc.i4.1
-			IL_009d: ldloc.0
-			IL_009e: stelem.ref
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00a9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_00ae: ldc.i4.1
-			IL_00af: conv.r8
-			IL_00b0: ldstr ""
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldc.i4.0
-			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_00c1: stloc.s 6
-			IL_00c3: ldloc.3
-			IL_00c4: ldloc.s 5
-			IL_00c6: ldloc.s 6
-			IL_00c8: castclass [System.Runtime]System.Delegate
-			IL_00cd: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::'request'(object, class [System.Runtime]System.Delegate)
-			IL_00d2: stloc.2
-			IL_00d3: ldloc.2
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d9: ldstr "end"
-			IL_00de: ldstr "hello tls"
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00e8: pop
-			IL_00e9: ldnull
-			IL_00ea: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_Post_Basic/Scope::https
+			IL_0022: stloc.3
+			IL_0023: ldloc.1
+			IL_0024: ldstr "port"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002e: stloc.s 4
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0035: dup
+			IL_0036: ldstr "host"
+			IL_003b: ldstr "127.0.0.1"
+			IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0045: dup
+			IL_0046: ldstr "port"
+			IL_004b: ldloc.s 4
+			IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0052: dup
+			IL_0053: ldstr "method"
+			IL_0058: ldstr "POST"
+			IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0062: dup
+			IL_0063: ldstr "path"
+			IL_0068: ldstr "/submit"
+			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0072: dup
+			IL_0073: ldstr "rejectUnauthorized"
+			IL_0078: ldc.i4.0
+			IL_0079: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_007e: stloc.s 5
+			IL_0080: ldnull
+			IL_0081: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5::__js_call__(object[], object, object)
+			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_008c: ldc.i4.2
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: stelem.ref
+			IL_0096: dup
+			IL_0097: ldc.i4.1
+			IL_0098: ldloc.0
+			IL_0099: stelem.ref
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00a4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_00a9: ldc.i4.1
+			IL_00aa: conv.r8
+			IL_00ab: ldstr ""
+			IL_00b0: ldc.i4.0
+			IL_00b1: ldc.i4.0
+			IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_00bc: stloc.s 6
+			IL_00be: ldloc.3
+			IL_00bf: ldloc.s 5
+			IL_00c1: ldloc.s 6
+			IL_00c3: castclass [System.Runtime]System.Delegate
+			IL_00c8: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::'request'(object, class [System.Runtime]System.Delegate)
+			IL_00cd: stloc.2
+			IL_00ce: ldloc.2
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d4: ldstr "end"
+			IL_00d9: ldstr "hello tls"
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e3: pop
+			IL_00e4: ldnull
+			IL_00e5: ret
 		} // end of method ArrowFunction_L21C31::__js_call__
 
 	} // end of class ArrowFunction_L21C31
@@ -917,14 +916,14 @@
 			73 65 72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object https
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule https
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x274a
+			// Method begins at RVA 0x2742
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -950,7 +949,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 338 (0x152)
+		// Code size: 333 (0x14d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Https_Request_Post_Basic/Scope,
@@ -972,7 +971,7 @@
 		IL_0012: stloc.3
 		IL_0013: ldloc.0
 		IL_0014: ldloc.3
-		IL_0015: stfld object Modules.Https_Request_Post_Basic/Scope::https
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_Post_Basic/Scope::https
 		IL_001a: ldarg.1
 		IL_001b: ldstr "./Tls_TestCertificates"
 		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
@@ -998,82 +997,81 @@
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0064: stloc.2
 		IL_0065: ldloc.0
-		IL_0066: ldfld object Modules.Https_Request_Post_Basic/Scope::https
-		IL_006b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-		IL_0070: stloc.3
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0076: dup
-		IL_0077: ldstr "key"
-		IL_007c: ldloc.2
-		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0082: dup
-		IL_0083: ldstr "cert"
-		IL_0088: ldloc.1
-		IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.0
-		IL_0091: castclass Modules.Https_Request_Post_Basic/Scope
-		IL_0096: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object, object, object)
-		IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00a1: ldc.i4.1
-		IL_00a2: newarr [System.Runtime]System.Object
-		IL_00a7: dup
-		IL_00a8: ldc.i4.0
-		IL_00a9: ldloc.0
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_00ba: ldc.i4.2
-		IL_00bb: conv.r8
-		IL_00bc: ldstr ""
-		IL_00c1: ldc.i4.0
-		IL_00c2: ldc.i4.0
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_00cd: stloc.s 6
-		IL_00cf: ldloc.3
-		IL_00d0: ldloc.s 5
-		IL_00d2: ldloc.s 6
-		IL_00d4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::createServer(object, object)
-		IL_00d9: stloc.s 4
-		IL_00db: ldloc.0
-		IL_00dc: ldloc.s 4
-		IL_00de: stfld object Modules.Https_Request_Post_Basic/Scope::server
-		IL_00e3: ldloc.0
-		IL_00e4: ldfld object Modules.Https_Request_Post_Basic/Scope::server
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.0
-		IL_00f1: castclass Modules.Https_Request_Post_Basic/Scope
-		IL_00f6: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object)
-		IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0101: ldc.i4.1
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: dup
-		IL_0108: ldc.i4.0
-		IL_0109: ldloc.0
-		IL_010a: stelem.ref
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0115: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_011a: ldc.i4.0
-		IL_011b: conv.r8
-		IL_011c: ldstr ""
-		IL_0121: ldc.i4.0
-		IL_0122: ldc.i4.0
-		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_012d: stloc.s 7
-		IL_012f: ldloc.s 4
-		IL_0131: ldstr "listen"
-		IL_0136: ldc.r8 0.0
-		IL_013f: box [System.Runtime]System.Double
-		IL_0144: ldstr "127.0.0.1"
-		IL_0149: ldloc.s 7
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0150: pop
-		IL_0151: ret
+		IL_0066: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_Post_Basic/Scope::https
+		IL_006b: stloc.3
+		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0071: dup
+		IL_0072: ldstr "key"
+		IL_0077: ldloc.2
+		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_007d: dup
+		IL_007e: ldstr "cert"
+		IL_0083: ldloc.1
+		IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.0
+		IL_008c: castclass Modules.Https_Request_Post_Basic/Scope
+		IL_0091: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object, object, object)
+		IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_009c: ldc.i4.1
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: dup
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldloc.0
+		IL_00a5: stelem.ref
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00b0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_00b5: ldc.i4.2
+		IL_00b6: conv.r8
+		IL_00b7: ldstr ""
+		IL_00bc: ldc.i4.0
+		IL_00bd: ldc.i4.0
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_00c8: stloc.s 6
+		IL_00ca: ldloc.3
+		IL_00cb: ldloc.s 5
+		IL_00cd: ldloc.s 6
+		IL_00cf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::createServer(object, object)
+		IL_00d4: stloc.s 4
+		IL_00d6: ldloc.0
+		IL_00d7: ldloc.s 4
+		IL_00d9: stfld object Modules.Https_Request_Post_Basic/Scope::server
+		IL_00de: ldloc.0
+		IL_00df: ldfld object Modules.Https_Request_Post_Basic/Scope::server
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e9: stloc.s 4
+		IL_00eb: ldloc.0
+		IL_00ec: castclass Modules.Https_Request_Post_Basic/Scope
+		IL_00f1: ldftn object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31::__js_call__(class Modules.Https_Request_Post_Basic/Scope, object)
+		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00fc: ldc.i4.1
+		IL_00fd: newarr [System.Runtime]System.Object
+		IL_0102: dup
+		IL_0103: ldc.i4.0
+		IL_0104: ldloc.0
+		IL_0105: stelem.ref
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0110: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0115: ldc.i4.0
+		IL_0116: conv.r8
+		IL_0117: ldstr ""
+		IL_011c: ldc.i4.0
+		IL_011d: ldc.i4.0
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0128: stloc.s 7
+		IL_012a: ldloc.s 4
+		IL_012c: ldstr "listen"
+		IL_0131: ldc.r8 0.0
+		IL_013a: box [System.Runtime]System.Double
+		IL_013f: ldstr "127.0.0.1"
+		IL_0144: ldloc.s 7
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_014b: pop
+		IL_014c: ret
 	} // end of method Https_Request_Post_Basic::__js_module_init__
 
 } // end of class Modules.Https_Request_Post_Basic
@@ -1089,7 +1087,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x279b
+			// Method begins at RVA 0x2793
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1113,7 +1111,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21b0
+		// Method begins at RVA 0x21ac
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 8
@@ -1153,7 +1151,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27a4
+		// Method begins at RVA 0x279c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2647
+				// Method begins at RVA 0x263f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x2234
 			// Header size: 12
 			// Code size: 175 (0xaf)
 			.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2662
+						// Method begins at RVA 0x265a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -175,7 +175,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2540
+					// Method begins at RVA 0x2538
 					// Header size: 12
 					// Code size: 38 (0x26)
 					.maxstack 8
@@ -221,7 +221,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2674
+							// Method begins at RVA 0x266c
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -244,7 +244,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 00 00 00 00 00 00
 						)
-						// Method begins at RVA 0x261c
+						// Method begins at RVA 0x2614
 						// Header size: 1
 						// Code size: 33 (0x21)
 						.maxstack 8
@@ -269,7 +269,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x266b
+						// Method begins at RVA 0x2663
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -293,7 +293,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2574
+					// Method begins at RVA 0x256c
 					// Header size: 12
 					// Code size: 156 (0x9c)
 					.maxstack 8
@@ -381,7 +381,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2659
+					// Method begins at RVA 0x2651
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -406,7 +406,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2414
+				// Method begins at RVA 0x240c
 				// Header size: 12
 				// Code size: 286 (0x11e)
 				.maxstack 8
@@ -542,7 +542,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2650
+				// Method begins at RVA 0x2648
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -568,9 +568,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x22f4
+			// Method begins at RVA 0x22f0
 			// Header size: 12
-			// Code size: 275 (0x113)
+			// Code size: 270 (0x10e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/Scope,
@@ -618,65 +618,64 @@
 			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
 			IL_005f: stloc.2
 			IL_0060: ldarg.0
-			IL_0061: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
-			IL_0066: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-			IL_006b: stloc.s 7
-			IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0072: dup
-			IL_0073: ldstr "method"
-			IL_0078: ldstr "GET"
-			IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0082: dup
-			IL_0083: ldstr "headers"
-			IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_008d: dup
-			IL_008e: ldstr "Accept-Encoding"
-			IL_0093: ldstr "identity"
+			IL_0061: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_UrlObject_WithOptions/Scope::https
+			IL_0066: stloc.s 7
+			IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_006d: dup
+			IL_006e: ldstr "method"
+			IL_0073: ldstr "GET"
+			IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_007d: dup
+			IL_007e: ldstr "headers"
+			IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0088: dup
+			IL_0089: ldstr "Accept-Encoding"
+			IL_008e: ldstr "identity"
+			IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0098: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_009d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00a2: dup
-			IL_00a3: ldstr "rejectUnauthorized"
-			IL_00a8: ldc.i4.0
-			IL_00a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00ae: stloc.s 8
-			IL_00b0: ldnull
-			IL_00b1: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
-			IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_00bc: ldc.i4.2
-			IL_00bd: newarr [System.Runtime]System.Object
-			IL_00c2: dup
-			IL_00c3: ldc.i4.0
-			IL_00c4: ldarg.0
-			IL_00c5: stelem.ref
-			IL_00c6: dup
-			IL_00c7: ldc.i4.1
-			IL_00c8: ldloc.0
-			IL_00c9: stelem.ref
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00d4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
-			IL_00d9: ldc.i4.1
-			IL_00da: conv.r8
-			IL_00db: ldstr ""
-			IL_00e0: ldc.i4.0
-			IL_00e1: ldc.i4.0
-			IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
-			IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
-			IL_00ec: stloc.s 9
-			IL_00ee: ldloc.s 7
-			IL_00f0: ldloc.2
-			IL_00f1: ldloc.s 8
-			IL_00f3: ldloc.s 9
-			IL_00f5: castclass [System.Runtime]System.Delegate
-			IL_00fa: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::'request'(object, object, class [System.Runtime]System.Delegate)
-			IL_00ff: stloc.3
-			IL_0100: ldloc.3
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0106: ldstr "end"
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0110: pop
-			IL_0111: ldnull
-			IL_0112: ret
+			IL_009d: dup
+			IL_009e: ldstr "rejectUnauthorized"
+			IL_00a3: ldc.i4.0
+			IL_00a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00a9: stloc.s 8
+			IL_00ab: ldnull
+			IL_00ac: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5::__js_call__(object[], object, object)
+			IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_00b7: ldc.i4.2
+			IL_00b8: newarr [System.Runtime]System.Object
+			IL_00bd: dup
+			IL_00be: ldc.i4.0
+			IL_00bf: ldarg.0
+			IL_00c0: stelem.ref
+			IL_00c1: dup
+			IL_00c2: ldc.i4.1
+			IL_00c3: ldloc.0
+			IL_00c4: stelem.ref
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00cf: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc1
+			IL_00d4: ldc.i4.1
+			IL_00d5: conv.r8
+			IL_00d6: ldstr ""
+			IL_00db: ldc.i4.0
+			IL_00dc: ldc.i4.0
+			IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0, float64, string, bool, bool)
+			IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc1>(!!0)
+			IL_00e7: stloc.s 9
+			IL_00e9: ldloc.s 7
+			IL_00eb: ldloc.2
+			IL_00ec: ldloc.s 8
+			IL_00ee: ldloc.s 9
+			IL_00f0: castclass [System.Runtime]System.Delegate
+			IL_00f5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::'request'(object, object, class [System.Runtime]System.Delegate)
+			IL_00fa: stloc.3
+			IL_00fb: ldloc.3
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0101: ldstr "end"
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_010b: pop
+			IL_010c: ldnull
+			IL_010d: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -691,7 +690,7 @@
 			72 3d 7b 73 65 72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object https
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule https
 		.field public object NodeUrl
 		.field public object server
 
@@ -699,7 +698,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x263e
+			// Method begins at RVA 0x2636
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -725,7 +724,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 404 (0x194)
+		// Code size: 399 (0x18f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Https_Request_UrlObject_WithOptions/Scope,
@@ -748,7 +747,7 @@
 		IL_0012: stloc.3
 		IL_0013: ldloc.0
 		IL_0014: ldloc.3
-		IL_0015: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_UrlObject_WithOptions/Scope::https
 		IL_001a: ldarg.1
 		IL_001b: ldstr "node:url"
 		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
@@ -797,81 +796,80 @@
 		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00ab: stloc.2
 		IL_00ac: ldloc.0
-		IL_00ad: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::https
-		IL_00b2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule
-		IL_00b7: stloc.3
-		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00bd: dup
-		IL_00be: ldstr "key"
-		IL_00c3: ldloc.2
-		IL_00c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00c9: dup
-		IL_00ca: ldstr "cert"
-		IL_00cf: ldloc.1
-		IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00d5: stloc.s 6
-		IL_00d7: ldnull
-		IL_00d8: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L7C67::__js_call__(object, object, object)
-		IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00e3: ldc.i4.1
-		IL_00e4: newarr [System.Runtime]System.Object
-		IL_00e9: dup
-		IL_00ea: ldc.i4.0
-		IL_00eb: ldloc.0
-		IL_00ec: stelem.ref
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00f7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
-		IL_00fc: ldc.i4.2
-		IL_00fd: conv.r8
-		IL_00fe: ldstr ""
-		IL_0103: ldc.i4.0
-		IL_0104: ldc.i4.0
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
-		IL_010f: stloc.s 7
-		IL_0111: ldloc.3
-		IL_0112: ldloc.s 6
-		IL_0114: ldloc.s 7
-		IL_0116: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::createServer(object, object)
-		IL_011b: stloc.s 5
-		IL_011d: ldloc.0
-		IL_011e: ldloc.s 5
-		IL_0120: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-		IL_0125: ldloc.0
-		IL_0126: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0130: stloc.s 5
-		IL_0132: ldloc.0
-		IL_0133: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
-		IL_0138: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31::__js_call__(class Modules.Https_Request_UrlObject_WithOptions/Scope, object)
-		IL_013e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0143: ldc.i4.1
-		IL_0144: newarr [System.Runtime]System.Object
-		IL_0149: dup
-		IL_014a: ldc.i4.0
-		IL_014b: ldloc.0
-		IL_014c: stelem.ref
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0157: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_015c: ldc.i4.0
-		IL_015d: conv.r8
-		IL_015e: ldstr ""
-		IL_0163: ldc.i4.0
-		IL_0164: ldc.i4.0
-		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_016a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_016f: stloc.s 8
-		IL_0171: ldloc.s 5
-		IL_0173: ldstr "listen"
-		IL_0178: ldc.r8 0.0
-		IL_0181: box [System.Runtime]System.Double
-		IL_0186: ldstr "127.0.0.1"
-		IL_018b: ldloc.s 8
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0192: pop
-		IL_0193: ret
+		IL_00ad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_UrlObject_WithOptions/Scope::https
+		IL_00b2: stloc.3
+		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b8: dup
+		IL_00b9: ldstr "key"
+		IL_00be: ldloc.2
+		IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00c4: dup
+		IL_00c5: ldstr "cert"
+		IL_00ca: ldloc.1
+		IL_00cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00d0: stloc.s 6
+		IL_00d2: ldnull
+		IL_00d3: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L7C67::__js_call__(object, object, object)
+		IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00de: ldc.i4.1
+		IL_00df: newarr [System.Runtime]System.Object
+		IL_00e4: dup
+		IL_00e5: ldc.i4.0
+		IL_00e6: ldloc.0
+		IL_00e7: stelem.ref
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00f2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2
+		IL_00f7: ldc.i4.2
+		IL_00f8: conv.r8
+		IL_00f9: ldstr ""
+		IL_00fe: ldc.i4.0
+		IL_00ff: ldc.i4.0
+		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2>(!!0)
+		IL_010a: stloc.s 7
+		IL_010c: ldloc.3
+		IL_010d: ldloc.s 6
+		IL_010f: ldloc.s 7
+		IL_0111: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule::createServer(object, object)
+		IL_0116: stloc.s 5
+		IL_0118: ldloc.0
+		IL_0119: ldloc.s 5
+		IL_011b: stfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+		IL_0120: ldloc.0
+		IL_0121: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012b: stloc.s 5
+		IL_012d: ldloc.0
+		IL_012e: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+		IL_0133: ldftn object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31::__js_call__(class Modules.Https_Request_UrlObject_WithOptions/Scope, object)
+		IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_013e: ldc.i4.1
+		IL_013f: newarr [System.Runtime]System.Object
+		IL_0144: dup
+		IL_0145: ldc.i4.0
+		IL_0146: ldloc.0
+		IL_0147: stelem.ref
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0152: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0157: ldc.i4.0
+		IL_0158: conv.r8
+		IL_0159: ldstr ""
+		IL_015e: ldc.i4.0
+		IL_015f: ldc.i4.0
+		IL_0160: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_016a: stloc.s 8
+		IL_016c: ldloc.s 5
+		IL_016e: ldstr "listen"
+		IL_0173: ldc.r8 0.0
+		IL_017c: box [System.Runtime]System.Double
+		IL_0181: ldstr "127.0.0.1"
+		IL_0186: ldloc.s 8
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_018d: pop
+		IL_018e: ret
 	} // end of method Https_Request_UrlObject_WithOptions::__js_module_init__
 
 } // end of class Modules.Https_Request_UrlObject_WithOptions
@@ -887,7 +885,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x267d
+			// Method begins at RVA 0x2675
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -911,7 +909,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21f0
+		// Method begins at RVA 0x21ec
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 8
@@ -951,7 +949,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2686
+		// Method begins at RVA 0x267e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x251a
+				// Method begins at RVA 0x250a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2270
+			// Method begins at RVA 0x2264
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -81,7 +81,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2537
+					// Method begins at RVA 0x2527
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2418
+				// Method begins at RVA 0x2407
 				// Header size: 1
 				// Code size: 46 (0x2e)
 				.maxstack 8
@@ -146,7 +146,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2540
+					// Method begins at RVA 0x2530
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -170,7 +170,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x2438
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -213,7 +213,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2552
+						// Method begins at RVA 0x2542
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -236,7 +236,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x24ef
+					// Method begins at RVA 0x24df
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -261,7 +261,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2549
+					// Method begins at RVA 0x2539
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -285,7 +285,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2480
+				// Method begins at RVA 0x2470
 				// Header size: 12
 				// Code size: 99 (0x63)
 				.maxstack 8
@@ -351,7 +351,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2523
+				// Method begins at RVA 0x2513
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -380,9 +380,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x228c
+			// Method begins at RVA 0x2280
 			// Header size: 12
-			// Code size: 384 (0x180)
+			// Code size: 379 (0x17b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope,
@@ -402,128 +402,127 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule
-			IL_0027: ldloc.1
-			IL_0028: ldstr "port"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: stloc.2
-			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0038: dup
-			IL_0039: ldstr "port"
-			IL_003e: ldloc.2
-			IL_003f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0044: dup
-			IL_0045: ldstr "host"
-			IL_004a: ldstr "127.0.0.1"
-			IL_004f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0054: dup
-			IL_0055: ldstr "rejectUnauthorized"
-			IL_005a: ldc.i4.0
-			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0060: stloc.3
-			IL_0061: ldnull
-			IL_0062: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L17C5::__js_call__(object[], object)
-			IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_006d: ldc.i4.2
-			IL_006e: newarr [System.Runtime]System.Object
-			IL_0073: dup
-			IL_0074: ldc.i4.0
-			IL_0075: ldarg.0
-			IL_0076: stelem.ref
-			IL_0077: dup
-			IL_0078: ldc.i4.1
-			IL_0079: ldloc.0
-			IL_007a: stelem.ref
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0085: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_008a: ldc.i4.0
-			IL_008b: conv.r8
-			IL_008c: ldstr ""
-			IL_0091: ldc.i4.0
-			IL_0092: ldc.i4.0
-			IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_009d: stloc.s 4
-			IL_009f: ldstr "connect"
-			IL_00a4: ldloc.3
-			IL_00a5: ldloc.s 4
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ac: stloc.2
-			IL_00ad: ldloc.0
-			IL_00ae: ldloc.2
-			IL_00af: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_00b4: ldloc.0
-			IL_00b5: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_00ba: ldstr "Cannot access 'client' before initialization"
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c9: stloc.2
-			IL_00ca: ldnull
-			IL_00cb: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L22C21::__js_call__(object, object)
-			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d6: ldc.i4.1
-			IL_00d7: newarr [System.Runtime]System.Object
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldarg.0
-			IL_00df: stelem.ref
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00ea: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00ef: ldc.i4.1
-			IL_00f0: conv.r8
-			IL_00f1: ldstr ""
-			IL_00f6: ldc.i4.0
-			IL_00f7: ldc.i4.0
-			IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-			IL_0102: stloc.s 5
-			IL_0104: ldloc.2
-			IL_0105: ldstr "on"
-			IL_010a: ldstr "data"
-			IL_010f: ldloc.s 5
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0116: pop
-			IL_0117: ldloc.0
-			IL_0118: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
-			IL_011d: ldstr "Cannot access 'client' before initialization"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012c: stloc.2
-			IL_012d: ldnull
-			IL_012e: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22::__js_call__(object[], object)
-			IL_0134: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0139: ldc.i4.2
-			IL_013a: newarr [System.Runtime]System.Object
-			IL_013f: dup
-			IL_0140: ldc.i4.0
-			IL_0141: ldarg.0
-			IL_0142: stelem.ref
-			IL_0143: dup
-			IL_0144: ldc.i4.1
-			IL_0145: ldloc.0
-			IL_0146: stelem.ref
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0151: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_0156: ldc.i4.0
-			IL_0157: conv.r8
-			IL_0158: ldstr ""
-			IL_015d: ldc.i4.0
-			IL_015e: ldc.i4.0
-			IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_0169: stloc.s 4
-			IL_016b: ldloc.2
-			IL_016c: ldstr "on"
-			IL_0171: ldstr "close"
-			IL_0176: ldloc.s 4
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_017d: pop
-			IL_017e: ldnull
-			IL_017f: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+			IL_0022: ldloc.1
+			IL_0023: ldstr "port"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: stloc.2
+			IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0033: dup
+			IL_0034: ldstr "port"
+			IL_0039: ldloc.2
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: dup
+			IL_0040: ldstr "host"
+			IL_0045: ldstr "127.0.0.1"
+			IL_004a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_004f: dup
+			IL_0050: ldstr "rejectUnauthorized"
+			IL_0055: ldc.i4.0
+			IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_005b: stloc.3
+			IL_005c: ldnull
+			IL_005d: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L17C5::__js_call__(object[], object)
+			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0068: ldc.i4.2
+			IL_0069: newarr [System.Runtime]System.Object
+			IL_006e: dup
+			IL_006f: ldc.i4.0
+			IL_0070: ldarg.0
+			IL_0071: stelem.ref
+			IL_0072: dup
+			IL_0073: ldc.i4.1
+			IL_0074: ldloc.0
+			IL_0075: stelem.ref
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0080: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0085: ldc.i4.0
+			IL_0086: conv.r8
+			IL_0087: ldstr ""
+			IL_008c: ldc.i4.0
+			IL_008d: ldc.i4.0
+			IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0098: stloc.s 4
+			IL_009a: ldstr "connect"
+			IL_009f: ldloc.3
+			IL_00a0: ldloc.s 4
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00a7: stloc.2
+			IL_00a8: ldloc.0
+			IL_00a9: ldloc.2
+			IL_00aa: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00af: ldloc.0
+			IL_00b0: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_00b5: ldstr "Cannot access 'client' before initialization"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c4: stloc.2
+			IL_00c5: ldnull
+			IL_00c6: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L22C21::__js_call__(object, object)
+			IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00d1: ldc.i4.1
+			IL_00d2: newarr [System.Runtime]System.Object
+			IL_00d7: dup
+			IL_00d8: ldc.i4.0
+			IL_00d9: ldarg.0
+			IL_00da: stelem.ref
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00e5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00ea: ldc.i4.1
+			IL_00eb: conv.r8
+			IL_00ec: ldstr ""
+			IL_00f1: ldc.i4.0
+			IL_00f2: ldc.i4.0
+			IL_00f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+			IL_00fd: stloc.s 5
+			IL_00ff: ldloc.2
+			IL_0100: ldstr "on"
+			IL_0105: ldstr "data"
+			IL_010a: ldloc.s 5
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0111: pop
+			IL_0112: ldloc.0
+			IL_0113: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/Scope::client
+			IL_0118: ldstr "Cannot access 'client' before initialization"
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0127: stloc.2
+			IL_0128: ldnull
+			IL_0129: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22::__js_call__(object[], object)
+			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0134: ldc.i4.2
+			IL_0135: newarr [System.Runtime]System.Object
+			IL_013a: dup
+			IL_013b: ldc.i4.0
+			IL_013c: ldarg.0
+			IL_013d: stelem.ref
+			IL_013e: dup
+			IL_013f: ldc.i4.1
+			IL_0140: ldloc.0
+			IL_0141: stelem.ref
+			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_014c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0151: ldc.i4.0
+			IL_0152: conv.r8
+			IL_0153: ldstr ""
+			IL_0158: ldc.i4.0
+			IL_0159: ldc.i4.0
+			IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_0164: stloc.s 4
+			IL_0166: ldloc.2
+			IL_0167: ldstr "on"
+			IL_016c: ldstr "close"
+			IL_0171: ldloc.s 4
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0178: pop
+			IL_0179: ldnull
+			IL_017a: ret
 		} // end of method ArrowFunction_L13C31::__js_call__
 
 	} // end of class ArrowFunction_L13C31
@@ -537,14 +536,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object 'tls'
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule 'tls'
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2511
+			// Method begins at RVA 0x2501
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -570,7 +569,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 457 (0x1c9)
+		// Code size: 447 (0x1bf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Tls_CreateSecureContext_Server_Handshake/Scope,
@@ -596,7 +595,7 @@
 		IL_0012: stloc.s 4
 		IL_0014: ldloc.0
 		IL_0015: ldloc.s 4
-		IL_0017: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+		IL_0017: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
 		IL_001c: ldarg.1
 		IL_001d: ldstr "./Tls_TestCertificates"
 		IL_0022: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
@@ -622,121 +621,119 @@
 		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0066: stloc.2
 		IL_0067: ldloc.0
-		IL_0068: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-		IL_006d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule
-		IL_0072: stloc.s 4
-		IL_0074: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0079: dup
-		IL_007a: ldstr "key"
-		IL_007f: ldloc.2
-		IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0085: dup
-		IL_0086: ldstr "cert"
-		IL_008b: ldloc.1
-		IL_008c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0091: stloc.s 6
-		IL_0093: ldloc.s 4
-		IL_0095: ldloc.s 6
-		IL_0097: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule::createSecureContext(object)
-		IL_009c: stloc.3
-		IL_009d: ldstr "console"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 5
-		IL_00ae: ldloc.3
-		IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_00b4: ldc.i4.0
-		IL_00b5: ceq
-		IL_00b7: stloc.s 7
-		IL_00b9: ldloc.s 7
-		IL_00bb: ldc.i4.0
-		IL_00bc: ceq
-		IL_00be: stloc.s 7
-		IL_00c0: ldloc.s 7
-		IL_00c2: box [System.Runtime]System.Boolean
-		IL_00c7: stloc.s 8
-		IL_00c9: ldstr "secureContext:"
-		IL_00ce: ldloc.s 8
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00d5: stloc.s 9
-		IL_00d7: ldloc.s 5
-		IL_00d9: ldstr "log"
-		IL_00de: ldloc.s 9
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e5: pop
-		IL_00e6: ldloc.0
-		IL_00e7: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
-		IL_00ec: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule
-		IL_00f1: stloc.s 4
-		IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00f8: dup
-		IL_00f9: ldstr "secureContext"
-		IL_00fe: ldloc.3
-		IL_00ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0104: stloc.s 6
-		IL_0106: ldnull
-		IL_0107: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L9C52::__js_call__(object, object)
-		IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0126: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_012b: ldc.i4.1
-		IL_012c: conv.r8
-		IL_012d: ldstr ""
-		IL_0132: ldc.i4.0
-		IL_0133: ldc.i4.0
-		IL_0134: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_013e: stloc.s 10
-		IL_0140: ldloc.s 4
-		IL_0142: ldloc.s 6
-		IL_0144: ldloc.s 10
-		IL_0146: castclass [System.Runtime]System.Delegate
-		IL_014b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule::createServer(object, class [System.Runtime]System.Delegate)
-		IL_0150: stloc.s 5
-		IL_0152: ldloc.0
-		IL_0153: ldloc.s 5
-		IL_0155: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-		IL_015a: ldloc.0
-		IL_015b: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0165: stloc.s 5
-		IL_0167: ldloc.0
-		IL_0168: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
-		IL_016d: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31::__js_call__(class Modules.Tls_CreateSecureContext_Server_Handshake/Scope, object)
-		IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0178: ldc.i4.1
-		IL_0179: newarr [System.Runtime]System.Object
-		IL_017e: dup
-		IL_017f: ldc.i4.0
-		IL_0180: ldloc.0
-		IL_0181: stelem.ref
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_018c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0191: ldc.i4.0
-		IL_0192: conv.r8
-		IL_0193: ldstr ""
-		IL_0198: ldc.i4.0
-		IL_0199: ldc.i4.0
-		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_01a4: stloc.s 11
-		IL_01a6: ldloc.s 5
-		IL_01a8: ldstr "listen"
-		IL_01ad: ldc.r8 0.0
-		IL_01b6: box [System.Runtime]System.Double
-		IL_01bb: ldstr "127.0.0.1"
-		IL_01c0: ldloc.s 11
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_01c7: pop
-		IL_01c8: ret
+		IL_0068: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+		IL_006d: stloc.s 4
+		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0074: dup
+		IL_0075: ldstr "key"
+		IL_007a: ldloc.2
+		IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0080: dup
+		IL_0081: ldstr "cert"
+		IL_0086: ldloc.1
+		IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_008c: stloc.s 6
+		IL_008e: ldloc.s 4
+		IL_0090: ldloc.s 6
+		IL_0092: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule::createSecureContext(object)
+		IL_0097: stloc.3
+		IL_0098: ldstr "console"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a7: stloc.s 5
+		IL_00a9: ldloc.3
+		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+		IL_00af: ldc.i4.0
+		IL_00b0: ceq
+		IL_00b2: stloc.s 7
+		IL_00b4: ldloc.s 7
+		IL_00b6: ldc.i4.0
+		IL_00b7: ceq
+		IL_00b9: stloc.s 7
+		IL_00bb: ldloc.s 7
+		IL_00bd: box [System.Runtime]System.Boolean
+		IL_00c2: stloc.s 8
+		IL_00c4: ldstr "secureContext:"
+		IL_00c9: ldloc.s 8
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00d0: stloc.s 9
+		IL_00d2: ldloc.s 5
+		IL_00d4: ldstr "log"
+		IL_00d9: ldloc.s 9
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e0: pop
+		IL_00e1: ldloc.0
+		IL_00e2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
+		IL_00e7: stloc.s 4
+		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00ee: dup
+		IL_00ef: ldstr "secureContext"
+		IL_00f4: ldloc.3
+		IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00fa: stloc.s 6
+		IL_00fc: ldnull
+		IL_00fd: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L9C52::__js_call__(object, object)
+		IL_0103: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0108: ldc.i4.1
+		IL_0109: newarr [System.Runtime]System.Object
+		IL_010e: dup
+		IL_010f: ldc.i4.0
+		IL_0110: ldloc.0
+		IL_0111: stelem.ref
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_011c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0121: ldc.i4.1
+		IL_0122: conv.r8
+		IL_0123: ldstr ""
+		IL_0128: ldc.i4.0
+		IL_0129: ldc.i4.0
+		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_0134: stloc.s 10
+		IL_0136: ldloc.s 4
+		IL_0138: ldloc.s 6
+		IL_013a: ldloc.s 10
+		IL_013c: castclass [System.Runtime]System.Delegate
+		IL_0141: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule::createServer(object, class [System.Runtime]System.Delegate)
+		IL_0146: stloc.s 5
+		IL_0148: ldloc.0
+		IL_0149: ldloc.s 5
+		IL_014b: stfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
+		IL_0150: ldloc.0
+		IL_0151: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015b: stloc.s 5
+		IL_015d: ldloc.0
+		IL_015e: castclass Modules.Tls_CreateSecureContext_Server_Handshake/Scope
+		IL_0163: ldftn object Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31::__js_call__(class Modules.Tls_CreateSecureContext_Server_Handshake/Scope, object)
+		IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016e: ldc.i4.1
+		IL_016f: newarr [System.Runtime]System.Object
+		IL_0174: dup
+		IL_0175: ldc.i4.0
+		IL_0176: ldloc.0
+		IL_0177: stelem.ref
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0182: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0187: ldc.i4.0
+		IL_0188: conv.r8
+		IL_0189: ldstr ""
+		IL_018e: ldc.i4.0
+		IL_018f: ldc.i4.0
+		IL_0190: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0195: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_019a: stloc.s 11
+		IL_019c: ldloc.s 5
+		IL_019e: ldstr "listen"
+		IL_01a3: ldc.r8 0.0
+		IL_01ac: box [System.Runtime]System.Double
+		IL_01b1: ldstr "127.0.0.1"
+		IL_01b6: ldloc.s 11
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_01bd: pop
+		IL_01be: ret
 	} // end of method Tls_CreateSecureContext_Server_Handshake::__js_module_init__
 
 } // end of class Modules.Tls_CreateSecureContext_Server_Handshake
@@ -752,7 +749,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x255b
+			// Method begins at RVA 0x254b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -776,7 +773,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2228
+		// Method begins at RVA 0x221c
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 8
@@ -816,7 +813,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2564
+		// Method begins at RVA 0x2554
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2606
+				// Method begins at RVA 0x25fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21f4
 			// Header size: 1
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -87,7 +87,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2623
+					// Method begins at RVA 0x261b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -111,7 +111,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23fc
+				// Method begins at RVA 0x23f4
 				// Header size: 12
 				// Code size: 297 (0x129)
 				.maxstack 8
@@ -242,7 +242,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x262c
+					// Method begins at RVA 0x2624
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -266,7 +266,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2534
+				// Method begins at RVA 0x252c
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -309,7 +309,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x263e
+						// Method begins at RVA 0x2636
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -332,7 +332,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25db
+					// Method begins at RVA 0x25d3
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -357,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2635
+					// Method begins at RVA 0x262d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -381,7 +381,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x256c
+				// Method begins at RVA 0x2564
 				// Header size: 12
 				// Code size: 99 (0x63)
 				.maxstack 8
@@ -447,7 +447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260f
+				// Method begins at RVA 0x2607
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -476,9 +476,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2228
+			// Method begins at RVA 0x2224
 			// Header size: 12
-			// Code size: 455 (0x1c7)
+			// Code size: 450 (0x1c2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope,
@@ -521,128 +521,127 @@
 			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0060: pop
 			IL_0061: ldarg.0
-			IL_0062: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
-			IL_0067: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule
-			IL_006c: ldloc.1
-			IL_006d: ldstr "port"
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0077: stloc.2
-			IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_007d: dup
-			IL_007e: ldstr "port"
-			IL_0083: ldloc.2
-			IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0089: dup
-			IL_008a: ldstr "host"
-			IL_008f: ldstr "127.0.0.1"
-			IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0099: dup
-			IL_009a: ldstr "rejectUnauthorized"
-			IL_009f: ldc.i4.0
-			IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_00a5: stloc.s 5
-			IL_00a7: ldnull
-			IL_00a8: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L17C5::__js_call__(object[], object)
-			IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00b3: ldc.i4.2
-			IL_00b4: newarr [System.Runtime]System.Object
-			IL_00b9: dup
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldarg.0
-			IL_00bc: stelem.ref
-			IL_00bd: dup
-			IL_00be: ldc.i4.1
-			IL_00bf: ldloc.0
-			IL_00c0: stelem.ref
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00cb: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_00d0: ldc.i4.0
-			IL_00d1: conv.r8
-			IL_00d2: ldstr ""
-			IL_00d7: ldc.i4.0
-			IL_00d8: ldc.i4.0
-			IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_00e3: stloc.s 6
-			IL_00e5: ldstr "connect"
-			IL_00ea: ldloc.s 5
-			IL_00ec: ldloc.s 6
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f3: stloc.2
-			IL_00f4: ldloc.0
-			IL_00f5: ldloc.2
-			IL_00f6: stfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_00fb: ldloc.0
-			IL_00fc: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_0101: ldstr "Cannot access 'client' before initialization"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.2
-			IL_0111: ldnull
-			IL_0112: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L24C21::__js_call__(object, object)
-			IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_011d: ldc.i4.1
-			IL_011e: newarr [System.Runtime]System.Object
-			IL_0123: dup
-			IL_0124: ldc.i4.0
-			IL_0125: ldarg.0
-			IL_0126: stelem.ref
-			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0131: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_0136: ldc.i4.1
-			IL_0137: conv.r8
-			IL_0138: ldstr ""
-			IL_013d: ldc.i4.0
-			IL_013e: ldc.i4.0
-			IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-			IL_0149: stloc.s 7
-			IL_014b: ldloc.2
-			IL_014c: ldstr "on"
-			IL_0151: ldstr "data"
-			IL_0156: ldloc.s 7
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_015d: pop
-			IL_015e: ldloc.0
-			IL_015f: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-			IL_0164: ldstr "Cannot access 'client' before initialization"
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0173: stloc.2
-			IL_0174: ldnull
-			IL_0175: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22::__js_call__(object[], object)
-			IL_017b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0180: ldc.i4.2
-			IL_0181: newarr [System.Runtime]System.Object
-			IL_0186: dup
-			IL_0187: ldc.i4.0
-			IL_0188: ldarg.0
-			IL_0189: stelem.ref
-			IL_018a: dup
-			IL_018b: ldc.i4.1
-			IL_018c: ldloc.0
-			IL_018d: stelem.ref
-			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0198: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
-			IL_019d: ldc.i4.0
-			IL_019e: conv.r8
-			IL_019f: ldstr ""
-			IL_01a4: ldc.i4.0
-			IL_01a5: ldc.i4.0
-			IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
-			IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
-			IL_01b0: stloc.s 6
-			IL_01b2: ldloc.2
-			IL_01b3: ldstr "on"
-			IL_01b8: ldstr "close"
-			IL_01bd: ldloc.s 6
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01c4: pop
-			IL_01c5: ldnull
-			IL_01c6: ret
+			IL_0062: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
+			IL_0067: ldloc.1
+			IL_0068: ldstr "port"
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0072: stloc.2
+			IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0078: dup
+			IL_0079: ldstr "port"
+			IL_007e: ldloc.2
+			IL_007f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0084: dup
+			IL_0085: ldstr "host"
+			IL_008a: ldstr "127.0.0.1"
+			IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0094: dup
+			IL_0095: ldstr "rejectUnauthorized"
+			IL_009a: ldc.i4.0
+			IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_00a0: stloc.s 5
+			IL_00a2: ldnull
+			IL_00a3: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L17C5::__js_call__(object[], object)
+			IL_00a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00ae: ldc.i4.2
+			IL_00af: newarr [System.Runtime]System.Object
+			IL_00b4: dup
+			IL_00b5: ldc.i4.0
+			IL_00b6: ldarg.0
+			IL_00b7: stelem.ref
+			IL_00b8: dup
+			IL_00b9: ldc.i4.1
+			IL_00ba: ldloc.0
+			IL_00bb: stelem.ref
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00c6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_00cb: ldc.i4.0
+			IL_00cc: conv.r8
+			IL_00cd: ldstr ""
+			IL_00d2: ldc.i4.0
+			IL_00d3: ldc.i4.0
+			IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_00de: stloc.s 6
+			IL_00e0: ldstr "connect"
+			IL_00e5: ldloc.s 5
+			IL_00e7: ldloc.s 6
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ee: stloc.2
+			IL_00ef: ldloc.0
+			IL_00f0: ldloc.2
+			IL_00f1: stfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_00f6: ldloc.0
+			IL_00f7: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_00fc: ldstr "Cannot access 'client' before initialization"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010b: stloc.2
+			IL_010c: ldnull
+			IL_010d: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L24C21::__js_call__(object, object)
+			IL_0113: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0118: ldc.i4.1
+			IL_0119: newarr [System.Runtime]System.Object
+			IL_011e: dup
+			IL_011f: ldc.i4.0
+			IL_0120: ldarg.0
+			IL_0121: stelem.ref
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_012c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0131: ldc.i4.1
+			IL_0132: conv.r8
+			IL_0133: ldstr ""
+			IL_0138: ldc.i4.0
+			IL_0139: ldc.i4.0
+			IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+			IL_0144: stloc.s 7
+			IL_0146: ldloc.2
+			IL_0147: ldstr "on"
+			IL_014c: ldstr "data"
+			IL_0151: ldloc.s 7
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0158: pop
+			IL_0159: ldloc.0
+			IL_015a: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+			IL_015f: ldstr "Cannot access 'client' before initialization"
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016e: stloc.2
+			IL_016f: ldnull
+			IL_0170: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22::__js_call__(object[], object)
+			IL_0176: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_017b: ldc.i4.2
+			IL_017c: newarr [System.Runtime]System.Object
+			IL_0181: dup
+			IL_0182: ldc.i4.0
+			IL_0183: ldarg.0
+			IL_0184: stelem.ref
+			IL_0185: dup
+			IL_0186: ldc.i4.1
+			IL_0187: ldloc.0
+			IL_0188: stelem.ref
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0193: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunc0
+			IL_0198: ldc.i4.0
+			IL_0199: conv.r8
+			IL_019a: ldstr ""
+			IL_019f: ldc.i4.0
+			IL_01a0: ldc.i4.0
+			IL_01a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0, float64, string, bool, bool)
+			IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFunc0>(!!0)
+			IL_01ab: stloc.s 6
+			IL_01ad: ldloc.2
+			IL_01ae: ldstr "on"
+			IL_01b3: ldstr "close"
+			IL_01b8: ldloc.s 6
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01bf: pop
+			IL_01c0: ldnull
+			IL_01c1: ret
 		} // end of method ArrowFunction_L11C31::__js_call__
 
 	} // end of class ArrowFunction_L11C31
@@ -656,14 +655,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object 'tls'
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule 'tls'
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25fd
+			// Method begins at RVA 0x25f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -689,7 +688,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 338 (0x152)
+		// Code size: 333 (0x14d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Tls_CreateServer_Connect_Basic/Scope,
@@ -711,7 +710,7 @@
 		IL_0012: stloc.3
 		IL_0013: ldloc.0
 		IL_0014: ldloc.3
-		IL_0015: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
 		IL_001a: ldarg.1
 		IL_001b: ldstr "./Tls_TestCertificates"
 		IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
@@ -737,82 +736,81 @@
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0064: stloc.2
 		IL_0065: ldloc.0
-		IL_0066: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
-		IL_006b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule
-		IL_0070: stloc.3
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0076: dup
-		IL_0077: ldstr "key"
-		IL_007c: ldloc.2
-		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0082: dup
-		IL_0083: ldstr "cert"
-		IL_0088: ldloc.1
-		IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008e: stloc.s 5
-		IL_0090: ldnull
-		IL_0091: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L6C65::__js_call__(object, object)
-		IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_00b5: ldc.i4.1
-		IL_00b6: conv.r8
-		IL_00b7: ldstr ""
-		IL_00bc: ldc.i4.0
-		IL_00bd: ldc.i4.0
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
-		IL_00c8: stloc.s 6
-		IL_00ca: ldloc.3
-		IL_00cb: ldloc.s 5
-		IL_00cd: ldloc.s 6
-		IL_00cf: castclass [System.Runtime]System.Delegate
-		IL_00d4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule::createServer(object, class [System.Runtime]System.Delegate)
-		IL_00d9: stloc.s 4
-		IL_00db: ldloc.0
-		IL_00dc: ldloc.s 4
-		IL_00de: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-		IL_00e3: ldloc.0
-		IL_00e4: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.0
-		IL_00f1: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
-		IL_00f6: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31::__js_call__(class Modules.Tls_CreateServer_Connect_Basic/Scope, object)
-		IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0101: ldc.i4.1
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: dup
-		IL_0108: ldc.i4.0
-		IL_0109: ldloc.0
-		IL_010a: stelem.ref
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0115: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_011a: ldc.i4.0
-		IL_011b: conv.r8
-		IL_011c: ldstr ""
-		IL_0121: ldc.i4.0
-		IL_0122: ldc.i4.0
-		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_012d: stloc.s 7
-		IL_012f: ldloc.s 4
-		IL_0131: ldstr "listen"
-		IL_0136: ldc.r8 0.0
-		IL_013f: box [System.Runtime]System.Double
-		IL_0144: ldstr "127.0.0.1"
-		IL_0149: ldloc.s 7
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0150: pop
-		IL_0151: ret
+		IL_0066: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
+		IL_006b: stloc.3
+		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0071: dup
+		IL_0072: ldstr "key"
+		IL_0077: ldloc.2
+		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_007d: dup
+		IL_007e: ldstr "cert"
+		IL_0083: ldloc.1
+		IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0089: stloc.s 5
+		IL_008b: ldnull
+		IL_008c: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L6C65::__js_call__(object, object)
+		IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ab: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00b0: ldc.i4.1
+		IL_00b1: conv.r8
+		IL_00b2: ldstr ""
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldc.i4.0
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0)
+		IL_00c3: stloc.s 6
+		IL_00c5: ldloc.3
+		IL_00c6: ldloc.s 5
+		IL_00c8: ldloc.s 6
+		IL_00ca: castclass [System.Runtime]System.Delegate
+		IL_00cf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule::createServer(object, class [System.Runtime]System.Delegate)
+		IL_00d4: stloc.s 4
+		IL_00d6: ldloc.0
+		IL_00d7: ldloc.s 4
+		IL_00d9: stfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
+		IL_00de: ldloc.0
+		IL_00df: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e9: stloc.s 4
+		IL_00eb: ldloc.0
+		IL_00ec: castclass Modules.Tls_CreateServer_Connect_Basic/Scope
+		IL_00f1: ldftn object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31::__js_call__(class Modules.Tls_CreateServer_Connect_Basic/Scope, object)
+		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00fc: ldc.i4.1
+		IL_00fd: newarr [System.Runtime]System.Object
+		IL_0102: dup
+		IL_0103: ldc.i4.0
+		IL_0104: ldloc.0
+		IL_0105: stelem.ref
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0110: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0115: ldc.i4.0
+		IL_0116: conv.r8
+		IL_0117: ldstr ""
+		IL_011c: ldc.i4.0
+		IL_011d: ldc.i4.0
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0128: stloc.s 7
+		IL_012a: ldloc.s 4
+		IL_012c: ldstr "listen"
+		IL_0131: ldc.r8 0.0
+		IL_013a: box [System.Runtime]System.Double
+		IL_013f: ldstr "127.0.0.1"
+		IL_0144: ldloc.s 7
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_014b: pop
+		IL_014c: ret
 	} // end of method Tls_CreateServer_Connect_Basic::__js_module_init__
 
 } // end of class Modules.Tls_CreateServer_Connect_Basic
@@ -828,7 +826,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2647
+			// Method begins at RVA 0x263f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -852,7 +850,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21b0
+		// Method begins at RVA 0x21ac
 		// Header size: 12
 		// Code size: 60 (0x3c)
 		.maxstack 8
@@ -892,7 +890,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2650
+		// Method begins at RVA 0x2648
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2638
+					// Method begins at RVA 0x2630
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2394
+				// Method begins at RVA 0x238c
 				// Header size: 12
 				// Code size: 60 (0x3c)
 				.maxstack 8
@@ -100,7 +100,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x264a
+						// Method begins at RVA 0x2642
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x256c
+					// Method begins at RVA 0x2564
 					// Header size: 12
 					// Code size: 140 (0x8c)
 					.maxstack 8
@@ -193,7 +193,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2641
+					// Method begins at RVA 0x2639
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -217,7 +217,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23dc
+				// Method begins at RVA 0x23d4
 				// Header size: 12
 				// Code size: 145 (0x91)
 				.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262f
+				// Method begins at RVA 0x2627
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -334,7 +334,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2128
+			// Method begins at RVA 0x2124
 			// Header size: 12
 			// Code size: 238 (0xee)
 			.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2667
+					// Method begins at RVA 0x265f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -478,7 +478,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2479
+				// Method begins at RVA 0x2471
 				// Header size: 1
 				// Code size: 46 (0x2e)
 				.maxstack 8
@@ -512,7 +512,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2670
+					// Method begins at RVA 0x2668
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -537,7 +537,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24a8
+				// Method begins at RVA 0x24a0
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -583,7 +583,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2682
+						// Method begins at RVA 0x267a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -606,7 +606,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2604
+					// Method begins at RVA 0x25fc
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -631,7 +631,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2679
+					// Method begins at RVA 0x2671
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -655,7 +655,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24dc
+				// Method begins at RVA 0x24d4
 				// Header size: 12
 				// Code size: 129 (0x81)
 				.maxstack 8
@@ -733,7 +733,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2653
+				// Method begins at RVA 0x264b
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -762,9 +762,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x2220
 			// Header size: 12
-			// Code size: 355 (0x163)
+			// Code size: 350 (0x15e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope,
@@ -784,123 +784,122 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-			IL_0027: ldloc.1
-			IL_0028: ldstr "port"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: stloc.2
-			IL_0033: ldloc.1
-			IL_0034: ldstr "address"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: stloc.3
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0058: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_005d: ldc.i4.0
-			IL_005e: conv.r8
-			IL_005f: ldstr ""
-			IL_0064: ldc.i4.0
-			IL_0065: ldc.i4.1
-			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_006b: stloc.s 4
-			IL_006d: ldstr "connect"
-			IL_0072: ldloc.2
-			IL_0073: ldloc.3
-			IL_0074: ldloc.s 4
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_007b: stloc.3
-			IL_007c: ldloc.0
-			IL_007d: ldloc.3
-			IL_007e: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0083: ldloc.0
-			IL_0084: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0089: ldstr "Cannot access 'client' before initialization"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: ldstr "setEncoding"
-			IL_009d: ldstr "utf8"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a7: pop
-			IL_00a8: ldloc.0
-			IL_00a9: ldstr ""
-			IL_00ae: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-			IL_00b3: ldloc.0
-			IL_00b4: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_00b9: ldstr "Cannot access 'client' before initialization"
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c8: stloc.3
-			IL_00c9: ldc.i4.2
-			IL_00ca: newarr [System.Runtime]System.Object
-			IL_00cf: dup
-			IL_00d0: ldc.i4.0
-			IL_00d1: ldarg.0
-			IL_00d2: stelem.ref
-			IL_00d3: dup
-			IL_00d4: ldc.i4.1
-			IL_00d5: ldloc.0
-			IL_00d6: stelem.ref
-			IL_00d7: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00e2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00e7: ldc.i4.1
-			IL_00e8: conv.r8
-			IL_00e9: ldstr ""
-			IL_00ee: ldc.i4.0
-			IL_00ef: ldc.i4.1
-			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldloc.3
-			IL_00f8: ldstr "on"
-			IL_00fd: ldstr "data"
-			IL_0102: ldloc.s 5
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0109: pop
-			IL_010a: ldloc.0
-			IL_010b: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0110: ldstr "Cannot access 'client' before initialization"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011f: stloc.3
-			IL_0120: ldc.i4.2
-			IL_0121: newarr [System.Runtime]System.Object
-			IL_0126: dup
-			IL_0127: ldc.i4.0
-			IL_0128: ldarg.0
-			IL_0129: stelem.ref
-			IL_012a: dup
-			IL_012b: ldc.i4.1
-			IL_012c: ldloc.0
-			IL_012d: stelem.ref
-			IL_012e: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
-			IL_0134: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0139: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_013e: ldc.i4.0
-			IL_013f: conv.r8
-			IL_0140: ldstr ""
-			IL_0145: ldc.i4.0
-			IL_0146: ldc.i4.1
-			IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_014c: stloc.s 4
-			IL_014e: ldloc.3
-			IL_014f: ldstr "on"
-			IL_0154: ldstr "end"
-			IL_0159: ldloc.s 4
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0160: pop
-			IL_0161: ldnull
-			IL_0162: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
+			IL_0022: ldloc.1
+			IL_0023: ldstr "port"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: stloc.2
+			IL_002e: ldloc.1
+			IL_002f: ldstr "address"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0039: stloc.3
+			IL_003a: ldc.i4.2
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: dup
+			IL_0045: ldc.i4.1
+			IL_0046: ldloc.0
+			IL_0047: stelem.ref
+			IL_0048: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0058: ldc.i4.0
+			IL_0059: conv.r8
+			IL_005a: ldstr ""
+			IL_005f: ldc.i4.0
+			IL_0060: ldc.i4.1
+			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0066: stloc.s 4
+			IL_0068: ldstr "connect"
+			IL_006d: ldloc.2
+			IL_006e: ldloc.3
+			IL_006f: ldloc.s 4
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0076: stloc.3
+			IL_0077: ldloc.0
+			IL_0078: ldloc.3
+			IL_0079: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_007e: ldloc.0
+			IL_007f: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_0084: ldstr "Cannot access 'client' before initialization"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0093: ldstr "setEncoding"
+			IL_0098: ldstr "utf8"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a2: pop
+			IL_00a3: ldloc.0
+			IL_00a4: ldstr ""
+			IL_00a9: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
+			IL_00ae: ldloc.0
+			IL_00af: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_00b4: ldstr "Cannot access 'client' before initialization"
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c3: stloc.3
+			IL_00c4: ldc.i4.2
+			IL_00c5: newarr [System.Runtime]System.Object
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldarg.0
+			IL_00cd: stelem.ref
+			IL_00ce: dup
+			IL_00cf: ldc.i4.1
+			IL_00d0: ldloc.0
+			IL_00d1: stelem.ref
+			IL_00d2: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00dd: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00e2: ldc.i4.1
+			IL_00e3: conv.r8
+			IL_00e4: ldstr ""
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldc.i4.1
+			IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00f0: stloc.s 5
+			IL_00f2: ldloc.3
+			IL_00f3: ldstr "on"
+			IL_00f8: ldstr "data"
+			IL_00fd: ldloc.s 5
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0104: pop
+			IL_0105: ldloc.0
+			IL_0106: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_010b: ldstr "Cannot access 'client' before initialization"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011a: stloc.3
+			IL_011b: ldc.i4.2
+			IL_011c: newarr [System.Runtime]System.Object
+			IL_0121: dup
+			IL_0122: ldc.i4.0
+			IL_0123: ldarg.0
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.1
+			IL_0127: ldloc.0
+			IL_0128: stelem.ref
+			IL_0129: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
+			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0134: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0139: ldc.i4.0
+			IL_013a: conv.r8
+			IL_013b: ldstr ""
+			IL_0140: ldc.i4.0
+			IL_0141: ldc.i4.1
+			IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0147: stloc.s 4
+			IL_0149: ldloc.3
+			IL_014a: ldstr "on"
+			IL_014f: ldstr "end"
+			IL_0154: ldloc.s 4
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_015b: pop
+			IL_015c: ldnull
+			IL_015d: ret
 		} // end of method FunctionExpression_L22C30::__js_call__
 
 	} // end of class FunctionExpression_L22C30
@@ -914,14 +913,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object net
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule net
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2626
+			// Method begins at RVA 0x261e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -947,7 +946,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 197 (0xc5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope,
@@ -967,63 +966,62 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-		IL_0025: stloc.1
-		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_002b: dup
-		IL_002c: ldstr "allowHalfOpen"
-		IL_0031: ldc.i4.1
-		IL_0032: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0037: stloc.2
-		IL_0038: ldloc.0
-		IL_0039: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_003e: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
-		IL_0044: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0049: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_004e: ldc.i4.1
-		IL_004f: conv.r8
-		IL_0050: ldstr ""
-		IL_0055: ldc.i4.0
-		IL_0056: ldc.i4.1
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_005c: stloc.3
-		IL_005d: ldloc.1
-		IL_005e: ldloc.2
-		IL_005f: ldloc.3
-		IL_0060: castclass [System.Runtime]System.Delegate
-		IL_0065: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(object, class [System.Runtime]System.Delegate)
-		IL_006a: stloc.s 4
-		IL_006c: ldloc.0
-		IL_006d: ldloc.s 4
-		IL_006f: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-		IL_0074: ldloc.0
-		IL_0075: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.0
-		IL_0082: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_0087: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
-		IL_008d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0092: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0097: ldc.i4.0
-		IL_0098: conv.r8
-		IL_0099: ldstr ""
-		IL_009e: ldc.i4.0
-		IL_009f: ldc.i4.1
-		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_00a5: stloc.s 5
-		IL_00a7: ldloc.s 4
-		IL_00a9: ldstr "listen"
-		IL_00ae: ldc.r8 0.0
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: ldstr "127.0.0.1"
-		IL_00c1: ldloc.s 5
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::net
+		IL_0020: stloc.1
+		IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0026: dup
+		IL_0027: ldstr "allowHalfOpen"
+		IL_002c: ldc.i4.1
+		IL_002d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0032: stloc.2
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+		IL_0039: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
+		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0044: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0049: ldc.i4.1
+		IL_004a: conv.r8
+		IL_004b: ldstr ""
+		IL_0050: ldc.i4.0
+		IL_0051: ldc.i4.1
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0057: stloc.3
+		IL_0058: ldloc.1
+		IL_0059: ldloc.2
+		IL_005a: ldloc.3
+		IL_005b: castclass [System.Runtime]System.Delegate
+		IL_0060: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(object, class [System.Runtime]System.Delegate)
+		IL_0065: stloc.s 4
+		IL_0067: ldloc.0
+		IL_0068: ldloc.s 4
+		IL_006a: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
+		IL_006f: ldloc.0
+		IL_0070: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::server
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007a: stloc.s 4
+		IL_007c: ldloc.0
+		IL_007d: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+		IL_0082: ldftn object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
+		IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_008d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0092: ldc.i4.0
+		IL_0093: conv.r8
+		IL_0094: ldstr ""
+		IL_0099: ldc.i4.0
+		IL_009a: ldc.i4.1
+		IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_00a0: stloc.s 5
+		IL_00a2: ldloc.s 4
+		IL_00a4: ldstr "listen"
+		IL_00a9: ldc.r8 0.0
+		IL_00b2: box [System.Runtime]System.Double
+		IL_00b7: ldstr "127.0.0.1"
+		IL_00bc: ldloc.s 5
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00c3: pop
+		IL_00c4: ret
 	} // end of method Net_CreateServer_AllowHalfOpen_Delayed_Response::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response
@@ -1035,7 +1033,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x268b
+		// Method begins at RVA 0x2683
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25e1
+					// Method begins at RVA 0x25d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23b4
+				// Method begins at RVA 0x23ac
 				// Header size: 12
 				// Code size: 60 (0x3c)
 				.maxstack 8
@@ -96,7 +96,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ea
+					// Method begins at RVA 0x25e2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23fc
+				// Method begins at RVA 0x23f4
 				// Header size: 12
 				// Code size: 159 (0x9f)
 				.maxstack 8
@@ -205,7 +205,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d8
+				// Method begins at RVA 0x25d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -232,7 +232,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x210c
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -332,7 +332,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2607
+					// Method begins at RVA 0x25ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -356,7 +356,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24a7
+				// Method begins at RVA 0x249f
 				// Header size: 1
 				// Code size: 46 (0x2e)
 				.maxstack 8
@@ -390,7 +390,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2610
+					// Method begins at RVA 0x2608
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -415,7 +415,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24d8
+				// Method begins at RVA 0x24d0
 				// Header size: 12
 				// Code size: 60 (0x3c)
 				.maxstack 8
@@ -468,7 +468,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2622
+						// Method begins at RVA 0x261a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -491,7 +491,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x25ad
+					// Method begins at RVA 0x25a5
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -516,7 +516,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2619
+					// Method begins at RVA 0x2611
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -540,7 +540,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2520
+				// Method begins at RVA 0x2518
 				// Header size: 12
 				// Code size: 129 (0x81)
 				.maxstack 8
@@ -618,7 +618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f3
+				// Method begins at RVA 0x25eb
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -647,9 +647,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
-			// Method begins at RVA 0x21cc
+			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 474 (0x1da)
+			// Code size: 469 (0x1d5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope,
@@ -721,114 +721,113 @@
 			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_00b7: pop
 			IL_00b8: ldarg.0
-			IL_00b9: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-			IL_00be: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-			IL_00c3: ldloc.1
-			IL_00c4: ldstr "port"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ce: stloc.2
-			IL_00cf: ldloc.1
-			IL_00d0: ldstr "address"
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00da: stloc.3
-			IL_00db: ldc.i4.2
-			IL_00dc: newarr [System.Runtime]System.Object
-			IL_00e1: dup
-			IL_00e2: ldc.i4.0
-			IL_00e3: ldarg.0
-			IL_00e4: stelem.ref
-			IL_00e5: dup
-			IL_00e6: ldc.i4.1
-			IL_00e7: ldloc.0
-			IL_00e8: stelem.ref
-			IL_00e9: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00f4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_00f9: ldc.i4.0
-			IL_00fa: conv.r8
-			IL_00fb: ldstr ""
-			IL_0100: ldc.i4.0
-			IL_0101: ldc.i4.1
-			IL_0102: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_0107: stloc.s 7
-			IL_0109: ldstr "connect"
-			IL_010e: ldloc.2
-			IL_010f: ldloc.3
-			IL_0110: ldloc.s 7
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0117: stloc.3
-			IL_0118: ldloc.0
-			IL_0119: ldloc.3
-			IL_011a: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_011f: ldloc.0
-			IL_0120: ldstr ""
-			IL_0125: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
-			IL_012a: ldloc.0
-			IL_012b: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_0130: ldstr "Cannot access 'client' before initialization"
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013f: stloc.3
-			IL_0140: ldc.i4.2
-			IL_0141: newarr [System.Runtime]System.Object
-			IL_0146: dup
-			IL_0147: ldc.i4.0
-			IL_0148: ldarg.0
-			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.1
-			IL_014c: ldloc.0
-			IL_014d: stelem.ref
-			IL_014e: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
-			IL_0154: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0159: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_015e: ldc.i4.1
-			IL_015f: conv.r8
-			IL_0160: ldstr ""
-			IL_0165: ldc.i4.0
-			IL_0166: ldc.i4.1
-			IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_016c: stloc.s 8
-			IL_016e: ldloc.3
-			IL_016f: ldstr "on"
-			IL_0174: ldstr "data"
-			IL_0179: ldloc.s 8
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0180: pop
-			IL_0181: ldloc.0
-			IL_0182: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
-			IL_0187: ldstr "Cannot access 'client' before initialization"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0196: stloc.3
-			IL_0197: ldc.i4.2
-			IL_0198: newarr [System.Runtime]System.Object
-			IL_019d: dup
-			IL_019e: ldc.i4.0
-			IL_019f: ldarg.0
-			IL_01a0: stelem.ref
-			IL_01a1: dup
-			IL_01a2: ldc.i4.1
-			IL_01a3: ldloc.0
-			IL_01a4: stelem.ref
-			IL_01a5: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
-			IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_01b0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_01b5: ldc.i4.0
-			IL_01b6: conv.r8
-			IL_01b7: ldstr ""
-			IL_01bc: ldc.i4.0
-			IL_01bd: ldc.i4.1
-			IL_01be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_01c3: stloc.s 7
-			IL_01c5: ldloc.3
-			IL_01c6: ldstr "on"
-			IL_01cb: ldstr "end"
-			IL_01d0: ldloc.s 7
-			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01d7: pop
-			IL_01d8: ldnull
-			IL_01d9: ret
+			IL_00b9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_Connect_Basic/Scope::net
+			IL_00be: ldloc.1
+			IL_00bf: ldstr "port"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c9: stloc.2
+			IL_00ca: ldloc.1
+			IL_00cb: ldstr "address"
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d5: stloc.3
+			IL_00d6: ldc.i4.2
+			IL_00d7: newarr [System.Runtime]System.Object
+			IL_00dc: dup
+			IL_00dd: ldc.i4.0
+			IL_00de: ldarg.0
+			IL_00df: stelem.ref
+			IL_00e0: dup
+			IL_00e1: ldc.i4.1
+			IL_00e2: ldloc.0
+			IL_00e3: stelem.ref
+			IL_00e4: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00ef: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_00f4: ldc.i4.0
+			IL_00f5: conv.r8
+			IL_00f6: ldstr ""
+			IL_00fb: ldc.i4.0
+			IL_00fc: ldc.i4.1
+			IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0102: stloc.s 7
+			IL_0104: ldstr "connect"
+			IL_0109: ldloc.2
+			IL_010a: ldloc.3
+			IL_010b: ldloc.s 7
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0112: stloc.3
+			IL_0113: ldloc.0
+			IL_0114: ldloc.3
+			IL_0115: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_011a: ldloc.0
+			IL_011b: ldstr ""
+			IL_0120: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
+			IL_0125: ldloc.0
+			IL_0126: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_012b: ldstr "Cannot access 'client' before initialization"
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013a: stloc.3
+			IL_013b: ldc.i4.2
+			IL_013c: newarr [System.Runtime]System.Object
+			IL_0141: dup
+			IL_0142: ldc.i4.0
+			IL_0143: ldarg.0
+			IL_0144: stelem.ref
+			IL_0145: dup
+			IL_0146: ldc.i4.1
+			IL_0147: ldloc.0
+			IL_0148: stelem.ref
+			IL_0149: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
+			IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0154: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0159: ldc.i4.1
+			IL_015a: conv.r8
+			IL_015b: ldstr ""
+			IL_0160: ldc.i4.0
+			IL_0161: ldc.i4.1
+			IL_0162: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0167: stloc.s 8
+			IL_0169: ldloc.3
+			IL_016a: ldstr "on"
+			IL_016f: ldstr "data"
+			IL_0174: ldloc.s 8
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_017b: pop
+			IL_017c: ldloc.0
+			IL_017d: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::client
+			IL_0182: ldstr "Cannot access 'client' before initialization"
+			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0191: stloc.3
+			IL_0192: ldc.i4.2
+			IL_0193: newarr [System.Runtime]System.Object
+			IL_0198: dup
+			IL_0199: ldc.i4.0
+			IL_019a: ldarg.0
+			IL_019b: stelem.ref
+			IL_019c: dup
+			IL_019d: ldc.i4.1
+			IL_019e: ldloc.0
+			IL_019f: stelem.ref
+			IL_01a0: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
+			IL_01a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_01ab: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_01b0: ldc.i4.0
+			IL_01b1: conv.r8
+			IL_01b2: ldstr ""
+			IL_01b7: ldc.i4.0
+			IL_01b8: ldc.i4.1
+			IL_01b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_01be: stloc.s 7
+			IL_01c0: ldloc.3
+			IL_01c1: ldstr "on"
+			IL_01c6: ldstr "end"
+			IL_01cb: ldloc.s 7
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01d2: pop
+			IL_01d3: ldnull
+			IL_01d4: ret
 		} // end of method FunctionExpression_L19C30::__js_call__
 
 	} // end of class FunctionExpression_L19C30
@@ -842,14 +841,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object net
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule net
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25cf
+			// Method begins at RVA 0x25c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -875,7 +874,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 174 (0xae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_CreateServer_Connect_Basic/Scope,
@@ -894,56 +893,55 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_Connect_Basic/Scope::net
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::net
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.0
-		IL_0027: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_002c: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
-		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_003c: ldc.i4.1
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_004a: stloc.2
-		IL_004b: ldloc.1
-		IL_004c: ldloc.2
-		IL_004d: castclass [System.Runtime]System.Delegate
-		IL_0052: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
-		IL_0057: stloc.3
-		IL_0058: ldloc.0
-		IL_0059: ldloc.3
-		IL_005a: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-		IL_005f: ldloc.0
-		IL_0060: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.0
-		IL_006c: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_0071: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
-		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 4
-		IL_0091: ldloc.3
-		IL_0092: ldstr "listen"
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: ldstr "127.0.0.1"
-		IL_00aa: ldloc.s 4
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_Connect_Basic/Scope::net
+		IL_0020: stloc.1
+		IL_0021: ldloc.0
+		IL_0022: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+		IL_0027: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0037: ldc.i4.1
+		IL_0038: conv.r8
+		IL_0039: ldstr ""
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldloc.1
+		IL_0047: ldloc.2
+		IL_0048: castclass [System.Runtime]System.Delegate
+		IL_004d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
+		IL_0052: stloc.3
+		IL_0053: ldloc.0
+		IL_0054: ldloc.3
+		IL_0055: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+		IL_005a: ldloc.0
+		IL_005b: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: stloc.3
+		IL_0066: ldloc.0
+		IL_0067: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+		IL_006c: ldftn object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
+		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0077: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_007c: ldc.i4.0
+		IL_007d: conv.r8
+		IL_007e: ldstr ""
+		IL_0083: ldc.i4.0
+		IL_0084: ldc.i4.1
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.3
+		IL_008d: ldstr "listen"
+		IL_0092: ldc.r8 0.0
+		IL_009b: box [System.Runtime]System.Double
+		IL_00a0: ldstr "127.0.0.1"
+		IL_00a5: ldloc.s 4
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Net_CreateServer_Connect_Basic::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_Connect_Basic
@@ -955,7 +953,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x262b
+		// Method begins at RVA 0x2623
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27b4
+						// Method begins at RVA 0x27ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27ab
+					// Method begins at RVA 0x27a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22e0
+				// Method begins at RVA 0x22d8
 				// Header size: 12
 				// Code size: 579 (0x243)
 				.maxstack 8
@@ -305,7 +305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a2
+				// Method begins at RVA 0x279a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -332,7 +332,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x210c
 			// Header size: 12
 			// Code size: 116 (0x74)
 			.maxstack 8
@@ -409,7 +409,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27d1
+					// Method begins at RVA 0x27c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -433,7 +433,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2530
+				// Method begins at RVA 0x2528
 				// Header size: 12
 				// Code size: 114 (0x72)
 				.maxstack 8
@@ -486,7 +486,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27da
+					// Method begins at RVA 0x27d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -511,7 +511,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25b0
+				// Method begins at RVA 0x25a8
 				// Header size: 12
 				// Code size: 116 (0x74)
 				.maxstack 8
@@ -581,7 +581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27ec
+						// Method begins at RVA 0x27e4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -604,7 +604,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2777
+					// Method begins at RVA 0x276f
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -629,7 +629,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27e3
+					// Method begins at RVA 0x27db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -653,7 +653,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2630
+				// Method begins at RVA 0x2628
 				// Header size: 12
 				// Code size: 315 (0x13b)
 				.maxstack 8
@@ -788,7 +788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27bd
+				// Method begins at RVA 0x27b5
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -817,9 +817,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x218c
 			// Header size: 12
-			// Code size: 323 (0x143)
+			// Code size: 318 (0x13e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope,
@@ -840,117 +840,116 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-			IL_0027: ldloc.1
-			IL_0028: ldstr "port"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: stloc.2
-			IL_0033: ldloc.1
-			IL_0034: ldstr "address"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: stloc.3
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0058: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_005d: ldc.i4.0
-			IL_005e: conv.r8
-			IL_005f: ldstr ""
-			IL_0064: ldc.i4.0
-			IL_0065: ldc.i4.1
-			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_006b: stloc.s 4
-			IL_006d: ldstr "connect"
-			IL_0072: ldloc.2
-			IL_0073: ldloc.3
-			IL_0074: ldloc.s 4
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_007b: stloc.3
-			IL_007c: ldloc.0
-			IL_007d: ldloc.3
-			IL_007e: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_0083: ldc.i4.0
-			IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0089: stloc.s 5
-			IL_008b: ldloc.0
-			IL_008c: ldloc.s 5
-			IL_008e: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
-			IL_0093: ldloc.0
-			IL_0094: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_0099: ldstr "Cannot access 'client' before initialization"
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a8: stloc.3
-			IL_00a9: ldc.i4.2
-			IL_00aa: newarr [System.Runtime]System.Object
-			IL_00af: dup
-			IL_00b0: ldc.i4.0
-			IL_00b1: ldarg.0
-			IL_00b2: stelem.ref
-			IL_00b3: dup
-			IL_00b4: ldc.i4.1
-			IL_00b5: ldloc.0
-			IL_00b6: stelem.ref
-			IL_00b7: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00c2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00c7: ldc.i4.1
-			IL_00c8: conv.r8
-			IL_00c9: ldstr ""
-			IL_00ce: ldc.i4.0
-			IL_00cf: ldc.i4.1
-			IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00d5: stloc.s 6
-			IL_00d7: ldloc.3
-			IL_00d8: ldstr "on"
-			IL_00dd: ldstr "data"
-			IL_00e2: ldloc.s 6
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00e9: pop
-			IL_00ea: ldloc.0
-			IL_00eb: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
-			IL_00f0: ldstr "Cannot access 'client' before initialization"
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ff: stloc.3
-			IL_0100: ldc.i4.2
-			IL_0101: newarr [System.Runtime]System.Object
-			IL_0106: dup
-			IL_0107: ldc.i4.0
-			IL_0108: ldarg.0
-			IL_0109: stelem.ref
-			IL_010a: dup
-			IL_010b: ldc.i4.1
-			IL_010c: ldloc.0
-			IL_010d: stelem.ref
-			IL_010e: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
-			IL_0114: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0119: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_011e: ldc.i4.0
-			IL_011f: conv.r8
-			IL_0120: ldstr ""
-			IL_0125: ldc.i4.0
-			IL_0126: ldc.i4.1
-			IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_012c: stloc.s 4
-			IL_012e: ldloc.3
-			IL_012f: ldstr "on"
-			IL_0134: ldstr "end"
-			IL_0139: ldloc.s 4
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0140: pop
-			IL_0141: ldnull
-			IL_0142: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
+			IL_0022: ldloc.1
+			IL_0023: ldstr "port"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: stloc.2
+			IL_002e: ldloc.1
+			IL_002f: ldstr "address"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0039: stloc.3
+			IL_003a: ldc.i4.2
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: dup
+			IL_0045: ldc.i4.1
+			IL_0046: ldloc.0
+			IL_0047: stelem.ref
+			IL_0048: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0058: ldc.i4.0
+			IL_0059: conv.r8
+			IL_005a: ldstr ""
+			IL_005f: ldc.i4.0
+			IL_0060: ldc.i4.1
+			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0066: stloc.s 4
+			IL_0068: ldstr "connect"
+			IL_006d: ldloc.2
+			IL_006e: ldloc.3
+			IL_006f: ldloc.s 4
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0076: stloc.3
+			IL_0077: ldloc.0
+			IL_0078: ldloc.3
+			IL_0079: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_007e: ldc.i4.0
+			IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0084: stloc.s 5
+			IL_0086: ldloc.0
+			IL_0087: ldloc.s 5
+			IL_0089: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::reply
+			IL_008e: ldloc.0
+			IL_008f: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_0094: ldstr "Cannot access 'client' before initialization"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a3: stloc.3
+			IL_00a4: ldc.i4.2
+			IL_00a5: newarr [System.Runtime]System.Object
+			IL_00aa: dup
+			IL_00ab: ldc.i4.0
+			IL_00ac: ldarg.0
+			IL_00ad: stelem.ref
+			IL_00ae: dup
+			IL_00af: ldc.i4.1
+			IL_00b0: ldloc.0
+			IL_00b1: stelem.ref
+			IL_00b2: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00bd: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00c2: ldc.i4.1
+			IL_00c3: conv.r8
+			IL_00c4: ldstr ""
+			IL_00c9: ldc.i4.0
+			IL_00ca: ldc.i4.1
+			IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00d0: stloc.s 6
+			IL_00d2: ldloc.3
+			IL_00d3: ldstr "on"
+			IL_00d8: ldstr "data"
+			IL_00dd: ldloc.s 6
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00e4: pop
+			IL_00e5: ldloc.0
+			IL_00e6: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::client
+			IL_00eb: ldstr "Cannot access 'client' before initialization"
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fa: stloc.3
+			IL_00fb: ldc.i4.2
+			IL_00fc: newarr [System.Runtime]System.Object
+			IL_0101: dup
+			IL_0102: ldc.i4.0
+			IL_0103: ldarg.0
+			IL_0104: stelem.ref
+			IL_0105: dup
+			IL_0106: ldc.i4.1
+			IL_0107: ldloc.0
+			IL_0108: stelem.ref
+			IL_0109: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
+			IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0114: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0119: ldc.i4.0
+			IL_011a: conv.r8
+			IL_011b: ldstr ""
+			IL_0120: ldc.i4.0
+			IL_0121: ldc.i4.1
+			IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0127: stloc.s 4
+			IL_0129: ldloc.3
+			IL_012a: ldstr "on"
+			IL_012f: ldstr "end"
+			IL_0134: ldloc.s 4
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_013b: pop
+			IL_013c: ldnull
+			IL_013d: ret
 		} // end of method FunctionExpression_L23C30::__js_call__
 
 	} // end of class FunctionExpression_L23C30
@@ -964,14 +963,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object net
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule net
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2799
+			// Method begins at RVA 0x2791
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -997,7 +996,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 174 (0xae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope,
@@ -1016,56 +1015,55 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.0
-		IL_0027: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_002c: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
-		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_003c: ldc.i4.1
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_004a: stloc.2
-		IL_004b: ldloc.1
-		IL_004c: ldloc.2
-		IL_004d: castclass [System.Runtime]System.Delegate
-		IL_0052: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
-		IL_0057: stloc.3
-		IL_0058: ldloc.0
-		IL_0059: ldloc.3
-		IL_005a: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-		IL_005f: ldloc.0
-		IL_0060: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.0
-		IL_006c: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_0071: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
-		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 4
-		IL_0091: ldloc.3
-		IL_0092: ldstr "listen"
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: ldstr "127.0.0.1"
-		IL_00aa: ldloc.s 4
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
+		IL_0020: stloc.1
+		IL_0021: ldloc.0
+		IL_0022: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+		IL_0027: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0037: ldc.i4.1
+		IL_0038: conv.r8
+		IL_0039: ldstr ""
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldloc.1
+		IL_0047: ldloc.2
+		IL_0048: castclass [System.Runtime]System.Delegate
+		IL_004d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
+		IL_0052: stloc.3
+		IL_0053: ldloc.0
+		IL_0054: ldloc.3
+		IL_0055: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+		IL_005a: ldloc.0
+		IL_005b: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: stloc.3
+		IL_0066: ldloc.0
+		IL_0067: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+		IL_006c: ldftn object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
+		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0077: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_007c: ldc.i4.0
+		IL_007d: conv.r8
+		IL_007e: ldstr ""
+		IL_0083: ldc.i4.0
+		IL_0084: ldc.i4.1
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.3
+		IL_008d: ldstr "listen"
+		IL_0092: ldc.r8 0.0
+		IL_009b: box [System.Runtime]System.Double
+		IL_00a0: ldstr "127.0.0.1"
+		IL_00a5: ldloc.s 4
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Net_Socket_Binary_Data_Defaults_To_Buffer::__js_module_init__
 
 } // end of class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer
@@ -1077,7 +1075,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27f5
+		// Method begins at RVA 0x27ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2636
+				// Method begins at RVA 0x262e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x214c
+			// Method begins at RVA 0x2148
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x265c
+						// Method begins at RVA 0x2654
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -128,7 +128,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2665
+						// Method begins at RVA 0x265d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2653
+					// Method begins at RVA 0x264b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -170,7 +170,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2310
+				// Method begins at RVA 0x2308
 				// Header size: 12
 				// Code size: 393 (0x189)
 				.maxstack 8
@@ -341,7 +341,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x266e
+					// Method begins at RVA 0x2666
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24b8
+				// Method begins at RVA 0x24b0
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -405,7 +405,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2680
+						// Method begins at RVA 0x2678
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -428,7 +428,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x260b
+					// Method begins at RVA 0x2603
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -453,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2677
+					// Method begins at RVA 0x266f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -477,7 +477,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24e0
+				// Method begins at RVA 0x24d8
 				// Header size: 12
 				// Code size: 287 (0x11f)
 				.maxstack 8
@@ -608,7 +608,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x263f
+				// Method begins at RVA 0x2637
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -637,9 +637,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x21a8
 			// Header size: 12
-			// Code size: 344 (0x158)
+			// Code size: 339 (0x153)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope,
@@ -659,120 +659,119 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-			IL_0027: ldloc.1
-			IL_0028: ldstr "port"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: stloc.2
-			IL_0033: ldloc.1
-			IL_0034: ldstr "address"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: stloc.3
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0058: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_005d: ldc.i4.0
-			IL_005e: conv.r8
-			IL_005f: ldstr ""
-			IL_0064: ldc.i4.0
-			IL_0065: ldc.i4.1
-			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_006b: stloc.s 4
-			IL_006d: ldstr "connect"
-			IL_0072: ldloc.2
-			IL_0073: ldloc.3
-			IL_0074: ldloc.s 4
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_007b: stloc.3
-			IL_007c: ldloc.0
-			IL_007d: ldloc.3
-			IL_007e: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0083: ldloc.0
-			IL_0084: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0089: ldstr "Cannot access 'client' before initialization"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: ldstr "setEncoding"
-			IL_009d: ldstr "utf8"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a7: pop
-			IL_00a8: ldloc.0
-			IL_00a9: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_00ae: ldstr "Cannot access 'client' before initialization"
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bd: stloc.3
-			IL_00be: ldc.i4.2
-			IL_00bf: newarr [System.Runtime]System.Object
-			IL_00c4: dup
-			IL_00c5: ldc.i4.0
-			IL_00c6: ldarg.0
-			IL_00c7: stelem.ref
-			IL_00c8: dup
-			IL_00c9: ldc.i4.1
-			IL_00ca: ldloc.0
-			IL_00cb: stelem.ref
-			IL_00cc: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-			IL_00d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00dc: ldc.i4.1
-			IL_00dd: conv.r8
-			IL_00de: ldstr ""
-			IL_00e3: ldc.i4.0
-			IL_00e4: ldc.i4.1
-			IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00ea: stloc.s 5
-			IL_00ec: ldloc.3
-			IL_00ed: ldstr "on"
-			IL_00f2: ldstr "data"
-			IL_00f7: ldloc.s 5
-			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00fe: pop
-			IL_00ff: ldloc.0
-			IL_0100: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0105: ldstr "Cannot access 'client' before initialization"
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.3
-			IL_0115: ldc.i4.2
-			IL_0116: newarr [System.Runtime]System.Object
-			IL_011b: dup
-			IL_011c: ldc.i4.0
-			IL_011d: ldarg.0
-			IL_011e: stelem.ref
-			IL_011f: dup
-			IL_0120: ldc.i4.1
-			IL_0121: ldloc.0
-			IL_0122: stelem.ref
-			IL_0123: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
-			IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_012e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_0133: ldc.i4.0
-			IL_0134: conv.r8
-			IL_0135: ldstr ""
-			IL_013a: ldc.i4.0
-			IL_013b: ldc.i4.1
-			IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_0141: stloc.s 4
-			IL_0143: ldloc.3
-			IL_0144: ldstr "on"
-			IL_0149: ldstr "end"
-			IL_014e: ldloc.s 4
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0155: pop
-			IL_0156: ldnull
-			IL_0157: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
+			IL_0022: ldloc.1
+			IL_0023: ldstr "port"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: stloc.2
+			IL_002e: ldloc.1
+			IL_002f: ldstr "address"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0039: stloc.3
+			IL_003a: ldc.i4.2
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: dup
+			IL_0045: ldc.i4.1
+			IL_0046: ldloc.0
+			IL_0047: stelem.ref
+			IL_0048: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0058: ldc.i4.0
+			IL_0059: conv.r8
+			IL_005a: ldstr ""
+			IL_005f: ldc.i4.0
+			IL_0060: ldc.i4.1
+			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0066: stloc.s 4
+			IL_0068: ldstr "connect"
+			IL_006d: ldloc.2
+			IL_006e: ldloc.3
+			IL_006f: ldloc.s 4
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0076: stloc.3
+			IL_0077: ldloc.0
+			IL_0078: ldloc.3
+			IL_0079: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_007e: ldloc.0
+			IL_007f: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_0084: ldstr "Cannot access 'client' before initialization"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0093: ldstr "setEncoding"
+			IL_0098: ldstr "utf8"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a2: pop
+			IL_00a3: ldloc.0
+			IL_00a4: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_00a9: ldstr "Cannot access 'client' before initialization"
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b8: stloc.3
+			IL_00b9: ldc.i4.2
+			IL_00ba: newarr [System.Runtime]System.Object
+			IL_00bf: dup
+			IL_00c0: ldc.i4.0
+			IL_00c1: ldarg.0
+			IL_00c2: stelem.ref
+			IL_00c3: dup
+			IL_00c4: ldc.i4.1
+			IL_00c5: ldloc.0
+			IL_00c6: stelem.ref
+			IL_00c7: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+			IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00d2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00d7: ldc.i4.1
+			IL_00d8: conv.r8
+			IL_00d9: ldstr ""
+			IL_00de: ldc.i4.0
+			IL_00df: ldc.i4.1
+			IL_00e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00e5: stloc.s 5
+			IL_00e7: ldloc.3
+			IL_00e8: ldstr "on"
+			IL_00ed: ldstr "data"
+			IL_00f2: ldloc.s 5
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00f9: pop
+			IL_00fa: ldloc.0
+			IL_00fb: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_0100: ldstr "Cannot access 'client' before initialization"
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010f: stloc.3
+			IL_0110: ldc.i4.2
+			IL_0111: newarr [System.Runtime]System.Object
+			IL_0116: dup
+			IL_0117: ldc.i4.0
+			IL_0118: ldarg.0
+			IL_0119: stelem.ref
+			IL_011a: dup
+			IL_011b: ldc.i4.1
+			IL_011c: ldloc.0
+			IL_011d: stelem.ref
+			IL_011e: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
+			IL_0124: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0129: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_012e: ldc.i4.0
+			IL_012f: conv.r8
+			IL_0130: ldstr ""
+			IL_0135: ldc.i4.0
+			IL_0136: ldc.i4.1
+			IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_013c: stloc.s 4
+			IL_013e: ldloc.3
+			IL_013f: ldstr "on"
+			IL_0144: ldstr "end"
+			IL_0149: ldloc.s 4
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0150: pop
+			IL_0151: ldnull
+			IL_0152: ret
 		} // end of method FunctionExpression_L16C30::__js_call__
 
 	} // end of class FunctionExpression_L16C30
@@ -799,7 +798,7 @@
 			73 65 72 76 65 72 7d 00 00
 		)
 		// Fields
-		.field public object net
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule net
 		.field public object serverKeepAliveLine
 		.field public object clientKeepAliveLine
 		.field public object clientNoDelayLine
@@ -811,7 +810,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x262d
+			// Method begins at RVA 0x2625
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -837,7 +836,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 239 (0xef)
+		// Code size: 234 (0xea)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope,
@@ -856,7 +855,7 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
 		IL_001a: ldloc.0
 		IL_001b: ldc.i4.0
 		IL_001c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
@@ -878,54 +877,53 @@
 		IL_004c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_0051: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientDataLine
 		IL_0056: ldloc.0
-		IL_0057: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
-		IL_005c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-		IL_0061: stloc.1
-		IL_0062: ldloc.0
-		IL_0063: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_0068: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
-		IL_006e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0073: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0078: ldc.i4.1
-		IL_0079: conv.r8
-		IL_007a: ldstr ""
-		IL_007f: ldc.i4.0
-		IL_0080: ldc.i4.1
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0086: stloc.2
-		IL_0087: ldloc.1
-		IL_0088: ldloc.2
-		IL_0089: castclass [System.Runtime]System.Delegate
-		IL_008e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
-		IL_0093: stloc.3
-		IL_0094: ldloc.0
-		IL_0095: ldloc.3
-		IL_0096: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-		IL_009b: ldloc.0
-		IL_009c: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a6: stloc.3
-		IL_00a7: ldloc.0
-		IL_00a8: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_00ad: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
-		IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_00bd: ldc.i4.0
-		IL_00be: conv.r8
-		IL_00bf: ldstr ""
-		IL_00c4: ldc.i4.0
-		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_00cb: stloc.s 4
-		IL_00cd: ldloc.3
-		IL_00ce: ldstr "listen"
-		IL_00d3: ldc.r8 0.0
-		IL_00dc: box [System.Runtime]System.Double
-		IL_00e1: ldstr "127.0.0.1"
-		IL_00e6: ldloc.s 4
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00ed: pop
-		IL_00ee: ret
+		IL_0057: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
+		IL_005c: stloc.1
+		IL_005d: ldloc.0
+		IL_005e: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+		IL_0063: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
+		IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0073: ldc.i4.1
+		IL_0074: conv.r8
+		IL_0075: ldstr ""
+		IL_007a: ldc.i4.0
+		IL_007b: ldc.i4.1
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0081: stloc.2
+		IL_0082: ldloc.1
+		IL_0083: ldloc.2
+		IL_0084: castclass [System.Runtime]System.Delegate
+		IL_0089: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
+		IL_008e: stloc.3
+		IL_008f: ldloc.0
+		IL_0090: ldloc.3
+		IL_0091: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+		IL_0096: ldloc.0
+		IL_0097: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a1: stloc.3
+		IL_00a2: ldloc.0
+		IL_00a3: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+		IL_00a8: ldftn object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
+		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00b3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00b8: ldc.i4.0
+		IL_00b9: conv.r8
+		IL_00ba: ldstr ""
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldc.i4.1
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_00c6: stloc.s 4
+		IL_00c8: ldloc.3
+		IL_00c9: ldstr "listen"
+		IL_00ce: ldc.r8 0.0
+		IL_00d7: box [System.Runtime]System.Double
+		IL_00dc: ldstr "127.0.0.1"
+		IL_00e1: ldloc.s 4
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00e8: pop
+		IL_00e9: ret
 	} // end of method Net_Socket_KeepAlive_And_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Net_Socket_KeepAlive_And_Unsupported_Options
@@ -937,7 +935,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2689
+		// Method begins at RVA 0x2681
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x269c
+					// Method begins at RVA 0x2694
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2358
+				// Method begins at RVA 0x2350
 				// Header size: 12
 				// Code size: 104 (0x68)
 				.maxstack 8
@@ -112,7 +112,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a5
+					// Method begins at RVA 0x269d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -136,7 +136,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23cc
+				// Method begins at RVA 0x23c4
 				// Header size: 12
 				// Code size: 115 (0x73)
 				.maxstack 8
@@ -209,7 +209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2693
+				// Method begins at RVA 0x268b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -236,7 +236,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x210c
 			// Header size: 12
 			// Code size: 203 (0xcb)
 			.maxstack 8
@@ -347,7 +347,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26cb
+						// Method begins at RVA 0x26c3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -371,7 +371,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2608
+					// Method begins at RVA 0x2600
 					// Header size: 12
 					// Code size: 84 (0x54)
 					.maxstack 8
@@ -414,7 +414,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c2
+					// Method begins at RVA 0x26ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -438,7 +438,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x244c
+				// Method begins at RVA 0x2444
 				// Header size: 12
 				// Code size: 170 (0xaa)
 				.maxstack 8
@@ -524,7 +524,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26d4
+					// Method begins at RVA 0x26cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -549,7 +549,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2504
+				// Method begins at RVA 0x24fc
 				// Header size: 12
 				// Code size: 104 (0x68)
 				.maxstack 8
@@ -618,7 +618,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26e6
+						// Method begins at RVA 0x26de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -641,7 +641,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2668
+					// Method begins at RVA 0x2660
 					// Header size: 1
 					// Code size: 33 (0x21)
 					.maxstack 8
@@ -666,7 +666,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26dd
+					// Method begins at RVA 0x26d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -690,7 +690,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2578
+				// Method begins at RVA 0x2570
 				// Header size: 12
 				// Code size: 129 (0x81)
 				.maxstack 8
@@ -768,7 +768,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ae
+				// Method begins at RVA 0x26a6
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -797,9 +797,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21e4
 			// Header size: 12
-			// Code size: 355 (0x163)
+			// Code size: 350 (0x15e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope,
@@ -819,123 +819,122 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-			IL_0027: ldloc.1
-			IL_0028: ldstr "port"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: stloc.2
-			IL_0033: ldloc.1
-			IL_0034: ldstr "address"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: stloc.3
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0058: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_005d: ldc.i4.0
-			IL_005e: conv.r8
-			IL_005f: ldstr ""
-			IL_0064: ldc.i4.0
-			IL_0065: ldc.i4.1
-			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_006b: stloc.s 4
-			IL_006d: ldstr "connect"
-			IL_0072: ldloc.2
-			IL_0073: ldloc.3
-			IL_0074: ldloc.s 4
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_007b: stloc.3
-			IL_007c: ldloc.0
-			IL_007d: ldloc.3
-			IL_007e: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0083: ldloc.0
-			IL_0084: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0089: ldstr "Cannot access 'client' before initialization"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: ldstr "setEncoding"
-			IL_009d: ldstr "utf8"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a7: pop
-			IL_00a8: ldloc.0
-			IL_00a9: ldstr ""
-			IL_00ae: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-			IL_00b3: ldloc.0
-			IL_00b4: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_00b9: ldstr "Cannot access 'client' before initialization"
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c8: stloc.3
-			IL_00c9: ldc.i4.2
-			IL_00ca: newarr [System.Runtime]System.Object
-			IL_00cf: dup
-			IL_00d0: ldc.i4.0
-			IL_00d1: ldarg.0
-			IL_00d2: stelem.ref
-			IL_00d3: dup
-			IL_00d4: ldc.i4.1
-			IL_00d5: ldloc.0
-			IL_00d6: stelem.ref
-			IL_00d7: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
-			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00e2: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00e7: ldc.i4.1
-			IL_00e8: conv.r8
-			IL_00e9: ldstr ""
-			IL_00ee: ldc.i4.0
-			IL_00ef: ldc.i4.1
-			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldloc.3
-			IL_00f8: ldstr "on"
-			IL_00fd: ldstr "data"
-			IL_0102: ldloc.s 5
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0109: pop
-			IL_010a: ldloc.0
-			IL_010b: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0110: ldstr "Cannot access 'client' before initialization"
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011f: stloc.3
-			IL_0120: ldc.i4.2
-			IL_0121: newarr [System.Runtime]System.Object
-			IL_0126: dup
-			IL_0127: ldc.i4.0
-			IL_0128: ldarg.0
-			IL_0129: stelem.ref
-			IL_012a: dup
-			IL_012b: ldc.i4.1
-			IL_012c: ldloc.0
-			IL_012d: stelem.ref
-			IL_012e: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
-			IL_0134: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0139: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_013e: ldc.i4.0
-			IL_013f: conv.r8
-			IL_0140: ldstr ""
-			IL_0145: ldc.i4.0
-			IL_0146: ldc.i4.1
-			IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_014c: stloc.s 4
-			IL_014e: ldloc.3
-			IL_014f: ldstr "on"
-			IL_0154: ldstr "end"
-			IL_0159: ldloc.s 4
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0160: pop
-			IL_0161: ldnull
-			IL_0162: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_SetEncoding_Utf8/Scope::net
+			IL_0022: ldloc.1
+			IL_0023: ldstr "port"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: stloc.2
+			IL_002e: ldloc.1
+			IL_002f: ldstr "address"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0039: stloc.3
+			IL_003a: ldc.i4.2
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: dup
+			IL_0045: ldc.i4.1
+			IL_0046: ldloc.0
+			IL_0047: stelem.ref
+			IL_0048: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
+			IL_004e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0053: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0058: ldc.i4.0
+			IL_0059: conv.r8
+			IL_005a: ldstr ""
+			IL_005f: ldc.i4.0
+			IL_0060: ldc.i4.1
+			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0066: stloc.s 4
+			IL_0068: ldstr "connect"
+			IL_006d: ldloc.2
+			IL_006e: ldloc.3
+			IL_006f: ldloc.s 4
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0076: stloc.3
+			IL_0077: ldloc.0
+			IL_0078: ldloc.3
+			IL_0079: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_007e: ldloc.0
+			IL_007f: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_0084: ldstr "Cannot access 'client' before initialization"
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0093: ldstr "setEncoding"
+			IL_0098: ldstr "utf8"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a2: pop
+			IL_00a3: ldloc.0
+			IL_00a4: ldstr ""
+			IL_00a9: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
+			IL_00ae: ldloc.0
+			IL_00af: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_00b4: ldstr "Cannot access 'client' before initialization"
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c3: stloc.3
+			IL_00c4: ldc.i4.2
+			IL_00c5: newarr [System.Runtime]System.Object
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldarg.0
+			IL_00cd: stelem.ref
+			IL_00ce: dup
+			IL_00cf: ldc.i4.1
+			IL_00d0: ldloc.0
+			IL_00d1: stelem.ref
+			IL_00d2: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
+			IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00dd: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00e2: ldc.i4.1
+			IL_00e3: conv.r8
+			IL_00e4: ldstr ""
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldc.i4.1
+			IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00f0: stloc.s 5
+			IL_00f2: ldloc.3
+			IL_00f3: ldstr "on"
+			IL_00f8: ldstr "data"
+			IL_00fd: ldloc.s 5
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0104: pop
+			IL_0105: ldloc.0
+			IL_0106: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_010b: ldstr "Cannot access 'client' before initialization"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011a: stloc.3
+			IL_011b: ldc.i4.2
+			IL_011c: newarr [System.Runtime]System.Object
+			IL_0121: dup
+			IL_0122: ldc.i4.0
+			IL_0123: ldarg.0
+			IL_0124: stelem.ref
+			IL_0125: dup
+			IL_0126: ldc.i4.1
+			IL_0127: ldloc.0
+			IL_0128: stelem.ref
+			IL_0129: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
+			IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0134: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0139: ldc.i4.0
+			IL_013a: conv.r8
+			IL_013b: ldstr ""
+			IL_0140: ldc.i4.0
+			IL_0141: ldc.i4.1
+			IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0147: stloc.s 4
+			IL_0149: ldloc.3
+			IL_014a: ldstr "on"
+			IL_014f: ldstr "end"
+			IL_0154: ldloc.s 4
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_015b: pop
+			IL_015c: ldnull
+			IL_015d: ret
 		} // end of method FunctionExpression_L20C30::__js_call__
 
 	} // end of class FunctionExpression_L20C30
@@ -949,14 +948,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object net
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule net
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x268a
+			// Method begins at RVA 0x2682
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -982,7 +981,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 174 (0xae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_SetEncoding_Utf8/Scope,
@@ -1001,56 +1000,55 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_SetEncoding_Utf8/Scope::net
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::net
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.0
-		IL_0027: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_002c: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
-		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_003c: ldc.i4.1
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_004a: stloc.2
-		IL_004b: ldloc.1
-		IL_004c: ldloc.2
-		IL_004d: castclass [System.Runtime]System.Delegate
-		IL_0052: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
-		IL_0057: stloc.3
-		IL_0058: ldloc.0
-		IL_0059: ldloc.3
-		IL_005a: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-		IL_005f: ldloc.0
-		IL_0060: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.0
-		IL_006c: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_0071: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
-		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 4
-		IL_0091: ldloc.3
-		IL_0092: ldstr "listen"
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: ldstr "127.0.0.1"
-		IL_00aa: ldloc.s 4
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_SetEncoding_Utf8/Scope::net
+		IL_0020: stloc.1
+		IL_0021: ldloc.0
+		IL_0022: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+		IL_0027: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0037: ldc.i4.1
+		IL_0038: conv.r8
+		IL_0039: ldstr ""
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldloc.1
+		IL_0047: ldloc.2
+		IL_0048: castclass [System.Runtime]System.Delegate
+		IL_004d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
+		IL_0052: stloc.3
+		IL_0053: ldloc.0
+		IL_0054: ldloc.3
+		IL_0055: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+		IL_005a: ldloc.0
+		IL_005b: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: stloc.3
+		IL_0066: ldloc.0
+		IL_0067: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+		IL_006c: ldftn object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
+		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0077: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_007c: ldc.i4.0
+		IL_007d: conv.r8
+		IL_007e: ldstr ""
+		IL_0083: ldc.i4.0
+		IL_0084: ldc.i4.1
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.3
+		IL_008d: ldstr "listen"
+		IL_0092: ldc.r8 0.0
+		IL_009b: box [System.Runtime]System.Double
+		IL_00a0: ldstr "127.0.0.1"
+		IL_00a5: ldloc.s 4
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Net_Socket_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Net_Socket_SetEncoding_Utf8
@@ -1062,7 +1060,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26ef
+		// Method begins at RVA 0x26e7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2450
+					// Method begins at RVA 0x2448
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22dc
+				// Method begins at RVA 0x22d4
 				// Header size: 12
 				// Code size: 132 (0x84)
 				.maxstack 8
@@ -111,7 +111,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2459
+					// Method begins at RVA 0x2451
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -135,7 +135,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x236c
+				// Method begins at RVA 0x2364
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -177,7 +177,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2447
+				// Method begins at RVA 0x243f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x210c
 			// Header size: 12
 			// Code size: 161 (0xa1)
 			.maxstack 8
@@ -293,7 +293,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x246b
+					// Method begins at RVA 0x2463
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23a3
+				// Method begins at RVA 0x239b
 				// Header size: 1
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -345,7 +345,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2474
+					// Method begins at RVA 0x246c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -369,7 +369,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23c8
+				// Method begins at RVA 0x23c0
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -408,7 +408,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247d
+					// Method begins at RVA 0x2475
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -432,7 +432,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x23ff
+				// Method begins at RVA 0x23f7
 				// Header size: 1
 				// Code size: 62 (0x3e)
 				.maxstack 8
@@ -466,7 +466,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2462
+				// Method begins at RVA 0x245a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -492,9 +492,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21bc
 			// Header size: 12
-			// Code size: 272 (0x110)
+			// Code size: 267 (0x10b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/Scope,
@@ -515,90 +515,89 @@
 			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_001b: stloc.1
 			IL_001c: ldarg.0
-			IL_001d: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-			IL_0022: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-			IL_0027: ldloc.1
-			IL_0028: ldstr "port"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: stloc.3
-			IL_0033: ldloc.1
-			IL_0034: ldstr "address"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: stloc.s 4
-			IL_0040: ldnull
-			IL_0041: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
-			IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_004c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_0051: ldc.i4.0
-			IL_0052: conv.r8
-			IL_0053: ldstr ""
-			IL_0058: ldc.i4.0
-			IL_0059: ldc.i4.1
-			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_005f: stloc.s 5
-			IL_0061: ldstr "connect"
-			IL_0066: ldloc.3
-			IL_0067: ldloc.s 4
-			IL_0069: ldloc.s 5
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0070: stloc.2
-			IL_0071: ldloc.2
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0077: ldstr "setEncoding"
-			IL_007c: ldstr "utf8"
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0086: pop
-			IL_0087: ldloc.2
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008d: stloc.s 4
-			IL_008f: ldnull
-			IL_0090: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
-			IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_009b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00a0: ldc.i4.1
-			IL_00a1: conv.r8
-			IL_00a2: ldstr ""
-			IL_00a7: ldc.i4.0
-			IL_00a8: ldc.i4.1
-			IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00ae: stloc.s 6
-			IL_00b0: ldloc.s 4
-			IL_00b2: ldstr "on"
-			IL_00b7: ldstr "data"
-			IL_00bc: ldloc.s 6
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00c3: pop
-			IL_00c4: ldloc.2
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ca: stloc.s 4
-			IL_00cc: ldc.i4.2
-			IL_00cd: newarr [System.Runtime]System.Object
-			IL_00d2: dup
-			IL_00d3: ldc.i4.0
-			IL_00d4: ldarg.0
-			IL_00d5: stelem.ref
-			IL_00d6: dup
-			IL_00d7: ldc.i4.1
-			IL_00d8: ldloc.0
-			IL_00d9: stelem.ref
-			IL_00da: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
-			IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00e5: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_00ea: ldc.i4.0
-			IL_00eb: conv.r8
-			IL_00ec: ldstr ""
-			IL_00f1: ldc.i4.0
-			IL_00f2: ldc.i4.1
-			IL_00f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_00f8: stloc.s 5
-			IL_00fa: ldloc.s 4
-			IL_00fc: ldstr "on"
-			IL_0101: ldstr "end"
-			IL_0106: ldloc.s 5
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_010d: pop
-			IL_010e: ldnull
-			IL_010f: ret
+			IL_001d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
+			IL_0022: ldloc.1
+			IL_0023: ldstr "port"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: stloc.3
+			IL_002e: ldloc.1
+			IL_002f: ldstr "address"
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0039: stloc.s 4
+			IL_003b: ldnull
+			IL_003c: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
+			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0047: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_004c: ldc.i4.0
+			IL_004d: conv.r8
+			IL_004e: ldstr ""
+			IL_0053: ldc.i4.0
+			IL_0054: ldc.i4.1
+			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_005a: stloc.s 5
+			IL_005c: ldstr "connect"
+			IL_0061: ldloc.3
+			IL_0062: ldloc.s 4
+			IL_0064: ldloc.s 5
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_006b: stloc.2
+			IL_006c: ldloc.2
+			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0072: ldstr "setEncoding"
+			IL_0077: ldstr "utf8"
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0081: pop
+			IL_0082: ldloc.2
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0088: stloc.s 4
+			IL_008a: ldnull
+			IL_008b: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
+			IL_0091: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0096: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_009b: ldc.i4.1
+			IL_009c: conv.r8
+			IL_009d: ldstr ""
+			IL_00a2: ldc.i4.0
+			IL_00a3: ldc.i4.1
+			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00a9: stloc.s 6
+			IL_00ab: ldloc.s 4
+			IL_00ad: ldstr "on"
+			IL_00b2: ldstr "data"
+			IL_00b7: ldloc.s 6
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00be: pop
+			IL_00bf: ldloc.2
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c5: stloc.s 4
+			IL_00c7: ldc.i4.2
+			IL_00c8: newarr [System.Runtime]System.Object
+			IL_00cd: dup
+			IL_00ce: ldc.i4.0
+			IL_00cf: ldarg.0
+			IL_00d0: stelem.ref
+			IL_00d1: dup
+			IL_00d2: ldc.i4.1
+			IL_00d3: ldloc.0
+			IL_00d4: stelem.ref
+			IL_00d5: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
+			IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00e0: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_00e5: ldc.i4.0
+			IL_00e6: conv.r8
+			IL_00e7: ldstr ""
+			IL_00ec: ldc.i4.0
+			IL_00ed: ldc.i4.1
+			IL_00ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_00f3: stloc.s 5
+			IL_00f5: ldloc.s 4
+			IL_00f7: ldstr "on"
+			IL_00fc: ldstr "end"
+			IL_0101: ldloc.s 5
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0108: pop
+			IL_0109: ldnull
+			IL_010a: ret
 		} // end of method FunctionExpression_L17C30::__js_call__
 
 	} // end of class FunctionExpression_L17C30
@@ -612,14 +611,14 @@
 			65 72 7d 00 00
 		)
 		// Fields
-		.field public object net
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule net
 		.field public object server
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x243e
+			// Method begins at RVA 0x2436
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -645,7 +644,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 174 (0xae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope,
@@ -664,56 +663,55 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
 		IL_001a: ldloc.0
-		IL_001b: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
-		IL_0020: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule
-		IL_0025: stloc.1
-		IL_0026: ldloc.0
-		IL_0027: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_002c: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
-		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_003c: ldc.i4.1
-		IL_003d: conv.r8
-		IL_003e: ldstr ""
-		IL_0043: ldc.i4.0
-		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_004a: stloc.2
-		IL_004b: ldloc.1
-		IL_004c: ldloc.2
-		IL_004d: castclass [System.Runtime]System.Delegate
-		IL_0052: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
-		IL_0057: stloc.3
-		IL_0058: ldloc.0
-		IL_0059: ldloc.3
-		IL_005a: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-		IL_005f: ldloc.0
-		IL_0060: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: stloc.3
-		IL_006b: ldloc.0
-		IL_006c: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_0071: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
-		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 4
-		IL_0091: ldloc.3
-		IL_0092: ldstr "listen"
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: ldstr "127.0.0.1"
-		IL_00aa: ldloc.s 4
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_001b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
+		IL_0020: stloc.1
+		IL_0021: ldloc.0
+		IL_0022: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
+		IL_0027: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
+		IL_002d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0037: ldc.i4.1
+		IL_0038: conv.r8
+		IL_0039: ldstr ""
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldloc.1
+		IL_0047: ldloc.2
+		IL_0048: castclass [System.Runtime]System.Delegate
+		IL_004d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule::createServer(class [System.Runtime]System.Delegate)
+		IL_0052: stloc.3
+		IL_0053: ldloc.0
+		IL_0054: ldloc.3
+		IL_0055: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
+		IL_005a: ldloc.0
+		IL_005b: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: stloc.3
+		IL_0066: ldloc.0
+		IL_0067: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
+		IL_006c: ldftn object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
+		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0077: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_007c: ldc.i4.0
+		IL_007d: conv.r8
+		IL_007e: ldstr ""
+		IL_0083: ldc.i4.0
+		IL_0084: ldc.i4.1
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.3
+		IL_008d: ldstr "listen"
+		IL_0092: ldc.r8 0.0
+		IL_009b: box [System.Runtime]System.Double
+		IL_00a0: ldstr "127.0.0.1"
+		IL_00a5: ldloc.s 4
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Net_Socket_Timeout_Allows_Graceful_End::__js_module_init__
 
 } // end of class Modules.Net_Socket_Timeout_Allows_Graceful_End
@@ -725,7 +723,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2486
+		// Method begins at RVA 0x247e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f7
+					// Method begins at RVA 0x21eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x219c
+				// Method begins at RVA 0x2190
 				// Header size: 12
 				// Code size: 61 (0x3d)
 				.maxstack 8
@@ -87,7 +87,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2200
+					// Method begins at RVA 0x21f4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ee
+				// Method begins at RVA 0x21e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,9 +132,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2124
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Path_DefaultParameterOverride/patchPath/Scope,
@@ -145,41 +145,40 @@
 			IL_0000: newobj instance void Modules.Require_Path_DefaultParameterOverride/patchPath/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.2
-			IL_0007: brtrue IL_0060
+			IL_0007: brtrue IL_005b
 
 			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.Require_Path_DefaultParameterOverride/Scope::path
-			IL_0012: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0017: ldnull
-			IL_0018: ldftn object Modules.Require_Path_DefaultParameterOverride/patchPath/ArrowFunction_L6C28::__js_call__(object)
-			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0023: ldc.i4.1
-			IL_0024: newarr [System.Runtime]System.Object
-			IL_0029: dup
-			IL_002a: ldc.i4.0
-			IL_002b: ldarg.0
-			IL_002c: stelem.ref
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_003c: ldc.i4.0
-			IL_003d: conv.r8
-			IL_003e: ldstr ""
-			IL_0043: ldc.i4.1
-			IL_0044: ldc.i4.0
-			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-			IL_004f: stloc.1
-			IL_0050: ldstr "join"
-			IL_0055: ldloc.1
-			IL_0056: ldc.i4.1
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_005c: stloc.2
-			IL_005d: ldloc.2
-			IL_005e: starg.s ignored
+			IL_000d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DefaultParameterOverride/Scope::path
+			IL_0012: ldnull
+			IL_0013: ldftn object Modules.Require_Path_DefaultParameterOverride/patchPath/ArrowFunction_L6C28::__js_call__(object)
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0032: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0037: ldc.i4.0
+			IL_0038: conv.r8
+			IL_0039: ldstr ""
+			IL_003e: ldc.i4.1
+			IL_003f: ldc.i4.0
+			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+			IL_004a: stloc.1
+			IL_004b: ldstr "join"
+			IL_0050: ldloc.1
+			IL_0051: ldc.i4.1
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0057: stloc.2
+			IL_0058: ldloc.2
+			IL_0059: starg.s ignored
 
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method patchPath::__js_call__
 
 	} // end of class patchPath
@@ -193,14 +192,14 @@
 			7b 70 61 74 63 68 50 61 74 68 7d 00 00
 		)
 		// Fields
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object patchPath
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e5
+			// Method begins at RVA 0x21d9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,7 +225,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 205 (0xcd)
+		// Code size: 200 (0xc8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_DefaultParameterOverride/Scope,
@@ -257,7 +256,7 @@
 		IL_0037: stloc.2
 		IL_0038: ldloc.0
 		IL_0039: ldloc.2
-		IL_003a: stfld object Modules.Require_Path_DefaultParameterOverride/Scope::path
+		IL_003a: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DefaultParameterOverride/Scope::path
 		IL_003f: nop
 		IL_0040: ldloc.1
 		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -268,50 +267,49 @@
 		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_005b: stloc.3
 		IL_005c: ldloc.0
-		IL_005d: ldfld object Modules.Require_Path_DefaultParameterOverride/Scope::path
-		IL_0062: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0067: stloc.2
-		IL_0068: ldloc.2
-		IL_0069: ldstr "join"
-		IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0073: brtrue IL_009b
+		IL_005d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DefaultParameterOverride/Scope::path
+		IL_0062: stloc.2
+		IL_0063: ldloc.2
+		IL_0064: ldstr "join"
+		IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_006e: brtrue IL_0096
 
-		IL_0078: ldloc.2
-		IL_0079: ldc.i4.2
-		IL_007a: newarr [System.Runtime]System.Object
-		IL_007f: dup
-		IL_0080: ldc.i4.0
-		IL_0081: ldstr "a"
-		IL_0086: stelem.ref
-		IL_0087: dup
-		IL_0088: ldc.i4.1
-		IL_0089: ldstr "b"
-		IL_008e: stelem.ref
-		IL_008f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0094: stloc.s 4
-		IL_0096: br IL_00be
+		IL_0073: ldloc.2
+		IL_0074: ldc.i4.2
+		IL_0075: newarr [System.Runtime]System.Object
+		IL_007a: dup
+		IL_007b: ldc.i4.0
+		IL_007c: ldstr "a"
+		IL_0081: stelem.ref
+		IL_0082: dup
+		IL_0083: ldc.i4.1
+		IL_0084: ldstr "b"
+		IL_0089: stelem.ref
+		IL_008a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_008f: stloc.s 4
+		IL_0091: br IL_00b9
 
-		IL_009b: ldloc.2
-		IL_009c: ldstr "join"
-		IL_00a1: ldc.i4.2
-		IL_00a2: newarr [System.Runtime]System.Object
-		IL_00a7: dup
-		IL_00a8: ldc.i4.0
-		IL_00a9: ldstr "a"
-		IL_00ae: stelem.ref
-		IL_00af: dup
-		IL_00b0: ldc.i4.1
-		IL_00b1: ldstr "b"
-		IL_00b6: stelem.ref
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_00bc: stloc.s 4
+		IL_0096: ldloc.2
+		IL_0097: ldstr "join"
+		IL_009c: ldc.i4.2
+		IL_009d: newarr [System.Runtime]System.Object
+		IL_00a2: dup
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldstr "a"
+		IL_00a9: stelem.ref
+		IL_00aa: dup
+		IL_00ab: ldc.i4.1
+		IL_00ac: ldstr "b"
+		IL_00b1: stelem.ref
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_00b7: stloc.s 4
 
-		IL_00be: ldloc.3
-		IL_00bf: ldstr "log"
-		IL_00c4: ldloc.s 4
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: pop
-		IL_00cc: ret
+		IL_00b9: ldloc.3
+		IL_00ba: ldstr "log"
+		IL_00bf: ldloc.s 4
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: pop
+		IL_00c7: ret
 	} // end of method Require_Path_DefaultParameterOverride::__js_module_init__
 
 } // end of class Modules.Require_Path_DefaultParameterOverride
@@ -323,7 +321,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2209
+		// Method begins at RVA 0x21fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DynamicImportOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DynamicImportOverride.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x221f
+					// Method begins at RVA 0x221b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21c4
+				// Method begins at RVA 0x21c0
 				// Header size: 12
 				// Code size: 61 (0x3d)
 				.maxstack 8
@@ -90,7 +90,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2216
+				// Method begins at RVA 0x2212
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 			)
 			// Method begins at RVA 0x20dc
 			// Header size: 12
-			// Code size: 219 (0xdb)
+			// Code size: 214 (0xd6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Path_DynamicImportOverride/ArrowFunction_L5C26/Scope,
@@ -166,51 +166,50 @@
 			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0068: stloc.1
 			IL_0069: ldarg.0
-			IL_006a: ldfld object Modules.Require_Path_DynamicImportOverride/Scope::path
-			IL_006f: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0074: stloc.3
-			IL_0075: ldloc.3
-			IL_0076: ldstr "join"
-			IL_007b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0080: brtrue IL_00a8
+			IL_006a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DynamicImportOverride/Scope::path
+			IL_006f: stloc.3
+			IL_0070: ldloc.3
+			IL_0071: ldstr "join"
+			IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_007b: brtrue IL_00a3
 
-			IL_0085: ldloc.3
-			IL_0086: ldc.i4.2
-			IL_0087: newarr [System.Runtime]System.Object
-			IL_008c: dup
-			IL_008d: ldc.i4.0
-			IL_008e: ldstr "a"
-			IL_0093: stelem.ref
-			IL_0094: dup
-			IL_0095: ldc.i4.1
-			IL_0096: ldstr "b"
-			IL_009b: stelem.ref
-			IL_009c: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_00a1: stloc.s 4
-			IL_00a3: br IL_00cb
+			IL_0080: ldloc.3
+			IL_0081: ldc.i4.2
+			IL_0082: newarr [System.Runtime]System.Object
+			IL_0087: dup
+			IL_0088: ldc.i4.0
+			IL_0089: ldstr "a"
+			IL_008e: stelem.ref
+			IL_008f: dup
+			IL_0090: ldc.i4.1
+			IL_0091: ldstr "b"
+			IL_0096: stelem.ref
+			IL_0097: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_009c: stloc.s 4
+			IL_009e: br IL_00c6
 
-			IL_00a8: ldloc.3
-			IL_00a9: ldstr "join"
-			IL_00ae: ldc.i4.2
-			IL_00af: newarr [System.Runtime]System.Object
-			IL_00b4: dup
-			IL_00b5: ldc.i4.0
-			IL_00b6: ldstr "a"
-			IL_00bb: stelem.ref
-			IL_00bc: dup
-			IL_00bd: ldc.i4.1
-			IL_00be: ldstr "b"
-			IL_00c3: stelem.ref
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00c9: stloc.s 4
+			IL_00a3: ldloc.3
+			IL_00a4: ldstr "join"
+			IL_00a9: ldc.i4.2
+			IL_00aa: newarr [System.Runtime]System.Object
+			IL_00af: dup
+			IL_00b0: ldc.i4.0
+			IL_00b1: ldstr "a"
+			IL_00b6: stelem.ref
+			IL_00b7: dup
+			IL_00b8: ldc.i4.1
+			IL_00b9: ldstr "b"
+			IL_00be: stelem.ref
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_00c4: stloc.s 4
 
-			IL_00cb: ldloc.1
-			IL_00cc: ldstr "log"
-			IL_00d1: ldloc.s 4
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d8: pop
-			IL_00d9: ldnull
-			IL_00da: ret
+			IL_00c6: ldloc.1
+			IL_00c7: ldstr "log"
+			IL_00cc: ldloc.s 4
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d3: pop
+			IL_00d4: ldnull
+			IL_00d5: ret
 		} // end of method ArrowFunction_L5C26::__js_call__
 
 	} // end of class ArrowFunction_L5C26
@@ -223,13 +222,13 @@
 			61 74 68 7d 00 00
 		)
 		// Fields
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x220d
+			// Method begins at RVA 0x2209
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -273,7 +272,7 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.Require_Path_DynamicImportOverride/Scope::path
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DynamicImportOverride/Scope::path
 		IL_001a: ldstr "node:path"
 		IL_001f: ldstr "Require_Path_DynamicImportOverride"
 		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.CommonJS.DynamicImport::Import(object, object)
@@ -319,7 +318,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2228
+		// Method begins at RVA 0x2224
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2128
+				// Method begins at RVA 0x2123
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			)
 			// Method begins at RVA 0x20f0
 			// Header size: 12
-			// Code size: 35 (0x23)
+			// Code size: 30 (0x1e)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -56,24 +56,23 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: ldc.i4.2
-			IL_000e: newarr [System.Runtime]System.Object
-			IL_0013: dup
-			IL_0014: ldc.i4.0
-			IL_0015: ldarg.2
-			IL_0016: stelem.ref
-			IL_0017: dup
-			IL_0018: ldc.i4.1
-			IL_0019: ldarg.3
-			IL_001a: stelem.ref
-			IL_001b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0020: stloc.1
-			IL_0021: ldloc.1
-			IL_0022: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_Join_NestedFunction/Scope::path
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldc.i4.2
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.2
+			IL_0011: stelem.ref
+			IL_0012: dup
+			IL_0013: ldc.i4.1
+			IL_0014: ldarg.3
+			IL_0015: stelem.ref
+			IL_0016: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_001b: stloc.1
+			IL_001c: ldloc.1
+			IL_001d: ret
 		} // end of method joinWrapper::__js_call__
 
 	} // end of class joinWrapper
@@ -87,14 +86,14 @@
 			72 3d 7b 6a 6f 69 6e 57 72 61 70 70 65 72 7d 00 00
 		)
 		// Fields
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object joinWrapper
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211f
+			// Method begins at RVA 0x211a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -152,7 +151,7 @@
 		IL_0037: stloc.3
 		IL_0038: ldloc.0
 		IL_0039: ldloc.3
-		IL_003a: stfld object Modules.Require_Path_Join_NestedFunction/Scope::path
+		IL_003a: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_Join_NestedFunction/Scope::path
 		IL_003f: nop
 		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0045: stloc.s 4
@@ -188,7 +187,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2131
+		// Method begins at RVA 0x212c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x259e
+				// Method begins at RVA 0x2556
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,24 +45,23 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2520
+			// Method begins at RVA 0x24dc
 			// Header size: 12
-			// Code size: 30 (0x1e)
+			// Code size: 25 (0x19)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_000b: ldstr "normalize"
-			IL_0010: ldarg.2
-			IL_0011: box [System.Runtime]System.Double
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001b: stloc.0
-			IL_001c: ldloc.0
-			IL_001d: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+			IL_0006: ldstr "normalize"
+			IL_000b: ldarg.2
+			IL_000c: box [System.Runtime]System.Double
+			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0016: stloc.0
+			IL_0017: ldloc.0
+			IL_0018: ret
 		} // end of method normalize::__js_call__
 
 	} // end of class normalize
@@ -78,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25a7
+				// Method begins at RVA 0x255f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +100,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x254c
+			// Method begins at RVA 0x2504
 			// Header size: 12
 			// Code size: 61 (0x3d)
 			.maxstack 8
@@ -148,7 +147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b0
+				// Method begins at RVA 0x2568
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -168,7 +167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b9
+				// Method begins at RVA 0x2571
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -188,7 +187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c2
+				// Method begins at RVA 0x257a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,7 +207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25cb
+				// Method begins at RVA 0x2583
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,14 +222,14 @@
 
 
 		// Fields
-		.field public object path
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule path
 		.field public object normalize
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2595
+			// Method begins at RVA 0x254d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -256,7 +255,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1191 (0x4a7)
+		// Code size: 1121 (0x461)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_MemberOverrides/Scope,
@@ -300,404 +299,390 @@
 		IL_0037: stloc.s 11
 		IL_0039: ldloc.0
 		IL_003a: ldloc.s 11
-		IL_003c: stfld object Modules.Require_Path_MemberOverrides/Scope::path
+		IL_003c: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
 		IL_0041: ldloc.0
-		IL_0042: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_0047: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_004c: ldstr "join"
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0056: stloc.2
-		IL_0057: ldloc.0
-		IL_0058: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_005d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0062: stloc.s 11
-		IL_0064: ldloc.s 11
-		IL_0066: ldstr "sep"
-		IL_006b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0070: brtrue IL_0082
+		IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_0047: ldstr "join"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0051: stloc.2
+		IL_0052: ldloc.0
+		IL_0053: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_0058: stloc.s 11
+		IL_005a: ldloc.s 11
+		IL_005c: ldstr "sep"
+		IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_0066: brtrue IL_0078
 
-		IL_0075: ldloc.s 11
-		IL_0077: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
-		IL_007c: stloc.3
-		IL_007d: br IL_008f
+		IL_006b: ldloc.s 11
+		IL_006d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
+		IL_0072: stloc.3
+		IL_0073: br IL_0085
 
-		IL_0082: ldloc.s 11
-		IL_0084: ldstr "sep"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_008e: stloc.3
+		IL_0078: ldloc.s 11
+		IL_007a: ldstr "sep"
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0084: stloc.3
 
-		IL_008f: nop
-		IL_0090: ldstr "console"
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009f: stloc.s 12
-		IL_00a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a6: stloc.s 13
-		IL_00a8: ldloc.1
-		IL_00a9: ldloc.s 13
-		IL_00ab: ldc.r8 123
-		IL_00b4: box [System.Runtime]System.Double
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00be: stloc.s 14
-		IL_00c0: ldloc.s 12
-		IL_00c2: ldstr "log"
-		IL_00c7: ldloc.s 14
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: pop
-		IL_00cf: ldloc.0
-		IL_00d0: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_00d5: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_00da: stloc.s 11
-		IL_00dc: ldnull
-		IL_00dd: ldftn object Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13::__js_call__(object)
-		IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00e8: ldc.i4.1
-		IL_00e9: newarr [System.Runtime]System.Object
-		IL_00ee: dup
-		IL_00ef: ldc.i4.0
-		IL_00f0: ldloc.0
-		IL_00f1: stelem.ref
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00fc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0101: ldc.i4.0
-		IL_0102: conv.r8
-		IL_0103: ldstr ""
-		IL_0108: ldc.i4.1
-		IL_0109: ldc.i4.0
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0114: stloc.s 15
-		IL_0116: ldloc.s 11
-		IL_0118: ldstr "join"
-		IL_011d: ldloc.s 15
-		IL_011f: ldc.i4.1
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0125: pop
-		IL_0126: ldloc.0
-		IL_0127: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_012c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0131: stloc.s 11
-		IL_0133: ldloc.s 11
-		IL_0135: ldstr "sep"
-		IL_013a: ldstr "!"
-		IL_013f: ldc.i4.1
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0145: pop
-		IL_0146: ldstr "console"
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0155: stloc.s 14
-		IL_0157: ldloc.0
-		IL_0158: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_015d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0162: stloc.s 11
-		IL_0164: ldloc.s 11
-		IL_0166: ldstr "join"
-		IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0170: brtrue IL_0199
+		IL_0085: nop
+		IL_0086: ldstr "console"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0095: stloc.s 12
+		IL_0097: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_009c: stloc.s 13
+		IL_009e: ldloc.1
+		IL_009f: ldloc.s 13
+		IL_00a1: ldc.r8 123
+		IL_00aa: box [System.Runtime]System.Double
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00b4: stloc.s 14
+		IL_00b6: ldloc.s 12
+		IL_00b8: ldstr "log"
+		IL_00bd: ldloc.s 14
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c4: pop
+		IL_00c5: ldloc.0
+		IL_00c6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_00cb: stloc.s 11
+		IL_00cd: ldnull
+		IL_00ce: ldftn object Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13::__js_call__(object)
+		IL_00d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00d9: ldc.i4.1
+		IL_00da: newarr [System.Runtime]System.Object
+		IL_00df: dup
+		IL_00e0: ldc.i4.0
+		IL_00e1: ldloc.0
+		IL_00e2: stelem.ref
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ed: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00f2: ldc.i4.0
+		IL_00f3: conv.r8
+		IL_00f4: ldstr ""
+		IL_00f9: ldc.i4.1
+		IL_00fa: ldc.i4.0
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0105: stloc.s 15
+		IL_0107: ldloc.s 11
+		IL_0109: ldstr "join"
+		IL_010e: ldloc.s 15
+		IL_0110: ldc.i4.1
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0116: pop
+		IL_0117: ldloc.0
+		IL_0118: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_011d: stloc.s 11
+		IL_011f: ldloc.s 11
+		IL_0121: ldstr "sep"
+		IL_0126: ldstr "!"
+		IL_012b: ldc.i4.1
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0131: pop
+		IL_0132: ldstr "console"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0141: stloc.s 14
+		IL_0143: ldloc.0
+		IL_0144: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_0149: stloc.s 11
+		IL_014b: ldloc.s 11
+		IL_014d: ldstr "join"
+		IL_0152: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_0157: brtrue IL_0180
 
-		IL_0175: ldloc.s 11
-		IL_0177: ldc.i4.2
-		IL_0178: newarr [System.Runtime]System.Object
-		IL_017d: dup
-		IL_017e: ldc.i4.0
-		IL_017f: ldstr "a"
-		IL_0184: stelem.ref
-		IL_0185: dup
-		IL_0186: ldc.i4.1
-		IL_0187: ldstr "b"
-		IL_018c: stelem.ref
-		IL_018d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0192: stloc.s 12
-		IL_0194: br IL_01bd
+		IL_015c: ldloc.s 11
+		IL_015e: ldc.i4.2
+		IL_015f: newarr [System.Runtime]System.Object
+		IL_0164: dup
+		IL_0165: ldc.i4.0
+		IL_0166: ldstr "a"
+		IL_016b: stelem.ref
+		IL_016c: dup
+		IL_016d: ldc.i4.1
+		IL_016e: ldstr "b"
+		IL_0173: stelem.ref
+		IL_0174: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_0179: stloc.s 12
+		IL_017b: br IL_01a4
 
-		IL_0199: ldloc.s 11
-		IL_019b: ldstr "join"
-		IL_01a0: ldc.i4.2
-		IL_01a1: newarr [System.Runtime]System.Object
-		IL_01a6: dup
-		IL_01a7: ldc.i4.0
-		IL_01a8: ldstr "a"
-		IL_01ad: stelem.ref
-		IL_01ae: dup
-		IL_01af: ldc.i4.1
-		IL_01b0: ldstr "b"
-		IL_01b5: stelem.ref
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_01bb: stloc.s 12
+		IL_0180: ldloc.s 11
+		IL_0182: ldstr "join"
+		IL_0187: ldc.i4.2
+		IL_0188: newarr [System.Runtime]System.Object
+		IL_018d: dup
+		IL_018e: ldc.i4.0
+		IL_018f: ldstr "a"
+		IL_0194: stelem.ref
+		IL_0195: dup
+		IL_0196: ldc.i4.1
+		IL_0197: ldstr "b"
+		IL_019c: stelem.ref
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_01a2: stloc.s 12
 
-		IL_01bd: ldloc.s 14
-		IL_01bf: ldstr "log"
-		IL_01c4: ldloc.s 12
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cb: pop
-		IL_01cc: ldstr "console"
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01db: stloc.s 12
-		IL_01dd: ldloc.0
-		IL_01de: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_01e3: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_01e8: stloc.s 11
-		IL_01ea: ldloc.s 11
-		IL_01ec: ldstr "sep"
-		IL_01f1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_01f6: brtrue IL_0209
+		IL_01a4: ldloc.s 14
+		IL_01a6: ldstr "log"
+		IL_01ab: ldloc.s 12
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b2: pop
+		IL_01b3: ldstr "console"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c2: stloc.s 12
+		IL_01c4: ldloc.0
+		IL_01c5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_01ca: stloc.s 11
+		IL_01cc: ldloc.s 11
+		IL_01ce: ldstr "sep"
+		IL_01d3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_01d8: brtrue IL_01eb
 
-		IL_01fb: ldloc.s 11
-		IL_01fd: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
-		IL_0202: stloc.s 14
-		IL_0204: br IL_0217
+		IL_01dd: ldloc.s 11
+		IL_01df: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
+		IL_01e4: stloc.s 14
+		IL_01e6: br IL_01f9
 
-		IL_0209: ldloc.s 11
-		IL_020b: ldstr "sep"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0215: stloc.s 14
+		IL_01eb: ldloc.s 11
+		IL_01ed: ldstr "sep"
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01f7: stloc.s 14
 
-		IL_0217: ldloc.s 12
-		IL_0219: ldstr "log"
-		IL_021e: ldloc.s 14
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0225: pop
-		IL_0226: ldloc.0
-		IL_0227: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_022c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0231: stloc.s 11
-		IL_0233: ldloc.s 11
-		IL_0235: ldstr "join"
-		IL_023a: ldc.r8 0.0
-		IL_0243: ldc.i4.1
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0249: pop
+		IL_01f9: ldloc.s 12
+		IL_01fb: ldstr "log"
+		IL_0200: ldloc.s 14
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0207: pop
+		IL_0208: ldloc.0
+		IL_0209: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_020e: stloc.s 11
+		IL_0210: ldloc.s 11
+		IL_0212: ldstr "join"
+		IL_0217: ldc.r8 0.0
+		IL_0220: ldc.i4.1
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0226: pop
 		.try
 		{
-			IL_024a: nop
-			IL_024b: ldloc.0
-			IL_024c: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-			IL_0251: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_0256: stloc.s 11
-			IL_0258: ldloc.s 11
-			IL_025a: ldstr "join"
-			IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0264: brtrue IL_0284
+			IL_0227: nop
+			IL_0228: ldloc.0
+			IL_0229: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+			IL_022e: stloc.s 11
+			IL_0230: ldloc.s 11
+			IL_0232: ldstr "join"
+			IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_023c: brtrue IL_025c
 
-			IL_0269: ldloc.s 11
-			IL_026b: ldc.i4.1
-			IL_026c: newarr [System.Runtime]System.Object
-			IL_0271: dup
-			IL_0272: ldc.i4.0
-			IL_0273: ldstr "a"
-			IL_0278: stelem.ref
-			IL_0279: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_027e: pop
-			IL_027f: br IL_029f
+			IL_0241: ldloc.s 11
+			IL_0243: ldc.i4.1
+			IL_0244: newarr [System.Runtime]System.Object
+			IL_0249: dup
+			IL_024a: ldc.i4.0
+			IL_024b: ldstr "a"
+			IL_0250: stelem.ref
+			IL_0251: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0256: pop
+			IL_0257: br IL_0277
 
-			IL_0284: ldloc.s 11
-			IL_0286: ldstr "join"
-			IL_028b: ldc.i4.1
-			IL_028c: newarr [System.Runtime]System.Object
-			IL_0291: dup
-			IL_0292: ldc.i4.0
-			IL_0293: ldstr "a"
-			IL_0298: stelem.ref
-			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_029e: pop
+			IL_025c: ldloc.s 11
+			IL_025e: ldstr "join"
+			IL_0263: ldc.i4.1
+			IL_0264: newarr [System.Runtime]System.Object
+			IL_0269: dup
+			IL_026a: ldc.i4.0
+			IL_026b: ldstr "a"
+			IL_0270: stelem.ref
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0276: pop
 
-			IL_029f: leave IL_0309
+			IL_0277: leave IL_02e1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02a4: stloc.s 4
-			IL_02a6: ldloc.s 4
-			IL_02a8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02ad: dup
-			IL_02ae: brtrue IL_02c4
+			IL_027c: stloc.s 4
+			IL_027e: ldloc.s 4
+			IL_0280: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0285: dup
+			IL_0286: brtrue IL_029c
 
-			IL_02b3: pop
-			IL_02b4: ldloc.s 4
-			IL_02b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02bb: dup
-			IL_02bc: brtrue IL_02d0
+			IL_028b: pop
+			IL_028c: ldloc.s 4
+			IL_028e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0293: dup
+			IL_0294: brtrue IL_02a8
 
-			IL_02c1: pop
-			IL_02c2: rethrow
+			IL_0299: pop
+			IL_029a: rethrow
 
-			IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02c9: stloc.s 5
-			IL_02cb: br IL_02d2
+			IL_029c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02a1: stloc.s 5
+			IL_02a3: br IL_02aa
 
-			IL_02d0: stloc.s 5
+			IL_02a8: stloc.s 5
 
-			IL_02d2: ldloc.s 5
-			IL_02d4: stloc.s 6
-			IL_02d6: ldstr "console"
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e5: stloc.s 14
-			IL_02e7: ldloc.s 6
-			IL_02e9: ldstr "name"
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f3: stloc.s 12
-			IL_02f5: ldloc.s 14
-			IL_02f7: ldstr "log"
-			IL_02fc: ldloc.s 12
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0303: pop
-			IL_0304: leave IL_0309
+			IL_02aa: ldloc.s 5
+			IL_02ac: stloc.s 6
+			IL_02ae: ldstr "console"
+			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02bd: stloc.s 14
+			IL_02bf: ldloc.s 6
+			IL_02c1: ldstr "name"
+			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02cb: stloc.s 12
+			IL_02cd: ldloc.s 14
+			IL_02cf: ldstr "log"
+			IL_02d4: ldloc.s 12
+			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02db: pop
+			IL_02dc: leave IL_02e1
 		} // end handler
 
-		IL_0309: ldloc.0
-		IL_030a: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_030f: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0314: stloc.s 11
-		IL_0316: ldloc.s 11
-		IL_0318: ldstr "join"
-		IL_031d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0322: stloc.s 16
-		IL_0324: ldloc.0
-		IL_0325: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_032a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_032f: stloc.s 11
-		IL_0331: ldloc.s 11
-		IL_0333: ldstr "sep"
-		IL_0338: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_033d: stloc.s 16
+		IL_02e1: ldloc.0
+		IL_02e2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_02e7: stloc.s 11
+		IL_02e9: ldloc.s 11
+		IL_02eb: ldstr "join"
+		IL_02f0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_02f5: stloc.s 16
+		IL_02f7: ldloc.0
+		IL_02f8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_02fd: stloc.s 11
+		IL_02ff: ldloc.s 11
+		IL_0301: ldstr "sep"
+		IL_0306: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_030b: stloc.s 16
 		.try
 		{
-			IL_033f: nop
-			IL_0340: ldloc.0
-			IL_0341: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-			IL_0346: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-			IL_034b: stloc.s 11
-			IL_034d: ldloc.s 11
-			IL_034f: ldstr "join"
-			IL_0354: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0359: brtrue IL_0379
+			IL_030d: nop
+			IL_030e: ldloc.0
+			IL_030f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+			IL_0314: stloc.s 11
+			IL_0316: ldloc.s 11
+			IL_0318: ldstr "join"
+			IL_031d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0322: brtrue IL_0342
 
-			IL_035e: ldloc.s 11
-			IL_0360: ldc.i4.1
-			IL_0361: newarr [System.Runtime]System.Object
-			IL_0366: dup
-			IL_0367: ldc.i4.0
-			IL_0368: ldstr "a"
-			IL_036d: stelem.ref
-			IL_036e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0373: pop
-			IL_0374: br IL_0394
+			IL_0327: ldloc.s 11
+			IL_0329: ldc.i4.1
+			IL_032a: newarr [System.Runtime]System.Object
+			IL_032f: dup
+			IL_0330: ldc.i4.0
+			IL_0331: ldstr "a"
+			IL_0336: stelem.ref
+			IL_0337: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_033c: pop
+			IL_033d: br IL_035d
 
-			IL_0379: ldloc.s 11
-			IL_037b: ldstr "join"
-			IL_0380: ldc.i4.1
-			IL_0381: newarr [System.Runtime]System.Object
-			IL_0386: dup
-			IL_0387: ldc.i4.0
-			IL_0388: ldstr "a"
-			IL_038d: stelem.ref
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0393: pop
+			IL_0342: ldloc.s 11
+			IL_0344: ldstr "join"
+			IL_0349: ldc.i4.1
+			IL_034a: newarr [System.Runtime]System.Object
+			IL_034f: dup
+			IL_0350: ldc.i4.0
+			IL_0351: ldstr "a"
+			IL_0356: stelem.ref
+			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_035c: pop
 
-			IL_0394: leave IL_03fe
+			IL_035d: leave IL_03c7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0399: stloc.s 7
-			IL_039b: ldloc.s 7
-			IL_039d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03a2: dup
-			IL_03a3: brtrue IL_03b9
+			IL_0362: stloc.s 7
+			IL_0364: ldloc.s 7
+			IL_0366: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_036b: dup
+			IL_036c: brtrue IL_0382
 
-			IL_03a8: pop
-			IL_03a9: ldloc.s 7
-			IL_03ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03b0: dup
-			IL_03b1: brtrue IL_03c5
+			IL_0371: pop
+			IL_0372: ldloc.s 7
+			IL_0374: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0379: dup
+			IL_037a: brtrue IL_038e
 
-			IL_03b6: pop
-			IL_03b7: rethrow
+			IL_037f: pop
+			IL_0380: rethrow
 
-			IL_03b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03be: stloc.s 8
-			IL_03c0: br IL_03c7
+			IL_0382: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0387: stloc.s 8
+			IL_0389: br IL_0390
 
-			IL_03c5: stloc.s 8
+			IL_038e: stloc.s 8
 
-			IL_03c7: ldloc.s 8
-			IL_03c9: stloc.s 9
-			IL_03cb: ldstr "console"
-			IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03da: stloc.s 12
-			IL_03dc: ldloc.s 9
-			IL_03de: ldstr "name"
-			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e8: stloc.s 14
-			IL_03ea: ldloc.s 12
-			IL_03ec: ldstr "log"
-			IL_03f1: ldloc.s 14
-			IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03f8: pop
-			IL_03f9: leave IL_03fe
+			IL_0390: ldloc.s 8
+			IL_0392: stloc.s 9
+			IL_0394: ldstr "console"
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a3: stloc.s 12
+			IL_03a5: ldloc.s 9
+			IL_03a7: ldstr "name"
+			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b1: stloc.s 14
+			IL_03b3: ldloc.s 12
+			IL_03b5: ldstr "log"
+			IL_03ba: ldloc.s 14
+			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03c1: pop
+			IL_03c2: leave IL_03c7
 		} // end handler
 
-		IL_03fe: ldstr "console"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040d: stloc.s 14
-		IL_040f: ldloc.0
-		IL_0410: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_0415: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_041a: stloc.s 11
-		IL_041c: ldloc.s 11
-		IL_041e: ldstr "sep"
-		IL_0423: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0428: brtrue IL_043b
+		IL_03c7: ldstr "console"
+		IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d6: stloc.s 14
+		IL_03d8: ldloc.0
+		IL_03d9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_03de: stloc.s 11
+		IL_03e0: ldloc.s 11
+		IL_03e2: ldstr "sep"
+		IL_03e7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_03ec: brtrue IL_03ff
 
-		IL_042d: ldloc.s 11
-		IL_042f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
-		IL_0434: stloc.s 12
-		IL_0436: br IL_0449
+		IL_03f1: ldloc.s 11
+		IL_03f3: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
+		IL_03f8: stloc.s 12
+		IL_03fa: br IL_040d
 
-		IL_043b: ldloc.s 11
-		IL_043d: ldstr "sep"
-		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0447: stloc.s 12
+		IL_03ff: ldloc.s 11
+		IL_0401: ldstr "sep"
+		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_040b: stloc.s 12
 
-		IL_0449: ldloc.s 12
-		IL_044b: ldnull
-		IL_044c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0451: stloc.s 16
-		IL_0453: ldloc.s 16
-		IL_0455: box [System.Runtime]System.Boolean
-		IL_045a: stloc.s 17
-		IL_045c: ldloc.s 14
-		IL_045e: ldstr "log"
-		IL_0463: ldloc.s 17
-		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_046a: pop
-		IL_046b: ldloc.0
-		IL_046c: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_0471: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0476: stloc.s 11
-		IL_0478: ldloc.s 11
-		IL_047a: ldstr "join"
-		IL_047f: ldloc.2
-		IL_0480: ldc.i4.1
-		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0486: pop
-		IL_0487: ldloc.0
-		IL_0488: ldfld object Modules.Require_Path_MemberOverrides/Scope::path
-		IL_048d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
-		IL_0492: stloc.s 11
-		IL_0494: ldloc.s 11
-		IL_0496: ldstr "sep"
-		IL_049b: ldloc.3
-		IL_049c: ldc.i4.1
-		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_04a2: pop
-		IL_04a3: ldnull
-		IL_04a4: stloc.s 10
-		IL_04a6: ret
+		IL_040d: ldloc.s 12
+		IL_040f: ldnull
+		IL_0410: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0415: stloc.s 16
+		IL_0417: ldloc.s 16
+		IL_0419: box [System.Runtime]System.Boolean
+		IL_041e: stloc.s 17
+		IL_0420: ldloc.s 14
+		IL_0422: ldstr "log"
+		IL_0427: ldloc.s 17
+		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_042e: pop
+		IL_042f: ldloc.0
+		IL_0430: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_0435: stloc.s 11
+		IL_0437: ldloc.s 11
+		IL_0439: ldstr "join"
+		IL_043e: ldloc.2
+		IL_043f: ldc.i4.1
+		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0445: pop
+		IL_0446: ldloc.0
+		IL_0447: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_044c: stloc.s 11
+		IL_044e: ldloc.s 11
+		IL_0450: ldstr "sep"
+		IL_0455: ldloc.3
+		IL_0456: ldc.i4.1
+		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_045c: pop
+		IL_045d: ldnull
+		IL_045e: stloc.s 10
+		IL_0460: ret
 	} // end of method Require_Path_MemberOverrides::__js_module_init__
 
 } // end of class Modules.Require_Path_MemberOverrides
@@ -709,7 +694,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25d4
+		// Method begins at RVA 0x258c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2acb
+					// Method begins at RVA 0x2aaf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ab0
+				// Method begins at RVA 0x2a94
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac2
+				// Method begins at RVA 0x2aa6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			)
 			// Method begins at RVA 0x211c
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 103 (0x67)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/Scope,
@@ -105,44 +105,43 @@
 			IL_0000: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_000c: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-			IL_0011: stloc.2
-			IL_0012: ldloc.2
-			IL_0013: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
-			IL_0018: stloc.3
-			IL_0019: ldloc.3
-			IL_001a: ldc.i4.1
-			IL_001b: newarr [System.Runtime]System.Object
-			IL_0020: dup
-			IL_0021: ldc.i4.0
-			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0027: dup
-			IL_0028: ldstr "objectMode"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: stelem.ref
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_0039: stloc.1
-			IL_003a: ldnull
-			IL_003b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
-			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0046: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_004b: ldc.i4.1
-			IL_004c: conv.r8
-			IL_004d: ldstr ""
-			IL_0052: ldc.i4.0
-			IL_0053: ldc.i4.1
-			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_0059: stloc.s 4
-			IL_005b: ldloc.1
-			IL_005c: ldstr "_write"
-			IL_0061: ldloc.s 4
-			IL_0063: ldc.i4.1
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0069: pop
-			IL_006a: ldloc.1
-			IL_006b: ret
+			IL_0007: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+			IL_000c: stloc.2
+			IL_000d: ldloc.2
+			IL_000e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
+			IL_0013: stloc.3
+			IL_0014: ldloc.3
+			IL_0015: ldc.i4.1
+			IL_0016: newarr [System.Runtime]System.Object
+			IL_001b: dup
+			IL_001c: ldc.i4.0
+			IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0022: dup
+			IL_0023: ldstr "objectMode"
+			IL_0028: ldc.i4.1
+			IL_0029: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_002e: stelem.ref
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_0034: stloc.1
+			IL_0035: ldnull
+			IL_0036: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
+			IL_003c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0046: ldc.i4.1
+			IL_0047: conv.r8
+			IL_0048: ldstr ""
+			IL_004d: ldc.i4.0
+			IL_004e: ldc.i4.1
+			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0054: stloc.s 4
+			IL_0056: ldloc.1
+			IL_0057: ldstr "_write"
+			IL_005c: ldloc.s 4
+			IL_005e: ldc.i4.1
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0064: pop
+			IL_0065: ldloc.1
+			IL_0066: ret
 		} // end of method createWritable::__js_call__
 
 	} // end of class createWritable
@@ -158,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad4
+				// Method begins at RVA 0x2ab8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -184,9 +183,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2194
+			// Method begins at RVA 0x2190
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 49 (0x31)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
@@ -194,27 +193,26 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Readable()
-			IL_0012: stloc.1
-			IL_0013: ldloc.1
-			IL_0014: ldc.i4.1
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0021: dup
-			IL_0022: ldstr "objectMode"
-			IL_0027: ldc.i4.1
-			IL_0028: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_002d: stelem.ref
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_0033: stloc.1
-			IL_0034: ldloc.1
-			IL_0035: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Readable()
+			IL_000d: stloc.1
+			IL_000e: ldloc.1
+			IL_000f: ldc.i4.1
+			IL_0010: newarr [System.Runtime]System.Object
+			IL_0015: dup
+			IL_0016: ldc.i4.0
+			IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001c: dup
+			IL_001d: ldstr "objectMode"
+			IL_0022: ldc.i4.1
+			IL_0023: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0028: stelem.ref
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_002e: stloc.1
+			IL_002f: ldloc.1
+			IL_0030: ret
 		} // end of method createReadable::__js_call__
 
 	} // end of class createReadable
@@ -234,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aef
+					// Method begins at RVA 0x2ad3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -257,7 +255,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ab3
+				// Method begins at RVA 0x2a97
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -279,7 +277,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b0a
+					// Method begins at RVA 0x2aee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -302,7 +300,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ab6
+				// Method begins at RVA 0x2a9a
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -339,7 +337,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae6
+					// Method begins at RVA 0x2aca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2af8
+					// Method begins at RVA 0x2adc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -379,7 +377,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b01
+					// Method begins at RVA 0x2ae5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -399,7 +397,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b13
+					// Method begins at RVA 0x2af7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -419,7 +417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b1c
+					// Method begins at RVA 0x2b00
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -439,7 +437,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b25
+					// Method begins at RVA 0x2b09
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -459,7 +457,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b2e
+					// Method begins at RVA 0x2b12
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +477,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b37
+					// Method begins at RVA 0x2b1b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -507,7 +505,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2add
+				// Method begins at RVA 0x2ac1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -531,9 +529,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21d0
 			// Header size: 12
-			// Code size: 2224 (0x8b0)
+			// Code size: 2204 (0x89c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -686,7 +684,7 @@
 
 			IL_00f0: ldloc.0
 			IL_00f1: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00f6: switch (IL_010f, IL_058b, IL_0558, IL_07c7, IL_0794)
+			IL_00f6: switch (IL_010f, IL_057c, IL_0549, IL_07b3, IL_0780)
 			.try
 			{
 				IL_010f: nop
@@ -694,804 +692,800 @@
 				IL_0111: ldc.i4.1
 				IL_0112: ldelem.ref
 				IL_0113: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0118: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_011d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-				IL_0122: stloc.s 12
-				IL_0124: ldarg.0
-				IL_0125: ldc.i4.1
-				IL_0126: ldelem.ref
-				IL_0127: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_012c: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_0131: ldc.i4.1
-				IL_0132: newarr [System.Runtime]System.Object
-				IL_0137: dup
-				IL_0138: ldc.i4.0
-				IL_0139: ldarg.0
-				IL_013a: ldc.i4.1
-				IL_013b: ldelem.ref
-				IL_013c: stelem.ref
-				IL_013d: stloc.s 13
-				IL_013f: ldloc.s 13
-				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0146: stloc.s 14
-				IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_014d: dup
-				IL_014e: ldstr "signal"
-				IL_0153: ldc.i4.0
-				IL_0154: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0159: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_015e: stloc.s 15
-				IL_0160: ldc.i4.1
-				IL_0161: newarr [System.Runtime]System.Object
-				IL_0166: dup
-				IL_0167: ldc.i4.0
-				IL_0168: ldarg.0
-				IL_0169: ldc.i4.1
-				IL_016a: ldelem.ref
-				IL_016b: stelem.ref
-				IL_016c: stloc.s 13
-				IL_016e: ldnull
-				IL_016f: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-				IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_017a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-				IL_017f: ldc.i4.0
-				IL_0180: conv.r8
-				IL_0181: ldstr ""
-				IL_0186: ldc.i4.0
-				IL_0187: ldc.i4.1
-				IL_0188: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-				IL_018d: stloc.s 16
-				IL_018f: ldloc.s 12
-				IL_0191: ldloc.s 14
-				IL_0193: ldloc.s 15
-				IL_0195: ldloc.s 16
-				IL_0197: castclass [System.Runtime]System.Delegate
-				IL_019c: callvirt instance class [System.Runtime]System.Delegate [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::finished(object, object, class [System.Runtime]System.Delegate)
-				IL_01a1: pop
-				IL_01a2: ldstr "console"
-				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_01ac: stloc.s 14
-				IL_01ae: ldloc.s 14
-				IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01b5: stloc.s 14
-				IL_01b7: ldloc.s 14
-				IL_01b9: ldstr "log"
-				IL_01be: ldstr "callback-finished:ok"
-				IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01c8: pop
-				IL_01c9: leave IL_0294
+				IL_0118: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_011d: stloc.s 12
+				IL_011f: ldarg.0
+				IL_0120: ldc.i4.1
+				IL_0121: ldelem.ref
+				IL_0122: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0127: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_012c: ldc.i4.1
+				IL_012d: newarr [System.Runtime]System.Object
+				IL_0132: dup
+				IL_0133: ldc.i4.0
+				IL_0134: ldarg.0
+				IL_0135: ldc.i4.1
+				IL_0136: ldelem.ref
+				IL_0137: stelem.ref
+				IL_0138: stloc.s 13
+				IL_013a: ldloc.s 13
+				IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0141: stloc.s 14
+				IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0148: dup
+				IL_0149: ldstr "signal"
+				IL_014e: ldc.i4.0
+				IL_014f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0154: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0159: stloc.s 15
+				IL_015b: ldc.i4.1
+				IL_015c: newarr [System.Runtime]System.Object
+				IL_0161: dup
+				IL_0162: ldc.i4.0
+				IL_0163: ldarg.0
+				IL_0164: ldc.i4.1
+				IL_0165: ldelem.ref
+				IL_0166: stelem.ref
+				IL_0167: stloc.s 13
+				IL_0169: ldnull
+				IL_016a: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+				IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_0175: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+				IL_017a: ldc.i4.0
+				IL_017b: conv.r8
+				IL_017c: ldstr ""
+				IL_0181: ldc.i4.0
+				IL_0182: ldc.i4.1
+				IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+				IL_0188: stloc.s 16
+				IL_018a: ldloc.s 12
+				IL_018c: ldloc.s 14
+				IL_018e: ldloc.s 15
+				IL_0190: ldloc.s 16
+				IL_0192: castclass [System.Runtime]System.Delegate
+				IL_0197: callvirt instance class [System.Runtime]System.Delegate [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::finished(object, object, class [System.Runtime]System.Delegate)
+				IL_019c: pop
+				IL_019d: ldstr "console"
+				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01a7: stloc.s 14
+				IL_01a9: ldloc.s 14
+				IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01b0: stloc.s 14
+				IL_01b2: ldloc.s 14
+				IL_01b4: ldstr "log"
+				IL_01b9: ldstr "callback-finished:ok"
+				IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01c3: pop
+				IL_01c4: leave IL_028f
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_01ce: stloc.1
-				IL_01cf: ldloc.1
-				IL_01d0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_01d5: dup
-				IL_01d6: brtrue IL_01eb
+				IL_01c9: stloc.1
+				IL_01ca: ldloc.1
+				IL_01cb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_01d0: dup
+				IL_01d1: brtrue IL_01e6
 
-				IL_01db: pop
-				IL_01dc: ldloc.1
-				IL_01dd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_01e2: dup
-				IL_01e3: brtrue IL_01f6
+				IL_01d6: pop
+				IL_01d7: ldloc.1
+				IL_01d8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_01dd: dup
+				IL_01de: brtrue IL_01f1
 
-				IL_01e8: pop
-				IL_01e9: rethrow
+				IL_01e3: pop
+				IL_01e4: rethrow
 
-				IL_01eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_01f0: stloc.2
-				IL_01f1: br IL_01f7
+				IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_01eb: stloc.2
+				IL_01ec: br IL_01f2
 
-				IL_01f6: stloc.2
+				IL_01f1: stloc.2
 
-				IL_01f7: ldloc.2
-				IL_01f8: stloc.3
-				IL_01f9: ldstr "console"
-				IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0203: stloc.s 14
-				IL_0205: ldloc.s 14
-				IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_020c: stloc.s 14
-				IL_020e: ldloc.3
-				IL_020f: ldstr "name"
-				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0219: stloc.s 17
-				IL_021b: ldstr "callback-finished:"
-				IL_0220: ldloc.s 17
-				IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0227: stloc.s 18
-				IL_0229: ldloc.s 18
-				IL_022b: ldstr ":"
-				IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0235: stloc.s 18
-				IL_0237: ldloc.3
-				IL_0238: ldstr "code"
-				IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0242: stloc.s 17
-				IL_0244: ldloc.s 18
-				IL_0246: ldloc.s 17
-				IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_024d: stloc.s 18
-				IL_024f: ldloc.s 14
-				IL_0251: ldstr "log"
-				IL_0256: ldloc.s 18
-				IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_025d: pop
-				IL_025e: ldstr "console"
-				IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0268: stloc.s 14
-				IL_026a: ldloc.s 14
-				IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0271: stloc.s 14
-				IL_0273: ldloc.3
-				IL_0274: ldstr "message"
-				IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_027e: stloc.s 17
-				IL_0280: ldloc.s 14
-				IL_0282: ldstr "log"
-				IL_0287: ldloc.s 17
-				IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_028e: pop
-				IL_028f: leave IL_0294
+				IL_01f2: ldloc.2
+				IL_01f3: stloc.3
+				IL_01f4: ldstr "console"
+				IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_01fe: stloc.s 14
+				IL_0200: ldloc.s 14
+				IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0207: stloc.s 14
+				IL_0209: ldloc.3
+				IL_020a: ldstr "name"
+				IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0214: stloc.s 17
+				IL_0216: ldstr "callback-finished:"
+				IL_021b: ldloc.s 17
+				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0222: stloc.s 18
+				IL_0224: ldloc.s 18
+				IL_0226: ldstr ":"
+				IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0230: stloc.s 18
+				IL_0232: ldloc.3
+				IL_0233: ldstr "code"
+				IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_023d: stloc.s 17
+				IL_023f: ldloc.s 18
+				IL_0241: ldloc.s 17
+				IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0248: stloc.s 18
+				IL_024a: ldloc.s 14
+				IL_024c: ldstr "log"
+				IL_0251: ldloc.s 18
+				IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0258: pop
+				IL_0259: ldstr "console"
+				IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0263: stloc.s 14
+				IL_0265: ldloc.s 14
+				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_026c: stloc.s 14
+				IL_026e: ldloc.3
+				IL_026f: ldstr "message"
+				IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0279: stloc.s 17
+				IL_027b: ldloc.s 14
+				IL_027d: ldstr "log"
+				IL_0282: ldloc.s 17
+				IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0289: pop
+				IL_028a: leave IL_028f
 			} // end handler
 			.try
 			{
-				IL_0294: nop
-				IL_0295: ldarg.0
-				IL_0296: ldc.i4.1
-				IL_0297: ldelem.ref
-				IL_0298: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_029d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_02a2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-				IL_02a7: stloc.s 12
-				IL_02a9: ldarg.0
-				IL_02aa: ldc.i4.1
-				IL_02ab: ldelem.ref
-				IL_02ac: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02b1: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-				IL_02b6: ldc.i4.1
-				IL_02b7: newarr [System.Runtime]System.Object
-				IL_02bc: dup
-				IL_02bd: ldc.i4.0
-				IL_02be: ldarg.0
-				IL_02bf: ldc.i4.1
-				IL_02c0: ldelem.ref
-				IL_02c1: stelem.ref
-				IL_02c2: stloc.s 13
-				IL_02c4: ldloc.s 13
-				IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_02cb: stloc.s 17
-				IL_02cd: ldarg.0
-				IL_02ce: ldc.i4.1
-				IL_02cf: ldelem.ref
-				IL_02d0: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02d5: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_02da: ldc.i4.1
-				IL_02db: newarr [System.Runtime]System.Object
-				IL_02e0: dup
-				IL_02e1: ldc.i4.0
-				IL_02e2: ldarg.0
-				IL_02e3: ldc.i4.1
-				IL_02e4: ldelem.ref
-				IL_02e5: stelem.ref
-				IL_02e6: stloc.s 13
-				IL_02e8: ldloc.s 13
-				IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_02ef: stloc.s 14
-				IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_02f6: stloc.s 15
-				IL_02f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_02fd: dup
-				IL_02fe: ldstr "signal"
-				IL_0303: ldloc.s 15
-				IL_0305: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_030a: stloc.s 15
-				IL_030c: ldc.i4.1
-				IL_030d: newarr [System.Runtime]System.Object
-				IL_0312: dup
-				IL_0313: ldc.i4.0
-				IL_0314: ldarg.0
-				IL_0315: ldc.i4.1
-				IL_0316: ldelem.ref
-				IL_0317: stelem.ref
-				IL_0318: stloc.s 13
-				IL_031a: ldnull
-				IL_031b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-				IL_0321: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0326: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-				IL_032b: ldc.i4.0
-				IL_032c: conv.r8
-				IL_032d: ldstr ""
-				IL_0332: ldc.i4.0
-				IL_0333: ldc.i4.1
-				IL_0334: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-				IL_0339: stloc.s 16
-				IL_033b: ldloc.s 12
-				IL_033d: ldc.i4.4
-				IL_033e: newarr [System.Runtime]System.Object
+				IL_028f: nop
+				IL_0290: ldarg.0
+				IL_0291: ldc.i4.1
+				IL_0292: ldelem.ref
+				IL_0293: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0298: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_029d: stloc.s 12
+				IL_029f: ldarg.0
+				IL_02a0: ldc.i4.1
+				IL_02a1: ldelem.ref
+				IL_02a2: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_02a7: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+				IL_02ac: ldc.i4.1
+				IL_02ad: newarr [System.Runtime]System.Object
+				IL_02b2: dup
+				IL_02b3: ldc.i4.0
+				IL_02b4: ldarg.0
+				IL_02b5: ldc.i4.1
+				IL_02b6: ldelem.ref
+				IL_02b7: stelem.ref
+				IL_02b8: stloc.s 13
+				IL_02ba: ldloc.s 13
+				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_02c1: stloc.s 17
+				IL_02c3: ldarg.0
+				IL_02c4: ldc.i4.1
+				IL_02c5: ldelem.ref
+				IL_02c6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_02cb: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_02d0: ldc.i4.1
+				IL_02d1: newarr [System.Runtime]System.Object
+				IL_02d6: dup
+				IL_02d7: ldc.i4.0
+				IL_02d8: ldarg.0
+				IL_02d9: ldc.i4.1
+				IL_02da: ldelem.ref
+				IL_02db: stelem.ref
+				IL_02dc: stloc.s 13
+				IL_02de: ldloc.s 13
+				IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_02e5: stloc.s 14
+				IL_02e7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02ec: stloc.s 15
+				IL_02ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02f3: dup
+				IL_02f4: ldstr "signal"
+				IL_02f9: ldloc.s 15
+				IL_02fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0300: stloc.s 15
+				IL_0302: ldc.i4.1
+				IL_0303: newarr [System.Runtime]System.Object
+				IL_0308: dup
+				IL_0309: ldc.i4.0
+				IL_030a: ldarg.0
+				IL_030b: ldc.i4.1
+				IL_030c: ldelem.ref
+				IL_030d: stelem.ref
+				IL_030e: stloc.s 13
+				IL_0310: ldnull
+				IL_0311: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+				IL_0317: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_031c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+				IL_0321: ldc.i4.0
+				IL_0322: conv.r8
+				IL_0323: ldstr ""
+				IL_0328: ldc.i4.0
+				IL_0329: ldc.i4.1
+				IL_032a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+				IL_032f: stloc.s 16
+				IL_0331: ldloc.s 12
+				IL_0333: ldc.i4.4
+				IL_0334: newarr [System.Runtime]System.Object
+				IL_0339: dup
+				IL_033a: ldc.i4.0
+				IL_033b: ldloc.s 17
+				IL_033d: stelem.ref
+				IL_033e: dup
+				IL_033f: ldc.i4.1
+				IL_0340: ldloc.s 14
+				IL_0342: stelem.ref
 				IL_0343: dup
-				IL_0344: ldc.i4.0
-				IL_0345: ldloc.s 17
+				IL_0344: ldc.i4.2
+				IL_0345: ldloc.s 15
 				IL_0347: stelem.ref
 				IL_0348: dup
-				IL_0349: ldc.i4.1
-				IL_034a: ldloc.s 14
+				IL_0349: ldc.i4.3
+				IL_034a: ldloc.s 16
 				IL_034c: stelem.ref
-				IL_034d: dup
-				IL_034e: ldc.i4.2
-				IL_034f: ldloc.s 15
-				IL_0351: stelem.ref
-				IL_0352: dup
-				IL_0353: ldc.i4.3
-				IL_0354: ldloc.s 16
-				IL_0356: stelem.ref
-				IL_0357: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::pipeline(object[])
-				IL_035c: pop
-				IL_035d: ldstr "console"
-				IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0367: stloc.s 14
-				IL_0369: ldloc.s 14
-				IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0370: stloc.s 14
-				IL_0372: ldloc.s 14
-				IL_0374: ldstr "log"
-				IL_0379: ldstr "callback-pipeline:ok"
-				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0383: pop
-				IL_0384: leave IL_0459
+				IL_034d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::pipeline(object[])
+				IL_0352: pop
+				IL_0353: ldstr "console"
+				IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_035d: stloc.s 14
+				IL_035f: ldloc.s 14
+				IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0366: stloc.s 14
+				IL_0368: ldloc.s 14
+				IL_036a: ldstr "log"
+				IL_036f: ldstr "callback-pipeline:ok"
+				IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0379: pop
+				IL_037a: leave IL_044f
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0389: stloc.s 4
-				IL_038b: ldloc.s 4
-				IL_038d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0392: dup
-				IL_0393: brtrue IL_03a9
+				IL_037f: stloc.s 4
+				IL_0381: ldloc.s 4
+				IL_0383: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0388: dup
+				IL_0389: brtrue IL_039f
 
-				IL_0398: pop
-				IL_0399: ldloc.s 4
-				IL_039b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_03a0: dup
-				IL_03a1: brtrue IL_03b5
+				IL_038e: pop
+				IL_038f: ldloc.s 4
+				IL_0391: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0396: dup
+				IL_0397: brtrue IL_03ab
 
-				IL_03a6: pop
-				IL_03a7: rethrow
+				IL_039c: pop
+				IL_039d: rethrow
 
-				IL_03a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_03ae: stloc.s 5
-				IL_03b0: br IL_03b7
+				IL_039f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_03a4: stloc.s 5
+				IL_03a6: br IL_03ad
 
-				IL_03b5: stloc.s 5
+				IL_03ab: stloc.s 5
 
-				IL_03b7: ldloc.s 5
-				IL_03b9: stloc.s 6
-				IL_03bb: ldstr "console"
-				IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_03c5: stloc.s 14
-				IL_03c7: ldloc.s 14
-				IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03ce: stloc.s 14
-				IL_03d0: ldloc.s 6
-				IL_03d2: ldstr "name"
-				IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03dc: stloc.s 17
-				IL_03de: ldstr "callback-pipeline:"
-				IL_03e3: ldloc.s 17
-				IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03ea: stloc.s 18
-				IL_03ec: ldloc.s 18
-				IL_03ee: ldstr ":"
-				IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03f8: stloc.s 18
-				IL_03fa: ldloc.s 6
-				IL_03fc: ldstr "code"
-				IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0406: stloc.s 17
-				IL_0408: ldloc.s 18
-				IL_040a: ldloc.s 17
-				IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0411: stloc.s 18
-				IL_0413: ldloc.s 14
-				IL_0415: ldstr "log"
-				IL_041a: ldloc.s 18
-				IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0421: pop
-				IL_0422: ldstr "console"
-				IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_042c: stloc.s 14
-				IL_042e: ldloc.s 14
-				IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0435: stloc.s 14
-				IL_0437: ldloc.s 6
-				IL_0439: ldstr "message"
-				IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0443: stloc.s 17
-				IL_0445: ldloc.s 14
-				IL_0447: ldstr "log"
-				IL_044c: ldloc.s 17
-				IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0453: pop
-				IL_0454: leave IL_0459
+				IL_03ad: ldloc.s 5
+				IL_03af: stloc.s 6
+				IL_03b1: ldstr "console"
+				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_03bb: stloc.s 14
+				IL_03bd: ldloc.s 14
+				IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03c4: stloc.s 14
+				IL_03c6: ldloc.s 6
+				IL_03c8: ldstr "name"
+				IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03d2: stloc.s 17
+				IL_03d4: ldstr "callback-pipeline:"
+				IL_03d9: ldloc.s 17
+				IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03e0: stloc.s 18
+				IL_03e2: ldloc.s 18
+				IL_03e4: ldstr ":"
+				IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_03ee: stloc.s 18
+				IL_03f0: ldloc.s 6
+				IL_03f2: ldstr "code"
+				IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03fc: stloc.s 17
+				IL_03fe: ldloc.s 18
+				IL_0400: ldloc.s 17
+				IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0407: stloc.s 18
+				IL_0409: ldloc.s 14
+				IL_040b: ldstr "log"
+				IL_0410: ldloc.s 18
+				IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0417: pop
+				IL_0418: ldstr "console"
+				IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0422: stloc.s 14
+				IL_0424: ldloc.s 14
+				IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_042b: stloc.s 14
+				IL_042d: ldloc.s 6
+				IL_042f: ldstr "message"
+				IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0439: stloc.s 17
+				IL_043b: ldloc.s 14
+				IL_043d: ldstr "log"
+				IL_0442: ldloc.s 17
+				IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0449: pop
+				IL_044a: leave IL_044f
 			} // end handler
 
-			IL_0459: ldloc.0
-			IL_045a: ldc.i4.0
-			IL_045b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0460: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0465: ldarg.0
-			IL_0466: ldc.i4.1
-			IL_0467: ldelem.ref
-			IL_0468: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_046d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_0472: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
-			IL_0477: stloc.s 19
-			IL_0479: ldarg.0
-			IL_047a: ldc.i4.1
-			IL_047b: ldelem.ref
-			IL_047c: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0481: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_0486: ldc.i4.1
-			IL_0487: newarr [System.Runtime]System.Object
-			IL_048c: dup
-			IL_048d: ldc.i4.0
-			IL_048e: ldarg.0
-			IL_048f: ldc.i4.1
-			IL_0490: ldelem.ref
-			IL_0491: stelem.ref
-			IL_0492: stloc.s 13
-			IL_0494: ldloc.s 13
-			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_049b: stloc.s 17
-			IL_049d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04a2: dup
-			IL_04a3: ldstr "signal"
-			IL_04a8: ldc.i4.0
-			IL_04a9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04b3: stloc.s 15
-			IL_04b5: ldloc.s 19
-			IL_04b7: ldloc.s 17
-			IL_04b9: ldloc.s 15
-			IL_04bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::finished(object, object)
-			IL_04c0: stloc.s 17
-			IL_04c2: ldloc.0
-			IL_04c3: ldc.i4.2
-			IL_04c4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04c9: ldloc.0
-			IL_04ca: ldloc.s 17
-			IL_04cc: ldarg.0
-			IL_04cd: ldc.i4.1
-			IL_04ce: ldloc.0
-			IL_04cf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04d4: ldc.i4.1
-			IL_04d5: ldstr "_pendingException"
-			IL_04da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_04df: ldloc.0
-			IL_04e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04e5: dup
-			IL_04e6: ldc.i4.0
-			IL_04e7: ldloc.1
-			IL_04e8: stelem.ref
-			IL_04e9: dup
-			IL_04ea: ldc.i4.1
-			IL_04eb: ldloc.2
-			IL_04ec: stelem.ref
-			IL_04ed: dup
-			IL_04ee: ldc.i4.2
-			IL_04ef: ldloc.3
+			IL_044f: ldloc.0
+			IL_0450: ldc.i4.0
+			IL_0451: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0456: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_045b: ldarg.0
+			IL_045c: ldc.i4.1
+			IL_045d: ldelem.ref
+			IL_045e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0463: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_0468: stloc.s 19
+			IL_046a: ldarg.0
+			IL_046b: ldc.i4.1
+			IL_046c: ldelem.ref
+			IL_046d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0472: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_0477: ldc.i4.1
+			IL_0478: newarr [System.Runtime]System.Object
+			IL_047d: dup
+			IL_047e: ldc.i4.0
+			IL_047f: ldarg.0
+			IL_0480: ldc.i4.1
+			IL_0481: ldelem.ref
+			IL_0482: stelem.ref
+			IL_0483: stloc.s 13
+			IL_0485: ldloc.s 13
+			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_048c: stloc.s 17
+			IL_048e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0493: dup
+			IL_0494: ldstr "signal"
+			IL_0499: ldc.i4.0
+			IL_049a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_049f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04a4: stloc.s 15
+			IL_04a6: ldloc.s 19
+			IL_04a8: ldloc.s 17
+			IL_04aa: ldloc.s 15
+			IL_04ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::finished(object, object)
+			IL_04b1: stloc.s 17
+			IL_04b3: ldloc.0
+			IL_04b4: ldc.i4.2
+			IL_04b5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04ba: ldloc.0
+			IL_04bb: ldloc.s 17
+			IL_04bd: ldarg.0
+			IL_04be: ldc.i4.1
+			IL_04bf: ldloc.0
+			IL_04c0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04c5: ldc.i4.1
+			IL_04c6: ldstr "_pendingException"
+			IL_04cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_04d0: ldloc.0
+			IL_04d1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04d6: dup
+			IL_04d7: ldc.i4.0
+			IL_04d8: ldloc.1
+			IL_04d9: stelem.ref
+			IL_04da: dup
+			IL_04db: ldc.i4.1
+			IL_04dc: ldloc.2
+			IL_04dd: stelem.ref
+			IL_04de: dup
+			IL_04df: ldc.i4.2
+			IL_04e0: ldloc.3
+			IL_04e1: stelem.ref
+			IL_04e2: dup
+			IL_04e3: ldc.i4.3
+			IL_04e4: ldloc.s 4
+			IL_04e6: stelem.ref
+			IL_04e7: dup
+			IL_04e8: ldc.i4.4
+			IL_04e9: ldloc.s 5
+			IL_04eb: stelem.ref
+			IL_04ec: dup
+			IL_04ed: ldc.i4.5
+			IL_04ee: ldloc.s 6
 			IL_04f0: stelem.ref
 			IL_04f1: dup
-			IL_04f2: ldc.i4.3
-			IL_04f3: ldloc.s 4
+			IL_04f2: ldc.i4.6
+			IL_04f3: ldloc.s 7
 			IL_04f5: stelem.ref
 			IL_04f6: dup
-			IL_04f7: ldc.i4.4
-			IL_04f8: ldloc.s 5
+			IL_04f7: ldc.i4.7
+			IL_04f8: ldloc.s 8
 			IL_04fa: stelem.ref
 			IL_04fb: dup
-			IL_04fc: ldc.i4.5
-			IL_04fd: ldloc.s 6
+			IL_04fc: ldc.i4.8
+			IL_04fd: ldloc.s 9
 			IL_04ff: stelem.ref
 			IL_0500: dup
-			IL_0501: ldc.i4.6
-			IL_0502: ldloc.s 7
-			IL_0504: stelem.ref
-			IL_0505: dup
-			IL_0506: ldc.i4.7
-			IL_0507: ldloc.s 8
-			IL_0509: stelem.ref
-			IL_050a: dup
-			IL_050b: ldc.i4.8
-			IL_050c: ldloc.s 9
-			IL_050e: stelem.ref
-			IL_050f: dup
-			IL_0510: ldc.i4.s 9
-			IL_0512: ldloc.s 10
-			IL_0514: stelem.ref
-			IL_0515: dup
-			IL_0516: ldc.i4.s 10
-			IL_0518: ldloc.s 11
-			IL_051a: stelem.ref
-			IL_051b: dup
-			IL_051c: ldc.i4.s 11
-			IL_051e: ldloc.s 12
-			IL_0520: stelem.ref
-			IL_0521: dup
-			IL_0522: ldc.i4.s 12
-			IL_0524: ldloc.s 13
-			IL_0526: stelem.ref
-			IL_0527: dup
-			IL_0528: ldc.i4.s 13
-			IL_052a: ldloc.s 14
-			IL_052c: stelem.ref
-			IL_052d: dup
-			IL_052e: ldc.i4.s 14
-			IL_0530: ldloc.s 15
-			IL_0532: stelem.ref
-			IL_0533: dup
-			IL_0534: ldc.i4.s 15
-			IL_0536: ldloc.s 16
-			IL_0538: stelem.ref
-			IL_0539: dup
-			IL_053a: ldc.i4.s 16
-			IL_053c: ldloc.s 17
-			IL_053e: stelem.ref
-			IL_053f: dup
-			IL_0540: ldc.i4.s 17
-			IL_0542: ldloc.s 18
-			IL_0544: stelem.ref
-			IL_0545: dup
-			IL_0546: ldc.i4.s 18
-			IL_0548: ldloc.s 19
-			IL_054a: stelem.ref
-			IL_054b: pop
-			IL_054c: ldloc.0
-			IL_054d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0552: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0557: ret
+			IL_0501: ldc.i4.s 9
+			IL_0503: ldloc.s 10
+			IL_0505: stelem.ref
+			IL_0506: dup
+			IL_0507: ldc.i4.s 10
+			IL_0509: ldloc.s 11
+			IL_050b: stelem.ref
+			IL_050c: dup
+			IL_050d: ldc.i4.s 11
+			IL_050f: ldloc.s 12
+			IL_0511: stelem.ref
+			IL_0512: dup
+			IL_0513: ldc.i4.s 12
+			IL_0515: ldloc.s 13
+			IL_0517: stelem.ref
+			IL_0518: dup
+			IL_0519: ldc.i4.s 13
+			IL_051b: ldloc.s 14
+			IL_051d: stelem.ref
+			IL_051e: dup
+			IL_051f: ldc.i4.s 14
+			IL_0521: ldloc.s 15
+			IL_0523: stelem.ref
+			IL_0524: dup
+			IL_0525: ldc.i4.s 15
+			IL_0527: ldloc.s 16
+			IL_0529: stelem.ref
+			IL_052a: dup
+			IL_052b: ldc.i4.s 16
+			IL_052d: ldloc.s 17
+			IL_052f: stelem.ref
+			IL_0530: dup
+			IL_0531: ldc.i4.s 17
+			IL_0533: ldloc.s 18
+			IL_0535: stelem.ref
+			IL_0536: dup
+			IL_0537: ldc.i4.s 18
+			IL_0539: ldloc.s 19
+			IL_053b: stelem.ref
+			IL_053c: pop
+			IL_053d: ldloc.0
+			IL_053e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0543: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0548: ret
 
-			IL_0558: ldloc.0
-			IL_0559: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
-			IL_055e: pop
-			IL_055f: ldstr "console"
-			IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0569: stloc.s 17
-			IL_056b: ldloc.s 17
-			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0572: stloc.s 17
-			IL_0574: ldloc.s 17
-			IL_0576: ldstr "log"
-			IL_057b: ldstr "promise-finished:ok"
-			IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0585: pop
-			IL_0586: br IL_0641
+			IL_0549: ldloc.0
+			IL_054a: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_054f: pop
+			IL_0550: ldstr "console"
+			IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_055a: stloc.s 17
+			IL_055c: ldloc.s 17
+			IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0563: stloc.s 17
+			IL_0565: ldloc.s 17
+			IL_0567: ldstr "log"
+			IL_056c: ldstr "promise-finished:ok"
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0576: pop
+			IL_0577: br IL_0632
 
-			IL_058b: ldloc.0
-			IL_058c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0591: stloc.s 17
-			IL_0593: ldloc.0
-			IL_0594: ldc.i4.0
-			IL_0595: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_059a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_059f: ldloc.s 17
-			IL_05a1: stloc.s 7
-			IL_05a3: ldstr "console"
-			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05ad: stloc.s 17
-			IL_05af: ldloc.s 17
-			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05b6: stloc.s 17
-			IL_05b8: ldloc.s 7
-			IL_05ba: ldstr "name"
-			IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05c4: stloc.s 14
-			IL_05c6: ldstr "promise-finished:"
-			IL_05cb: ldloc.s 14
-			IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05d2: stloc.s 18
-			IL_05d4: ldloc.s 18
-			IL_05d6: ldstr ":"
-			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05e0: stloc.s 18
-			IL_05e2: ldloc.s 7
-			IL_05e4: ldstr "code"
-			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ee: stloc.s 14
-			IL_05f0: ldloc.s 18
-			IL_05f2: ldloc.s 14
-			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05f9: stloc.s 18
-			IL_05fb: ldloc.s 17
-			IL_05fd: ldstr "log"
-			IL_0602: ldloc.s 18
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0609: pop
-			IL_060a: ldstr "console"
-			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0614: stloc.s 17
-			IL_0616: ldloc.s 17
-			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_061d: stloc.s 17
-			IL_061f: ldloc.s 7
-			IL_0621: ldstr "message"
-			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_062b: stloc.s 14
-			IL_062d: ldloc.s 17
-			IL_062f: ldstr "log"
-			IL_0634: ldloc.s 14
-			IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_063b: pop
-			IL_063c: br IL_0641
+			IL_057c: ldloc.0
+			IL_057d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0582: stloc.s 17
+			IL_0584: ldloc.0
+			IL_0585: ldc.i4.0
+			IL_0586: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_058b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0590: ldloc.s 17
+			IL_0592: stloc.s 7
+			IL_0594: ldstr "console"
+			IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_059e: stloc.s 17
+			IL_05a0: ldloc.s 17
+			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a7: stloc.s 17
+			IL_05a9: ldloc.s 7
+			IL_05ab: ldstr "name"
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b5: stloc.s 14
+			IL_05b7: ldstr "promise-finished:"
+			IL_05bc: ldloc.s 14
+			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05c3: stloc.s 18
+			IL_05c5: ldloc.s 18
+			IL_05c7: ldstr ":"
+			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05d1: stloc.s 18
+			IL_05d3: ldloc.s 7
+			IL_05d5: ldstr "code"
+			IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05df: stloc.s 14
+			IL_05e1: ldloc.s 18
+			IL_05e3: ldloc.s 14
+			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05ea: stloc.s 18
+			IL_05ec: ldloc.s 17
+			IL_05ee: ldstr "log"
+			IL_05f3: ldloc.s 18
+			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05fa: pop
+			IL_05fb: ldstr "console"
+			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0605: stloc.s 17
+			IL_0607: ldloc.s 17
+			IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_060e: stloc.s 17
+			IL_0610: ldloc.s 7
+			IL_0612: ldstr "message"
+			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_061c: stloc.s 14
+			IL_061e: ldloc.s 17
+			IL_0620: ldstr "log"
+			IL_0625: ldloc.s 14
+			IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_062c: pop
+			IL_062d: br IL_0632
 
-			IL_0641: ldloc.0
-			IL_0642: ldc.i4.0
-			IL_0643: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0648: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_064d: ldarg.0
-			IL_064e: ldc.i4.1
-			IL_064f: ldelem.ref
-			IL_0650: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0655: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-			IL_065a: ldc.i4.1
-			IL_065b: newarr [System.Runtime]System.Object
-			IL_0660: dup
-			IL_0661: ldc.i4.0
+			IL_0632: ldloc.0
+			IL_0633: ldc.i4.0
+			IL_0634: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0639: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_063e: ldarg.0
+			IL_063f: ldc.i4.1
+			IL_0640: ldelem.ref
+			IL_0641: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0646: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+			IL_064b: ldc.i4.1
+			IL_064c: newarr [System.Runtime]System.Object
+			IL_0651: dup
+			IL_0652: ldc.i4.0
+			IL_0653: ldarg.0
+			IL_0654: ldc.i4.1
+			IL_0655: ldelem.ref
+			IL_0656: stelem.ref
+			IL_0657: stloc.s 13
+			IL_0659: ldloc.s 13
+			IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0660: stloc.s 8
 			IL_0662: ldarg.0
 			IL_0663: ldc.i4.1
 			IL_0664: ldelem.ref
-			IL_0665: stelem.ref
-			IL_0666: stloc.s 13
-			IL_0668: ldloc.s 13
-			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_066f: stloc.s 8
+			IL_0665: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_066a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_066f: stloc.s 19
 			IL_0671: ldarg.0
 			IL_0672: ldc.i4.1
 			IL_0673: ldelem.ref
 			IL_0674: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0679: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_067e: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
-			IL_0683: stloc.s 19
-			IL_0685: ldarg.0
-			IL_0686: ldc.i4.1
-			IL_0687: ldelem.ref
-			IL_0688: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_068d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_0692: ldc.i4.1
-			IL_0693: newarr [System.Runtime]System.Object
-			IL_0698: dup
-			IL_0699: ldc.i4.0
-			IL_069a: ldarg.0
-			IL_069b: ldc.i4.1
-			IL_069c: ldelem.ref
-			IL_069d: stelem.ref
-			IL_069e: stloc.s 13
-			IL_06a0: ldloc.s 13
-			IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_06a7: stloc.s 14
-			IL_06a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0679: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_067e: ldc.i4.1
+			IL_067f: newarr [System.Runtime]System.Object
+			IL_0684: dup
+			IL_0685: ldc.i4.0
+			IL_0686: ldarg.0
+			IL_0687: ldc.i4.1
+			IL_0688: ldelem.ref
+			IL_0689: stelem.ref
+			IL_068a: stloc.s 13
+			IL_068c: ldloc.s 13
+			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0693: stloc.s 14
+			IL_0695: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_069a: stloc.s 15
+			IL_069c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_06a1: dup
+			IL_06a2: ldstr "signal"
+			IL_06a7: ldloc.s 15
+			IL_06a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_06ae: stloc.s 15
-			IL_06b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06b5: dup
-			IL_06b6: ldstr "signal"
-			IL_06bb: ldloc.s 15
-			IL_06bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06c2: stloc.s 15
-			IL_06c4: ldloc.s 19
-			IL_06c6: ldc.i4.3
-			IL_06c7: newarr [System.Runtime]System.Object
-			IL_06cc: dup
-			IL_06cd: ldc.i4.0
+			IL_06b0: ldloc.s 19
+			IL_06b2: ldc.i4.3
+			IL_06b3: newarr [System.Runtime]System.Object
+			IL_06b8: dup
+			IL_06b9: ldc.i4.0
+			IL_06ba: ldloc.s 8
+			IL_06bc: stelem.ref
+			IL_06bd: dup
+			IL_06be: ldc.i4.1
+			IL_06bf: ldloc.s 14
+			IL_06c1: stelem.ref
+			IL_06c2: dup
+			IL_06c3: ldc.i4.2
+			IL_06c4: ldloc.s 15
+			IL_06c6: stelem.ref
+			IL_06c7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::pipeline(object[])
+			IL_06cc: stloc.s 9
 			IL_06ce: ldloc.s 8
-			IL_06d0: stelem.ref
-			IL_06d1: dup
-			IL_06d2: ldc.i4.1
-			IL_06d3: ldloc.s 14
-			IL_06d5: stelem.ref
-			IL_06d6: dup
-			IL_06d7: ldc.i4.2
-			IL_06d8: ldloc.s 15
-			IL_06da: stelem.ref
-			IL_06db: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::pipeline(object[])
-			IL_06e0: stloc.s 9
-			IL_06e2: ldloc.s 8
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06e9: stloc.s 14
-			IL_06eb: ldloc.s 14
-			IL_06ed: ldstr "push"
-			IL_06f2: ldc.i4.0
-			IL_06f3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06fd: pop
-			IL_06fe: ldloc.0
-			IL_06ff: ldc.i4.4
-			IL_0700: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0705: ldloc.0
-			IL_0706: ldloc.s 9
-			IL_0708: ldarg.0
-			IL_0709: ldc.i4.2
-			IL_070a: ldloc.0
-			IL_070b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0710: ldc.i4.3
-			IL_0711: ldstr "_pendingException"
-			IL_0716: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_071b: ldloc.0
-			IL_071c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0721: dup
-			IL_0722: ldc.i4.0
-			IL_0723: ldloc.1
-			IL_0724: stelem.ref
-			IL_0725: dup
-			IL_0726: ldc.i4.1
-			IL_0727: ldloc.2
-			IL_0728: stelem.ref
-			IL_0729: dup
-			IL_072a: ldc.i4.2
-			IL_072b: ldloc.3
+			IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d5: stloc.s 14
+			IL_06d7: ldloc.s 14
+			IL_06d9: ldstr "push"
+			IL_06de: ldc.i4.0
+			IL_06df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06e9: pop
+			IL_06ea: ldloc.0
+			IL_06eb: ldc.i4.4
+			IL_06ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06f1: ldloc.0
+			IL_06f2: ldloc.s 9
+			IL_06f4: ldarg.0
+			IL_06f5: ldc.i4.2
+			IL_06f6: ldloc.0
+			IL_06f7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06fc: ldc.i4.3
+			IL_06fd: ldstr "_pendingException"
+			IL_0702: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0707: ldloc.0
+			IL_0708: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_070d: dup
+			IL_070e: ldc.i4.0
+			IL_070f: ldloc.1
+			IL_0710: stelem.ref
+			IL_0711: dup
+			IL_0712: ldc.i4.1
+			IL_0713: ldloc.2
+			IL_0714: stelem.ref
+			IL_0715: dup
+			IL_0716: ldc.i4.2
+			IL_0717: ldloc.3
+			IL_0718: stelem.ref
+			IL_0719: dup
+			IL_071a: ldc.i4.3
+			IL_071b: ldloc.s 4
+			IL_071d: stelem.ref
+			IL_071e: dup
+			IL_071f: ldc.i4.4
+			IL_0720: ldloc.s 5
+			IL_0722: stelem.ref
+			IL_0723: dup
+			IL_0724: ldc.i4.5
+			IL_0725: ldloc.s 6
+			IL_0727: stelem.ref
+			IL_0728: dup
+			IL_0729: ldc.i4.6
+			IL_072a: ldloc.s 7
 			IL_072c: stelem.ref
 			IL_072d: dup
-			IL_072e: ldc.i4.3
-			IL_072f: ldloc.s 4
+			IL_072e: ldc.i4.7
+			IL_072f: ldloc.s 8
 			IL_0731: stelem.ref
 			IL_0732: dup
-			IL_0733: ldc.i4.4
-			IL_0734: ldloc.s 5
+			IL_0733: ldc.i4.8
+			IL_0734: ldloc.s 9
 			IL_0736: stelem.ref
 			IL_0737: dup
-			IL_0738: ldc.i4.5
-			IL_0739: ldloc.s 6
-			IL_073b: stelem.ref
-			IL_073c: dup
-			IL_073d: ldc.i4.6
-			IL_073e: ldloc.s 7
-			IL_0740: stelem.ref
-			IL_0741: dup
-			IL_0742: ldc.i4.7
-			IL_0743: ldloc.s 8
-			IL_0745: stelem.ref
-			IL_0746: dup
-			IL_0747: ldc.i4.8
-			IL_0748: ldloc.s 9
-			IL_074a: stelem.ref
-			IL_074b: dup
-			IL_074c: ldc.i4.s 9
-			IL_074e: ldloc.s 10
-			IL_0750: stelem.ref
-			IL_0751: dup
-			IL_0752: ldc.i4.s 10
-			IL_0754: ldloc.s 11
-			IL_0756: stelem.ref
-			IL_0757: dup
-			IL_0758: ldc.i4.s 11
-			IL_075a: ldloc.s 12
-			IL_075c: stelem.ref
-			IL_075d: dup
-			IL_075e: ldc.i4.s 12
-			IL_0760: ldloc.s 13
-			IL_0762: stelem.ref
-			IL_0763: dup
-			IL_0764: ldc.i4.s 13
-			IL_0766: ldloc.s 14
-			IL_0768: stelem.ref
-			IL_0769: dup
-			IL_076a: ldc.i4.s 14
-			IL_076c: ldloc.s 15
-			IL_076e: stelem.ref
-			IL_076f: dup
-			IL_0770: ldc.i4.s 15
-			IL_0772: ldloc.s 16
-			IL_0774: stelem.ref
-			IL_0775: dup
-			IL_0776: ldc.i4.s 16
-			IL_0778: ldloc.s 17
-			IL_077a: stelem.ref
-			IL_077b: dup
-			IL_077c: ldc.i4.s 17
-			IL_077e: ldloc.s 18
-			IL_0780: stelem.ref
-			IL_0781: dup
-			IL_0782: ldc.i4.s 18
-			IL_0784: ldloc.s 19
-			IL_0786: stelem.ref
-			IL_0787: pop
-			IL_0788: ldloc.0
-			IL_0789: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_078e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0793: ret
+			IL_0738: ldc.i4.s 9
+			IL_073a: ldloc.s 10
+			IL_073c: stelem.ref
+			IL_073d: dup
+			IL_073e: ldc.i4.s 10
+			IL_0740: ldloc.s 11
+			IL_0742: stelem.ref
+			IL_0743: dup
+			IL_0744: ldc.i4.s 11
+			IL_0746: ldloc.s 12
+			IL_0748: stelem.ref
+			IL_0749: dup
+			IL_074a: ldc.i4.s 12
+			IL_074c: ldloc.s 13
+			IL_074e: stelem.ref
+			IL_074f: dup
+			IL_0750: ldc.i4.s 13
+			IL_0752: ldloc.s 14
+			IL_0754: stelem.ref
+			IL_0755: dup
+			IL_0756: ldc.i4.s 14
+			IL_0758: ldloc.s 15
+			IL_075a: stelem.ref
+			IL_075b: dup
+			IL_075c: ldc.i4.s 15
+			IL_075e: ldloc.s 16
+			IL_0760: stelem.ref
+			IL_0761: dup
+			IL_0762: ldc.i4.s 16
+			IL_0764: ldloc.s 17
+			IL_0766: stelem.ref
+			IL_0767: dup
+			IL_0768: ldc.i4.s 17
+			IL_076a: ldloc.s 18
+			IL_076c: stelem.ref
+			IL_076d: dup
+			IL_076e: ldc.i4.s 18
+			IL_0770: ldloc.s 19
+			IL_0772: stelem.ref
+			IL_0773: pop
+			IL_0774: ldloc.0
+			IL_0775: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_077a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_077f: ret
 
-			IL_0794: ldloc.0
-			IL_0795: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_079a: pop
-			IL_079b: ldstr "console"
-			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07a5: stloc.s 14
-			IL_07a7: ldloc.s 14
-			IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ae: stloc.s 14
-			IL_07b0: ldloc.s 14
-			IL_07b2: ldstr "log"
-			IL_07b7: ldstr "promise-pipeline:ok"
-			IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07c1: pop
-			IL_07c2: br IL_087d
+			IL_0780: ldloc.0
+			IL_0781: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_0786: pop
+			IL_0787: ldstr "console"
+			IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0791: stloc.s 14
+			IL_0793: ldloc.s 14
+			IL_0795: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_079a: stloc.s 14
+			IL_079c: ldloc.s 14
+			IL_079e: ldstr "log"
+			IL_07a3: ldstr "promise-pipeline:ok"
+			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07ad: pop
+			IL_07ae: br IL_0869
 
-			IL_07c7: ldloc.0
-			IL_07c8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07cd: stloc.s 14
-			IL_07cf: ldloc.0
-			IL_07d0: ldc.i4.0
-			IL_07d1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07d6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07db: ldloc.s 14
-			IL_07dd: stloc.s 10
-			IL_07df: ldstr "console"
-			IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07e9: stloc.s 14
-			IL_07eb: ldloc.s 14
-			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07f2: stloc.s 14
-			IL_07f4: ldloc.s 10
-			IL_07f6: ldstr "name"
-			IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0800: stloc.s 17
-			IL_0802: ldstr "promise-pipeline:"
-			IL_0807: ldloc.s 17
-			IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_080e: stloc.s 18
-			IL_0810: ldloc.s 18
-			IL_0812: ldstr ":"
-			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_081c: stloc.s 18
-			IL_081e: ldloc.s 10
-			IL_0820: ldstr "code"
-			IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_082a: stloc.s 17
-			IL_082c: ldloc.s 18
-			IL_082e: ldloc.s 17
-			IL_0830: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0835: stloc.s 18
-			IL_0837: ldloc.s 14
-			IL_0839: ldstr "log"
-			IL_083e: ldloc.s 18
-			IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0845: pop
-			IL_0846: ldstr "console"
-			IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0850: stloc.s 14
-			IL_0852: ldloc.s 14
-			IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0859: stloc.s 14
-			IL_085b: ldloc.s 10
-			IL_085d: ldstr "message"
-			IL_0862: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0867: stloc.s 17
-			IL_0869: ldloc.s 14
-			IL_086b: ldstr "log"
-			IL_0870: ldloc.s 17
-			IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0877: pop
-			IL_0878: br IL_087d
+			IL_07b3: ldloc.0
+			IL_07b4: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07b9: stloc.s 14
+			IL_07bb: ldloc.0
+			IL_07bc: ldc.i4.0
+			IL_07bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07c2: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07c7: ldloc.s 14
+			IL_07c9: stloc.s 10
+			IL_07cb: ldstr "console"
+			IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d5: stloc.s 14
+			IL_07d7: ldloc.s 14
+			IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07de: stloc.s 14
+			IL_07e0: ldloc.s 10
+			IL_07e2: ldstr "name"
+			IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07ec: stloc.s 17
+			IL_07ee: ldstr "promise-pipeline:"
+			IL_07f3: ldloc.s 17
+			IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07fa: stloc.s 18
+			IL_07fc: ldloc.s 18
+			IL_07fe: ldstr ":"
+			IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0808: stloc.s 18
+			IL_080a: ldloc.s 10
+			IL_080c: ldstr "code"
+			IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0816: stloc.s 17
+			IL_0818: ldloc.s 18
+			IL_081a: ldloc.s 17
+			IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0821: stloc.s 18
+			IL_0823: ldloc.s 14
+			IL_0825: ldstr "log"
+			IL_082a: ldloc.s 18
+			IL_082c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0831: pop
+			IL_0832: ldstr "console"
+			IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_083c: stloc.s 14
+			IL_083e: ldloc.s 14
+			IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0845: stloc.s 14
+			IL_0847: ldloc.s 10
+			IL_0849: ldstr "message"
+			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0853: stloc.s 17
+			IL_0855: ldloc.s 14
+			IL_0857: ldstr "log"
+			IL_085c: ldloc.s 17
+			IL_085e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0863: pop
+			IL_0864: br IL_0869
 
-			IL_087d: ldnull
-			IL_087e: stloc.s 11
-			IL_0880: ldloc.0
-			IL_0881: ldc.i4.m1
-			IL_0882: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0887: ldloc.0
-			IL_0888: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_088d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0892: ldarg.0
-			IL_0893: ldc.i4.1
-			IL_0894: newarr [System.Runtime]System.Object
-			IL_0899: dup
-			IL_089a: ldc.i4.0
-			IL_089b: ldloc.s 11
-			IL_089d: stelem.ref
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08a3: pop
-			IL_08a4: ldloc.0
-			IL_08a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08aa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08af: ret
+			IL_0869: ldnull
+			IL_086a: stloc.s 11
+			IL_086c: ldloc.0
+			IL_086d: ldc.i4.m1
+			IL_086e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0873: ldloc.0
+			IL_0874: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0879: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_087e: ldarg.0
+			IL_087f: ldc.i4.1
+			IL_0880: newarr [System.Runtime]System.Object
+			IL_0885: dup
+			IL_0886: ldc.i4.0
+			IL_0887: ldloc.s 11
+			IL_0889: stelem.ref
+			IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_088f: pop
+			IL_0890: ldloc.0
+			IL_0891: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0896: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_089b: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1511,8 +1505,8 @@
 			69 6e 3d 7b 6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object 'stream'
-		.field public object streamPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule 'stream'
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule streamPromises
 		.field public object createWritable
 		.field public object createReadable
 		.field public object main
@@ -1521,7 +1515,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2ab9
+			// Method begins at RVA 0x2a9d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1612,14 +1606,14 @@
 		IL_0093: stloc.3
 		IL_0094: ldloc.0
 		IL_0095: ldloc.3
-		IL_0096: stfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+		IL_0096: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
 		IL_009b: ldarg.1
 		IL_009c: ldstr "node:stream/promises"
 		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_00a6: stloc.s 4
 		IL_00a8: ldloc.0
 		IL_00a9: ldloc.s 4
-		IL_00ab: stfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+		IL_00ab: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
 		IL_00b0: nop
 		IL_00b1: nop
 		IL_00b2: nop
@@ -1639,7 +1633,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b40
+		// Method begins at RVA 0x2b24
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x233e
+					// Method begins at RVA 0x2334
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2329
+				// Method begins at RVA 0x231f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2335
+				// Method begins at RVA 0x232b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			)
 			// Method begins at RVA 0x20c0
 			// Header size: 12
-			// Code size: 605 (0x25d)
+			// Code size: 595 (0x253)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Finished_Basic/main/Scope,
@@ -199,180 +199,178 @@
 
 			IL_00a5: ldloc.0
 			IL_00a6: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00ab: switch (IL_00b8, IL_01ad)
+			IL_00ab: switch (IL_00b8, IL_01a3)
 
 			IL_00b8: ldarg.0
 			IL_00b9: ldc.i4.1
 			IL_00ba: ldelem.ref
 			IL_00bb: castclass Modules.Stream_Promises_Finished_Basic/Scope
-			IL_00c0: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::'stream'
-			IL_00c5: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-			IL_00ca: stloc.3
-			IL_00cb: ldloc.3
-			IL_00cc: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
-			IL_00d1: stloc.s 4
-			IL_00d3: ldc.i4.0
-			IL_00d4: newarr [System.Runtime]System.Object
-			IL_00d9: stloc.s 5
-			IL_00db: ldloc.s 4
-			IL_00dd: ldloc.s 5
-			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_00e4: stloc.1
-			IL_00e5: ldc.i4.1
-			IL_00e6: newarr [System.Runtime]System.Object
-			IL_00eb: dup
-			IL_00ec: ldc.i4.0
-			IL_00ed: ldarg.0
-			IL_00ee: ldc.i4.1
-			IL_00ef: ldelem.ref
-			IL_00f0: stelem.ref
-			IL_00f1: stloc.s 5
-			IL_00f3: ldnull
-			IL_00f4: ldftn object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
-			IL_00fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00ff: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_0104: ldc.i4.0
-			IL_0105: conv.r8
-			IL_0106: ldstr ""
-			IL_010b: ldc.i4.0
-			IL_010c: ldc.i4.1
-			IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_0112: stloc.s 6
-			IL_0114: ldloc.1
-			IL_0115: ldstr "_write"
-			IL_011a: ldloc.s 6
-			IL_011c: ldc.i4.1
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0122: pop
-			IL_0123: ldarg.0
-			IL_0124: ldc.i4.1
-			IL_0125: ldelem.ref
-			IL_0126: castclass Modules.Stream_Promises_Finished_Basic/Scope
-			IL_012b: ldfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
-			IL_0130: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
-			IL_0135: stloc.s 7
-			IL_0137: ldloc.s 7
-			IL_0139: ldloc.1
-			IL_013a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::finished(object)
-			IL_013f: stloc.2
-			IL_0140: ldloc.1
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0146: stloc.s 4
-			IL_0148: ldloc.s 4
-			IL_014a: ldstr "end"
-			IL_014f: ldstr "done"
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0159: pop
-			IL_015a: ldloc.0
-			IL_015b: ldc.i4.1
-			IL_015c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0161: ldloc.0
-			IL_0162: ldloc.2
-			IL_0163: ldarg.0
-			IL_0164: ldc.i4.1
-			IL_0165: ldloc.0
-			IL_0166: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_016b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0170: ldloc.0
-			IL_0171: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0176: dup
-			IL_0177: ldc.i4.0
-			IL_0178: ldloc.1
-			IL_0179: stelem.ref
-			IL_017a: dup
-			IL_017b: ldc.i4.1
-			IL_017c: ldloc.2
-			IL_017d: stelem.ref
-			IL_017e: dup
-			IL_017f: ldc.i4.2
-			IL_0180: ldloc.3
+			IL_00c0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Promises_Finished_Basic/Scope::'stream'
+			IL_00c5: stloc.3
+			IL_00c6: ldloc.3
+			IL_00c7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
+			IL_00cc: stloc.s 4
+			IL_00ce: ldc.i4.0
+			IL_00cf: newarr [System.Runtime]System.Object
+			IL_00d4: stloc.s 5
+			IL_00d6: ldloc.s 4
+			IL_00d8: ldloc.s 5
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_00df: stloc.1
+			IL_00e0: ldc.i4.1
+			IL_00e1: newarr [System.Runtime]System.Object
+			IL_00e6: dup
+			IL_00e7: ldc.i4.0
+			IL_00e8: ldarg.0
+			IL_00e9: ldc.i4.1
+			IL_00ea: ldelem.ref
+			IL_00eb: stelem.ref
+			IL_00ec: stloc.s 5
+			IL_00ee: ldnull
+			IL_00ef: ldftn object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
+			IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_00fa: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_00ff: ldc.i4.0
+			IL_0100: conv.r8
+			IL_0101: ldstr ""
+			IL_0106: ldc.i4.0
+			IL_0107: ldc.i4.1
+			IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_010d: stloc.s 6
+			IL_010f: ldloc.1
+			IL_0110: ldstr "_write"
+			IL_0115: ldloc.s 6
+			IL_0117: ldc.i4.1
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_011d: pop
+			IL_011e: ldarg.0
+			IL_011f: ldc.i4.1
+			IL_0120: ldelem.ref
+			IL_0121: castclass Modules.Stream_Promises_Finished_Basic/Scope
+			IL_0126: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
+			IL_012b: stloc.s 7
+			IL_012d: ldloc.s 7
+			IL_012f: ldloc.1
+			IL_0130: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::finished(object)
+			IL_0135: stloc.2
+			IL_0136: ldloc.1
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013c: stloc.s 4
+			IL_013e: ldloc.s 4
+			IL_0140: ldstr "end"
+			IL_0145: ldstr "done"
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_014f: pop
+			IL_0150: ldloc.0
+			IL_0151: ldc.i4.1
+			IL_0152: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0157: ldloc.0
+			IL_0158: ldloc.2
+			IL_0159: ldarg.0
+			IL_015a: ldc.i4.1
+			IL_015b: ldloc.0
+			IL_015c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0166: ldloc.0
+			IL_0167: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_016c: dup
+			IL_016d: ldc.i4.0
+			IL_016e: ldloc.1
+			IL_016f: stelem.ref
+			IL_0170: dup
+			IL_0171: ldc.i4.1
+			IL_0172: ldloc.2
+			IL_0173: stelem.ref
+			IL_0174: dup
+			IL_0175: ldc.i4.2
+			IL_0176: ldloc.3
+			IL_0177: stelem.ref
+			IL_0178: dup
+			IL_0179: ldc.i4.3
+			IL_017a: ldloc.s 4
+			IL_017c: stelem.ref
+			IL_017d: dup
+			IL_017e: ldc.i4.4
+			IL_017f: ldloc.s 5
 			IL_0181: stelem.ref
 			IL_0182: dup
-			IL_0183: ldc.i4.3
-			IL_0184: ldloc.s 4
+			IL_0183: ldc.i4.5
+			IL_0184: ldloc.s 6
 			IL_0186: stelem.ref
 			IL_0187: dup
-			IL_0188: ldc.i4.4
-			IL_0189: ldloc.s 5
+			IL_0188: ldc.i4.6
+			IL_0189: ldloc.s 7
 			IL_018b: stelem.ref
 			IL_018c: dup
-			IL_018d: ldc.i4.5
-			IL_018e: ldloc.s 6
+			IL_018d: ldc.i4.7
+			IL_018e: ldloc.s 8
 			IL_0190: stelem.ref
 			IL_0191: dup
-			IL_0192: ldc.i4.6
-			IL_0193: ldloc.s 7
+			IL_0192: ldc.i4.8
+			IL_0193: ldloc.s 9
 			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.7
-			IL_0198: ldloc.s 8
-			IL_019a: stelem.ref
-			IL_019b: dup
-			IL_019c: ldc.i4.8
-			IL_019d: ldloc.s 9
-			IL_019f: stelem.ref
-			IL_01a0: pop
-			IL_01a1: ldloc.0
-			IL_01a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ac: ret
+			IL_0196: pop
+			IL_0197: ldloc.0
+			IL_0198: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_019d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01a2: ret
 
-			IL_01ad: ldloc.0
-			IL_01ae: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
-			IL_01b3: pop
-			IL_01b4: ldstr "console"
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01be: stloc.s 4
-			IL_01c0: ldloc.s 4
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c7: stloc.s 4
-			IL_01c9: ldloc.1
-			IL_01ca: ldstr "destroyed"
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d4: stloc.s 8
-			IL_01d6: ldstr "destroyed:"
-			IL_01db: ldloc.s 8
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01e2: stloc.s 9
-			IL_01e4: ldloc.s 4
-			IL_01e6: ldstr "log"
-			IL_01eb: ldloc.s 9
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01f2: pop
-			IL_01f3: ldstr "console"
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01fd: stloc.s 4
-			IL_01ff: ldloc.s 4
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0206: stloc.s 4
-			IL_0208: ldloc.1
-			IL_0209: ldstr "writable"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0213: stloc.s 8
-			IL_0215: ldstr "writable:"
-			IL_021a: ldloc.s 8
-			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0221: stloc.s 9
-			IL_0223: ldloc.s 4
-			IL_0225: ldstr "log"
-			IL_022a: ldloc.s 9
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0231: pop
-			IL_0232: ldloc.0
-			IL_0233: ldc.i4.m1
-			IL_0234: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0239: ldloc.0
-			IL_023a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0244: ldarg.0
-			IL_0245: ldc.i4.1
-			IL_0246: newarr [System.Runtime]System.Object
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0250: pop
-			IL_0251: ldloc.0
-			IL_0252: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0257: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_025c: ret
+			IL_01a3: ldloc.0
+			IL_01a4: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
+			IL_01a9: pop
+			IL_01aa: ldstr "console"
+			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b4: stloc.s 4
+			IL_01b6: ldloc.s 4
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bd: stloc.s 4
+			IL_01bf: ldloc.1
+			IL_01c0: ldstr "destroyed"
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ca: stloc.s 8
+			IL_01cc: ldstr "destroyed:"
+			IL_01d1: ldloc.s 8
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01d8: stloc.s 9
+			IL_01da: ldloc.s 4
+			IL_01dc: ldstr "log"
+			IL_01e1: ldloc.s 9
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01e8: pop
+			IL_01e9: ldstr "console"
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f3: stloc.s 4
+			IL_01f5: ldloc.s 4
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fc: stloc.s 4
+			IL_01fe: ldloc.1
+			IL_01ff: ldstr "writable"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0209: stloc.s 8
+			IL_020b: ldstr "writable:"
+			IL_0210: ldloc.s 8
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0217: stloc.s 9
+			IL_0219: ldloc.s 4
+			IL_021b: ldstr "log"
+			IL_0220: ldloc.s 9
+			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0227: pop
+			IL_0228: ldloc.0
+			IL_0229: ldc.i4.m1
+			IL_022a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_022f: ldloc.0
+			IL_0230: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0235: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_023a: ldarg.0
+			IL_023b: ldc.i4.1
+			IL_023c: newarr [System.Runtime]System.Object
+			IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0246: pop
+			IL_0247: ldloc.0
+			IL_0248: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0252: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -388,15 +386,15 @@
 			7b 6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object 'stream'
-		.field public object streamPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule 'stream'
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule streamPromises
 		.field public object main
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x232c
+			// Method begins at RVA 0x2322
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -456,14 +454,14 @@
 		IL_003b: stloc.2
 		IL_003c: ldloc.0
 		IL_003d: ldloc.2
-		IL_003e: stfld object Modules.Stream_Promises_Finished_Basic/Scope::'stream'
+		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Promises_Finished_Basic/Scope::'stream'
 		IL_0043: ldarg.1
 		IL_0044: ldstr "node:stream/promises"
 		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_004e: stloc.3
 		IL_004f: ldloc.0
 		IL_0050: ldloc.3
-		IL_0051: stfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
+		IL_0051: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
 		IL_0056: nop
 		IL_0057: ldloc.1
 		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -481,7 +479,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2347
+		// Method begins at RVA 0x233d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x264e
+					// Method begins at RVA 0x263a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25b8
+				// Method begins at RVA 0x25a4
 				// Header size: 12
 				// Code size: 72 (0x48)
 				.maxstack 8
@@ -97,7 +97,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2657
+					// Method begins at RVA 0x2643
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -122,7 +122,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x260c
+				// Method begins at RVA 0x25f8
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -167,7 +167,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2645
+				// Method begins at RVA 0x2631
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -193,7 +193,7 @@
 			)
 			// Method begins at RVA 0x20c0
 			// Header size: 12
-			// Code size: 1259 (0x4eb)
+			// Code size: 1239 (0x4d7)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope,
@@ -321,409 +321,405 @@
 
 			IL_00d2: ldloc.0
 			IL_00d3: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00d8: switch (IL_00e5, IL_0370)
+			IL_00d8: switch (IL_00e5, IL_035c)
 
 			IL_00e5: ldarg.0
 			IL_00e6: ldc.i4.1
 			IL_00e7: ldelem.ref
 			IL_00e8: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_00ed: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_00f2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-			IL_00f7: stloc.s 5
-			IL_00f9: ldloc.s 5
-			IL_00fb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Readable()
-			IL_0100: stloc.s 6
-			IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0107: dup
-			IL_0108: ldstr "objectMode"
-			IL_010d: ldc.i4.1
-			IL_010e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0113: stloc.s 7
-			IL_0115: ldc.i4.1
-			IL_0116: newarr [System.Runtime]System.Object
-			IL_011b: dup
-			IL_011c: ldc.i4.0
-			IL_011d: ldloc.s 7
-			IL_011f: stelem.ref
-			IL_0120: stloc.s 8
-			IL_0122: ldloc.s 6
-			IL_0124: ldloc.s 8
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_012b: stloc.1
-			IL_012c: ldarg.0
-			IL_012d: ldc.i4.1
-			IL_012e: ldelem.ref
-			IL_012f: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_0134: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_0139: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-			IL_013e: stloc.s 5
-			IL_0140: ldloc.s 5
-			IL_0142: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Transform()
-			IL_0147: stloc.s 6
-			IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_014e: dup
-			IL_014f: ldstr "objectMode"
-			IL_0154: ldc.i4.1
-			IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_015a: stloc.s 7
-			IL_015c: ldc.i4.1
-			IL_015d: newarr [System.Runtime]System.Object
-			IL_0162: dup
-			IL_0163: ldc.i4.0
-			IL_0164: ldloc.s 7
-			IL_0166: stelem.ref
-			IL_0167: stloc.s 8
-			IL_0169: ldloc.s 6
-			IL_016b: ldloc.s 8
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_0172: stloc.2
-			IL_0173: ldarg.0
-			IL_0174: ldc.i4.1
-			IL_0175: ldelem.ref
-			IL_0176: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_017b: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
-			IL_0180: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule
-			IL_0185: stloc.s 5
-			IL_0187: ldloc.s 5
-			IL_0189: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
-			IL_018e: stloc.s 6
-			IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0195: dup
-			IL_0196: ldstr "objectMode"
-			IL_019b: ldc.i4.1
-			IL_019c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_01a1: stloc.s 7
-			IL_01a3: ldc.i4.1
-			IL_01a4: newarr [System.Runtime]System.Object
-			IL_01a9: dup
-			IL_01aa: ldc.i4.0
-			IL_01ab: ldloc.s 7
-			IL_01ad: stelem.ref
-			IL_01ae: stloc.s 8
-			IL_01b0: ldloc.s 6
-			IL_01b2: ldloc.s 8
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
-			IL_01b9: stloc.3
-			IL_01ba: ldc.i4.0
-			IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01c0: stloc.s 9
-			IL_01c2: ldloc.0
-			IL_01c3: ldloc.s 9
-			IL_01c5: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_01ca: ldc.i4.2
-			IL_01cb: newarr [System.Runtime]System.Object
-			IL_01d0: dup
-			IL_01d1: ldc.i4.0
-			IL_01d2: ldarg.0
-			IL_01d3: ldc.i4.1
-			IL_01d4: ldelem.ref
-			IL_01d5: stelem.ref
-			IL_01d6: dup
-			IL_01d7: ldc.i4.1
-			IL_01d8: ldloc.0
-			IL_01d9: stelem.ref
-			IL_01da: stloc.s 8
-			IL_01dc: ldloc.s 8
-			IL_01de: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
-			IL_01e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_01e9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_01ee: ldc.i4.1
-			IL_01ef: conv.r8
-			IL_01f0: ldstr ""
-			IL_01f5: ldc.i4.0
-			IL_01f6: ldc.i4.1
-			IL_01f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_01fc: stloc.s 10
-			IL_01fe: ldloc.2
-			IL_01ff: ldstr "_transform"
-			IL_0204: ldloc.s 10
-			IL_0206: ldc.i4.1
-			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_020c: pop
-			IL_020d: ldc.i4.2
-			IL_020e: newarr [System.Runtime]System.Object
-			IL_0213: dup
-			IL_0214: ldc.i4.0
-			IL_0215: ldarg.0
-			IL_0216: ldc.i4.1
-			IL_0217: ldelem.ref
-			IL_0218: stelem.ref
-			IL_0219: dup
-			IL_021a: ldc.i4.1
-			IL_021b: ldloc.0
-			IL_021c: stelem.ref
-			IL_021d: stloc.s 8
-			IL_021f: ldloc.s 8
-			IL_0221: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
-			IL_0227: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_022c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_0231: ldc.i4.1
-			IL_0232: conv.r8
-			IL_0233: ldstr ""
-			IL_0238: ldc.i4.0
-			IL_0239: ldc.i4.1
-			IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_023f: stloc.s 10
-			IL_0241: ldloc.3
-			IL_0242: ldstr "_write"
-			IL_0247: ldloc.s 10
-			IL_0249: ldc.i4.1
-			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_024f: pop
-			IL_0250: ldarg.0
-			IL_0251: ldc.i4.1
-			IL_0252: ldelem.ref
-			IL_0253: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
-			IL_0258: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
-			IL_025d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
-			IL_0262: stloc.s 11
-			IL_0264: ldloc.s 11
-			IL_0266: ldc.i4.3
-			IL_0267: newarr [System.Runtime]System.Object
-			IL_026c: dup
-			IL_026d: ldc.i4.0
-			IL_026e: ldloc.1
-			IL_026f: stelem.ref
-			IL_0270: dup
-			IL_0271: ldc.i4.1
-			IL_0272: ldloc.2
-			IL_0273: stelem.ref
-			IL_0274: dup
-			IL_0275: ldc.i4.2
-			IL_0276: ldloc.3
-			IL_0277: stelem.ref
-			IL_0278: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::pipeline(object[])
-			IL_027d: stloc.s 4
-			IL_027f: ldloc.1
-			IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0285: stloc.s 6
-			IL_0287: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_028c: dup
-			IL_028d: ldstr "value"
-			IL_0292: ldc.r8 1
-			IL_029b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_02a0: stloc.s 7
-			IL_02a2: ldloc.s 6
-			IL_02a4: ldstr "push"
-			IL_02a9: ldloc.s 7
-			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02b0: pop
-			IL_02b1: ldloc.1
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b7: stloc.s 6
-			IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02be: dup
-			IL_02bf: ldstr "value"
-			IL_02c4: ldc.r8 2
-			IL_02cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_02d2: stloc.s 7
-			IL_02d4: ldloc.s 6
-			IL_02d6: ldstr "push"
-			IL_02db: ldloc.s 7
-			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02e2: pop
-			IL_02e3: ldloc.1
-			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e9: stloc.s 6
-			IL_02eb: ldloc.s 6
-			IL_02ed: ldstr "push"
-			IL_02f2: ldc.i4.0
-			IL_02f3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02fd: pop
-			IL_02fe: ldloc.0
-			IL_02ff: ldc.i4.1
-			IL_0300: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0305: ldloc.0
-			IL_0306: ldloc.s 4
-			IL_0308: ldarg.0
-			IL_0309: ldc.i4.1
-			IL_030a: ldloc.0
-			IL_030b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0310: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0315: ldloc.0
-			IL_0316: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_031b: dup
-			IL_031c: ldc.i4.0
-			IL_031d: ldloc.1
-			IL_031e: stelem.ref
-			IL_031f: dup
-			IL_0320: ldc.i4.1
-			IL_0321: ldloc.2
-			IL_0322: stelem.ref
-			IL_0323: dup
-			IL_0324: ldc.i4.2
-			IL_0325: ldloc.3
+			IL_00ed: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_00f2: stloc.s 5
+			IL_00f4: ldloc.s 5
+			IL_00f6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Readable()
+			IL_00fb: stloc.s 6
+			IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0102: dup
+			IL_0103: ldstr "objectMode"
+			IL_0108: ldc.i4.1
+			IL_0109: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_010e: stloc.s 7
+			IL_0110: ldc.i4.1
+			IL_0111: newarr [System.Runtime]System.Object
+			IL_0116: dup
+			IL_0117: ldc.i4.0
+			IL_0118: ldloc.s 7
+			IL_011a: stelem.ref
+			IL_011b: stloc.s 8
+			IL_011d: ldloc.s 6
+			IL_011f: ldloc.s 8
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_0126: stloc.1
+			IL_0127: ldarg.0
+			IL_0128: ldc.i4.1
+			IL_0129: ldelem.ref
+			IL_012a: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_012f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_0134: stloc.s 5
+			IL_0136: ldloc.s 5
+			IL_0138: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Transform()
+			IL_013d: stloc.s 6
+			IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0144: dup
+			IL_0145: ldstr "objectMode"
+			IL_014a: ldc.i4.1
+			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0150: stloc.s 7
+			IL_0152: ldc.i4.1
+			IL_0153: newarr [System.Runtime]System.Object
+			IL_0158: dup
+			IL_0159: ldc.i4.0
+			IL_015a: ldloc.s 7
+			IL_015c: stelem.ref
+			IL_015d: stloc.s 8
+			IL_015f: ldloc.s 6
+			IL_0161: ldloc.s 8
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_0168: stloc.2
+			IL_0169: ldarg.0
+			IL_016a: ldc.i4.1
+			IL_016b: ldelem.ref
+			IL_016c: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_0171: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+			IL_0176: stloc.s 5
+			IL_0178: ldloc.s 5
+			IL_017a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
+			IL_017f: stloc.s 6
+			IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0186: dup
+			IL_0187: ldstr "objectMode"
+			IL_018c: ldc.i4.1
+			IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0192: stloc.s 7
+			IL_0194: ldc.i4.1
+			IL_0195: newarr [System.Runtime]System.Object
+			IL_019a: dup
+			IL_019b: ldc.i4.0
+			IL_019c: ldloc.s 7
+			IL_019e: stelem.ref
+			IL_019f: stloc.s 8
+			IL_01a1: ldloc.s 6
+			IL_01a3: ldloc.s 8
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ConstructValue(object, object[])
+			IL_01aa: stloc.3
+			IL_01ab: ldc.i4.0
+			IL_01ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01b1: stloc.s 9
+			IL_01b3: ldloc.0
+			IL_01b4: ldloc.s 9
+			IL_01b6: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_01bb: ldc.i4.2
+			IL_01bc: newarr [System.Runtime]System.Object
+			IL_01c1: dup
+			IL_01c2: ldc.i4.0
+			IL_01c3: ldarg.0
+			IL_01c4: ldc.i4.1
+			IL_01c5: ldelem.ref
+			IL_01c6: stelem.ref
+			IL_01c7: dup
+			IL_01c8: ldc.i4.1
+			IL_01c9: ldloc.0
+			IL_01ca: stelem.ref
+			IL_01cb: stloc.s 8
+			IL_01cd: ldloc.s 8
+			IL_01cf: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
+			IL_01d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_01da: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_01df: ldc.i4.1
+			IL_01e0: conv.r8
+			IL_01e1: ldstr ""
+			IL_01e6: ldc.i4.0
+			IL_01e7: ldc.i4.1
+			IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_01ed: stloc.s 10
+			IL_01ef: ldloc.2
+			IL_01f0: ldstr "_transform"
+			IL_01f5: ldloc.s 10
+			IL_01f7: ldc.i4.1
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01fd: pop
+			IL_01fe: ldc.i4.2
+			IL_01ff: newarr [System.Runtime]System.Object
+			IL_0204: dup
+			IL_0205: ldc.i4.0
+			IL_0206: ldarg.0
+			IL_0207: ldc.i4.1
+			IL_0208: ldelem.ref
+			IL_0209: stelem.ref
+			IL_020a: dup
+			IL_020b: ldc.i4.1
+			IL_020c: ldloc.0
+			IL_020d: stelem.ref
+			IL_020e: stloc.s 8
+			IL_0210: ldloc.s 8
+			IL_0212: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
+			IL_0218: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_021d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0222: ldc.i4.1
+			IL_0223: conv.r8
+			IL_0224: ldstr ""
+			IL_0229: ldc.i4.0
+			IL_022a: ldc.i4.1
+			IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0230: stloc.s 10
+			IL_0232: ldloc.3
+			IL_0233: ldstr "_write"
+			IL_0238: ldloc.s 10
+			IL_023a: ldc.i4.1
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0240: pop
+			IL_0241: ldarg.0
+			IL_0242: ldc.i4.1
+			IL_0243: ldelem.ref
+			IL_0244: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
+			IL_0249: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
+			IL_024e: stloc.s 11
+			IL_0250: ldloc.s 11
+			IL_0252: ldc.i4.3
+			IL_0253: newarr [System.Runtime]System.Object
+			IL_0258: dup
+			IL_0259: ldc.i4.0
+			IL_025a: ldloc.1
+			IL_025b: stelem.ref
+			IL_025c: dup
+			IL_025d: ldc.i4.1
+			IL_025e: ldloc.2
+			IL_025f: stelem.ref
+			IL_0260: dup
+			IL_0261: ldc.i4.2
+			IL_0262: ldloc.3
+			IL_0263: stelem.ref
+			IL_0264: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::pipeline(object[])
+			IL_0269: stloc.s 4
+			IL_026b: ldloc.1
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0271: stloc.s 6
+			IL_0273: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0278: dup
+			IL_0279: ldstr "value"
+			IL_027e: ldc.r8 1
+			IL_0287: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_028c: stloc.s 7
+			IL_028e: ldloc.s 6
+			IL_0290: ldstr "push"
+			IL_0295: ldloc.s 7
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_029c: pop
+			IL_029d: ldloc.1
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a3: stloc.s 6
+			IL_02a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02aa: dup
+			IL_02ab: ldstr "value"
+			IL_02b0: ldc.r8 2
+			IL_02b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_02be: stloc.s 7
+			IL_02c0: ldloc.s 6
+			IL_02c2: ldstr "push"
+			IL_02c7: ldloc.s 7
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02ce: pop
+			IL_02cf: ldloc.1
+			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d5: stloc.s 6
+			IL_02d7: ldloc.s 6
+			IL_02d9: ldstr "push"
+			IL_02de: ldc.i4.0
+			IL_02df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02e9: pop
+			IL_02ea: ldloc.0
+			IL_02eb: ldc.i4.1
+			IL_02ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02f1: ldloc.0
+			IL_02f2: ldloc.s 4
+			IL_02f4: ldarg.0
+			IL_02f5: ldc.i4.1
+			IL_02f6: ldloc.0
+			IL_02f7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0301: ldloc.0
+			IL_0302: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0307: dup
+			IL_0308: ldc.i4.0
+			IL_0309: ldloc.1
+			IL_030a: stelem.ref
+			IL_030b: dup
+			IL_030c: ldc.i4.1
+			IL_030d: ldloc.2
+			IL_030e: stelem.ref
+			IL_030f: dup
+			IL_0310: ldc.i4.2
+			IL_0311: ldloc.3
+			IL_0312: stelem.ref
+			IL_0313: dup
+			IL_0314: ldc.i4.3
+			IL_0315: ldloc.s 4
+			IL_0317: stelem.ref
+			IL_0318: dup
+			IL_0319: ldc.i4.4
+			IL_031a: ldloc.s 5
+			IL_031c: stelem.ref
+			IL_031d: dup
+			IL_031e: ldc.i4.5
+			IL_031f: ldloc.s 6
+			IL_0321: stelem.ref
+			IL_0322: dup
+			IL_0323: ldc.i4.6
+			IL_0324: ldloc.s 7
 			IL_0326: stelem.ref
 			IL_0327: dup
-			IL_0328: ldc.i4.3
-			IL_0329: ldloc.s 4
+			IL_0328: ldc.i4.7
+			IL_0329: ldloc.s 8
 			IL_032b: stelem.ref
 			IL_032c: dup
-			IL_032d: ldc.i4.4
-			IL_032e: ldloc.s 5
+			IL_032d: ldc.i4.8
+			IL_032e: ldloc.s 9
 			IL_0330: stelem.ref
 			IL_0331: dup
-			IL_0332: ldc.i4.5
-			IL_0333: ldloc.s 6
-			IL_0335: stelem.ref
-			IL_0336: dup
-			IL_0337: ldc.i4.6
-			IL_0338: ldloc.s 7
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.7
-			IL_033d: ldloc.s 8
-			IL_033f: stelem.ref
-			IL_0340: dup
-			IL_0341: ldc.i4.8
-			IL_0342: ldloc.s 9
-			IL_0344: stelem.ref
-			IL_0345: dup
-			IL_0346: ldc.i4.s 9
-			IL_0348: ldloc.s 10
-			IL_034a: stelem.ref
-			IL_034b: dup
-			IL_034c: ldc.i4.s 10
-			IL_034e: ldloc.s 11
-			IL_0350: stelem.ref
-			IL_0351: dup
-			IL_0352: ldc.i4.s 11
-			IL_0354: ldloc.s 12
-			IL_0356: stelem.ref
-			IL_0357: dup
-			IL_0358: ldc.i4.s 12
-			IL_035a: ldloc.s 13
-			IL_035c: stelem.ref
-			IL_035d: dup
-			IL_035e: ldc.i4.s 13
-			IL_0360: ldloc.s 14
-			IL_0362: stelem.ref
-			IL_0363: pop
-			IL_0364: ldloc.0
-			IL_0365: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_036f: ret
+			IL_0332: ldc.i4.s 9
+			IL_0334: ldloc.s 10
+			IL_0336: stelem.ref
+			IL_0337: dup
+			IL_0338: ldc.i4.s 10
+			IL_033a: ldloc.s 11
+			IL_033c: stelem.ref
+			IL_033d: dup
+			IL_033e: ldc.i4.s 11
+			IL_0340: ldloc.s 12
+			IL_0342: stelem.ref
+			IL_0343: dup
+			IL_0344: ldc.i4.s 12
+			IL_0346: ldloc.s 13
+			IL_0348: stelem.ref
+			IL_0349: dup
+			IL_034a: ldc.i4.s 13
+			IL_034c: ldloc.s 14
+			IL_034e: stelem.ref
+			IL_034f: pop
+			IL_0350: ldloc.0
+			IL_0351: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0356: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_035b: ret
 
-			IL_0370: ldloc.0
-			IL_0371: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
-			IL_0376: pop
-			IL_0377: ldstr "console"
-			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0381: stloc.s 6
-			IL_0383: ldloc.s 6
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_038a: stloc.s 6
-			IL_038c: ldloc.1
-			IL_038d: ldstr "readableObjectMode"
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0397: stloc.s 12
-			IL_0399: ldstr "readableObjectMode:"
-			IL_039e: ldloc.s 12
-			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03a5: stloc.s 13
-			IL_03a7: ldloc.s 6
-			IL_03a9: ldstr "log"
-			IL_03ae: ldloc.s 13
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03b5: pop
-			IL_03b6: ldstr "console"
-			IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03c0: stloc.s 6
-			IL_03c2: ldloc.s 6
-			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c9: stloc.s 6
-			IL_03cb: ldloc.2
-			IL_03cc: ldstr "readableObjectMode"
-			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d6: stloc.s 12
-			IL_03d8: ldstr "transformReadableObjectMode:"
-			IL_03dd: ldloc.s 12
-			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03e4: stloc.s 13
-			IL_03e6: ldloc.s 6
-			IL_03e8: ldstr "log"
-			IL_03ed: ldloc.s 13
-			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03f4: pop
-			IL_03f5: ldstr "console"
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ff: stloc.s 6
-			IL_0401: ldloc.s 6
-			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0408: stloc.s 6
-			IL_040a: ldloc.2
-			IL_040b: ldstr "writableObjectMode"
-			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0415: stloc.s 12
-			IL_0417: ldstr "transformWritableObjectMode:"
-			IL_041c: ldloc.s 12
-			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0423: stloc.s 13
-			IL_0425: ldloc.s 6
-			IL_0427: ldstr "log"
-			IL_042c: ldloc.s 13
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0433: pop
-			IL_0434: ldstr "console"
-			IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_043e: stloc.s 6
-			IL_0440: ldloc.s 6
-			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0447: stloc.s 6
-			IL_0449: ldloc.3
-			IL_044a: ldstr "writableObjectMode"
-			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0454: stloc.s 12
-			IL_0456: ldstr "writableObjectMode:"
-			IL_045b: ldloc.s 12
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0462: stloc.s 13
-			IL_0464: ldloc.s 6
-			IL_0466: ldstr "log"
-			IL_046b: ldloc.s 13
-			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0472: pop
-			IL_0473: ldstr "console"
-			IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_047d: stloc.s 6
-			IL_047f: ldloc.s 6
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0486: stloc.s 6
-			IL_0488: ldloc.0
-			IL_0489: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_048e: ldc.i4.1
-			IL_048f: newarr [System.Runtime]System.Object
-			IL_0494: dup
-			IL_0495: ldc.i4.0
-			IL_0496: ldstr ","
-			IL_049b: stelem.ref
-			IL_049c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04a1: stloc.s 14
-			IL_04a3: ldstr "written:"
-			IL_04a8: ldloc.s 14
-			IL_04aa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04af: stloc.s 14
-			IL_04b1: ldloc.s 6
-			IL_04b3: ldstr "log"
-			IL_04b8: ldloc.s 14
-			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04bf: pop
-			IL_04c0: ldloc.0
-			IL_04c1: ldc.i4.m1
-			IL_04c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04c7: ldloc.0
-			IL_04c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_04d2: ldarg.0
-			IL_04d3: ldc.i4.1
-			IL_04d4: newarr [System.Runtime]System.Object
-			IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_04de: pop
-			IL_04df: ldloc.0
-			IL_04e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04e5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04ea: ret
+			IL_035c: ldloc.0
+			IL_035d: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
+			IL_0362: pop
+			IL_0363: ldstr "console"
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_036d: stloc.s 6
+			IL_036f: ldloc.s 6
+			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0376: stloc.s 6
+			IL_0378: ldloc.1
+			IL_0379: ldstr "readableObjectMode"
+			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0383: stloc.s 12
+			IL_0385: ldstr "readableObjectMode:"
+			IL_038a: ldloc.s 12
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0391: stloc.s 13
+			IL_0393: ldloc.s 6
+			IL_0395: ldstr "log"
+			IL_039a: ldloc.s 13
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03a1: pop
+			IL_03a2: ldstr "console"
+			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03ac: stloc.s 6
+			IL_03ae: ldloc.s 6
+			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b5: stloc.s 6
+			IL_03b7: ldloc.2
+			IL_03b8: ldstr "readableObjectMode"
+			IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c2: stloc.s 12
+			IL_03c4: ldstr "transformReadableObjectMode:"
+			IL_03c9: ldloc.s 12
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03d0: stloc.s 13
+			IL_03d2: ldloc.s 6
+			IL_03d4: ldstr "log"
+			IL_03d9: ldloc.s 13
+			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03e0: pop
+			IL_03e1: ldstr "console"
+			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03eb: stloc.s 6
+			IL_03ed: ldloc.s 6
+			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f4: stloc.s 6
+			IL_03f6: ldloc.2
+			IL_03f7: ldstr "writableObjectMode"
+			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0401: stloc.s 12
+			IL_0403: ldstr "transformWritableObjectMode:"
+			IL_0408: ldloc.s 12
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_040f: stloc.s 13
+			IL_0411: ldloc.s 6
+			IL_0413: ldstr "log"
+			IL_0418: ldloc.s 13
+			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_041f: pop
+			IL_0420: ldstr "console"
+			IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_042a: stloc.s 6
+			IL_042c: ldloc.s 6
+			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0433: stloc.s 6
+			IL_0435: ldloc.3
+			IL_0436: ldstr "writableObjectMode"
+			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0440: stloc.s 12
+			IL_0442: ldstr "writableObjectMode:"
+			IL_0447: ldloc.s 12
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_044e: stloc.s 13
+			IL_0450: ldloc.s 6
+			IL_0452: ldstr "log"
+			IL_0457: ldloc.s 13
+			IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_045e: pop
+			IL_045f: ldstr "console"
+			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0469: stloc.s 6
+			IL_046b: ldloc.s 6
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0472: stloc.s 6
+			IL_0474: ldloc.0
+			IL_0475: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_047a: ldc.i4.1
+			IL_047b: newarr [System.Runtime]System.Object
+			IL_0480: dup
+			IL_0481: ldc.i4.0
+			IL_0482: ldstr ","
+			IL_0487: stelem.ref
+			IL_0488: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_048d: stloc.s 14
+			IL_048f: ldstr "written:"
+			IL_0494: ldloc.s 14
+			IL_0496: call string [System.Runtime]System.String::Concat(string, string)
+			IL_049b: stloc.s 14
+			IL_049d: ldloc.s 6
+			IL_049f: ldstr "log"
+			IL_04a4: ldloc.s 14
+			IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04ab: pop
+			IL_04ac: ldloc.0
+			IL_04ad: ldc.i4.m1
+			IL_04ae: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04b3: ldloc.0
+			IL_04b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04be: ldarg.0
+			IL_04bf: ldc.i4.1
+			IL_04c0: newarr [System.Runtime]System.Object
+			IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04ca: pop
+			IL_04cb: ldloc.0
+			IL_04cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04d1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04d6: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -739,15 +735,15 @@
 			7b 6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object 'stream'
-		.field public object streamPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule 'stream'
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule streamPromises
 		.field public object main
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x263c
+			// Method begins at RVA 0x2628
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -807,14 +803,14 @@
 		IL_003b: stloc.2
 		IL_003c: ldloc.0
 		IL_003d: ldloc.2
-		IL_003e: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
+		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Promises_Pipeline_ObjectMode/Scope::'stream'
 		IL_0043: ldarg.1
 		IL_0044: ldstr "node:stream/promises"
 		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule>(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object)
 		IL_004e: stloc.3
 		IL_004f: ldloc.0
 		IL_0050: ldloc.3
-		IL_0051: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
+		IL_0051: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
 		IL_0056: nop
 		IL_0057: ldloc.1
 		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -832,7 +828,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2660
+		// Method begins at RVA 0x264c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2458
+				// Method begins at RVA 0x2450
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d0
+			// Method begins at RVA 0x21cc
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2461
+				// Method begins at RVA 0x2459
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,7 +105,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2203
+			// Method begins at RVA 0x21ff
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -134,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246a
+				// Method begins at RVA 0x2462
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2228
+			// Method begins at RVA 0x2224
 			// Header size: 12
 			// Code size: 84 (0x54)
 			.maxstack 8
@@ -214,7 +214,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247c
+					// Method begins at RVA 0x2474
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -237,7 +237,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2418
+				// Method begins at RVA 0x2410
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -259,7 +259,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2485
+					// Method begins at RVA 0x247d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -282,7 +282,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x241c
+				// Method begins at RVA 0x2414
 				// Header size: 12
 				// Code size: 39 (0x27)
 				.maxstack 8
@@ -323,7 +323,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x248e
+					// Method begins at RVA 0x2486
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -343,7 +343,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2497
+					// Method begins at RVA 0x248f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -361,7 +361,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2473
+				// Method begins at RVA 0x246b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -387,9 +387,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2288
+			// Method begins at RVA 0x2284
 			// Header size: 12
-			// Code size: 370 (0x172)
+			// Code size: 365 (0x16d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/Scope,
@@ -450,89 +450,88 @@
 			{
 				IL_007d: nop
 				IL_007e: ldarg.0
-				IL_007f: ldfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
-				IL_0084: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-				IL_0089: stloc.s 8
-				IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0090: dup
-				IL_0091: ldstr "signal"
-				IL_0096: ldloc.1
-				IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_009c: stloc.s 7
-				IL_009e: ldloc.s 8
-				IL_00a0: ldc.r8 0.0
-				IL_00a9: box [System.Runtime]System.Double
-				IL_00ae: ldstr "value"
-				IL_00b3: ldloc.s 7
-				IL_00b5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
-				IL_00ba: pop
-				IL_00bb: ldstr "console"
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ca: ldstr "log"
-				IL_00cf: ldstr "aborted-getter-no-throw"
-				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00d9: pop
-				IL_00da: leave IL_016c
+				IL_007f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
+				IL_0084: stloc.s 8
+				IL_0086: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_008b: dup
+				IL_008c: ldstr "signal"
+				IL_0091: ldloc.1
+				IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0097: stloc.s 7
+				IL_0099: ldloc.s 8
+				IL_009b: ldc.r8 0.0
+				IL_00a4: box [System.Runtime]System.Double
+				IL_00a9: ldstr "value"
+				IL_00ae: ldloc.s 7
+				IL_00b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
+				IL_00b5: pop
+				IL_00b6: ldstr "console"
+				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00c5: ldstr "log"
+				IL_00ca: ldstr "aborted-getter-no-throw"
+				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00d4: pop
+				IL_00d5: leave IL_0167
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_00df: stloc.2
-				IL_00e0: ldloc.2
-				IL_00e1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_00e6: dup
-				IL_00e7: brtrue IL_00fc
+				IL_00da: stloc.2
+				IL_00db: ldloc.2
+				IL_00dc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_00e1: dup
+				IL_00e2: brtrue IL_00f7
 
-				IL_00ec: pop
-				IL_00ed: ldloc.2
-				IL_00ee: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_00f3: dup
-				IL_00f4: brtrue IL_0107
+				IL_00e7: pop
+				IL_00e8: ldloc.2
+				IL_00e9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_00ee: dup
+				IL_00ef: brtrue IL_0102
 
-				IL_00f9: pop
-				IL_00fa: rethrow
+				IL_00f4: pop
+				IL_00f5: rethrow
 
-				IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0101: stloc.3
-				IL_0102: br IL_0108
+				IL_00f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_00fc: stloc.3
+				IL_00fd: br IL_0103
 
-				IL_0107: stloc.3
+				IL_0102: stloc.3
 
-				IL_0108: ldloc.3
-				IL_0109: stloc.s 4
-				IL_010b: ldstr "console"
-				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_011a: stloc.s 9
-				IL_011c: ldloc.s 4
-				IL_011e: ldstr "name"
-				IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0128: stloc.s 10
-				IL_012a: ldloc.s 9
-				IL_012c: ldstr "log"
-				IL_0131: ldloc.s 10
-				IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0138: pop
-				IL_0139: ldstr "console"
-				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0148: stloc.s 10
-				IL_014a: ldloc.s 4
-				IL_014c: ldstr "message"
-				IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0156: stloc.s 9
-				IL_0158: ldloc.s 10
-				IL_015a: ldstr "log"
-				IL_015f: ldloc.s 9
-				IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0166: pop
-				IL_0167: leave IL_016c
+				IL_0103: ldloc.3
+				IL_0104: stloc.s 4
+				IL_0106: ldstr "console"
+				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0115: stloc.s 9
+				IL_0117: ldloc.s 4
+				IL_0119: ldstr "name"
+				IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0123: stloc.s 10
+				IL_0125: ldloc.s 9
+				IL_0127: ldstr "log"
+				IL_012c: ldloc.s 10
+				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0133: pop
+				IL_0134: ldstr "console"
+				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0143: stloc.s 10
+				IL_0145: ldloc.s 4
+				IL_0147: ldstr "message"
+				IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0151: stloc.s 9
+				IL_0153: ldloc.s 10
+				IL_0155: ldstr "log"
+				IL_015a: ldloc.s 9
+				IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0161: pop
+				IL_0162: leave IL_0167
 			} // end handler
 
-			IL_016c: ldnull
-			IL_016d: stloc.s 5
-			IL_016f: ldloc.s 5
-			IL_0171: ret
+			IL_0167: ldnull
+			IL_0168: stloc.s 5
+			IL_016a: ldloc.s 5
+			IL_016c: ret
 		} // end of method FunctionExpression_L24C8::__js_call__
 
 	} // end of class FunctionExpression_L24C8
@@ -546,13 +545,13 @@
 			72 6f 6d 69 73 65 73 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x244f
+			// Method begins at RVA 0x2447
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -578,7 +577,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 370 (0x172)
+		// Code size: 365 (0x16d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope,
@@ -602,7 +601,7 @@
 		IL_0012: stloc.3
 		IL_0013: ldloc.0
 		IL_0014: ldloc.3
-		IL_0015: stfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
 		IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_001f: stloc.1
 		IL_0020: ldnull
@@ -628,91 +627,90 @@
 		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
 		IL_0062: pop
 		IL_0063: ldloc.0
-		IL_0064: ldfld object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
-		IL_0069: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-		IL_006e: stloc.3
-		IL_006f: ldloc.3
-		IL_0070: ldc.r8 0.0
-		IL_0079: box [System.Runtime]System.Double
-		IL_007e: ldstr "value"
-		IL_0083: ldloc.1
-		IL_0084: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
-		IL_0089: stloc.2
-		IL_008a: ldstr "console"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0099: stloc.s 6
-		IL_009b: ldloc.2
-		IL_009c: ldstr "then"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a6: stloc.s 7
-		IL_00a8: ldloc.s 7
-		IL_00aa: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_00af: stloc.s 8
-		IL_00b1: ldloc.s 6
-		IL_00b3: ldstr "log"
-		IL_00b8: ldloc.s 8
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: pop
-		IL_00c0: ldloc.2
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c6: stloc.s 6
-		IL_00c8: ldnull
-		IL_00c9: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
-		IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_00d9: ldc.i4.0
-		IL_00da: conv.r8
-		IL_00db: ldstr ""
-		IL_00e0: ldc.i4.0
-		IL_00e1: ldc.i4.1
-		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_00e7: stloc.s 4
-		IL_00e9: ldloc.s 6
-		IL_00eb: ldstr "then"
-		IL_00f0: ldloc.s 4
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f7: stloc.s 6
-		IL_00f9: ldloc.s 6
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0100: stloc.s 6
-		IL_0102: ldnull
-		IL_0103: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
-		IL_0109: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_010e: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0113: ldc.i4.1
-		IL_0114: conv.r8
-		IL_0115: ldstr ""
-		IL_011a: ldc.i4.0
-		IL_011b: ldc.i4.1
-		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0121: stloc.s 9
-		IL_0123: ldloc.s 6
-		IL_0125: ldstr "catch"
-		IL_012a: ldloc.s 9
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0131: stloc.s 6
-		IL_0133: ldloc.s 6
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013a: stloc.s 6
-		IL_013c: ldloc.0
-		IL_013d: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
-		IL_0142: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
-		IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_014d: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0152: ldc.i4.0
-		IL_0153: conv.r8
-		IL_0154: ldstr ""
-		IL_0159: ldc.i4.0
-		IL_015a: ldc.i4.1
-		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0160: stloc.s 4
-		IL_0162: ldloc.s 6
-		IL_0164: ldstr "then"
-		IL_0169: ldloc.s 4
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0170: pop
-		IL_0171: ret
+		IL_0064: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::timersPromises
+		IL_0069: stloc.3
+		IL_006a: ldloc.3
+		IL_006b: ldc.r8 0.0
+		IL_0074: box [System.Runtime]System.Double
+		IL_0079: ldstr "value"
+		IL_007e: ldloc.1
+		IL_007f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
+		IL_0084: stloc.2
+		IL_0085: ldstr "console"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0094: stloc.s 6
+		IL_0096: ldloc.2
+		IL_0097: ldstr "then"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: stloc.s 7
+		IL_00a3: ldloc.s 7
+		IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00aa: stloc.s 8
+		IL_00ac: ldloc.s 6
+		IL_00ae: ldstr "log"
+		IL_00b3: ldloc.s 8
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ba: pop
+		IL_00bb: ldloc.2
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c1: stloc.s 6
+		IL_00c3: ldnull
+		IL_00c4: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
+		IL_00ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00cf: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00d4: ldc.i4.0
+		IL_00d5: conv.r8
+		IL_00d6: ldstr ""
+		IL_00db: ldc.i4.0
+		IL_00dc: ldc.i4.1
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_00e2: stloc.s 4
+		IL_00e4: ldloc.s 6
+		IL_00e6: ldstr "then"
+		IL_00eb: ldloc.s 4
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f2: stloc.s 6
+		IL_00f4: ldloc.s 6
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.s 6
+		IL_00fd: ldnull
+		IL_00fe: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
+		IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0109: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_010e: ldc.i4.1
+		IL_010f: conv.r8
+		IL_0110: ldstr ""
+		IL_0115: ldc.i4.0
+		IL_0116: ldc.i4.1
+		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_011c: stloc.s 9
+		IL_011e: ldloc.s 6
+		IL_0120: ldstr "catch"
+		IL_0125: ldloc.s 9
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012c: stloc.s 6
+		IL_012e: ldloc.s 6
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: stloc.s 6
+		IL_0137: ldloc.0
+		IL_0138: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
+		IL_013d: ldftn object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
+		IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0148: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_014d: ldc.i4.0
+		IL_014e: conv.r8
+		IL_014f: ldstr ""
+		IL_0154: ldc.i4.0
+		IL_0155: ldc.i4.1
+		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_015b: stloc.s 4
+		IL_015d: ldloc.s 6
+		IL_015f: ldstr "then"
+		IL_0164: ldloc.s 4
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016b: pop
+		IL_016c: ret
 	} // end of method TimersPromises_Abort_GetterErrors_SurfaceCorrectly::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly
@@ -724,7 +722,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a0
+		// Method begins at RVA 0x2498
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x262f
+						// Method begins at RVA 0x2623
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2626
+					// Method begins at RVA 0x261a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2494
+				// Method begins at RVA 0x2488
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -112,7 +112,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2641
+						// Method begins at RVA 0x2635
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -130,7 +130,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2638
+					// Method begins at RVA 0x262c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -155,7 +155,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24c8
+				// Method begins at RVA 0x24bc
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -234,7 +234,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2653
+						// Method begins at RVA 0x2647
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -252,7 +252,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x264a
+					// Method begins at RVA 0x263e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -276,7 +276,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2548
+				// Method begins at RVA 0x253c
 				// Header size: 12
 				// Code size: 101 (0x65)
 				.maxstack 8
@@ -342,7 +342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x261d
+				// Method begins at RVA 0x2611
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -368,7 +368,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x21f0
+			// Method begins at RVA 0x21ec
 			// Header size: 12
 			// Code size: 207 (0xcf)
 			.maxstack 8
@@ -472,7 +472,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x265c
+				// Method begins at RVA 0x2650
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -496,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22cc
+			// Method begins at RVA 0x22c8
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -561,7 +561,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2665
+				// Method begins at RVA 0x2659
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +584,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2355
+			// Method begins at RVA 0x2351
 			// Header size: 1
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -613,7 +613,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x266e
+				// Method begins at RVA 0x2662
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -640,7 +640,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2374
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -685,7 +685,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2680
+					// Method begins at RVA 0x2674
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -708,7 +708,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25b9
+				// Method begins at RVA 0x25ad
 				// Header size: 1
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -737,7 +737,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2689
+					// Method begins at RVA 0x267d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -762,7 +762,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25dc
+				// Method begins at RVA 0x25d0
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -810,7 +810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2677
+				// Method begins at RVA 0x266b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -836,9 +836,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x23a4
+			// Method begins at RVA 0x23a0
 			// Header size: 12
-			// Code size: 225 (0xe1)
+			// Code size: 220 (0xdc)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -868,73 +868,72 @@
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_002c: pop
 			IL_002d: ldarg.0
-			IL_002e: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_0033: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_0038: stloc.2
-			IL_0039: ldloc.1
-			IL_003a: ldstr "signal"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0044: stloc.3
-			IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_004a: dup
-			IL_004b: ldstr "signal"
-			IL_0050: ldloc.3
-			IL_0051: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0056: stloc.s 4
-			IL_0058: ldloc.2
-			IL_0059: ldstr "immediate-value"
-			IL_005e: ldloc.s 4
-			IL_0060: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object, object)
-			IL_0065: stloc.3
-			IL_0066: ldloc.3
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006c: stloc.3
-			IL_006d: ldnull
-			IL_006e: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-			IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0079: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_007e: ldc.i4.0
-			IL_007f: conv.r8
-			IL_0080: ldstr ""
-			IL_0085: ldc.i4.0
-			IL_0086: ldc.i4.1
-			IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_008c: stloc.s 5
-			IL_008e: ldloc.3
-			IL_008f: ldstr "then"
-			IL_0094: ldloc.s 5
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a2: stloc.3
-			IL_00a3: ldc.i4.2
-			IL_00a4: newarr [System.Runtime]System.Object
-			IL_00a9: dup
-			IL_00aa: ldc.i4.0
-			IL_00ab: ldarg.0
-			IL_00ac: stelem.ref
-			IL_00ad: dup
-			IL_00ae: ldc.i4.1
-			IL_00af: ldloc.0
-			IL_00b0: stelem.ref
-			IL_00b1: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-			IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00bc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_00c1: ldc.i4.1
-			IL_00c2: conv.r8
-			IL_00c3: ldstr ""
-			IL_00c8: ldc.i4.0
-			IL_00c9: ldc.i4.1
-			IL_00ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_00cf: stloc.s 6
-			IL_00d1: ldloc.3
-			IL_00d2: ldstr "catch"
-			IL_00d7: ldloc.s 6
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00de: stloc.3
-			IL_00df: ldloc.3
-			IL_00e0: ret
+			IL_002e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+			IL_0033: stloc.2
+			IL_0034: ldloc.1
+			IL_0035: ldstr "signal"
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003f: stloc.3
+			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0045: dup
+			IL_0046: ldstr "signal"
+			IL_004b: ldloc.3
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0051: stloc.s 4
+			IL_0053: ldloc.2
+			IL_0054: ldstr "immediate-value"
+			IL_0059: ldloc.s 4
+			IL_005b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object, object)
+			IL_0060: stloc.3
+			IL_0061: ldloc.3
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0067: stloc.3
+			IL_0068: ldnull
+			IL_0069: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+			IL_006f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0074: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0079: ldc.i4.0
+			IL_007a: conv.r8
+			IL_007b: ldstr ""
+			IL_0080: ldc.i4.0
+			IL_0081: ldc.i4.1
+			IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_0087: stloc.s 5
+			IL_0089: ldloc.3
+			IL_008a: ldstr "then"
+			IL_008f: ldloc.s 5
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0096: stloc.3
+			IL_0097: ldloc.3
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009d: stloc.3
+			IL_009e: ldc.i4.2
+			IL_009f: newarr [System.Runtime]System.Object
+			IL_00a4: dup
+			IL_00a5: ldc.i4.0
+			IL_00a6: ldarg.0
+			IL_00a7: stelem.ref
+			IL_00a8: dup
+			IL_00a9: ldc.i4.1
+			IL_00aa: ldloc.0
+			IL_00ab: stelem.ref
+			IL_00ac: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+			IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00b7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_00bc: ldc.i4.1
+			IL_00bd: conv.r8
+			IL_00be: ldstr ""
+			IL_00c3: ldc.i4.0
+			IL_00c4: ldc.i4.1
+			IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_00ca: stloc.s 6
+			IL_00cc: ldloc.3
+			IL_00cd: ldstr "catch"
+			IL_00d2: ldloc.s 6
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d9: stloc.3
+			IL_00da: ldloc.3
+			IL_00db: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -952,7 +951,7 @@
 			74 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 		.field public object createController
 		.field public object logAbort
 
@@ -960,7 +959,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2614
+			// Method begins at RVA 0x2608
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -986,7 +985,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 403 (0x193)
+		// Code size: 398 (0x18e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope,
@@ -1037,7 +1036,7 @@
 		IL_0067: stloc.s 5
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 5
-		IL_006c: stfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+		IL_006c: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
 		IL_0071: nop
 		IL_0072: nop
 		IL_0073: ldloc.0
@@ -1046,91 +1045,90 @@
 		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 		IL_0083: stloc.1
 		IL_0084: ldloc.0
-		IL_0085: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-		IL_008a: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.1
-		IL_0092: ldstr "signal"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009c: stloc.s 6
-		IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00a3: dup
-		IL_00a4: ldstr "signal"
-		IL_00a9: ldloc.s 6
-		IL_00ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00b0: stloc.s 7
-		IL_00b2: ldloc.s 5
-		IL_00b4: ldc.r8 0.0
-		IL_00bd: box [System.Runtime]System.Double
-		IL_00c2: ldstr "timeout-value"
-		IL_00c7: ldloc.s 7
-		IL_00c9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
-		IL_00ce: stloc.2
-		IL_00cf: ldloc.1
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d5: ldstr "abort"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00df: pop
-		IL_00e0: ldloc.2
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e6: stloc.s 6
-		IL_00e8: ldnull
-		IL_00e9: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
-		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00f4: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_00f9: ldc.i4.0
-		IL_00fa: conv.r8
-		IL_00fb: ldstr ""
-		IL_0100: ldc.i4.0
-		IL_0101: ldc.i4.1
-		IL_0102: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0107: stloc.3
-		IL_0108: ldloc.s 6
-		IL_010a: ldstr "then"
-		IL_010f: ldloc.3
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: stloc.s 6
-		IL_0117: ldloc.s 6
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011e: stloc.s 6
-		IL_0120: ldloc.0
-		IL_0121: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0126: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
-		IL_012c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0131: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0136: ldc.i4.1
-		IL_0137: conv.r8
-		IL_0138: ldstr ""
-		IL_013d: ldc.i4.0
-		IL_013e: ldc.i4.1
-		IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_0144: stloc.s 4
-		IL_0146: ldloc.s 6
-		IL_0148: ldstr "catch"
-		IL_014d: ldloc.s 4
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0154: stloc.s 6
-		IL_0156: ldloc.s 6
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015d: stloc.s 6
-		IL_015f: ldloc.0
-		IL_0160: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0165: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0170: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0175: ldc.i4.0
-		IL_0176: conv.r8
-		IL_0177: ldstr ""
-		IL_017c: ldc.i4.0
-		IL_017d: ldc.i4.1
-		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0183: stloc.3
-		IL_0184: ldloc.s 6
-		IL_0186: ldstr "then"
-		IL_018b: ldloc.3
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0191: pop
-		IL_0192: ret
+		IL_0085: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+		IL_008a: stloc.s 5
+		IL_008c: ldloc.1
+		IL_008d: ldstr "signal"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0097: stloc.s 6
+		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_009e: dup
+		IL_009f: ldstr "signal"
+		IL_00a4: ldloc.s 6
+		IL_00a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00ab: stloc.s 7
+		IL_00ad: ldloc.s 5
+		IL_00af: ldc.r8 0.0
+		IL_00b8: box [System.Runtime]System.Double
+		IL_00bd: ldstr "timeout-value"
+		IL_00c2: ldloc.s 7
+		IL_00c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
+		IL_00c9: stloc.2
+		IL_00ca: ldloc.1
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: ldstr "abort"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00da: pop
+		IL_00db: ldloc.2
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e1: stloc.s 6
+		IL_00e3: ldnull
+		IL_00e4: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
+		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ef: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_00f4: ldc.i4.0
+		IL_00f5: conv.r8
+		IL_00f6: ldstr ""
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldc.i4.1
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0102: stloc.3
+		IL_0103: ldloc.s 6
+		IL_0105: ldstr "then"
+		IL_010a: ldloc.3
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: stloc.s 6
+		IL_0112: ldloc.s 6
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0119: stloc.s 6
+		IL_011b: ldloc.0
+		IL_011c: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0121: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
+		IL_0127: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_012c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_0131: ldc.i4.1
+		IL_0132: conv.r8
+		IL_0133: ldstr ""
+		IL_0138: ldc.i4.0
+		IL_0139: ldc.i4.1
+		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_013f: stloc.s 4
+		IL_0141: ldloc.s 6
+		IL_0143: ldstr "catch"
+		IL_0148: ldloc.s 4
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: stloc.s 6
+		IL_0151: ldloc.s 6
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0158: stloc.s 6
+		IL_015a: ldloc.0
+		IL_015b: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0160: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0170: ldc.i4.0
+		IL_0171: conv.r8
+		IL_0172: ldstr ""
+		IL_0177: ldc.i4.0
+		IL_0178: ldc.i4.1
+		IL_0179: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_017e: stloc.3
+		IL_017f: ldloc.s 6
+		IL_0181: ldstr "then"
+		IL_0186: ldloc.3
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018c: pop
+		IL_018d: ret
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis
@@ -1142,7 +1140,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2692
+		// Method begins at RVA 0x2686
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2318
+				// Method begins at RVA 0x2310
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x2178
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -76,7 +76,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2321
+				// Method begins at RVA 0x2319
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x219c
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -138,7 +138,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2333
+					// Method begins at RVA 0x232b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -163,7 +163,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2250
+				// Method begins at RVA 0x2248
 				// Header size: 12
 				// Code size: 179 (0xb3)
 				.maxstack 8
@@ -251,7 +251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x232a
+				// Method begins at RVA 0x2322
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,9 +278,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21c0
 			// Header size: 12
-			// Code size: 128 (0x80)
+			// Code size: 123 (0x7b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope,
@@ -300,45 +300,44 @@
 			IL_000f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_0014: pop
 			IL_0015: ldarg.0
-			IL_0016: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-			IL_001b: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_0020: stloc.2
-			IL_0021: ldloc.2
-			IL_0022: ldc.r8 0.0
-			IL_002b: box [System.Runtime]System.Double
-			IL_0030: ldstr "timeout"
-			IL_0035: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object)
-			IL_003a: stloc.3
-			IL_003b: ldloc.3
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0041: stloc.3
-			IL_0042: ldc.i4.2
-			IL_0043: newarr [System.Runtime]System.Object
-			IL_0048: dup
-			IL_0049: ldc.i4.0
-			IL_004a: ldarg.0
-			IL_004b: stelem.ref
-			IL_004c: dup
-			IL_004d: ldc.i4.1
-			IL_004e: ldloc.0
-			IL_004f: stelem.ref
-			IL_0050: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
-			IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_005b: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_0060: ldc.i4.1
-			IL_0061: conv.r8
-			IL_0062: ldstr ""
-			IL_0067: ldc.i4.0
-			IL_0068: ldc.i4.1
-			IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_006e: stloc.s 4
-			IL_0070: ldloc.3
-			IL_0071: ldstr "then"
-			IL_0076: ldloc.s 4
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007d: stloc.3
-			IL_007e: ldloc.3
-			IL_007f: ret
+			IL_0016: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+			IL_001b: stloc.2
+			IL_001c: ldloc.2
+			IL_001d: ldc.r8 0.0
+			IL_0026: box [System.Runtime]System.Double
+			IL_002b: ldstr "timeout"
+			IL_0030: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object)
+			IL_0035: stloc.3
+			IL_0036: ldloc.3
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.3
+			IL_003d: ldc.i4.2
+			IL_003e: newarr [System.Runtime]System.Object
+			IL_0043: dup
+			IL_0044: ldc.i4.0
+			IL_0045: ldarg.0
+			IL_0046: stelem.ref
+			IL_0047: dup
+			IL_0048: ldc.i4.1
+			IL_0049: ldloc.0
+			IL_004a: stelem.ref
+			IL_004b: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
+			IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0056: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_005b: ldc.i4.1
+			IL_005c: conv.r8
+			IL_005d: ldstr ""
+			IL_0062: ldc.i4.0
+			IL_0063: ldc.i4.1
+			IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0069: stloc.s 4
+			IL_006b: ldloc.3
+			IL_006c: ldstr "then"
+			IL_0071: ldloc.s 4
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0078: stloc.3
+			IL_0079: ldloc.3
+			IL_007a: ret
 		} // end of method FunctionExpression_L16C46::__js_call__
 
 	} // end of class FunctionExpression_L16C46
@@ -353,14 +352,14 @@
 			7b 6f 72 64 65 72 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Array order
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x230f
+			// Method begins at RVA 0x2307
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -386,7 +385,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 288 (0x120)
+		// Code size: 283 (0x11b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope,
@@ -406,7 +405,7 @@
 		IL_0012: stloc.1
 		IL_0013: ldloc.0
 		IL_0014: ldloc.1
-		IL_0015: stfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+		IL_0015: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
 		IL_001a: ldc.i4.0
 		IL_001b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_0020: stloc.2
@@ -464,34 +463,33 @@
 		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_00cb: pop
 		IL_00cc: ldloc.0
-		IL_00cd: ldfld object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-		IL_00d2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-		IL_00d7: stloc.1
-		IL_00d8: ldloc.1
-		IL_00d9: ldstr "immediate"
-		IL_00de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object)
-		IL_00e3: stloc.3
-		IL_00e4: ldloc.3
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ea: stloc.3
-		IL_00eb: ldloc.0
-		IL_00ec: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_00f1: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
-		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00fc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-		IL_0101: ldc.i4.1
-		IL_0102: conv.r8
-		IL_0103: ldstr ""
-		IL_0108: ldc.i4.0
-		IL_0109: ldc.i4.1
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-		IL_010f: stloc.s 5
-		IL_0111: ldloc.3
-		IL_0112: ldstr "then"
-		IL_0117: ldloc.s 5
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011e: pop
-		IL_011f: ret
+		IL_00cd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+		IL_00d2: stloc.1
+		IL_00d3: ldloc.1
+		IL_00d4: ldstr "immediate"
+		IL_00d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object)
+		IL_00de: stloc.3
+		IL_00df: ldloc.3
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e5: stloc.3
+		IL_00e6: ldloc.0
+		IL_00e7: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+		IL_00ec: ldftn object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
+		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f7: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+		IL_00fc: ldc.i4.1
+		IL_00fd: conv.r8
+		IL_00fe: ldstr ""
+		IL_0103: ldc.i4.0
+		IL_0104: ldc.i4.1
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+		IL_010a: stloc.s 5
+		IL_010c: ldloc.3
+		IL_010d: ldstr "then"
+		IL_0112: ldloc.s 5
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0119: pop
+		IL_011a: ret
 	} // end of method TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks::__js_module_init__
 
 } // end of class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
@@ -503,7 +501,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x233c
+		// Method begins at RVA 0x2334
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27e6
+						// Method begins at RVA 0x27e2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27dd
+					// Method begins at RVA 0x27d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2574
+				// Method begins at RVA 0x2570
 				// Header size: 12
 				// Code size: 38 (0x26)
 				.maxstack 8
@@ -112,7 +112,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x27f8
+						// Method begins at RVA 0x27f4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -130,7 +130,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27ef
+					// Method begins at RVA 0x27eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -155,7 +155,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25a8
+				// Method begins at RVA 0x25a4
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -234,7 +234,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x280a
+						// Method begins at RVA 0x2806
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -252,7 +252,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2801
+					// Method begins at RVA 0x27fd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -277,7 +277,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2628
+				// Method begins at RVA 0x2624
 				// Header size: 12
 				// Code size: 129 (0x81)
 				.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d4
+				// Method begins at RVA 0x27d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -494,7 +494,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x281c
+					// Method begins at RVA 0x2818
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -517,7 +517,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26b5
+				// Method begins at RVA 0x26b1
 				// Header size: 1
 				// Code size: 33 (0x21)
 				.maxstack 8
@@ -546,7 +546,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2825
+					// Method begins at RVA 0x2821
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -570,7 +570,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26d8
+				// Method begins at RVA 0x26d4
 				// Header size: 12
 				// Code size: 231 (0xe7)
 				.maxstack 8
@@ -680,7 +680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2813
+				// Method begins at RVA 0x280f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -706,7 +706,7 @@
 			)
 			// Method begins at RVA 0x21c8
 			// Header size: 12
-			// Code size: 926 (0x39e)
+			// Code size: 921 (0x399)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -817,7 +817,7 @@
 
 			IL_00b6: ldloc.0
 			IL_00b7: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00bc: switch (IL_00cd, IL_01b8, IL_0266)
+			IL_00bc: switch (IL_00cd, IL_01b3, IL_0261)
 
 			IL_00cd: ldarg.0
 			IL_00ce: ldc.i4.1
@@ -840,294 +840,293 @@
 			IL_00f1: ldc.i4.1
 			IL_00f2: ldelem.ref
 			IL_00f3: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_00f8: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_00fd: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_0102: stloc.s 6
-			IL_0104: ldloc.1
-			IL_0105: ldstr "signal"
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010f: stloc.s 7
-			IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0116: dup
-			IL_0117: ldstr "signal"
-			IL_011c: ldloc.s 7
-			IL_011e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0123: stloc.s 8
-			IL_0125: ldloc.s 6
-			IL_0127: ldc.r8 0.0
-			IL_0130: box [System.Runtime]System.Double
-			IL_0135: ldstr "tick"
-			IL_013a: ldloc.s 8
-			IL_013c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object, object)
-			IL_0141: stloc.2
-			IL_0142: ldloc.2
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0148: stloc.s 7
-			IL_014a: ldloc.s 7
-			IL_014c: ldstr "next"
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0156: stloc.s 7
-			IL_0158: ldloc.0
-			IL_0159: ldc.i4.1
-			IL_015a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00f8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
+			IL_00fd: stloc.s 6
+			IL_00ff: ldloc.1
+			IL_0100: ldstr "signal"
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_010a: stloc.s 7
+			IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0111: dup
+			IL_0112: ldstr "signal"
+			IL_0117: ldloc.s 7
+			IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_011e: stloc.s 8
+			IL_0120: ldloc.s 6
+			IL_0122: ldc.r8 0.0
+			IL_012b: box [System.Runtime]System.Double
+			IL_0130: ldstr "tick"
+			IL_0135: ldloc.s 8
+			IL_0137: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object, object)
+			IL_013c: stloc.2
+			IL_013d: ldloc.2
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0143: stloc.s 7
+			IL_0145: ldloc.s 7
+			IL_0147: ldstr "next"
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0151: stloc.s 7
+			IL_0153: ldloc.0
+			IL_0154: ldc.i4.1
+			IL_0155: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_015a: ldloc.0
+			IL_015b: ldloc.s 7
+			IL_015d: ldarg.0
+			IL_015e: ldc.i4.1
 			IL_015f: ldloc.0
-			IL_0160: ldloc.s 7
-			IL_0162: ldarg.0
-			IL_0163: ldc.i4.1
-			IL_0164: ldloc.0
-			IL_0165: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_016f: ldloc.0
-			IL_0170: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0175: dup
-			IL_0176: ldc.i4.0
-			IL_0177: ldloc.1
-			IL_0178: stelem.ref
-			IL_0179: dup
-			IL_017a: ldc.i4.1
-			IL_017b: ldloc.2
-			IL_017c: stelem.ref
-			IL_017d: dup
-			IL_017e: ldc.i4.2
-			IL_017f: ldloc.3
+			IL_0160: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_016a: ldloc.0
+			IL_016b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0170: dup
+			IL_0171: ldc.i4.0
+			IL_0172: ldloc.1
+			IL_0173: stelem.ref
+			IL_0174: dup
+			IL_0175: ldc.i4.1
+			IL_0176: ldloc.2
+			IL_0177: stelem.ref
+			IL_0178: dup
+			IL_0179: ldc.i4.2
+			IL_017a: ldloc.3
+			IL_017b: stelem.ref
+			IL_017c: dup
+			IL_017d: ldc.i4.3
+			IL_017e: ldloc.s 4
 			IL_0180: stelem.ref
 			IL_0181: dup
-			IL_0182: ldc.i4.3
-			IL_0183: ldloc.s 4
+			IL_0182: ldc.i4.4
+			IL_0183: ldloc.s 5
 			IL_0185: stelem.ref
 			IL_0186: dup
-			IL_0187: ldc.i4.4
-			IL_0188: ldloc.s 5
+			IL_0187: ldc.i4.5
+			IL_0188: ldloc.s 6
 			IL_018a: stelem.ref
 			IL_018b: dup
-			IL_018c: ldc.i4.5
-			IL_018d: ldloc.s 6
+			IL_018c: ldc.i4.6
+			IL_018d: ldloc.s 7
 			IL_018f: stelem.ref
 			IL_0190: dup
-			IL_0191: ldc.i4.6
-			IL_0192: ldloc.s 7
+			IL_0191: ldc.i4.7
+			IL_0192: ldloc.s 8
 			IL_0194: stelem.ref
 			IL_0195: dup
-			IL_0196: ldc.i4.7
-			IL_0197: ldloc.s 8
+			IL_0196: ldc.i4.8
+			IL_0197: ldloc.s 9
 			IL_0199: stelem.ref
 			IL_019a: dup
-			IL_019b: ldc.i4.8
-			IL_019c: ldloc.s 9
-			IL_019e: stelem.ref
-			IL_019f: dup
-			IL_01a0: ldc.i4.s 9
-			IL_01a2: ldloc.s 10
-			IL_01a4: stelem.ref
-			IL_01a5: dup
-			IL_01a6: ldc.i4.s 10
-			IL_01a8: ldloc.s 11
-			IL_01aa: stelem.ref
-			IL_01ab: pop
-			IL_01ac: ldloc.0
-			IL_01ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01b7: ret
+			IL_019b: ldc.i4.s 9
+			IL_019d: ldloc.s 10
+			IL_019f: stelem.ref
+			IL_01a0: dup
+			IL_01a1: ldc.i4.s 10
+			IL_01a3: ldloc.s 11
+			IL_01a5: stelem.ref
+			IL_01a6: pop
+			IL_01a7: ldloc.0
+			IL_01a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01ad: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b2: ret
 
-			IL_01b8: ldloc.0
-			IL_01b9: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
-			IL_01be: stloc.3
-			IL_01bf: ldstr "console"
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c9: stloc.s 7
-			IL_01cb: ldloc.s 7
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01d2: stloc.s 7
-			IL_01d4: ldloc.3
-			IL_01d5: ldstr "value"
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01df: stloc.s 9
-			IL_01e1: ldloc.s 7
-			IL_01e3: ldstr "log"
-			IL_01e8: ldloc.s 9
-			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01ef: pop
-			IL_01f0: ldloc.2
-			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f6: stloc.s 9
-			IL_01f8: ldloc.s 9
-			IL_01fa: ldstr "next"
-			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0204: stloc.s 9
-			IL_0206: ldloc.0
-			IL_0207: ldc.i4.2
-			IL_0208: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01b3: ldloc.0
+			IL_01b4: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
+			IL_01b9: stloc.3
+			IL_01ba: ldstr "console"
+			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01c4: stloc.s 7
+			IL_01c6: ldloc.s 7
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cd: stloc.s 7
+			IL_01cf: ldloc.3
+			IL_01d0: ldstr "value"
+			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01da: stloc.s 9
+			IL_01dc: ldloc.s 7
+			IL_01de: ldstr "log"
+			IL_01e3: ldloc.s 9
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ea: pop
+			IL_01eb: ldloc.2
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f1: stloc.s 9
+			IL_01f3: ldloc.s 9
+			IL_01f5: ldstr "next"
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01ff: stloc.s 9
+			IL_0201: ldloc.0
+			IL_0202: ldc.i4.2
+			IL_0203: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0208: ldloc.0
+			IL_0209: ldloc.s 9
+			IL_020b: ldarg.0
+			IL_020c: ldc.i4.2
 			IL_020d: ldloc.0
-			IL_020e: ldloc.s 9
-			IL_0210: ldarg.0
-			IL_0211: ldc.i4.2
-			IL_0212: ldloc.0
-			IL_0213: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0218: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_021d: ldloc.0
-			IL_021e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0223: dup
-			IL_0224: ldc.i4.0
-			IL_0225: ldloc.1
-			IL_0226: stelem.ref
-			IL_0227: dup
-			IL_0228: ldc.i4.1
-			IL_0229: ldloc.2
-			IL_022a: stelem.ref
-			IL_022b: dup
-			IL_022c: ldc.i4.2
-			IL_022d: ldloc.3
+			IL_020e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0213: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0218: ldloc.0
+			IL_0219: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_021e: dup
+			IL_021f: ldc.i4.0
+			IL_0220: ldloc.1
+			IL_0221: stelem.ref
+			IL_0222: dup
+			IL_0223: ldc.i4.1
+			IL_0224: ldloc.2
+			IL_0225: stelem.ref
+			IL_0226: dup
+			IL_0227: ldc.i4.2
+			IL_0228: ldloc.3
+			IL_0229: stelem.ref
+			IL_022a: dup
+			IL_022b: ldc.i4.3
+			IL_022c: ldloc.s 4
 			IL_022e: stelem.ref
 			IL_022f: dup
-			IL_0230: ldc.i4.3
-			IL_0231: ldloc.s 4
+			IL_0230: ldc.i4.4
+			IL_0231: ldloc.s 5
 			IL_0233: stelem.ref
 			IL_0234: dup
-			IL_0235: ldc.i4.4
-			IL_0236: ldloc.s 5
+			IL_0235: ldc.i4.5
+			IL_0236: ldloc.s 6
 			IL_0238: stelem.ref
 			IL_0239: dup
-			IL_023a: ldc.i4.5
-			IL_023b: ldloc.s 6
+			IL_023a: ldc.i4.6
+			IL_023b: ldloc.s 7
 			IL_023d: stelem.ref
 			IL_023e: dup
-			IL_023f: ldc.i4.6
-			IL_0240: ldloc.s 7
+			IL_023f: ldc.i4.7
+			IL_0240: ldloc.s 8
 			IL_0242: stelem.ref
 			IL_0243: dup
-			IL_0244: ldc.i4.7
-			IL_0245: ldloc.s 8
+			IL_0244: ldc.i4.8
+			IL_0245: ldloc.s 9
 			IL_0247: stelem.ref
 			IL_0248: dup
-			IL_0249: ldc.i4.8
-			IL_024a: ldloc.s 9
-			IL_024c: stelem.ref
-			IL_024d: dup
-			IL_024e: ldc.i4.s 9
-			IL_0250: ldloc.s 10
-			IL_0252: stelem.ref
-			IL_0253: dup
-			IL_0254: ldc.i4.s 10
-			IL_0256: ldloc.s 11
-			IL_0258: stelem.ref
-			IL_0259: pop
-			IL_025a: ldloc.0
-			IL_025b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0260: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0265: ret
+			IL_0249: ldc.i4.s 9
+			IL_024b: ldloc.s 10
+			IL_024d: stelem.ref
+			IL_024e: dup
+			IL_024f: ldc.i4.s 10
+			IL_0251: ldloc.s 11
+			IL_0253: stelem.ref
+			IL_0254: pop
+			IL_0255: ldloc.0
+			IL_0256: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_025b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0260: ret
 
-			IL_0266: ldloc.0
-			IL_0267: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
-			IL_026c: stloc.s 4
-			IL_026e: ldstr "console"
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0278: stloc.s 9
-			IL_027a: ldloc.s 9
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0281: stloc.s 9
-			IL_0283: ldloc.s 4
-			IL_0285: ldstr "value"
-			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028f: stloc.s 7
-			IL_0291: ldloc.s 9
-			IL_0293: ldstr "log"
-			IL_0298: ldloc.s 7
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_029f: pop
-			IL_02a0: ldloc.1
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a6: stloc.s 7
-			IL_02a8: ldstr "boom-reason"
-			IL_02ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_02b7: stloc.s 9
-			IL_02b9: ldloc.s 7
-			IL_02bb: ldstr "abort"
-			IL_02c0: ldloc.s 9
-			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02c7: pop
-			IL_02c8: ldloc.2
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ce: stloc.s 9
-			IL_02d0: ldloc.s 9
-			IL_02d2: ldstr "next"
-			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_02dc: stloc.s 9
-			IL_02de: ldloc.s 9
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e5: stloc.s 9
-			IL_02e7: ldc.i4.1
-			IL_02e8: newarr [System.Runtime]System.Object
-			IL_02ed: dup
-			IL_02ee: ldc.i4.0
-			IL_02ef: ldarg.0
-			IL_02f0: ldc.i4.1
-			IL_02f1: ldelem.ref
-			IL_02f2: stelem.ref
-			IL_02f3: stloc.s 5
-			IL_02f5: ldnull
-			IL_02f6: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-			IL_02fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0301: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-			IL_0306: ldc.i4.0
-			IL_0307: conv.r8
-			IL_0308: ldstr ""
-			IL_030d: ldc.i4.0
-			IL_030e: ldc.i4.1
-			IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-			IL_0314: stloc.s 10
-			IL_0316: ldloc.s 9
-			IL_0318: ldstr "then"
-			IL_031d: ldloc.s 10
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0324: stloc.s 9
-			IL_0326: ldloc.s 9
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_032d: stloc.s 9
-			IL_032f: ldc.i4.1
-			IL_0330: newarr [System.Runtime]System.Object
-			IL_0335: dup
-			IL_0336: ldc.i4.0
-			IL_0337: ldarg.0
-			IL_0338: ldc.i4.1
-			IL_0339: ldelem.ref
-			IL_033a: stelem.ref
-			IL_033b: stloc.s 5
-			IL_033d: ldnull
-			IL_033e: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-			IL_0344: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0349: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
-			IL_034e: ldc.i4.1
-			IL_034f: conv.r8
-			IL_0350: ldstr ""
-			IL_0355: ldc.i4.0
-			IL_0356: ldc.i4.1
-			IL_0357: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
-			IL_035c: stloc.s 11
-			IL_035e: ldloc.s 9
-			IL_0360: ldstr "catch"
-			IL_0365: ldloc.s 11
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_036c: stloc.s 9
-			IL_036e: ldloc.0
-			IL_036f: ldc.i4.m1
-			IL_0370: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0375: ldloc.0
-			IL_0376: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_037b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0380: ldarg.0
-			IL_0381: ldc.i4.1
-			IL_0382: newarr [System.Runtime]System.Object
-			IL_0387: dup
-			IL_0388: ldc.i4.0
-			IL_0389: ldloc.s 9
-			IL_038b: stelem.ref
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0391: pop
-			IL_0392: ldloc.0
-			IL_0393: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0398: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_039d: ret
+			IL_0261: ldloc.0
+			IL_0262: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
+			IL_0267: stloc.s 4
+			IL_0269: ldstr "console"
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0273: stloc.s 9
+			IL_0275: ldloc.s 9
+			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027c: stloc.s 9
+			IL_027e: ldloc.s 4
+			IL_0280: ldstr "value"
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028a: stloc.s 7
+			IL_028c: ldloc.s 9
+			IL_028e: ldstr "log"
+			IL_0293: ldloc.s 7
+			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_029a: pop
+			IL_029b: ldloc.1
+			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a1: stloc.s 7
+			IL_02a3: ldstr "boom-reason"
+			IL_02a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02b2: stloc.s 9
+			IL_02b4: ldloc.s 7
+			IL_02b6: ldstr "abort"
+			IL_02bb: ldloc.s 9
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02c2: pop
+			IL_02c3: ldloc.2
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c9: stloc.s 9
+			IL_02cb: ldloc.s 9
+			IL_02cd: ldstr "next"
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_02d7: stloc.s 9
+			IL_02d9: ldloc.s 9
+			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02e0: stloc.s 9
+			IL_02e2: ldc.i4.1
+			IL_02e3: newarr [System.Runtime]System.Object
+			IL_02e8: dup
+			IL_02e9: ldc.i4.0
+			IL_02ea: ldarg.0
+			IL_02eb: ldc.i4.1
+			IL_02ec: ldelem.ref
+			IL_02ed: stelem.ref
+			IL_02ee: stloc.s 5
+			IL_02f0: ldnull
+			IL_02f1: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+			IL_02f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_02fc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+			IL_0301: ldc.i4.0
+			IL_0302: conv.r8
+			IL_0303: ldstr ""
+			IL_0308: ldc.i4.0
+			IL_0309: ldc.i4.1
+			IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+			IL_030f: stloc.s 10
+			IL_0311: ldloc.s 9
+			IL_0313: ldstr "then"
+			IL_0318: ldloc.s 10
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_031f: stloc.s 9
+			IL_0321: ldloc.s 9
+			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0328: stloc.s 9
+			IL_032a: ldc.i4.1
+			IL_032b: newarr [System.Runtime]System.Object
+			IL_0330: dup
+			IL_0331: ldc.i4.0
+			IL_0332: ldarg.0
+			IL_0333: ldc.i4.1
+			IL_0334: ldelem.ref
+			IL_0335: stelem.ref
+			IL_0336: stloc.s 5
+			IL_0338: ldnull
+			IL_0339: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+			IL_033f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0344: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1
+			IL_0349: ldc.i4.1
+			IL_034a: conv.r8
+			IL_034b: ldstr ""
+			IL_0350: ldc.i4.0
+			IL_0351: ldc.i4.1
+			IL_0352: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1>(!!0, float64, string, bool, bool)
+			IL_0357: stloc.s 11
+			IL_0359: ldloc.s 9
+			IL_035b: ldstr "catch"
+			IL_0360: ldloc.s 11
+			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0367: stloc.s 9
+			IL_0369: ldloc.0
+			IL_036a: ldc.i4.m1
+			IL_036b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0370: ldloc.0
+			IL_0371: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_037b: ldarg.0
+			IL_037c: ldc.i4.1
+			IL_037d: newarr [System.Runtime]System.Object
+			IL_0382: dup
+			IL_0383: ldc.i4.0
+			IL_0384: ldloc.s 9
+			IL_0386: stelem.ref
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_038c: pop
+			IL_038d: ldloc.0
+			IL_038e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0393: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0398: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1144,7 +1143,7 @@
 			61 69 6e 3d 7b 6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 		.field public object createController
 		.field public object main
 
@@ -1152,7 +1151,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27cb
+			// Method begins at RVA 0x27c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1227,7 +1226,7 @@
 		IL_0067: stloc.3
 		IL_0068: ldloc.0
 		IL_0069: ldloc.3
-		IL_006a: stfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
+		IL_006a: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
 		IL_006f: nop
 		IL_0070: nop
 		IL_0071: ldloc.1
@@ -1246,7 +1245,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x282e
+		// Method begins at RVA 0x282a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
@@ -49,7 +49,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b0
+				// Method begins at RVA 0x26a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -75,7 +75,7 @@
 			)
 			// Method begins at RVA 0x20b0
 			// Header size: 12
-			// Code size: 1515 (0x5eb)
+			// Code size: 1500 (0x5dc)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope,
@@ -172,614 +172,611 @@
 
 			IL_0096: ldloc.0
 			IL_0097: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_009c: switch (IL_00c1, IL_015a, IL_0242, IL_02c8, IL_0339, IL_03aa, IL_04e2, IL_0586)
+			IL_009c: switch (IL_00c1, IL_0155, IL_0238, IL_02b9, IL_032a, IL_039b, IL_04d3, IL_0577)
 
 			IL_00c1: ldarg.0
 			IL_00c2: ldc.i4.1
 			IL_00c3: ldelem.ref
 			IL_00c4: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_00c9: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_00ce: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_00d3: stloc.s 7
-			IL_00d5: ldloc.s 7
-			IL_00d7: ldc.r8 0.0
-			IL_00e0: box [System.Runtime]System.Double
-			IL_00e5: ldstr "tick"
-			IL_00ea: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object)
-			IL_00ef: stloc.1
-			IL_00f0: ldloc.1
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f6: stloc.s 8
-			IL_00f8: ldloc.s 8
-			IL_00fa: ldstr "next"
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0104: stloc.s 8
-			IL_0106: ldloc.0
-			IL_0107: ldc.i4.1
-			IL_0108: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00c9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_00ce: stloc.s 7
+			IL_00d0: ldloc.s 7
+			IL_00d2: ldc.r8 0.0
+			IL_00db: box [System.Runtime]System.Double
+			IL_00e0: ldstr "tick"
+			IL_00e5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object)
+			IL_00ea: stloc.1
+			IL_00eb: ldloc.1
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f1: stloc.s 8
+			IL_00f3: ldloc.s 8
+			IL_00f5: ldstr "next"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00ff: stloc.s 8
+			IL_0101: ldloc.0
+			IL_0102: ldc.i4.1
+			IL_0103: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0108: ldloc.0
+			IL_0109: ldloc.s 8
+			IL_010b: ldarg.0
+			IL_010c: ldc.i4.1
 			IL_010d: ldloc.0
-			IL_010e: ldloc.s 8
-			IL_0110: ldarg.0
-			IL_0111: ldc.i4.1
-			IL_0112: ldloc.0
-			IL_0113: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0118: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_011d: ldloc.0
-			IL_011e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0123: dup
-			IL_0124: ldc.i4.0
-			IL_0125: ldloc.1
-			IL_0126: stelem.ref
-			IL_0127: dup
-			IL_0128: ldc.i4.1
-			IL_0129: ldloc.2
-			IL_012a: stelem.ref
-			IL_012b: dup
-			IL_012c: ldc.i4.2
-			IL_012d: ldloc.3
+			IL_010e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0118: ldloc.0
+			IL_0119: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_011e: dup
+			IL_011f: ldc.i4.0
+			IL_0120: ldloc.1
+			IL_0121: stelem.ref
+			IL_0122: dup
+			IL_0123: ldc.i4.1
+			IL_0124: ldloc.2
+			IL_0125: stelem.ref
+			IL_0126: dup
+			IL_0127: ldc.i4.2
+			IL_0128: ldloc.3
+			IL_0129: stelem.ref
+			IL_012a: dup
+			IL_012b: ldc.i4.3
+			IL_012c: ldloc.s 4
 			IL_012e: stelem.ref
 			IL_012f: dup
-			IL_0130: ldc.i4.3
-			IL_0131: ldloc.s 4
+			IL_0130: ldc.i4.4
+			IL_0131: ldloc.s 5
 			IL_0133: stelem.ref
 			IL_0134: dup
-			IL_0135: ldc.i4.4
-			IL_0136: ldloc.s 5
+			IL_0135: ldc.i4.5
+			IL_0136: ldloc.s 6
 			IL_0138: stelem.ref
 			IL_0139: dup
-			IL_013a: ldc.i4.5
-			IL_013b: ldloc.s 6
+			IL_013a: ldc.i4.6
+			IL_013b: ldloc.s 7
 			IL_013d: stelem.ref
 			IL_013e: dup
-			IL_013f: ldc.i4.6
-			IL_0140: ldloc.s 7
+			IL_013f: ldc.i4.7
+			IL_0140: ldloc.s 8
 			IL_0142: stelem.ref
 			IL_0143: dup
-			IL_0144: ldc.i4.7
-			IL_0145: ldloc.s 8
+			IL_0144: ldc.i4.8
+			IL_0145: ldloc.s 9
 			IL_0147: stelem.ref
-			IL_0148: dup
-			IL_0149: ldc.i4.8
-			IL_014a: ldloc.s 9
-			IL_014c: stelem.ref
-			IL_014d: pop
-			IL_014e: ldloc.0
-			IL_014f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0154: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0159: ret
+			IL_0148: pop
+			IL_0149: ldloc.0
+			IL_014a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_014f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0154: ret
 
-			IL_015a: ldloc.0
-			IL_015b: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited1
-			IL_0160: stloc.2
-			IL_0161: ldstr "console"
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016b: stloc.s 8
-			IL_016d: ldloc.s 8
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0174: stloc.s 8
-			IL_0176: ldloc.2
-			IL_0177: ldstr "value"
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0181: stloc.s 9
-			IL_0183: ldloc.s 8
-			IL_0185: ldstr "log"
-			IL_018a: ldloc.s 9
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0191: pop
-			IL_0192: ldstr "console"
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_019c: stloc.s 9
-			IL_019e: ldloc.s 9
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a5: stloc.s 9
-			IL_01a7: ldloc.2
-			IL_01a8: ldstr "done"
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b2: stloc.s 8
-			IL_01b4: ldloc.s 9
-			IL_01b6: ldstr "log"
-			IL_01bb: ldloc.s 8
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01c2: pop
-			IL_01c3: ldarg.0
-			IL_01c4: ldc.i4.1
-			IL_01c5: ldelem.ref
-			IL_01c6: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_01cb: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_01d0: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_01d5: stloc.s 7
-			IL_01d7: ldloc.s 7
-			IL_01d9: ldc.r8 0.0
-			IL_01e2: box [System.Runtime]System.Double
-			IL_01e7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object)
-			IL_01ec: stloc.s 8
-			IL_01ee: ldloc.0
+			IL_0155: ldloc.0
+			IL_0156: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited1
+			IL_015b: stloc.2
+			IL_015c: ldstr "console"
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0166: stloc.s 8
+			IL_0168: ldloc.s 8
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 8
+			IL_0171: ldloc.2
+			IL_0172: ldstr "value"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017c: stloc.s 9
+			IL_017e: ldloc.s 8
+			IL_0180: ldstr "log"
+			IL_0185: ldloc.s 9
+			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_018c: pop
+			IL_018d: ldstr "console"
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0197: stloc.s 9
+			IL_0199: ldloc.s 9
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a0: stloc.s 9
+			IL_01a2: ldloc.2
+			IL_01a3: ldstr "done"
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ad: stloc.s 8
+			IL_01af: ldloc.s 9
+			IL_01b1: ldstr "log"
+			IL_01b6: ldloc.s 8
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01bd: pop
+			IL_01be: ldarg.0
+			IL_01bf: ldc.i4.1
+			IL_01c0: ldelem.ref
+			IL_01c1: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
+			IL_01c6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_01cb: stloc.s 7
+			IL_01cd: ldloc.s 7
+			IL_01cf: ldc.r8 0.0
+			IL_01d8: box [System.Runtime]System.Double
+			IL_01dd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object)
+			IL_01e2: stloc.s 8
+			IL_01e4: ldloc.0
+			IL_01e5: ldc.i4.2
+			IL_01e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01eb: ldloc.0
+			IL_01ec: ldloc.s 8
+			IL_01ee: ldarg.0
 			IL_01ef: ldc.i4.2
-			IL_01f0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01f5: ldloc.0
-			IL_01f6: ldloc.s 8
-			IL_01f8: ldarg.0
-			IL_01f9: ldc.i4.2
-			IL_01fa: ldloc.0
-			IL_01fb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0200: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0205: ldloc.0
-			IL_0206: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_020b: dup
-			IL_020c: ldc.i4.0
-			IL_020d: ldloc.1
-			IL_020e: stelem.ref
-			IL_020f: dup
-			IL_0210: ldc.i4.1
-			IL_0211: ldloc.2
-			IL_0212: stelem.ref
-			IL_0213: dup
-			IL_0214: ldc.i4.2
-			IL_0215: ldloc.3
+			IL_01f0: ldloc.0
+			IL_01f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01fb: ldloc.0
+			IL_01fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0201: dup
+			IL_0202: ldc.i4.0
+			IL_0203: ldloc.1
+			IL_0204: stelem.ref
+			IL_0205: dup
+			IL_0206: ldc.i4.1
+			IL_0207: ldloc.2
+			IL_0208: stelem.ref
+			IL_0209: dup
+			IL_020a: ldc.i4.2
+			IL_020b: ldloc.3
+			IL_020c: stelem.ref
+			IL_020d: dup
+			IL_020e: ldc.i4.3
+			IL_020f: ldloc.s 4
+			IL_0211: stelem.ref
+			IL_0212: dup
+			IL_0213: ldc.i4.4
+			IL_0214: ldloc.s 5
 			IL_0216: stelem.ref
 			IL_0217: dup
-			IL_0218: ldc.i4.3
-			IL_0219: ldloc.s 4
+			IL_0218: ldc.i4.5
+			IL_0219: ldloc.s 6
 			IL_021b: stelem.ref
 			IL_021c: dup
-			IL_021d: ldc.i4.4
-			IL_021e: ldloc.s 5
+			IL_021d: ldc.i4.6
+			IL_021e: ldloc.s 7
 			IL_0220: stelem.ref
 			IL_0221: dup
-			IL_0222: ldc.i4.5
-			IL_0223: ldloc.s 6
+			IL_0222: ldc.i4.7
+			IL_0223: ldloc.s 8
 			IL_0225: stelem.ref
 			IL_0226: dup
-			IL_0227: ldc.i4.6
-			IL_0228: ldloc.s 7
+			IL_0227: ldc.i4.8
+			IL_0228: ldloc.s 9
 			IL_022a: stelem.ref
-			IL_022b: dup
-			IL_022c: ldc.i4.7
-			IL_022d: ldloc.s 8
-			IL_022f: stelem.ref
-			IL_0230: dup
-			IL_0231: ldc.i4.8
-			IL_0232: ldloc.s 9
-			IL_0234: stelem.ref
-			IL_0235: pop
-			IL_0236: ldloc.0
-			IL_0237: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_023c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0241: ret
+			IL_022b: pop
+			IL_022c: ldloc.0
+			IL_022d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0232: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0237: ret
 
-			IL_0242: ldloc.0
-			IL_0243: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited2
-			IL_0248: pop
-			IL_0249: ldarg.0
-			IL_024a: ldc.i4.1
-			IL_024b: ldelem.ref
-			IL_024c: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
-			IL_0251: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-			IL_0256: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_025b: stloc.s 7
-			IL_025d: ldloc.s 7
-			IL_025f: ldc.r8 0.0
-			IL_0268: box [System.Runtime]System.Double
-			IL_026d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object)
-			IL_0272: stloc.s 8
-			IL_0274: ldloc.0
-			IL_0275: ldc.i4.3
-			IL_0276: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_027b: ldloc.0
-			IL_027c: ldloc.s 8
-			IL_027e: ldarg.0
-			IL_027f: ldc.i4.3
-			IL_0280: ldloc.0
-			IL_0281: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0286: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_028b: ldloc.0
-			IL_028c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0291: dup
-			IL_0292: ldc.i4.0
-			IL_0293: ldloc.1
-			IL_0294: stelem.ref
-			IL_0295: dup
-			IL_0296: ldc.i4.1
-			IL_0297: ldloc.2
-			IL_0298: stelem.ref
-			IL_0299: dup
-			IL_029a: ldc.i4.2
-			IL_029b: ldloc.3
+			IL_0238: ldloc.0
+			IL_0239: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited2
+			IL_023e: pop
+			IL_023f: ldarg.0
+			IL_0240: ldc.i4.1
+			IL_0241: ldelem.ref
+			IL_0242: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
+			IL_0247: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+			IL_024c: stloc.s 7
+			IL_024e: ldloc.s 7
+			IL_0250: ldc.r8 0.0
+			IL_0259: box [System.Runtime]System.Double
+			IL_025e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object)
+			IL_0263: stloc.s 8
+			IL_0265: ldloc.0
+			IL_0266: ldc.i4.3
+			IL_0267: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_026c: ldloc.0
+			IL_026d: ldloc.s 8
+			IL_026f: ldarg.0
+			IL_0270: ldc.i4.3
+			IL_0271: ldloc.0
+			IL_0272: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_027c: ldloc.0
+			IL_027d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0282: dup
+			IL_0283: ldc.i4.0
+			IL_0284: ldloc.1
+			IL_0285: stelem.ref
+			IL_0286: dup
+			IL_0287: ldc.i4.1
+			IL_0288: ldloc.2
+			IL_0289: stelem.ref
+			IL_028a: dup
+			IL_028b: ldc.i4.2
+			IL_028c: ldloc.3
+			IL_028d: stelem.ref
+			IL_028e: dup
+			IL_028f: ldc.i4.3
+			IL_0290: ldloc.s 4
+			IL_0292: stelem.ref
+			IL_0293: dup
+			IL_0294: ldc.i4.4
+			IL_0295: ldloc.s 5
+			IL_0297: stelem.ref
+			IL_0298: dup
+			IL_0299: ldc.i4.5
+			IL_029a: ldloc.s 6
 			IL_029c: stelem.ref
 			IL_029d: dup
-			IL_029e: ldc.i4.3
-			IL_029f: ldloc.s 4
+			IL_029e: ldc.i4.6
+			IL_029f: ldloc.s 7
 			IL_02a1: stelem.ref
 			IL_02a2: dup
-			IL_02a3: ldc.i4.4
-			IL_02a4: ldloc.s 5
+			IL_02a3: ldc.i4.7
+			IL_02a4: ldloc.s 8
 			IL_02a6: stelem.ref
 			IL_02a7: dup
-			IL_02a8: ldc.i4.5
-			IL_02a9: ldloc.s 6
+			IL_02a8: ldc.i4.8
+			IL_02a9: ldloc.s 9
 			IL_02ab: stelem.ref
-			IL_02ac: dup
-			IL_02ad: ldc.i4.6
-			IL_02ae: ldloc.s 7
-			IL_02b0: stelem.ref
-			IL_02b1: dup
-			IL_02b2: ldc.i4.7
-			IL_02b3: ldloc.s 8
-			IL_02b5: stelem.ref
-			IL_02b6: dup
-			IL_02b7: ldc.i4.8
-			IL_02b8: ldloc.s 9
-			IL_02ba: stelem.ref
-			IL_02bb: pop
-			IL_02bc: ldloc.0
-			IL_02bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c7: ret
+			IL_02ac: pop
+			IL_02ad: ldloc.0
+			IL_02ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02b3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02b8: ret
 
-			IL_02c8: ldloc.0
-			IL_02c9: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited3
-			IL_02ce: pop
-			IL_02cf: ldloc.1
-			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d5: stloc.s 8
-			IL_02d7: ldloc.s 8
-			IL_02d9: ldstr "next"
-			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_02e3: stloc.s 8
-			IL_02e5: ldloc.0
-			IL_02e6: ldc.i4.4
-			IL_02e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02ec: ldloc.0
-			IL_02ed: ldloc.s 8
-			IL_02ef: ldarg.0
-			IL_02f0: ldc.i4.4
-			IL_02f1: ldloc.0
-			IL_02f2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02fc: ldloc.0
-			IL_02fd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0302: dup
-			IL_0303: ldc.i4.0
-			IL_0304: ldloc.1
-			IL_0305: stelem.ref
-			IL_0306: dup
-			IL_0307: ldc.i4.1
-			IL_0308: ldloc.2
-			IL_0309: stelem.ref
-			IL_030a: dup
-			IL_030b: ldc.i4.2
-			IL_030c: ldloc.3
+			IL_02b9: ldloc.0
+			IL_02ba: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited3
+			IL_02bf: pop
+			IL_02c0: ldloc.1
+			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c6: stloc.s 8
+			IL_02c8: ldloc.s 8
+			IL_02ca: ldstr "next"
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_02d4: stloc.s 8
+			IL_02d6: ldloc.0
+			IL_02d7: ldc.i4.4
+			IL_02d8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02dd: ldloc.0
+			IL_02de: ldloc.s 8
+			IL_02e0: ldarg.0
+			IL_02e1: ldc.i4.4
+			IL_02e2: ldloc.0
+			IL_02e3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02ed: ldloc.0
+			IL_02ee: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02f3: dup
+			IL_02f4: ldc.i4.0
+			IL_02f5: ldloc.1
+			IL_02f6: stelem.ref
+			IL_02f7: dup
+			IL_02f8: ldc.i4.1
+			IL_02f9: ldloc.2
+			IL_02fa: stelem.ref
+			IL_02fb: dup
+			IL_02fc: ldc.i4.2
+			IL_02fd: ldloc.3
+			IL_02fe: stelem.ref
+			IL_02ff: dup
+			IL_0300: ldc.i4.3
+			IL_0301: ldloc.s 4
+			IL_0303: stelem.ref
+			IL_0304: dup
+			IL_0305: ldc.i4.4
+			IL_0306: ldloc.s 5
+			IL_0308: stelem.ref
+			IL_0309: dup
+			IL_030a: ldc.i4.5
+			IL_030b: ldloc.s 6
 			IL_030d: stelem.ref
 			IL_030e: dup
-			IL_030f: ldc.i4.3
-			IL_0310: ldloc.s 4
+			IL_030f: ldc.i4.6
+			IL_0310: ldloc.s 7
 			IL_0312: stelem.ref
 			IL_0313: dup
-			IL_0314: ldc.i4.4
-			IL_0315: ldloc.s 5
+			IL_0314: ldc.i4.7
+			IL_0315: ldloc.s 8
 			IL_0317: stelem.ref
 			IL_0318: dup
-			IL_0319: ldc.i4.5
-			IL_031a: ldloc.s 6
+			IL_0319: ldc.i4.8
+			IL_031a: ldloc.s 9
 			IL_031c: stelem.ref
-			IL_031d: dup
-			IL_031e: ldc.i4.6
-			IL_031f: ldloc.s 7
-			IL_0321: stelem.ref
-			IL_0322: dup
-			IL_0323: ldc.i4.7
-			IL_0324: ldloc.s 8
-			IL_0326: stelem.ref
-			IL_0327: dup
-			IL_0328: ldc.i4.8
-			IL_0329: ldloc.s 9
-			IL_032b: stelem.ref
-			IL_032c: pop
-			IL_032d: ldloc.0
-			IL_032e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0333: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0338: ret
+			IL_031d: pop
+			IL_031e: ldloc.0
+			IL_031f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0324: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0329: ret
 
-			IL_0339: ldloc.0
-			IL_033a: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited4
-			IL_033f: stloc.3
-			IL_0340: ldloc.1
-			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0346: stloc.s 8
-			IL_0348: ldloc.s 8
-			IL_034a: ldstr "next"
-			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0354: stloc.s 8
-			IL_0356: ldloc.0
-			IL_0357: ldc.i4.5
-			IL_0358: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_035d: ldloc.0
-			IL_035e: ldloc.s 8
-			IL_0360: ldarg.0
-			IL_0361: ldc.i4.5
-			IL_0362: ldloc.0
-			IL_0363: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0368: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_036d: ldloc.0
-			IL_036e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0373: dup
-			IL_0374: ldc.i4.0
-			IL_0375: ldloc.1
-			IL_0376: stelem.ref
-			IL_0377: dup
-			IL_0378: ldc.i4.1
-			IL_0379: ldloc.2
-			IL_037a: stelem.ref
-			IL_037b: dup
-			IL_037c: ldc.i4.2
-			IL_037d: ldloc.3
+			IL_032a: ldloc.0
+			IL_032b: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited4
+			IL_0330: stloc.3
+			IL_0331: ldloc.1
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0337: stloc.s 8
+			IL_0339: ldloc.s 8
+			IL_033b: ldstr "next"
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0345: stloc.s 8
+			IL_0347: ldloc.0
+			IL_0348: ldc.i4.5
+			IL_0349: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_034e: ldloc.0
+			IL_034f: ldloc.s 8
+			IL_0351: ldarg.0
+			IL_0352: ldc.i4.5
+			IL_0353: ldloc.0
+			IL_0354: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0359: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_035e: ldloc.0
+			IL_035f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0364: dup
+			IL_0365: ldc.i4.0
+			IL_0366: ldloc.1
+			IL_0367: stelem.ref
+			IL_0368: dup
+			IL_0369: ldc.i4.1
+			IL_036a: ldloc.2
+			IL_036b: stelem.ref
+			IL_036c: dup
+			IL_036d: ldc.i4.2
+			IL_036e: ldloc.3
+			IL_036f: stelem.ref
+			IL_0370: dup
+			IL_0371: ldc.i4.3
+			IL_0372: ldloc.s 4
+			IL_0374: stelem.ref
+			IL_0375: dup
+			IL_0376: ldc.i4.4
+			IL_0377: ldloc.s 5
+			IL_0379: stelem.ref
+			IL_037a: dup
+			IL_037b: ldc.i4.5
+			IL_037c: ldloc.s 6
 			IL_037e: stelem.ref
 			IL_037f: dup
-			IL_0380: ldc.i4.3
-			IL_0381: ldloc.s 4
+			IL_0380: ldc.i4.6
+			IL_0381: ldloc.s 7
 			IL_0383: stelem.ref
 			IL_0384: dup
-			IL_0385: ldc.i4.4
-			IL_0386: ldloc.s 5
+			IL_0385: ldc.i4.7
+			IL_0386: ldloc.s 8
 			IL_0388: stelem.ref
 			IL_0389: dup
-			IL_038a: ldc.i4.5
-			IL_038b: ldloc.s 6
+			IL_038a: ldc.i4.8
+			IL_038b: ldloc.s 9
 			IL_038d: stelem.ref
-			IL_038e: dup
-			IL_038f: ldc.i4.6
-			IL_0390: ldloc.s 7
-			IL_0392: stelem.ref
-			IL_0393: dup
-			IL_0394: ldc.i4.7
-			IL_0395: ldloc.s 8
-			IL_0397: stelem.ref
-			IL_0398: dup
-			IL_0399: ldc.i4.8
-			IL_039a: ldloc.s 9
-			IL_039c: stelem.ref
-			IL_039d: pop
-			IL_039e: ldloc.0
-			IL_039f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03a9: ret
+			IL_038e: pop
+			IL_038f: ldloc.0
+			IL_0390: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0395: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_039a: ret
 
-			IL_03aa: ldloc.0
-			IL_03ab: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited5
-			IL_03b0: stloc.s 4
-			IL_03b2: ldstr "console"
-			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03bc: stloc.s 8
-			IL_03be: ldloc.s 8
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c5: stloc.s 8
-			IL_03c7: ldloc.3
-			IL_03c8: ldstr "value"
-			IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d2: stloc.s 9
-			IL_03d4: ldloc.s 8
-			IL_03d6: ldstr "log"
-			IL_03db: ldloc.s 9
-			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03e2: pop
-			IL_03e3: ldstr "console"
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ed: stloc.s 9
-			IL_03ef: ldloc.s 9
-			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f6: stloc.s 9
-			IL_03f8: ldloc.3
-			IL_03f9: ldstr "done"
-			IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0403: stloc.s 8
-			IL_0405: ldloc.s 9
-			IL_0407: ldstr "log"
-			IL_040c: ldloc.s 8
-			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0413: pop
-			IL_0414: ldstr "console"
-			IL_0419: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_041e: stloc.s 8
-			IL_0420: ldloc.s 8
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0427: stloc.s 8
-			IL_0429: ldloc.s 4
-			IL_042b: ldstr "value"
-			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0435: stloc.s 9
-			IL_0437: ldloc.s 8
-			IL_0439: ldstr "log"
-			IL_043e: ldloc.s 9
-			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0445: pop
-			IL_0446: ldstr "console"
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0450: stloc.s 9
-			IL_0452: ldloc.s 9
-			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0459: stloc.s 9
-			IL_045b: ldloc.s 4
-			IL_045d: ldstr "done"
-			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0467: stloc.s 8
-			IL_0469: ldloc.s 9
-			IL_046b: ldstr "log"
-			IL_0470: ldloc.s 8
-			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0477: pop
-			IL_0478: ldloc.1
-			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_047e: stloc.s 8
-			IL_0480: ldloc.s 8
-			IL_0482: ldstr "return"
-			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_048c: stloc.s 8
-			IL_048e: ldloc.0
-			IL_048f: ldc.i4.6
-			IL_0490: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0495: ldloc.0
-			IL_0496: ldloc.s 8
-			IL_0498: ldarg.0
-			IL_0499: ldc.i4.6
-			IL_049a: ldloc.0
-			IL_049b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_04a5: ldloc.0
-			IL_04a6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04ab: dup
-			IL_04ac: ldc.i4.0
-			IL_04ad: ldloc.1
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.1
-			IL_04b1: ldloc.2
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.2
-			IL_04b5: ldloc.3
+			IL_039b: ldloc.0
+			IL_039c: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited5
+			IL_03a1: stloc.s 4
+			IL_03a3: ldstr "console"
+			IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03ad: stloc.s 8
+			IL_03af: ldloc.s 8
+			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b6: stloc.s 8
+			IL_03b8: ldloc.3
+			IL_03b9: ldstr "value"
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c3: stloc.s 9
+			IL_03c5: ldloc.s 8
+			IL_03c7: ldstr "log"
+			IL_03cc: ldloc.s 9
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03d3: pop
+			IL_03d4: ldstr "console"
+			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03de: stloc.s 9
+			IL_03e0: ldloc.s 9
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e7: stloc.s 9
+			IL_03e9: ldloc.3
+			IL_03ea: ldstr "done"
+			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03f4: stloc.s 8
+			IL_03f6: ldloc.s 9
+			IL_03f8: ldstr "log"
+			IL_03fd: ldloc.s 8
+			IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0404: pop
+			IL_0405: ldstr "console"
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_040f: stloc.s 8
+			IL_0411: ldloc.s 8
+			IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0418: stloc.s 8
+			IL_041a: ldloc.s 4
+			IL_041c: ldstr "value"
+			IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0426: stloc.s 9
+			IL_0428: ldloc.s 8
+			IL_042a: ldstr "log"
+			IL_042f: ldloc.s 9
+			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0436: pop
+			IL_0437: ldstr "console"
+			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0441: stloc.s 9
+			IL_0443: ldloc.s 9
+			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_044a: stloc.s 9
+			IL_044c: ldloc.s 4
+			IL_044e: ldstr "done"
+			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0458: stloc.s 8
+			IL_045a: ldloc.s 9
+			IL_045c: ldstr "log"
+			IL_0461: ldloc.s 8
+			IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0468: pop
+			IL_0469: ldloc.1
+			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_046f: stloc.s 8
+			IL_0471: ldloc.s 8
+			IL_0473: ldstr "return"
+			IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_047d: stloc.s 8
+			IL_047f: ldloc.0
+			IL_0480: ldc.i4.6
+			IL_0481: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0486: ldloc.0
+			IL_0487: ldloc.s 8
+			IL_0489: ldarg.0
+			IL_048a: ldc.i4.6
+			IL_048b: ldloc.0
+			IL_048c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0491: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0496: ldloc.0
+			IL_0497: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_049c: dup
+			IL_049d: ldc.i4.0
+			IL_049e: ldloc.1
+			IL_049f: stelem.ref
+			IL_04a0: dup
+			IL_04a1: ldc.i4.1
+			IL_04a2: ldloc.2
+			IL_04a3: stelem.ref
+			IL_04a4: dup
+			IL_04a5: ldc.i4.2
+			IL_04a6: ldloc.3
+			IL_04a7: stelem.ref
+			IL_04a8: dup
+			IL_04a9: ldc.i4.3
+			IL_04aa: ldloc.s 4
+			IL_04ac: stelem.ref
+			IL_04ad: dup
+			IL_04ae: ldc.i4.4
+			IL_04af: ldloc.s 5
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.5
+			IL_04b4: ldloc.s 6
 			IL_04b6: stelem.ref
 			IL_04b7: dup
-			IL_04b8: ldc.i4.3
-			IL_04b9: ldloc.s 4
+			IL_04b8: ldc.i4.6
+			IL_04b9: ldloc.s 7
 			IL_04bb: stelem.ref
 			IL_04bc: dup
-			IL_04bd: ldc.i4.4
-			IL_04be: ldloc.s 5
+			IL_04bd: ldc.i4.7
+			IL_04be: ldloc.s 8
 			IL_04c0: stelem.ref
 			IL_04c1: dup
-			IL_04c2: ldc.i4.5
-			IL_04c3: ldloc.s 6
+			IL_04c2: ldc.i4.8
+			IL_04c3: ldloc.s 9
 			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.6
-			IL_04c8: ldloc.s 7
-			IL_04ca: stelem.ref
-			IL_04cb: dup
-			IL_04cc: ldc.i4.7
-			IL_04cd: ldloc.s 8
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.8
-			IL_04d2: ldloc.s 9
-			IL_04d4: stelem.ref
-			IL_04d5: pop
-			IL_04d6: ldloc.0
-			IL_04d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04dc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04e1: ret
+			IL_04c6: pop
+			IL_04c7: ldloc.0
+			IL_04c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04d2: ret
 
-			IL_04e2: ldloc.0
-			IL_04e3: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited6
-			IL_04e8: stloc.s 5
-			IL_04ea: ldstr "console"
-			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04f4: stloc.s 8
-			IL_04f6: ldloc.s 8
-			IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04fd: stloc.s 8
-			IL_04ff: ldloc.s 5
-			IL_0501: ldstr "done"
-			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050b: stloc.s 9
-			IL_050d: ldloc.s 8
-			IL_050f: ldstr "log"
-			IL_0514: ldloc.s 9
-			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_051b: pop
-			IL_051c: ldloc.1
-			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0522: stloc.s 9
-			IL_0524: ldloc.s 9
-			IL_0526: ldstr "next"
-			IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0530: stloc.s 9
-			IL_0532: ldloc.0
-			IL_0533: ldc.i4.7
-			IL_0534: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0539: ldloc.0
-			IL_053a: ldloc.s 9
-			IL_053c: ldarg.0
-			IL_053d: ldc.i4.7
-			IL_053e: ldloc.0
-			IL_053f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0544: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0549: ldloc.0
-			IL_054a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_054f: dup
-			IL_0550: ldc.i4.0
-			IL_0551: ldloc.1
-			IL_0552: stelem.ref
-			IL_0553: dup
-			IL_0554: ldc.i4.1
-			IL_0555: ldloc.2
-			IL_0556: stelem.ref
-			IL_0557: dup
-			IL_0558: ldc.i4.2
-			IL_0559: ldloc.3
+			IL_04d3: ldloc.0
+			IL_04d4: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited6
+			IL_04d9: stloc.s 5
+			IL_04db: ldstr "console"
+			IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04e5: stloc.s 8
+			IL_04e7: ldloc.s 8
+			IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ee: stloc.s 8
+			IL_04f0: ldloc.s 5
+			IL_04f2: ldstr "done"
+			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fc: stloc.s 9
+			IL_04fe: ldloc.s 8
+			IL_0500: ldstr "log"
+			IL_0505: ldloc.s 9
+			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_050c: pop
+			IL_050d: ldloc.1
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0513: stloc.s 9
+			IL_0515: ldloc.s 9
+			IL_0517: ldstr "next"
+			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0521: stloc.s 9
+			IL_0523: ldloc.0
+			IL_0524: ldc.i4.7
+			IL_0525: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_052a: ldloc.0
+			IL_052b: ldloc.s 9
+			IL_052d: ldarg.0
+			IL_052e: ldc.i4.7
+			IL_052f: ldloc.0
+			IL_0530: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0535: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_053a: ldloc.0
+			IL_053b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0540: dup
+			IL_0541: ldc.i4.0
+			IL_0542: ldloc.1
+			IL_0543: stelem.ref
+			IL_0544: dup
+			IL_0545: ldc.i4.1
+			IL_0546: ldloc.2
+			IL_0547: stelem.ref
+			IL_0548: dup
+			IL_0549: ldc.i4.2
+			IL_054a: ldloc.3
+			IL_054b: stelem.ref
+			IL_054c: dup
+			IL_054d: ldc.i4.3
+			IL_054e: ldloc.s 4
+			IL_0550: stelem.ref
+			IL_0551: dup
+			IL_0552: ldc.i4.4
+			IL_0553: ldloc.s 5
+			IL_0555: stelem.ref
+			IL_0556: dup
+			IL_0557: ldc.i4.5
+			IL_0558: ldloc.s 6
 			IL_055a: stelem.ref
 			IL_055b: dup
-			IL_055c: ldc.i4.3
-			IL_055d: ldloc.s 4
+			IL_055c: ldc.i4.6
+			IL_055d: ldloc.s 7
 			IL_055f: stelem.ref
 			IL_0560: dup
-			IL_0561: ldc.i4.4
-			IL_0562: ldloc.s 5
+			IL_0561: ldc.i4.7
+			IL_0562: ldloc.s 8
 			IL_0564: stelem.ref
 			IL_0565: dup
-			IL_0566: ldc.i4.5
-			IL_0567: ldloc.s 6
+			IL_0566: ldc.i4.8
+			IL_0567: ldloc.s 9
 			IL_0569: stelem.ref
-			IL_056a: dup
-			IL_056b: ldc.i4.6
-			IL_056c: ldloc.s 7
-			IL_056e: stelem.ref
-			IL_056f: dup
-			IL_0570: ldc.i4.7
-			IL_0571: ldloc.s 8
-			IL_0573: stelem.ref
-			IL_0574: dup
-			IL_0575: ldc.i4.8
-			IL_0576: ldloc.s 9
-			IL_0578: stelem.ref
-			IL_0579: pop
-			IL_057a: ldloc.0
-			IL_057b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0580: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0585: ret
+			IL_056a: pop
+			IL_056b: ldloc.0
+			IL_056c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0571: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0576: ret
 
-			IL_0586: ldloc.0
-			IL_0587: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited7
-			IL_058c: stloc.s 6
-			IL_058e: ldstr "console"
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0598: stloc.s 9
-			IL_059a: ldloc.s 9
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a1: stloc.s 9
-			IL_05a3: ldloc.s 6
-			IL_05a5: ldstr "done"
-			IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05af: stloc.s 8
-			IL_05b1: ldloc.s 9
-			IL_05b3: ldstr "log"
-			IL_05b8: ldloc.s 8
-			IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05bf: pop
-			IL_05c0: ldloc.0
-			IL_05c1: ldc.i4.m1
-			IL_05c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c7: ldloc.0
-			IL_05c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05d2: ldarg.0
-			IL_05d3: ldc.i4.1
-			IL_05d4: newarr [System.Runtime]System.Object
-			IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05de: pop
-			IL_05df: ldloc.0
-			IL_05e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05ea: ret
+			IL_0577: ldloc.0
+			IL_0578: ldfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/Scope::_awaited7
+			IL_057d: stloc.s 6
+			IL_057f: ldstr "console"
+			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0589: stloc.s 9
+			IL_058b: ldloc.s 9
+			IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0592: stloc.s 9
+			IL_0594: ldloc.s 6
+			IL_0596: ldstr "done"
+			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a0: stloc.s 8
+			IL_05a2: ldloc.s 9
+			IL_05a4: ldstr "log"
+			IL_05a9: ldloc.s 8
+			IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05b0: pop
+			IL_05b1: ldloc.0
+			IL_05b2: ldc.i4.m1
+			IL_05b3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05b8: ldloc.0
+			IL_05b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_05c3: ldarg.0
+			IL_05c4: ldc.i4.1
+			IL_05c5: newarr [System.Runtime]System.Object
+			IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05cf: pop
+			IL_05d0: ldloc.0
+			IL_05d1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05d6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05db: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -794,14 +791,14 @@
 			6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 		.field public object main
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26a7
+			// Method begins at RVA 0x2698
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -860,7 +857,7 @@
 		IL_003b: stloc.2
 		IL_003c: ldloc.0
 		IL_003d: ldloc.2
-		IL_003e: stfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
+		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
 		IL_0043: nop
 		IL_0044: ldloc.1
 		IL_0045: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -878,7 +875,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26b9
+		// Method begins at RVA 0x26aa
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24df
+				// Method begins at RVA 0x24da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x24fa
+						// Method begins at RVA 0x24f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24f1
+					// Method begins at RVA 0x24ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24e8
+				// Method begins at RVA 0x24e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			)
 			// Method begins at RVA 0x20b0
 			// Header size: 12
-			// Code size: 1050 (0x41a)
+			// Code size: 1045 (0x415)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope,
@@ -233,7 +233,7 @@
 
 			IL_00ca: ldloc.0
 			IL_00cb: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00d0: switch (IL_00e9, IL_0267, IL_0327, IL_01e7, IL_031b)
+			IL_00d0: switch (IL_00e9, IL_0262, IL_0322, IL_01e2, IL_0316)
 
 			IL_00e9: ldc.r8 0.0
 			IL_00f2: stloc.1
@@ -241,345 +241,344 @@
 			IL_00f4: ldc.i4.1
 			IL_00f5: ldelem.ref
 			IL_00f6: castclass Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope
-			IL_00fb: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
-			IL_0100: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_0105: stloc.s 8
-			IL_0107: ldloc.s 8
-			IL_0109: ldc.r8 0.0
-			IL_0112: box [System.Runtime]System.Double
-			IL_0117: ldstr "tick"
-			IL_011c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object)
-			IL_0121: stloc.s 9
-			IL_0123: ldloc.s 9
-			IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetAsyncIterator(object)
-			IL_012a: stloc.2
-			IL_012b: ldc.i4.0
-			IL_012c: stloc.3
-			IL_012d: ldc.i4.0
-			IL_012e: stloc.s 4
-			IL_0130: ldloc.0
-			IL_0131: ldc.i4.0
-			IL_0132: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0137: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_013c: ldloc.0
-			IL_013d: ldc.i4.0
-			IL_013e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0143: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0148: ldloc.0
-			IL_0149: ldc.i4.0
-			IL_014a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_014f: ldloc.0
-			IL_0150: ldc.i4.0
-			IL_0151: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_00fb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
+			IL_0100: stloc.s 8
+			IL_0102: ldloc.s 8
+			IL_0104: ldc.r8 0.0
+			IL_010d: box [System.Runtime]System.Double
+			IL_0112: ldstr "tick"
+			IL_0117: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object)
+			IL_011c: stloc.s 9
+			IL_011e: ldloc.s 9
+			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetAsyncIterator(object)
+			IL_0125: stloc.2
+			IL_0126: ldc.i4.0
+			IL_0127: stloc.3
+			IL_0128: ldc.i4.0
+			IL_0129: stloc.s 4
+			IL_012b: ldloc.0
+			IL_012c: ldc.i4.0
+			IL_012d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0132: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0137: ldloc.0
+			IL_0138: ldc.i4.0
+			IL_0139: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_013e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0143: ldloc.0
+			IL_0144: ldc.i4.0
+			IL_0145: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_014a: ldloc.0
+			IL_014b: ldc.i4.0
+			IL_014c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_0156: ldloc.2
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorNext(object)
-			IL_015c: stloc.s 9
-			IL_015e: ldloc.0
-			IL_015f: ldc.i4.3
-			IL_0160: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0151: ldloc.2
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorNext(object)
+			IL_0157: stloc.s 9
+			IL_0159: ldloc.0
+			IL_015a: ldc.i4.3
+			IL_015b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0160: ldloc.0
+			IL_0161: ldloc.s 9
+			IL_0163: ldarg.0
+			IL_0164: ldc.i4.1
 			IL_0165: ldloc.0
-			IL_0166: ldloc.s 9
-			IL_0168: ldarg.0
-			IL_0169: ldc.i4.1
-			IL_016a: ldloc.0
-			IL_016b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0170: ldc.i4.1
-			IL_0171: ldstr "_pendingException"
-			IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_017b: ldloc.0
-			IL_017c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0181: dup
-			IL_0182: ldc.i4.0
-			IL_0183: ldloc.1
-			IL_0184: box [System.Runtime]System.Double
-			IL_0189: stelem.ref
-			IL_018a: dup
-			IL_018b: ldc.i4.1
-			IL_018c: ldloc.2
-			IL_018d: stelem.ref
-			IL_018e: dup
-			IL_018f: ldc.i4.2
-			IL_0190: ldloc.3
-			IL_0191: box [System.Runtime]System.Boolean
-			IL_0196: stelem.ref
-			IL_0197: dup
-			IL_0198: ldc.i4.3
-			IL_0199: ldloc.s 4
-			IL_019b: box [System.Runtime]System.Boolean
+			IL_0166: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_016b: ldc.i4.1
+			IL_016c: ldstr "_pendingException"
+			IL_0171: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0176: ldloc.0
+			IL_0177: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_017c: dup
+			IL_017d: ldc.i4.0
+			IL_017e: ldloc.1
+			IL_017f: box [System.Runtime]System.Double
+			IL_0184: stelem.ref
+			IL_0185: dup
+			IL_0186: ldc.i4.1
+			IL_0187: ldloc.2
+			IL_0188: stelem.ref
+			IL_0189: dup
+			IL_018a: ldc.i4.2
+			IL_018b: ldloc.3
+			IL_018c: box [System.Runtime]System.Boolean
+			IL_0191: stelem.ref
+			IL_0192: dup
+			IL_0193: ldc.i4.3
+			IL_0194: ldloc.s 4
+			IL_0196: box [System.Runtime]System.Boolean
+			IL_019b: stelem.ref
+			IL_019c: dup
+			IL_019d: ldc.i4.4
+			IL_019e: ldloc.s 5
 			IL_01a0: stelem.ref
 			IL_01a1: dup
-			IL_01a2: ldc.i4.4
-			IL_01a3: ldloc.s 5
-			IL_01a5: stelem.ref
-			IL_01a6: dup
-			IL_01a7: ldc.i4.5
-			IL_01a8: ldloc.s 6
-			IL_01aa: box [System.Runtime]System.Boolean
-			IL_01af: stelem.ref
-			IL_01b0: dup
-			IL_01b1: ldc.i4.6
-			IL_01b2: ldloc.s 7
-			IL_01b4: box [System.Runtime]System.Boolean
+			IL_01a2: ldc.i4.5
+			IL_01a3: ldloc.s 6
+			IL_01a5: box [System.Runtime]System.Boolean
+			IL_01aa: stelem.ref
+			IL_01ab: dup
+			IL_01ac: ldc.i4.6
+			IL_01ad: ldloc.s 7
+			IL_01af: box [System.Runtime]System.Boolean
+			IL_01b4: stelem.ref
+			IL_01b5: dup
+			IL_01b6: ldc.i4.7
+			IL_01b7: ldloc.s 8
 			IL_01b9: stelem.ref
 			IL_01ba: dup
-			IL_01bb: ldc.i4.7
-			IL_01bc: ldloc.s 8
+			IL_01bb: ldc.i4.8
+			IL_01bc: ldloc.s 9
 			IL_01be: stelem.ref
 			IL_01bf: dup
-			IL_01c0: ldc.i4.8
-			IL_01c1: ldloc.s 9
-			IL_01c3: stelem.ref
-			IL_01c4: dup
-			IL_01c5: ldc.i4.s 9
-			IL_01c7: ldloc.s 10
-			IL_01c9: box [System.Runtime]System.Boolean
-			IL_01ce: stelem.ref
-			IL_01cf: dup
-			IL_01d0: ldc.i4.s 10
-			IL_01d2: ldloc.s 11
-			IL_01d4: box [System.Runtime]System.Double
-			IL_01d9: stelem.ref
-			IL_01da: pop
-			IL_01db: ldloc.0
-			IL_01dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01e6: ret
+			IL_01c0: ldc.i4.s 9
+			IL_01c2: ldloc.s 10
+			IL_01c4: box [System.Runtime]System.Boolean
+			IL_01c9: stelem.ref
+			IL_01ca: dup
+			IL_01cb: ldc.i4.s 10
+			IL_01cd: ldloc.s 11
+			IL_01cf: box [System.Runtime]System.Double
+			IL_01d4: stelem.ref
+			IL_01d5: pop
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01dc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01e1: ret
 
-			IL_01e7: ldloc.0
-			IL_01e8: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited1
-			IL_01ed: stloc.s 9
-			IL_01ef: ldloc.s 9
-			IL_01f1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-			IL_01f6: stloc.s 10
-			IL_01f8: ldloc.s 10
-			IL_01fa: brtrue IL_0260
+			IL_01e2: ldloc.0
+			IL_01e3: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited1
+			IL_01e8: stloc.s 9
+			IL_01ea: ldloc.s 9
+			IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+			IL_01f1: stloc.s 10
+			IL_01f3: ldloc.s 10
+			IL_01f5: brtrue IL_025b
 
-			IL_01ff: ldloc.s 9
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-			IL_0206: stloc.s 9
-			IL_0208: ldloc.s 9
-			IL_020a: stloc.s 5
-			IL_020c: ldstr "console"
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0216: stloc.s 9
-			IL_0218: ldloc.s 9
-			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021f: stloc.s 9
-			IL_0221: ldloc.s 9
-			IL_0223: ldstr "log"
-			IL_0228: ldloc.s 5
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_022f: pop
-			IL_0230: ldloc.1
-			IL_0231: ldc.r8 1
-			IL_023a: add
-			IL_023b: stloc.1
-			IL_023c: ldloc.1
-			IL_023d: stloc.s 11
-			IL_023f: ldloc.s 11
-			IL_0241: ldc.r8 3
-			IL_024a: ceq
-			IL_024c: brfalse IL_0256
+			IL_01fa: ldloc.s 9
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+			IL_0201: stloc.s 9
+			IL_0203: ldloc.s 9
+			IL_0205: stloc.s 5
+			IL_0207: ldstr "console"
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0211: stloc.s 9
+			IL_0213: ldloc.s 9
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021a: stloc.s 9
+			IL_021c: ldloc.s 9
+			IL_021e: ldstr "log"
+			IL_0223: ldloc.s 5
+			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022a: pop
+			IL_022b: ldloc.1
+			IL_022c: ldc.r8 1
+			IL_0235: add
+			IL_0236: stloc.1
+			IL_0237: ldloc.1
+			IL_0238: stloc.s 11
+			IL_023a: ldloc.s 11
+			IL_023c: ldc.r8 3
+			IL_0245: ceq
+			IL_0247: brfalse IL_0251
 
-			IL_0251: br IL_025b
+			IL_024c: br IL_0256
 
-			IL_0256: br IL_0156
+			IL_0251: br IL_0151
 
-			IL_025b: br IL_027a
+			IL_0256: br IL_0275
 
-			IL_0260: ldc.i4.1
-			IL_0261: stloc.3
-			IL_0262: br IL_027a
+			IL_025b: ldc.i4.1
+			IL_025c: stloc.3
+			IL_025d: br IL_0275
 
-			IL_0267: ldloc.0
-			IL_0268: ldc.i4.1
-			IL_0269: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_026e: ldloc.0
-			IL_026f: ldc.i4.0
-			IL_0270: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0275: br IL_027a
+			IL_0262: ldloc.0
+			IL_0263: ldc.i4.1
+			IL_0264: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0269: ldloc.0
+			IL_026a: ldc.i4.0
+			IL_026b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0270: br IL_0275
 
-			IL_027a: ldloc.3
-			IL_027b: brtrue IL_0322
+			IL_0275: ldloc.3
+			IL_0276: brtrue IL_031d
 
-			IL_0280: ldloc.s 4
-			IL_0282: brtrue IL_0322
+			IL_027b: ldloc.s 4
+			IL_027d: brtrue IL_031d
 
-			IL_0287: ldc.i4.1
-			IL_0288: stloc.s 4
-			IL_028a: ldloc.2
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorClose(object)
-			IL_0290: stloc.s 9
-			IL_0292: ldloc.0
-			IL_0293: ldc.i4.4
-			IL_0294: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0282: ldc.i4.1
+			IL_0283: stloc.s 4
+			IL_0285: ldloc.2
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorClose(object)
+			IL_028b: stloc.s 9
+			IL_028d: ldloc.0
+			IL_028e: ldc.i4.4
+			IL_028f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0294: ldloc.0
+			IL_0295: ldloc.s 9
+			IL_0297: ldarg.0
+			IL_0298: ldc.i4.2
 			IL_0299: ldloc.0
-			IL_029a: ldloc.s 9
-			IL_029c: ldarg.0
-			IL_029d: ldc.i4.2
-			IL_029e: ldloc.0
-			IL_029f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02a4: ldc.i4.2
-			IL_02a5: ldstr "_pendingException"
-			IL_02aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_02af: ldloc.0
-			IL_02b0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02b5: dup
-			IL_02b6: ldc.i4.0
-			IL_02b7: ldloc.1
-			IL_02b8: box [System.Runtime]System.Double
-			IL_02bd: stelem.ref
-			IL_02be: dup
-			IL_02bf: ldc.i4.1
-			IL_02c0: ldloc.2
-			IL_02c1: stelem.ref
-			IL_02c2: dup
-			IL_02c3: ldc.i4.2
-			IL_02c4: ldloc.3
-			IL_02c5: box [System.Runtime]System.Boolean
-			IL_02ca: stelem.ref
-			IL_02cb: dup
-			IL_02cc: ldc.i4.3
-			IL_02cd: ldloc.s 4
-			IL_02cf: box [System.Runtime]System.Boolean
+			IL_029a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_029f: ldc.i4.2
+			IL_02a0: ldstr "_pendingException"
+			IL_02a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_02aa: ldloc.0
+			IL_02ab: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02b0: dup
+			IL_02b1: ldc.i4.0
+			IL_02b2: ldloc.1
+			IL_02b3: box [System.Runtime]System.Double
+			IL_02b8: stelem.ref
+			IL_02b9: dup
+			IL_02ba: ldc.i4.1
+			IL_02bb: ldloc.2
+			IL_02bc: stelem.ref
+			IL_02bd: dup
+			IL_02be: ldc.i4.2
+			IL_02bf: ldloc.3
+			IL_02c0: box [System.Runtime]System.Boolean
+			IL_02c5: stelem.ref
+			IL_02c6: dup
+			IL_02c7: ldc.i4.3
+			IL_02c8: ldloc.s 4
+			IL_02ca: box [System.Runtime]System.Boolean
+			IL_02cf: stelem.ref
+			IL_02d0: dup
+			IL_02d1: ldc.i4.4
+			IL_02d2: ldloc.s 5
 			IL_02d4: stelem.ref
 			IL_02d5: dup
-			IL_02d6: ldc.i4.4
-			IL_02d7: ldloc.s 5
-			IL_02d9: stelem.ref
-			IL_02da: dup
-			IL_02db: ldc.i4.5
-			IL_02dc: ldloc.s 6
-			IL_02de: box [System.Runtime]System.Boolean
-			IL_02e3: stelem.ref
-			IL_02e4: dup
-			IL_02e5: ldc.i4.6
-			IL_02e6: ldloc.s 7
-			IL_02e8: box [System.Runtime]System.Boolean
+			IL_02d6: ldc.i4.5
+			IL_02d7: ldloc.s 6
+			IL_02d9: box [System.Runtime]System.Boolean
+			IL_02de: stelem.ref
+			IL_02df: dup
+			IL_02e0: ldc.i4.6
+			IL_02e1: ldloc.s 7
+			IL_02e3: box [System.Runtime]System.Boolean
+			IL_02e8: stelem.ref
+			IL_02e9: dup
+			IL_02ea: ldc.i4.7
+			IL_02eb: ldloc.s 8
 			IL_02ed: stelem.ref
 			IL_02ee: dup
-			IL_02ef: ldc.i4.7
-			IL_02f0: ldloc.s 8
+			IL_02ef: ldc.i4.8
+			IL_02f0: ldloc.s 9
 			IL_02f2: stelem.ref
 			IL_02f3: dup
-			IL_02f4: ldc.i4.8
-			IL_02f5: ldloc.s 9
-			IL_02f7: stelem.ref
-			IL_02f8: dup
-			IL_02f9: ldc.i4.s 9
-			IL_02fb: ldloc.s 10
-			IL_02fd: box [System.Runtime]System.Boolean
-			IL_0302: stelem.ref
-			IL_0303: dup
-			IL_0304: ldc.i4.s 10
-			IL_0306: ldloc.s 11
-			IL_0308: box [System.Runtime]System.Double
-			IL_030d: stelem.ref
-			IL_030e: pop
-			IL_030f: ldloc.0
-			IL_0310: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0315: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_031a: ret
+			IL_02f4: ldc.i4.s 9
+			IL_02f6: ldloc.s 10
+			IL_02f8: box [System.Runtime]System.Boolean
+			IL_02fd: stelem.ref
+			IL_02fe: dup
+			IL_02ff: ldc.i4.s 10
+			IL_0301: ldloc.s 11
+			IL_0303: box [System.Runtime]System.Double
+			IL_0308: stelem.ref
+			IL_0309: pop
+			IL_030a: ldloc.0
+			IL_030b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0310: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0315: ret
 
-			IL_031b: ldloc.0
-			IL_031c: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited2
-			IL_0321: pop
+			IL_0316: ldloc.0
+			IL_0317: ldfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/Scope::_awaited2
+			IL_031c: pop
 
-			IL_0322: br IL_033a
+			IL_031d: br IL_0335
 
-			IL_0327: ldloc.0
-			IL_0328: ldc.i4.1
-			IL_0329: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_032e: ldloc.0
-			IL_032f: ldc.i4.0
-			IL_0330: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0335: br IL_033a
+			IL_0322: ldloc.0
+			IL_0323: ldc.i4.1
+			IL_0324: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0329: ldloc.0
+			IL_032a: ldc.i4.0
+			IL_032b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0330: br IL_0335
 
-			IL_033a: ldloc.0
-			IL_033b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0340: stloc.s 6
-			IL_0342: ldloc.s 6
-			IL_0344: brfalse IL_0381
+			IL_0335: ldloc.0
+			IL_0336: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_033b: stloc.s 6
+			IL_033d: ldloc.s 6
+			IL_033f: brfalse IL_037c
 
-			IL_0349: ldloc.0
-			IL_034a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_034f: stloc.s 9
-			IL_0351: ldloc.0
-			IL_0352: ldc.i4.m1
-			IL_0353: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0358: ldloc.0
-			IL_0359: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0363: ldarg.0
-			IL_0364: ldc.i4.1
-			IL_0365: newarr [System.Runtime]System.Object
-			IL_036a: dup
-			IL_036b: ldc.i4.0
-			IL_036c: ldloc.s 9
-			IL_036e: stelem.ref
-			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0374: pop
-			IL_0375: ldloc.0
-			IL_0376: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_037b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0380: ret
+			IL_0344: ldloc.0
+			IL_0345: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_034a: stloc.s 9
+			IL_034c: ldloc.0
+			IL_034d: ldc.i4.m1
+			IL_034e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0353: ldloc.0
+			IL_0354: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0359: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_035e: ldarg.0
+			IL_035f: ldc.i4.1
+			IL_0360: newarr [System.Runtime]System.Object
+			IL_0365: dup
+			IL_0366: ldc.i4.0
+			IL_0367: ldloc.s 9
+			IL_0369: stelem.ref
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_036f: pop
+			IL_0370: ldloc.0
+			IL_0371: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0376: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_037b: ret
 
-			IL_0381: ldloc.0
-			IL_0382: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0387: stloc.s 7
-			IL_0389: ldloc.s 7
-			IL_038b: brfalse IL_03c8
+			IL_037c: ldloc.0
+			IL_037d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0382: stloc.s 7
+			IL_0384: ldloc.s 7
+			IL_0386: brfalse IL_03c3
 
-			IL_0390: ldloc.0
-			IL_0391: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0396: stloc.s 9
-			IL_0398: ldloc.0
-			IL_0399: ldc.i4.m1
-			IL_039a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_039f: ldloc.0
-			IL_03a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03aa: ldarg.0
-			IL_03ab: ldc.i4.1
-			IL_03ac: newarr [System.Runtime]System.Object
-			IL_03b1: dup
-			IL_03b2: ldc.i4.0
-			IL_03b3: ldloc.s 9
-			IL_03b5: stelem.ref
-			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03bb: pop
-			IL_03bc: ldloc.0
-			IL_03bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03c7: ret
+			IL_038b: ldloc.0
+			IL_038c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0391: stloc.s 9
+			IL_0393: ldloc.0
+			IL_0394: ldc.i4.m1
+			IL_0395: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_039a: ldloc.0
+			IL_039b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03a5: ldarg.0
+			IL_03a6: ldc.i4.1
+			IL_03a7: newarr [System.Runtime]System.Object
+			IL_03ac: dup
+			IL_03ad: ldc.i4.0
+			IL_03ae: ldloc.s 9
+			IL_03b0: stelem.ref
+			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03b6: pop
+			IL_03b7: ldloc.0
+			IL_03b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03c2: ret
 
-			IL_03c8: ldstr "console"
-			IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03d2: stloc.s 9
-			IL_03d4: ldloc.s 9
-			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03db: stloc.s 9
-			IL_03dd: ldloc.s 9
-			IL_03df: ldstr "log"
-			IL_03e4: ldstr "break-done"
-			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03ee: pop
-			IL_03ef: ldloc.0
-			IL_03f0: ldc.i4.m1
-			IL_03f1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03f6: ldloc.0
-			IL_03f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0401: ldarg.0
-			IL_0402: ldc.i4.1
-			IL_0403: newarr [System.Runtime]System.Object
-			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_040d: pop
-			IL_040e: ldloc.0
-			IL_040f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0414: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0419: ret
+			IL_03c3: ldstr "console"
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03cd: stloc.s 9
+			IL_03cf: ldloc.s 9
+			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d6: stloc.s 9
+			IL_03d8: ldloc.s 9
+			IL_03da: ldstr "log"
+			IL_03df: ldstr "break-done"
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03e9: pop
+			IL_03ea: ldloc.0
+			IL_03eb: ldc.i4.m1
+			IL_03ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03f1: ldloc.0
+			IL_03f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03fc: ldarg.0
+			IL_03fd: ldc.i4.1
+			IL_03fe: newarr [System.Runtime]System.Object
+			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0408: pop
+			IL_0409: ldloc.0
+			IL_040a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_040f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0414: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -594,14 +593,14 @@
 			6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 		.field public object main
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24d6
+			// Method begins at RVA 0x24d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -660,7 +659,7 @@
 		IL_003b: stloc.2
 		IL_003c: ldloc.0
 		IL_003d: ldloc.2
-		IL_003e: stfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
+		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
 		IL_0043: nop
 		IL_0044: ldloc.1
 		IL_0045: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -678,7 +677,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2503
+		// Method begins at RVA 0x24fe
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
@@ -33,7 +33,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2321
+				// Method begins at RVA 0x231c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -59,7 +59,7 @@
 			)
 			// Method begins at RVA 0x20b0
 			// Header size: 12
-			// Code size: 604 (0x25c)
+			// Code size: 599 (0x257)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope,
@@ -141,191 +141,190 @@
 
 			IL_0086: ldloc.0
 			IL_0087: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_008c: switch (IL_009d, IL_0135, IL_01f9)
+			IL_008c: switch (IL_009d, IL_0130, IL_01f4)
 
 			IL_009d: ldarg.0
 			IL_009e: ldc.i4.1
 			IL_009f: ldelem.ref
 			IL_00a0: castclass Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope
-			IL_00a5: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
-			IL_00aa: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
-			IL_00af: stloc.s 4
-			IL_00b1: ldstr "Number"
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00bb: stloc.s 5
-			IL_00bd: ldloc.s 5
-			IL_00bf: ldstr "POSITIVE_INFINITY"
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c9: stloc.s 5
-			IL_00cb: ldloc.s 4
-			IL_00cd: ldloc.s 5
-			IL_00cf: ldstr "tick"
-			IL_00d4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object)
-			IL_00d9: stloc.1
-			IL_00da: ldloc.1
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e0: stloc.s 5
-			IL_00e2: ldloc.s 5
-			IL_00e4: ldstr "next"
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00ee: stloc.s 5
-			IL_00f0: ldloc.0
-			IL_00f1: ldc.i4.1
-			IL_00f2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00a5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
+			IL_00aa: stloc.s 4
+			IL_00ac: ldstr "Number"
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b6: stloc.s 5
+			IL_00b8: ldloc.s 5
+			IL_00ba: ldstr "POSITIVE_INFINITY"
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c4: stloc.s 5
+			IL_00c6: ldloc.s 4
+			IL_00c8: ldloc.s 5
+			IL_00ca: ldstr "tick"
+			IL_00cf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object)
+			IL_00d4: stloc.1
+			IL_00d5: ldloc.1
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00db: stloc.s 5
+			IL_00dd: ldloc.s 5
+			IL_00df: ldstr "next"
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00e9: stloc.s 5
+			IL_00eb: ldloc.0
+			IL_00ec: ldc.i4.1
+			IL_00ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00f2: ldloc.0
+			IL_00f3: ldloc.s 5
+			IL_00f5: ldarg.0
+			IL_00f6: ldc.i4.1
 			IL_00f7: ldloc.0
-			IL_00f8: ldloc.s 5
-			IL_00fa: ldarg.0
-			IL_00fb: ldc.i4.1
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0102: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0107: ldloc.0
-			IL_0108: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_010d: dup
-			IL_010e: ldc.i4.0
-			IL_010f: ldloc.1
-			IL_0110: stelem.ref
-			IL_0111: dup
-			IL_0112: ldc.i4.1
-			IL_0113: ldloc.2
-			IL_0114: stelem.ref
-			IL_0115: dup
-			IL_0116: ldc.i4.2
-			IL_0117: ldloc.3
+			IL_00f8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0102: ldloc.0
+			IL_0103: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0108: dup
+			IL_0109: ldc.i4.0
+			IL_010a: ldloc.1
+			IL_010b: stelem.ref
+			IL_010c: dup
+			IL_010d: ldc.i4.1
+			IL_010e: ldloc.2
+			IL_010f: stelem.ref
+			IL_0110: dup
+			IL_0111: ldc.i4.2
+			IL_0112: ldloc.3
+			IL_0113: stelem.ref
+			IL_0114: dup
+			IL_0115: ldc.i4.3
+			IL_0116: ldloc.s 4
 			IL_0118: stelem.ref
 			IL_0119: dup
-			IL_011a: ldc.i4.3
-			IL_011b: ldloc.s 4
+			IL_011a: ldc.i4.4
+			IL_011b: ldloc.s 5
 			IL_011d: stelem.ref
 			IL_011e: dup
-			IL_011f: ldc.i4.4
-			IL_0120: ldloc.s 5
+			IL_011f: ldc.i4.5
+			IL_0120: ldloc.s 6
 			IL_0122: stelem.ref
-			IL_0123: dup
-			IL_0124: ldc.i4.5
-			IL_0125: ldloc.s 6
-			IL_0127: stelem.ref
-			IL_0128: pop
-			IL_0129: ldloc.0
-			IL_012a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_012f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0134: ret
+			IL_0123: pop
+			IL_0124: ldloc.0
+			IL_0125: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_012a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_012f: ret
 
-			IL_0135: ldloc.0
-			IL_0136: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited1
-			IL_013b: stloc.2
-			IL_013c: ldstr "console"
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0146: stloc.s 5
-			IL_0148: ldloc.s 5
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014f: stloc.s 5
-			IL_0151: ldloc.2
-			IL_0152: ldstr "value"
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015c: stloc.s 6
-			IL_015e: ldloc.s 5
-			IL_0160: ldstr "log"
-			IL_0165: ldloc.s 6
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_016c: pop
-			IL_016d: ldstr "console"
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0177: stloc.s 6
-			IL_0179: ldloc.s 6
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0180: stloc.s 6
-			IL_0182: ldloc.2
-			IL_0183: ldstr "done"
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018d: stloc.s 5
-			IL_018f: ldloc.s 6
-			IL_0191: ldstr "log"
-			IL_0196: ldloc.s 5
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_019d: pop
-			IL_019e: ldloc.1
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a4: stloc.s 5
-			IL_01a6: ldloc.s 5
-			IL_01a8: ldstr "return"
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01b2: stloc.s 5
-			IL_01b4: ldloc.0
-			IL_01b5: ldc.i4.2
-			IL_01b6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0130: ldloc.0
+			IL_0131: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited1
+			IL_0136: stloc.2
+			IL_0137: ldstr "console"
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0141: stloc.s 5
+			IL_0143: ldloc.s 5
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014a: stloc.s 5
+			IL_014c: ldloc.2
+			IL_014d: ldstr "value"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0157: stloc.s 6
+			IL_0159: ldloc.s 5
+			IL_015b: ldstr "log"
+			IL_0160: ldloc.s 6
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0167: pop
+			IL_0168: ldstr "console"
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0172: stloc.s 6
+			IL_0174: ldloc.s 6
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017b: stloc.s 6
+			IL_017d: ldloc.2
+			IL_017e: ldstr "done"
+			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0188: stloc.s 5
+			IL_018a: ldloc.s 6
+			IL_018c: ldstr "log"
+			IL_0191: ldloc.s 5
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0198: pop
+			IL_0199: ldloc.1
+			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019f: stloc.s 5
+			IL_01a1: ldloc.s 5
+			IL_01a3: ldstr "return"
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01ad: stloc.s 5
+			IL_01af: ldloc.0
+			IL_01b0: ldc.i4.2
+			IL_01b1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01b6: ldloc.0
+			IL_01b7: ldloc.s 5
+			IL_01b9: ldarg.0
+			IL_01ba: ldc.i4.2
 			IL_01bb: ldloc.0
-			IL_01bc: ldloc.s 5
-			IL_01be: ldarg.0
-			IL_01bf: ldc.i4.2
-			IL_01c0: ldloc.0
-			IL_01c1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01cb: ldloc.0
-			IL_01cc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01d1: dup
-			IL_01d2: ldc.i4.0
-			IL_01d3: ldloc.1
-			IL_01d4: stelem.ref
-			IL_01d5: dup
-			IL_01d6: ldc.i4.1
-			IL_01d7: ldloc.2
-			IL_01d8: stelem.ref
-			IL_01d9: dup
-			IL_01da: ldc.i4.2
-			IL_01db: ldloc.3
+			IL_01bc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01c6: ldloc.0
+			IL_01c7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01cc: dup
+			IL_01cd: ldc.i4.0
+			IL_01ce: ldloc.1
+			IL_01cf: stelem.ref
+			IL_01d0: dup
+			IL_01d1: ldc.i4.1
+			IL_01d2: ldloc.2
+			IL_01d3: stelem.ref
+			IL_01d4: dup
+			IL_01d5: ldc.i4.2
+			IL_01d6: ldloc.3
+			IL_01d7: stelem.ref
+			IL_01d8: dup
+			IL_01d9: ldc.i4.3
+			IL_01da: ldloc.s 4
 			IL_01dc: stelem.ref
 			IL_01dd: dup
-			IL_01de: ldc.i4.3
-			IL_01df: ldloc.s 4
+			IL_01de: ldc.i4.4
+			IL_01df: ldloc.s 5
 			IL_01e1: stelem.ref
 			IL_01e2: dup
-			IL_01e3: ldc.i4.4
-			IL_01e4: ldloc.s 5
+			IL_01e3: ldc.i4.5
+			IL_01e4: ldloc.s 6
 			IL_01e6: stelem.ref
-			IL_01e7: dup
-			IL_01e8: ldc.i4.5
-			IL_01e9: ldloc.s 6
-			IL_01eb: stelem.ref
-			IL_01ec: pop
-			IL_01ed: ldloc.0
-			IL_01ee: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01f3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01f8: ret
+			IL_01e7: pop
+			IL_01e8: ldloc.0
+			IL_01e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01ee: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01f3: ret
 
-			IL_01f9: ldloc.0
-			IL_01fa: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited2
-			IL_01ff: stloc.3
-			IL_0200: ldstr "console"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_020a: stloc.s 5
-			IL_020c: ldloc.s 5
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0213: stloc.s 5
-			IL_0215: ldloc.3
-			IL_0216: ldstr "done"
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0220: stloc.s 6
-			IL_0222: ldloc.s 5
-			IL_0224: ldstr "log"
-			IL_0229: ldloc.s 6
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0230: pop
-			IL_0231: ldloc.0
-			IL_0232: ldc.i4.m1
-			IL_0233: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0238: ldloc.0
-			IL_0239: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0243: ldarg.0
-			IL_0244: ldc.i4.1
-			IL_0245: newarr [System.Runtime]System.Object
-			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_024f: pop
-			IL_0250: ldloc.0
-			IL_0251: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0256: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_025b: ret
+			IL_01f4: ldloc.0
+			IL_01f5: ldfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/Scope::_awaited2
+			IL_01fa: stloc.3
+			IL_01fb: ldstr "console"
+			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0205: stloc.s 5
+			IL_0207: ldloc.s 5
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020e: stloc.s 5
+			IL_0210: ldloc.3
+			IL_0211: ldstr "done"
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021b: stloc.s 6
+			IL_021d: ldloc.s 5
+			IL_021f: ldstr "log"
+			IL_0224: ldloc.s 6
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022b: pop
+			IL_022c: ldloc.0
+			IL_022d: ldc.i4.m1
+			IL_022e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0233: ldloc.0
+			IL_0234: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_023e: ldarg.0
+			IL_023f: ldc.i4.1
+			IL_0240: newarr [System.Runtime]System.Object
+			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_024a: pop
+			IL_024b: ldloc.0
+			IL_024c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0251: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0256: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -340,14 +339,14 @@
 			6d 61 69 6e 7d 00 00
 		)
 		// Fields
-		.field public object timersPromises
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule timersPromises
 		.field public object main
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x2313
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -406,7 +405,7 @@
 		IL_003b: stloc.2
 		IL_003c: ldloc.0
 		IL_003d: ldloc.2
-		IL_003e: stfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
+		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
 		IL_0043: nop
 		IL_0044: ldloc.1
 		IL_0045: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -424,7 +423,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x232a
+		// Method begins at RVA 0x2325
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27b3
+					// Method begins at RVA 0x2772
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x27bc
+					// Method begins at RVA 0x277b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27aa
+				// Method begins at RVA 0x2769
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2504
+			// Method begins at RVA 0x24ec
 			// Header size: 12
 			// Code size: 284 (0x11c)
 			.maxstack 8
@@ -217,7 +217,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c5
+				// Method begins at RVA 0x2784
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -243,9 +243,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x263c
+			// Method begins at RVA 0x2624
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 48 (0x30)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule,
@@ -254,22 +254,21 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_000b: stloc.0
-			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0011: dup
-			IL_0012: ldstr "chunkSize"
-			IL_0017: ldc.r8 1024
-			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "abc"
-			IL_002c: ldloc.1
-			IL_002d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-			IL_0032: stloc.2
-			IL_0033: ldloc.2
-			IL_0034: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_0006: stloc.0
+			IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_000c: dup
+			IL_000d: ldstr "chunkSize"
+			IL_0012: ldc.r8 1024
+			IL_001b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0020: stloc.1
+			IL_0021: ldloc.0
+			IL_0022: ldstr "abc"
+			IL_0027: ldloc.1
+			IL_0028: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+			IL_002d: stloc.2
+			IL_002e: ldloc.2
+			IL_002f: ret
 		} // end of method ArrowFunction_L25C37::__js_call__
 
 	} // end of class ArrowFunction_L25C37
@@ -285,7 +284,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ce
+				// Method begins at RVA 0x278d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -311,9 +310,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2680
+			// Method begins at RVA 0x2660
 			// Header size: 12
-			// Code size: 73 (0x49)
+			// Code size: 63 (0x3f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule,
@@ -323,30 +322,28 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_000b: stloc.0
-			IL_000c: ldarg.0
-			IL_000d: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0012: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_0017: stloc.1
-			IL_0018: ldloc.1
-			IL_0019: ldstr "abc"
-			IL_001e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object)
-			IL_0023: stloc.2
-			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0029: dup
-			IL_002a: ldstr "flush"
-			IL_002f: ldc.r8 2
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003d: stloc.3
-			IL_003e: ldloc.0
-			IL_003f: ldloc.2
-			IL_0040: ldloc.3
-			IL_0041: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object, object)
-			IL_0046: stloc.2
-			IL_0047: ldloc.2
-			IL_0048: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_000d: stloc.1
+			IL_000e: ldloc.1
+			IL_000f: ldstr "abc"
+			IL_0014: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object)
+			IL_0019: stloc.2
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001f: dup
+			IL_0020: ldstr "flush"
+			IL_0025: ldc.r8 2
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0033: stloc.3
+			IL_0034: ldloc.0
+			IL_0035: ldloc.2
+			IL_0036: ldloc.3
+			IL_0037: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object, object)
+			IL_003c: stloc.2
+			IL_003d: ldloc.2
+			IL_003e: ret
 		} // end of method ArrowFunction_L26C39::__js_call__
 
 	} // end of class ArrowFunction_L26C39
@@ -362,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d7
+				// Method begins at RVA 0x2796
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -388,9 +385,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x26d8
+			// Method begins at RVA 0x26ac
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 48 (0x30)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule,
@@ -399,22 +396,21 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_000b: stloc.0
-			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0011: dup
-			IL_0012: ldstr "level"
-			IL_0017: ldc.r8 10
-			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "abc"
-			IL_002c: ldloc.1
-			IL_002d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-			IL_0032: stloc.2
-			IL_0033: ldloc.2
-			IL_0034: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_0006: stloc.0
+			IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_000c: dup
+			IL_000d: ldstr "level"
+			IL_0012: ldc.r8 10
+			IL_001b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0020: stloc.1
+			IL_0021: ldloc.0
+			IL_0022: ldstr "abc"
+			IL_0027: ldloc.1
+			IL_0028: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+			IL_002d: stloc.2
+			IL_002e: ldloc.2
+			IL_002f: ret
 		} // end of method ArrowFunction_L27C28::__js_call__
 
 	} // end of class ArrowFunction_L27C28
@@ -430,7 +426,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e0
+				// Method begins at RVA 0x279f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -456,9 +452,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x271c
+			// Method begins at RVA 0x26e8
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 48 (0x30)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule,
@@ -467,22 +463,21 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_000b: stloc.0
-			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0011: dup
-			IL_0012: ldstr "level"
-			IL_0017: ldc.r8 (00 00 00 00 00 00 F8 FF)
-			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "abc"
-			IL_002c: ldloc.1
-			IL_002d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-			IL_0032: stloc.2
-			IL_0033: ldloc.2
-			IL_0034: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_0006: stloc.0
+			IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_000c: dup
+			IL_000d: ldstr "level"
+			IL_0012: ldc.r8 (00 00 00 00 00 00 F8 FF)
+			IL_001b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0020: stloc.1
+			IL_0021: ldloc.0
+			IL_0022: ldstr "abc"
+			IL_0027: ldloc.1
+			IL_0028: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+			IL_002d: stloc.2
+			IL_002e: ldloc.2
+			IL_002f: ret
 		} // end of method ArrowFunction_L28C28::__js_call__
 
 	} // end of class ArrowFunction_L28C28
@@ -498,7 +493,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e9
+				// Method begins at RVA 0x27a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -524,9 +519,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2760
+			// Method begins at RVA 0x2724
 			// Header size: 12
-			// Code size: 53 (0x35)
+			// Code size: 48 (0x30)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule,
@@ -535,22 +530,21 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_0006: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_000b: stloc.0
-			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0011: dup
-			IL_0012: ldstr "level"
-			IL_0017: ldc.r8 (00 00 00 00 00 00 F0 7F)
-			IL_0020: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "abc"
-			IL_002c: ldloc.1
-			IL_002d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-			IL_0032: stloc.2
-			IL_0033: ldloc.2
-			IL_0034: ret
+			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_0006: stloc.0
+			IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_000c: dup
+			IL_000d: ldstr "level"
+			IL_0012: ldc.r8 (00 00 00 00 00 00 F0 7F)
+			IL_001b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0020: stloc.1
+			IL_0021: ldloc.0
+			IL_0022: ldstr "abc"
+			IL_0027: ldloc.1
+			IL_0028: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+			IL_002d: stloc.2
+			IL_002e: ldloc.2
+			IL_002f: ret
 		} // end of method ArrowFunction_L29C33::__js_call__
 
 	} // end of class ArrowFunction_L29C33
@@ -571,7 +565,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f2
+				// Method begins at RVA 0x27b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -591,7 +585,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27fb
+				// Method begins at RVA 0x27ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -606,14 +600,14 @@
 
 
 		// Fields
-		.field public object zlib
+		.field public class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule zlib
 		.field public object logError
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x27a1
+			// Method begins at RVA 0x2760
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -639,7 +633,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1162 (0x48a)
+		// Code size: 1137 (0x471)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
@@ -684,364 +678,359 @@
 		IL_0032: stloc.s 6
 		IL_0034: ldloc.0
 		IL_0035: ldloc.s 6
-		IL_0037: stfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_0037: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
 		IL_003c: nop
 		IL_003d: ldstr "console"
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_004c: stloc.s 7
 		IL_004e: ldloc.0
-		IL_004f: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_0054: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-		IL_0059: stloc.s 6
-		IL_005b: ldloc.0
-		IL_005c: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_0061: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-		IL_0066: stloc.s 8
-		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_006d: dup
-		IL_006e: ldstr "level"
-		IL_0073: ldc.r8 1
-		IL_007c: neg
-		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0082: stloc.s 9
-		IL_0084: ldloc.s 8
-		IL_0086: ldstr "abc"
-		IL_008b: ldloc.s 9
-		IL_008d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-		IL_0092: stloc.s 10
-		IL_0094: ldloc.s 6
-		IL_0096: ldloc.s 10
-		IL_0098: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
-		IL_009d: stloc.s 10
-		IL_009f: ldloc.s 10
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a6: ldstr "toString"
-		IL_00ab: ldstr "utf8"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b5: stloc.s 10
-		IL_00b7: ldloc.s 7
-		IL_00b9: ldstr "log"
-		IL_00be: ldstr "gzip level -1 roundtrip:"
-		IL_00c3: ldloc.s 10
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00ca: pop
-		IL_00cb: ldstr "console"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00da: stloc.s 10
-		IL_00dc: ldloc.0
-		IL_00dd: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_00e2: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-		IL_00e7: stloc.s 6
-		IL_00e9: ldloc.0
-		IL_00ea: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_00ef: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-		IL_00f4: stloc.s 8
-		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00fb: dup
-		IL_00fc: ldstr "level"
-		IL_0101: ldc.r8 1.5
-		IL_010a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_010f: stloc.s 9
-		IL_0111: ldloc.s 8
-		IL_0113: ldstr "abc"
-		IL_0118: ldloc.s 9
-		IL_011a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-		IL_011f: stloc.s 7
-		IL_0121: ldloc.s 6
-		IL_0123: ldloc.s 7
-		IL_0125: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
-		IL_012a: stloc.s 7
-		IL_012c: ldloc.s 7
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0133: ldstr "toString"
-		IL_0138: ldstr "utf8"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0142: stloc.s 7
-		IL_0144: ldloc.s 10
-		IL_0146: ldstr "log"
-		IL_014b: ldstr "gzip level 1.5 roundtrip:"
-		IL_0150: ldloc.s 7
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0157: pop
-		IL_0158: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_015d: stloc.s 11
-		IL_015f: ldloc.0
-		IL_0160: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0165: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0170: ldc.i4.1
-		IL_0171: newarr [System.Runtime]System.Object
-		IL_0176: dup
-		IL_0177: ldc.i4.0
-		IL_0178: ldloc.0
-		IL_0179: stelem.ref
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0184: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0189: ldc.i4.0
-		IL_018a: conv.r8
-		IL_018b: ldstr ""
-		IL_0190: ldc.i4.0
-		IL_0191: ldc.i4.0
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0197: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_019c: stloc.s 12
-		IL_019e: ldloc.1
-		IL_019f: ldloc.s 11
-		IL_01a1: ldstr "gzip unsupported option"
-		IL_01a6: ldloc.s 12
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01ad: pop
-		IL_01ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b3: stloc.s 11
-		IL_01b5: ldloc.0
-		IL_01b6: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01bb: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_01c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01c6: ldc.i4.1
-		IL_01c7: newarr [System.Runtime]System.Object
-		IL_01cc: dup
-		IL_01cd: ldc.i4.0
-		IL_01ce: ldloc.0
-		IL_01cf: stelem.ref
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01da: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_01df: ldc.i4.0
-		IL_01e0: conv.r8
-		IL_01e1: ldstr ""
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldc.i4.0
-		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_01f2: stloc.s 12
-		IL_01f4: ldloc.1
-		IL_01f5: ldloc.s 11
-		IL_01f7: ldstr "gunzip unsupported option"
-		IL_01fc: ldloc.s 12
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0203: pop
-		IL_0204: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0209: stloc.s 11
-		IL_020b: ldloc.0
-		IL_020c: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0211: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_0217: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_021c: ldc.i4.1
-		IL_021d: newarr [System.Runtime]System.Object
-		IL_0222: dup
-		IL_0223: ldc.i4.0
-		IL_0224: ldloc.0
-		IL_0225: stelem.ref
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0230: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_0235: ldc.i4.0
-		IL_0236: conv.r8
-		IL_0237: ldstr ""
-		IL_023c: ldc.i4.0
-		IL_023d: ldc.i4.0
-		IL_023e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_0248: stloc.s 12
-		IL_024a: ldloc.1
-		IL_024b: ldloc.s 11
-		IL_024d: ldstr "gzip bad level"
-		IL_0252: ldloc.s 12
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0259: pop
-		IL_025a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_025f: stloc.s 11
-		IL_0261: ldloc.0
-		IL_0262: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0267: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_026d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0272: ldc.i4.1
-		IL_0273: newarr [System.Runtime]System.Object
-		IL_0278: dup
-		IL_0279: ldc.i4.0
-		IL_027a: ldloc.0
-		IL_027b: stelem.ref
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0286: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_028b: ldc.i4.0
-		IL_028c: conv.r8
-		IL_028d: ldstr ""
-		IL_0292: ldc.i4.0
-		IL_0293: ldc.i4.0
-		IL_0294: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_0299: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_029e: stloc.s 12
-		IL_02a0: ldloc.1
-		IL_02a1: ldloc.s 11
-		IL_02a3: ldstr "gzip NaN level"
-		IL_02a8: ldloc.s 12
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02af: pop
-		IL_02b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02b5: stloc.s 11
-		IL_02b7: ldloc.0
-		IL_02b8: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_02bd: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_02c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02c8: ldc.i4.1
-		IL_02c9: newarr [System.Runtime]System.Object
-		IL_02ce: dup
-		IL_02cf: ldc.i4.0
-		IL_02d0: ldloc.0
-		IL_02d1: stelem.ref
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02dc: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
-		IL_02e1: ldc.i4.0
-		IL_02e2: conv.r8
-		IL_02e3: ldstr ""
-		IL_02e8: ldc.i4.0
-		IL_02e9: ldc.i4.0
-		IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
-		IL_02ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
-		IL_02f4: stloc.s 12
-		IL_02f6: ldloc.1
-		IL_02f7: ldloc.s 11
-		IL_02f9: ldstr "gzip Infinity level"
-		IL_02fe: ldloc.s 12
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0305: pop
+		IL_004f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_0054: stloc.s 6
+		IL_0056: ldloc.0
+		IL_0057: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_005c: stloc.s 8
+		IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0063: dup
+		IL_0064: ldstr "level"
+		IL_0069: ldc.r8 1
+		IL_0072: neg
+		IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0078: stloc.s 9
+		IL_007a: ldloc.s 8
+		IL_007c: ldstr "abc"
+		IL_0081: ldloc.s 9
+		IL_0083: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+		IL_0088: stloc.s 10
+		IL_008a: ldloc.s 6
+		IL_008c: ldloc.s 10
+		IL_008e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
+		IL_0093: stloc.s 10
+		IL_0095: ldloc.s 10
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009c: ldstr "toString"
+		IL_00a1: ldstr "utf8"
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ab: stloc.s 10
+		IL_00ad: ldloc.s 7
+		IL_00af: ldstr "log"
+		IL_00b4: ldstr "gzip level -1 roundtrip:"
+		IL_00b9: ldloc.s 10
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00c0: pop
+		IL_00c1: ldstr "console"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.s 10
+		IL_00d2: ldloc.0
+		IL_00d3: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_00d8: stloc.s 6
+		IL_00da: ldloc.0
+		IL_00db: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_00e0: stloc.s 8
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e7: dup
+		IL_00e8: ldstr "level"
+		IL_00ed: ldc.r8 1.5
+		IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00fb: stloc.s 9
+		IL_00fd: ldloc.s 8
+		IL_00ff: ldstr "abc"
+		IL_0104: ldloc.s 9
+		IL_0106: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+		IL_010b: stloc.s 7
+		IL_010d: ldloc.s 6
+		IL_010f: ldloc.s 7
+		IL_0111: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
+		IL_0116: stloc.s 7
+		IL_0118: ldloc.s 7
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011f: ldstr "toString"
+		IL_0124: ldstr "utf8"
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012e: stloc.s 7
+		IL_0130: ldloc.s 10
+		IL_0132: ldstr "log"
+		IL_0137: ldstr "gzip level 1.5 roundtrip:"
+		IL_013c: ldloc.s 7
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0143: pop
+		IL_0144: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0149: stloc.s 11
+		IL_014b: ldloc.0
+		IL_014c: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0151: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_015c: ldc.i4.1
+		IL_015d: newarr [System.Runtime]System.Object
+		IL_0162: dup
+		IL_0163: ldc.i4.0
+		IL_0164: ldloc.0
+		IL_0165: stelem.ref
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0170: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0175: ldc.i4.0
+		IL_0176: conv.r8
+		IL_0177: ldstr ""
+		IL_017c: ldc.i4.0
+		IL_017d: ldc.i4.0
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0188: stloc.s 12
+		IL_018a: ldloc.1
+		IL_018b: ldloc.s 11
+		IL_018d: ldstr "gzip unsupported option"
+		IL_0192: ldloc.s 12
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0199: pop
+		IL_019a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019f: stloc.s 11
+		IL_01a1: ldloc.0
+		IL_01a2: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_01a7: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01b2: ldc.i4.1
+		IL_01b3: newarr [System.Runtime]System.Object
+		IL_01b8: dup
+		IL_01b9: ldc.i4.0
+		IL_01ba: ldloc.0
+		IL_01bb: stelem.ref
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01c6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_01cb: ldc.i4.0
+		IL_01cc: conv.r8
+		IL_01cd: ldstr ""
+		IL_01d2: ldc.i4.0
+		IL_01d3: ldc.i4.0
+		IL_01d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_01de: stloc.s 12
+		IL_01e0: ldloc.1
+		IL_01e1: ldloc.s 11
+		IL_01e3: ldstr "gunzip unsupported option"
+		IL_01e8: ldloc.s 12
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01ef: pop
+		IL_01f0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f5: stloc.s 11
+		IL_01f7: ldloc.0
+		IL_01f8: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_01fd: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0208: ldc.i4.1
+		IL_0209: newarr [System.Runtime]System.Object
+		IL_020e: dup
+		IL_020f: ldc.i4.0
+		IL_0210: ldloc.0
+		IL_0211: stelem.ref
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_021c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0221: ldc.i4.0
+		IL_0222: conv.r8
+		IL_0223: ldstr ""
+		IL_0228: ldc.i4.0
+		IL_0229: ldc.i4.0
+		IL_022a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_022f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_0234: stloc.s 12
+		IL_0236: ldloc.1
+		IL_0237: ldloc.s 11
+		IL_0239: ldstr "gzip bad level"
+		IL_023e: ldloc.s 12
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0245: pop
+		IL_0246: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_024b: stloc.s 11
+		IL_024d: ldloc.0
+		IL_024e: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0253: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0259: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_025e: ldc.i4.1
+		IL_025f: newarr [System.Runtime]System.Object
+		IL_0264: dup
+		IL_0265: ldc.i4.0
+		IL_0266: ldloc.0
+		IL_0267: stelem.ref
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0272: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_0277: ldc.i4.0
+		IL_0278: conv.r8
+		IL_0279: ldstr ""
+		IL_027e: ldc.i4.0
+		IL_027f: ldc.i4.0
+		IL_0280: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_0285: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_028a: stloc.s 12
+		IL_028c: ldloc.1
+		IL_028d: ldloc.s 11
+		IL_028f: ldstr "gzip NaN level"
+		IL_0294: ldloc.s 12
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_029b: pop
+		IL_029c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02a1: stloc.s 11
+		IL_02a3: ldloc.0
+		IL_02a4: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_02a9: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_02af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02b4: ldc.i4.1
+		IL_02b5: newarr [System.Runtime]System.Object
+		IL_02ba: dup
+		IL_02bb: ldc.i4.0
+		IL_02bc: ldloc.0
+		IL_02bd: stelem.ref
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02c8: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0
+		IL_02cd: ldc.i4.0
+		IL_02ce: conv.r8
+		IL_02cf: ldstr ""
+		IL_02d4: ldc.i4.0
+		IL_02d5: ldc.i4.0
+		IL_02d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0, float64, string, bool, bool)
+		IL_02db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0>(!!0)
+		IL_02e0: stloc.s 12
+		IL_02e2: ldloc.1
+		IL_02e3: ldloc.s 11
+		IL_02e5: ldstr "gzip Infinity level"
+		IL_02ea: ldloc.s 12
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02f1: pop
 		.try
 		{
-			IL_0306: nop
-			IL_0307: ldloc.0
-			IL_0308: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_030d: castclass [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule
-			IL_0312: stloc.s 6
-			IL_0314: ldstr "not gzip"
-			IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_031e: stloc.s 13
-			IL_0320: ldloc.s 6
-			IL_0322: ldloc.s 13
-			IL_0324: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
-			IL_0329: pop
-			IL_032a: ldstr "console"
-			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0339: ldstr "log"
-			IL_033e: ldstr "gunzip invalid data threw:"
-			IL_0343: ldc.i4.0
-			IL_0344: box [System.Runtime]System.Boolean
-			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_034e: pop
-			IL_034f: leave IL_0486
+			IL_02f2: nop
+			IL_02f3: ldloc.0
+			IL_02f4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_02f9: stloc.s 6
+			IL_02fb: ldstr "not gzip"
+			IL_0300: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0305: stloc.s 13
+			IL_0307: ldloc.s 6
+			IL_0309: ldloc.s 13
+			IL_030b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
+			IL_0310: pop
+			IL_0311: ldstr "console"
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0320: ldstr "log"
+			IL_0325: ldstr "gunzip invalid data threw:"
+			IL_032a: ldc.i4.0
+			IL_032b: box [System.Runtime]System.Boolean
+			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0335: pop
+			IL_0336: leave IL_046d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0354: stloc.2
-			IL_0355: ldloc.2
-			IL_0356: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_035b: dup
-			IL_035c: brtrue IL_0371
+			IL_033b: stloc.2
+			IL_033c: ldloc.2
+			IL_033d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0342: dup
+			IL_0343: brtrue IL_0358
 
-			IL_0361: pop
-			IL_0362: ldloc.2
-			IL_0363: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0368: dup
-			IL_0369: brtrue IL_037c
+			IL_0348: pop
+			IL_0349: ldloc.2
+			IL_034a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_034f: dup
+			IL_0350: brtrue IL_0363
 
-			IL_036e: pop
-			IL_036f: rethrow
+			IL_0355: pop
+			IL_0356: rethrow
 
-			IL_0371: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0376: stloc.3
-			IL_0377: br IL_037d
+			IL_0358: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_035d: stloc.3
+			IL_035e: br IL_0364
 
-			IL_037c: stloc.3
+			IL_0363: stloc.3
 
-			IL_037d: ldloc.3
-			IL_037e: stloc.s 4
-			IL_0380: ldstr "console"
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_038f: ldstr "log"
-			IL_0394: ldstr "gunzip invalid data threw:"
-			IL_0399: ldc.i4.1
-			IL_039a: box [System.Runtime]System.Boolean
-			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03a4: pop
-			IL_03a5: ldstr "console"
-			IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b4: stloc.s 7
-			IL_03b6: ldloc.s 4
-			IL_03b8: ldstr "name"
-			IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c2: stloc.s 10
-			IL_03c4: ldloc.s 7
-			IL_03c6: ldstr "log"
-			IL_03cb: ldstr "gunzip invalid data name:"
-			IL_03d0: ldloc.s 10
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03d7: pop
-			IL_03d8: ldstr "console"
-			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03e7: stloc.s 10
-			IL_03e9: ldloc.s 4
-			IL_03eb: ldstr "message"
-			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f5: stloc.s 7
-			IL_03f7: ldloc.s 7
-			IL_03f9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_03fe: stloc.s 14
-			IL_0400: ldloc.s 14
-			IL_0402: ldstr "string"
-			IL_0407: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_040c: stloc.s 15
-			IL_040e: ldloc.s 15
-			IL_0410: box [System.Runtime]System.Boolean
-			IL_0415: stloc.s 16
-			IL_0417: ldloc.s 16
-			IL_0419: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_041e: stloc.s 15
-			IL_0420: ldloc.s 15
-			IL_0422: brfalse IL_0469
+			IL_0364: ldloc.3
+			IL_0365: stloc.s 4
+			IL_0367: ldstr "console"
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0376: ldstr "log"
+			IL_037b: ldstr "gunzip invalid data threw:"
+			IL_0380: ldc.i4.1
+			IL_0381: box [System.Runtime]System.Boolean
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_038b: pop
+			IL_038c: ldstr "console"
+			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_039b: stloc.s 7
+			IL_039d: ldloc.s 4
+			IL_039f: ldstr "name"
+			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a9: stloc.s 10
+			IL_03ab: ldloc.s 7
+			IL_03ad: ldstr "log"
+			IL_03b2: ldstr "gunzip invalid data name:"
+			IL_03b7: ldloc.s 10
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_03be: pop
+			IL_03bf: ldstr "console"
+			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ce: stloc.s 10
+			IL_03d0: ldloc.s 4
+			IL_03d2: ldstr "message"
+			IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03dc: stloc.s 7
+			IL_03de: ldloc.s 7
+			IL_03e0: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_03e5: stloc.s 14
+			IL_03e7: ldloc.s 14
+			IL_03e9: ldstr "string"
+			IL_03ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03f3: stloc.s 15
+			IL_03f5: ldloc.s 15
+			IL_03f7: box [System.Runtime]System.Boolean
+			IL_03fc: stloc.s 16
+			IL_03fe: ldloc.s 16
+			IL_0400: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0405: stloc.s 15
+			IL_0407: ldloc.s 15
+			IL_0409: brfalse IL_0450
 
-			IL_0427: ldloc.s 4
-			IL_0429: ldstr "message"
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0433: stloc.s 7
-			IL_0435: ldloc.s 7
-			IL_0437: ldstr "length"
-			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0441: stloc.s 7
-			IL_0443: ldloc.s 7
-			IL_0445: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_044a: ldc.r8 0.0
-			IL_0453: cgt
-			IL_0455: stloc.s 15
-			IL_0457: ldloc.s 15
-			IL_0459: box [System.Runtime]System.Boolean
-			IL_045e: stloc.s 17
-			IL_0460: ldloc.s 17
-			IL_0462: stloc.s 19
-			IL_0464: br IL_046d
+			IL_040e: ldloc.s 4
+			IL_0410: ldstr "message"
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_041a: stloc.s 7
+			IL_041c: ldloc.s 7
+			IL_041e: ldstr "length"
+			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0428: stloc.s 7
+			IL_042a: ldloc.s 7
+			IL_042c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0431: ldc.r8 0.0
+			IL_043a: cgt
+			IL_043c: stloc.s 15
+			IL_043e: ldloc.s 15
+			IL_0440: box [System.Runtime]System.Boolean
+			IL_0445: stloc.s 17
+			IL_0447: ldloc.s 17
+			IL_0449: stloc.s 19
+			IL_044b: br IL_0454
 
-			IL_0469: ldloc.s 16
-			IL_046b: stloc.s 19
+			IL_0450: ldloc.s 16
+			IL_0452: stloc.s 19
 
-			IL_046d: ldloc.s 10
-			IL_046f: ldstr "log"
-			IL_0474: ldstr "gunzip invalid data message length > 0:"
-			IL_0479: ldloc.s 19
-			IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0480: pop
-			IL_0481: leave IL_0486
+			IL_0454: ldloc.s 10
+			IL_0456: ldstr "log"
+			IL_045b: ldstr "gunzip invalid data message length > 0:"
+			IL_0460: ldloc.s 19
+			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0467: pop
+			IL_0468: leave IL_046d
 		} // end handler
 
-		IL_0486: ldnull
-		IL_0487: stloc.s 5
-		IL_0489: ret
+		IL_046d: ldnull
+		IL_046e: stloc.s 5
+		IL_0470: ret
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths
@@ -1053,7 +1042,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2804
+		// Method begins at RVA 0x27c3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -555,6 +555,46 @@ public class SymbolTableTypeInferenceTests
     }
 
     [Fact]
+    public void GeneratedAssembly_CapturedNodeContractBindingUsesStableInterfaceFieldType()
+    {
+        var entryPath = Path.Combine(
+            Path.GetTempPath(),
+            "Jroc.Tests",
+            "CapturedNodeContractFieldType",
+            Guid.NewGuid().ToString("N"),
+            "entry.js");
+
+        var artifact = JrocInMemoryCompiler.Compile(new JrocInMemoryCompileRequest(entryPath)
+        {
+            SourceText = """
+                const stablePath = require('node:path');
+                let unstablePath = require('node:path');
+
+                function stable() {
+                    return stablePath.join('a', 'b');
+                }
+
+                function unstable() {
+                    return unstablePath.join('a', 'b');
+                }
+
+                unstablePath = { join: function (left, right) { return left + right; } };
+                """
+        });
+
+        using var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+        var moduleType = loadedAssembly.Assembly.GetType("Modules.entry", throwOnError: true)!;
+        var scopeType = moduleType.GetNestedType("Scope", BindingFlags.Public | BindingFlags.NonPublic)!;
+
+        Assert.Equal(
+            typeof(Jroc.Runtime.Node.Contracts.IPathModule),
+            scopeType.GetField("stablePath", BindingFlags.Public | BindingFlags.Instance)!.FieldType);
+        Assert.Equal(
+            typeof(object),
+            scopeType.GetField("unstablePath", BindingFlags.Public | BindingFlags.Instance)!.FieldType);
+    }
+
+    [Fact]
     public void SymbolTable_InferTypes_ClassInstanceFields_Primitives()
     {
         var code = @"


### PR DESCRIPTION
## Summary
- preserve proven stable CLR types when declaring captured scope fields
- retain `object` fields for TDZ-checked and unstable/reassigned bindings
- cover typed Node contracts, dynamic bindings, and updated IL snapshots

Fixes #1671

## Validation
- `dotnet build jroc.sln --no-restore --nologo`
- focused captured-contract, integration generator, and Node Path execution/generator tests